### PR TITLE
fix(cidade): respeitar filtro de data padrao (ano atual) em todos os componentes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pipeline ETL para cruzamento de dados abertos do governo federal brasileiro, voltado para deteccao de fraudes em licitacoes, emendas parlamentares, cartao corporativo, eleicoes e programas sociais.
 
-> **Vibe coded** com [Claude Code](https://claude.ai/claude-code) (Opus 4.6) e Codex (GPT-5.4) - da modelagem do schema ate o ultimo `INSERT INTO`.
+> **Vibe coded** com [Claude Code](https://claude.ai/claude-code) (Opus 4.6 e 4.7) e Codex (GPT-5.4 e 5.5) - da modelagem do schema ate o ultimo `INSERT INTO`.
 
 ## O que faz
 

--- a/web/queries/registry.py
+++ b/web/queries/registry.py
@@ -131,7 +131,9 @@ SELECT san.nome_sancionado, san.cpf_cnpj_sancionado,
        END AS abrangencia,
        san.dt_inicio_sancao, san.dt_final_sancao,
        d.municipio, d.nome_credor,
-       SUM(d.valor_pago) AS total_pago, COUNT(*) AS qtd_empenhos
+       SUM(d.valor_pago) AS total_pago, COUNT(*) AS qtd_empenhos,
+       MIN(d.data_empenho) AS primeiro_empenho_no_filtro,
+       MAX(d.data_empenho) AS ultimo_empenho_no_filtro
 FROM (
     SELECT nome_sancionado, cpf_cnpj_sancionado, categoria_sancao,
            dt_inicio_sancao, dt_final_sancao, 'CEIS' AS origem,
@@ -177,7 +179,9 @@ SELECT san.nome_sancionado, san.cpf_cnpj_sancionado,
        END AS abrangencia,
        san.dt_inicio_sancao, san.dt_final_sancao,
        d.municipio, d.nome_credor,
-       SUM(d.valor_pago) AS total_pago, COUNT(*) AS qtd_empenhos
+       SUM(d.valor_pago) AS total_pago, COUNT(*) AS qtd_empenhos,
+       MIN(d.data_empenho) AS primeiro_empenho_no_filtro,
+       MAX(d.data_empenho) AS ultimo_empenho_no_filtro
 FROM (
     SELECT nome_sancionado, cpf_cnpj_sancionado, categoria_sancao,
            dt_inicio_sancao, dt_final_sancao, 'CEIS' AS origem,

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -655,24 +655,39 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
     except Exception:
         kpi_ctx = None
     if kpi_ctx is None:
+        # Replica a estrategia de _kpi_summary_payload (usado por /api/kpis)
+        # para que SSR e API produzam o mesmo resultado mesmo quando apenas
+        # ANO:PERFIL esta no cache mas ANO:TOP_* faltam: la, _load_*_for_kpis
+        # cai para uma query live datada. Fazer o mesmo aqui evita primeiro
+        # paint com KPIs zerados/subestimados que depois sao corrigidos pela
+        # chamada subsequente a /api/kpis.
         fornecedores_dicts: list[dict] = []
         servidores_dicts: list[dict] = []
+        ano_payload: MunicipioPayload | None = None
+        if perfil_periodo == "ANO":
+            ano_payload = MunicipioPayload(
+                municipio=canonical_mun,
+                data_inicio=date_ctx["default_data_inicio"],
+                data_fim=date_ctx["default_data_fim"],
+            )
         try:
-            forn_cached = read_web_cache("TOP_FORNECEDORES", canonical_mun, periodo="ANO")
-            if not forn_cached and not perfil_periodo:
+            if ano_payload is not None:
+                fornecedores_dicts = _load_fornecedores_for_kpis(canonical_mun, ano_payload, "ANO")
+            else:
                 forn_cached = read_web_cache("TOP_FORNECEDORES", canonical_mun)
-            if forn_cached:
-                fcols, frows = forn_cached
-                fornecedores_dicts = [_row_to_dict(fcols, r) for r in frows]
+                if forn_cached:
+                    fcols, frows = forn_cached
+                    fornecedores_dicts = [_row_to_dict(fcols, r) for r in frows]
         except Exception:
             pass
         try:
-            serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun, periodo="ANO")
-            if not serv_cached and not perfil_periodo:
+            if ano_payload is not None:
+                servidores_dicts = _load_servidores_for_kpis(canonical_mun, ano_payload, "ANO")
+            else:
                 serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun)
-            if serv_cached:
-                scols, srows = serv_cached
-                servidores_dicts = [_row_to_dict(scols, r) for r in srows]
+                if serv_cached:
+                    scols, srows = serv_cached
+                    servidores_dicts = [_row_to_dict(scols, r) for r in srows]
         except Exception:
             pass
         kpi_ctx = compute_cidade_kpis(perfil, fornecedores_dicts, servidores_dicts)
@@ -1008,11 +1023,14 @@ async def get_kpis(municipio_path: str, payload: MunicipioPayload):
 
 @router.post("/api/perfil")
 async def get_perfil(payload: MunicipioPayload):
-    """Retorna perfil do municipio como JSON, com filtro temporal opcional."""
+    """Retorna perfil do municipio + narrativa, com filtro temporal opcional."""
     municipio = _normalize_municipio(payload.municipio)
     periodo = _get_periodo(payload)
-    perfil = _load_perfil_for_kpis(municipio, payload, periodo)
-    return JSONResponse(perfil or {})
+    perfil = _load_perfil_for_kpis(municipio, payload, periodo) or {}
+    # Narrativa date-aware: o cliente substitui o HTML em #cityNarrative
+    # quando o filtro muda, evitando que o texto fique desalinhado dos KPIs.
+    narrative = build_narrative(perfil, get_pb_medias(), periodo=periodo) if perfil else None
+    return JSONResponse({"perfil": perfil, "narrative": narrative})
 
 
 @router.get("/api/heatmap/{municipio_path}")

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -566,6 +566,27 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
         "default_data_fim": _today.isoformat(),
     }
 
+    # Default da UI eh "Ano atual": sobrepoe os campos do perfil sensiveis ao
+    # filtro com o cache ANO:PERFIL para alinhar o primeiro paint com o filtro
+    # ativo (evita flash de all-time). Mantem campos historicos (risco_score,
+    # qtd_licitacoes, pct_proponente_unico) intactos para narrativa/ranking.
+    try:
+        cached_ano = read_web_cache("PERFIL", municipio, periodo="ANO")
+        if cached_ano:
+            ano_cols, ano_rows = cached_ano
+            if ano_rows:
+                ano = _row_to_dict(ano_cols, ano_rows[0])
+                for fld in (
+                    "qtd_empenhos", "total_empenhado", "total_pago",
+                    "qtd_fornecedores", "qtd_sem_licitacao", "pct_sem_licitacao",
+                    "qtd_dezembro", "pct_dezembro", "pct_nao_executado",
+                    "receita_arrecadada", "total_folha", "pct_folha_receita",
+                ):
+                    if fld in ano and ano[fld] is not None:
+                        perfil[fld] = ano[fld]
+    except Exception:
+        pass
+
     narrative = build_narrative(perfil, get_pb_medias())
 
     # Carrega fornecedorese servidores do cache (sem fallback live: a hero
@@ -575,9 +596,14 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
     canonical_mun = str(perfil.get("municipio") or municipio)
     # Tenta cache KPI_SUMMARY pre-computado (warm_cache.py). Se nao houver,
     # carrega listas e roda compute_cidade_kpis em runtime.
+    # Default da UI eh "Ano atual": tenta primeiro a variante ANO:KPI_SUMMARY
+    # (e ANO:TOP_*) para que os KPIs/concentracao/score do primeiro paint ja
+    # respeitem o filtro. Cai para all-time se o ANO ainda nao foi populado.
     kpi_ctx: dict | None = None
     try:
-        cached_summary = read_web_cache("KPI_SUMMARY", canonical_mun)
+        cached_summary = read_web_cache("KPI_SUMMARY", canonical_mun, periodo="ANO")
+        if not cached_summary:
+            cached_summary = read_web_cache("KPI_SUMMARY", canonical_mun)
         if cached_summary:
             scols, srows = cached_summary
             if srows and srows[0]:
@@ -593,14 +619,18 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
         fornecedores_dicts: list[dict] = []
         servidores_dicts: list[dict] = []
         try:
-            forn_cached = read_web_cache("TOP_FORNECEDORES", canonical_mun)
+            forn_cached = read_web_cache("TOP_FORNECEDORES", canonical_mun, periodo="ANO")
+            if not forn_cached:
+                forn_cached = read_web_cache("TOP_FORNECEDORES", canonical_mun)
             if forn_cached:
                 fcols, frows = forn_cached
                 fornecedores_dicts = [_row_to_dict(fcols, r) for r in frows]
         except Exception:
             pass
         try:
-            serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun)
+            serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun, periodo="ANO")
+            if not serv_cached:
+                serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun)
             if serv_cached:
                 scols, srows = serv_cached
                 servidores_dicts = [_row_to_dict(scols, r) for r in srows]
@@ -802,10 +832,11 @@ async def batch_cache(municipio_path: str, periodo: str = ""):
                     elif ":" in qid:
                         # Prefixed but not matching: skip
                         pass
-                    else:
-                        # Fallback: only for queries without dated variants (TOP_SERVIDORES)
-                        if periodo and qid == "TOP_SERVIDORES" and qid not in result:
-                            result[qid] = entry
+                    # Sem fallback all-time: hoje todas as queries que aparecem
+                    # nos cards/panels (TOP_FORNECEDORES, TOP_SERVIDORES, Q##)
+                    # tem variante datada e cache ANO:* populado pelo warm_cache.
+                    # Aceitar entradas all-time aqui contaminaria a resposta com
+                    # dados que nao respeitam o filtro de periodo.
     except Exception:
         pass
     return JSONResponse(result)

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -359,11 +359,16 @@ def _compare_vs_mediana(valor, mediana, higher_is_worse: bool = True) -> str:
     return "abaixo da m&eacute;dia da Para&iacute;ba" if higher_is_worse else "abaixo da m&eacute;dia da Para&iacute;ba"
 
 
-def build_narrative(perfil: dict, medias: dict | None = None) -> dict:
+def build_narrative(perfil: dict, medias: dict | None = None, periodo: str = "") -> dict:
     """Monta narrativa humana a partir do perfil + agregados PB.
 
     Retorna dict com chaves `citizen` (HTML para modo cidadao) e `auditor`
     (HTML para modo auditor) — ambas prontas para |safe no template.
+
+    `periodo`: '' = all-time (default), 'ANO' = ano corrente, 'CUSTOM' = filtro
+    customizado. Quando filtrado, omite comparadores PB (medianas all-time) e o
+    risco_score (vem da MV all-time) para nao misturar escalas, e adiciona um
+    prefixo identificando o periodo no inicio da frase.
     """
     medias = medias or {}
     municipio = (perfil.get("municipio") or "Este munic&iacute;pio").title()
@@ -373,6 +378,17 @@ def build_narrative(perfil: dict, medias: dict | None = None) -> dict:
     pct_sem_licitacao = perfil.get("pct_sem_licitacao") or 0
     risco_score = perfil.get("risco_score")
     pct_folha = perfil.get("pct_folha_receita") or 0
+
+    is_filtered = bool(periodo)
+    if periodo == "ANO":
+        period_label_citizen = f"Em <strong>{date.today().year}</strong> (ate hoje), "
+        period_label_auditor = f"<strong>{date.today().year}</strong> (ate hoje) — "
+    elif periodo == "CUSTOM":
+        period_label_citizen = "<strong>No per&iacute;odo selecionado</strong>, "
+        period_label_auditor = "<strong>Per&iacute;odo selecionado</strong> — "
+    else:
+        period_label_citizen = ""
+        period_label_auditor = ""
 
     pct_pago = 0.0
     try:
@@ -386,22 +402,31 @@ def build_narrative(perfil: dict, medias: dict | None = None) -> dict:
 
     # ----- Cidadao -----
     qtd_forn_fmt = f"{qtd_fornecedores:,}".replace(",", ".")
-    frag_citizen = [f"A prefeitura de <strong>{municipio}</strong> j&aacute; pagou "
-                    f"<a href=\"#fornecedores\"><strong>{_fmt_brl_narrative(total_pago)}</strong></a> "
-                    f"a <a href=\"#fornecedores\"><strong>{qtd_forn_fmt}</strong> empresas</a>."]
+    if is_filtered:
+        frag_citizen = [f"{period_label_citizen}a prefeitura de <strong>{municipio}</strong> pagou "
+                        f"<a href=\"#fornecedores\"><strong>{_fmt_brl_narrative(total_pago)}</strong></a> "
+                        f"a <a href=\"#fornecedores\"><strong>{qtd_forn_fmt}</strong> empresas</a>."]
+    else:
+        frag_citizen = [f"A prefeitura de <strong>{municipio}</strong> j&aacute; pagou "
+                        f"<a href=\"#fornecedores\"><strong>{_fmt_brl_narrative(total_pago)}</strong></a> "
+                        f"a <a href=\"#fornecedores\"><strong>{qtd_forn_fmt}</strong> empresas</a>."]
 
     if pct_sem_licitacao:
-        cmp_sl = _compare_vs_mediana(pct_sem_licitacao, mediana_pct_sem_licitacao, higher_is_worse=True)
         sl_txt = (
             f" Desse dinheiro, <a href=\"#licitacoes\"><strong>{_fmt_pct(pct_sem_licitacao)}</strong> "
             f"saiu em compras sem concorr&ecirc;ncia</a>"
         )
-        if cmp_sl and mediana_pct_sem_licitacao:
-            sl_txt += f" — {cmp_sl} (mediana: {_fmt_pct(mediana_pct_sem_licitacao)})"
+        # Comparador PB so faz sentido em all-time (medianas sao all-time).
+        if not is_filtered:
+            cmp_sl = _compare_vs_mediana(pct_sem_licitacao, mediana_pct_sem_licitacao, higher_is_worse=True)
+            if cmp_sl and mediana_pct_sem_licitacao:
+                sl_txt += f" — {cmp_sl} (mediana: {_fmt_pct(mediana_pct_sem_licitacao)})"
         sl_txt += "."
         frag_citizen.append(sl_txt)
 
-    if risco_score is not None:
+    # risco_score vem da MV mv_municipio_pb_risco (all-time). Omitir quando
+    # filtrado para nao confundir o usuario com uma metrica fora de escala.
+    if risco_score is not None and not is_filtered:
         cmp_nota = _compare_vs_mediana(risco_score, mediana_risco, higher_is_worse=True)
         nota_txt = (
             f" A <a href=\"#relatorio\"><strong>nota de aten&ccedil;&atilde;o</strong></a> desta cidade "
@@ -416,20 +441,23 @@ def build_narrative(perfil: dict, medias: dict | None = None) -> dict:
 
     # ----- Auditor -----
     frag_auditor = [
-        f"<strong>{municipio}</strong>: "
+        f"{period_label_auditor}<strong>{municipio}</strong>: "
         f"{_fmt_brl_narrative(total_empenhado)} empenhado / "
         f"<a href=\"#fornecedores\">{_fmt_brl_narrative(total_pago)} pago</a> "
         f"({_fmt_pct(pct_pago, decimals=1)})."
     ]
     if pct_sem_licitacao:
+        med_suffix = ""
+        if not is_filtered and mediana_pct_sem_licitacao:
+            med_suffix = f" (p50 PB: {_fmt_pct(mediana_pct_sem_licitacao)})"
         frag_auditor.append(
             f" <a href=\"#licitacoes\">Dispensa/inexigibilidade: {_fmt_pct(pct_sem_licitacao)}</a>"
-            + (f" (p50 PB: {_fmt_pct(mediana_pct_sem_licitacao)})" if mediana_pct_sem_licitacao else "")
+            + med_suffix
             + "."
         )
     if pct_folha:
         frag_auditor.append(f" Folha/receita: {_fmt_pct(pct_folha)}.")
-    if risco_score is not None:
+    if risco_score is not None and not is_filtered:
         frag_auditor.append(
             f" <a href=\"#relatorio\">Risco composto: {float(risco_score):.0f}/100</a>"
             + (f" (p50 PB: {float(mediana_risco):.0f})" if mediana_risco is not None else "")
@@ -566,16 +594,23 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
         "default_data_fim": _today.isoformat(),
     }
 
+    # IMPORTANTE: cache eh keyed pelo nome canonico (com acento). Derivar antes
+    # do overlay para que tanto PERFIL quanto KPI_SUMMARY/TOP_* batam quando
+    # a URL veio sem acento.
+    canonical_mun = str(perfil.get("municipio") or municipio)
+
     # Default da UI eh "Ano atual": sobrepoe os campos do perfil sensiveis ao
     # filtro com o cache ANO:PERFIL para alinhar o primeiro paint com o filtro
     # ativo (evita flash de all-time). Mantem campos historicos (risco_score,
-    # qtd_licitacoes, pct_proponente_unico) intactos para narrativa/ranking.
+    # qtd_licitacoes, pct_proponente_unico) intactos.
+    perfil_periodo = ""  # "" = all-time, "ANO" = ano corrente
     try:
-        cached_ano = read_web_cache("PERFIL", municipio, periodo="ANO")
+        cached_ano = read_web_cache("PERFIL", canonical_mun, periodo="ANO")
         if cached_ano:
             ano_cols, ano_rows = cached_ano
             if ano_rows:
                 ano = _row_to_dict(ano_cols, ano_rows[0])
+                applied = False
                 for fld in (
                     "qtd_empenhos", "total_empenhado", "total_pago",
                     "qtd_fornecedores", "qtd_sem_licitacao", "pct_sem_licitacao",
@@ -584,25 +619,29 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
                 ):
                     if fld in ano and ano[fld] is not None:
                         perfil[fld] = ano[fld]
+                        applied = True
+                if applied:
+                    perfil_periodo = "ANO"
     except Exception:
         pass
 
-    narrative = build_narrative(perfil, get_pb_medias())
+    # Narrativa date-aware: quando o perfil foi sobreposto com dados ANO,
+    # build_narrative omite comparadores PB (medianas all-time) e o risco_score
+    # (MV all-time) e adiciona um prefixo identificando o periodo.
+    narrative = build_narrative(perfil, get_pb_medias(), periodo=perfil_periodo)
 
-    # Carrega fornecedorese servidores do cache (sem fallback live: a hero
-    # KPI strip eh "best effort", se nao houver cache os cards mostram 0).
-    # IMPORTANTE: usar perfil['municipio'] (nome canonico com acento) ao inves
-    # do `municipio` do URL — o cache eh keyed pelo nome canonico.
-    canonical_mun = str(perfil.get("municipio") or municipio)
-    # Tenta cache KPI_SUMMARY pre-computado (warm_cache.py). Se nao houver,
-    # carrega listas e roda compute_cidade_kpis em runtime.
-    # Default da UI eh "Ano atual": tenta primeiro a variante ANO:KPI_SUMMARY
-    # (e ANO:TOP_*) para que os KPIs/concentracao/score do primeiro paint ja
-    # respeitem o filtro. Cai para all-time se o ANO ainda nao foi populado.
+    # Carrega KPI_SUMMARY com ANO-first; SEM fallback all-time se ANO faltou:
+    # como o primeiro paint precisa refletir o filtro 'Ano atual', mostrar
+    # numeros all-time aqui apenas para depois ser corrigido pelo /api/kpis
+    # recria exatamente o flash que este PR tenta eliminar. Em cache miss do
+    # ANO, cai para o calculo live via compute_cidade_kpis (que ja le os
+    # caches ANO:TOP_* abaixo, e tambem nao usa fallback all-time).
     kpi_ctx: dict | None = None
     try:
         cached_summary = read_web_cache("KPI_SUMMARY", canonical_mun, periodo="ANO")
-        if not cached_summary:
+        if not cached_summary and not perfil_periodo:
+            # Nao ha ANO disponivel para esta cidade: aceita all-time (consistente
+            # com perfil all-time tambem nao sobreposto).
             cached_summary = read_web_cache("KPI_SUMMARY", canonical_mun)
         if cached_summary:
             scols, srows = cached_summary
@@ -620,7 +659,7 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
         servidores_dicts: list[dict] = []
         try:
             forn_cached = read_web_cache("TOP_FORNECEDORES", canonical_mun, periodo="ANO")
-            if not forn_cached:
+            if not forn_cached and not perfil_periodo:
                 forn_cached = read_web_cache("TOP_FORNECEDORES", canonical_mun)
             if forn_cached:
                 fcols, frows = forn_cached
@@ -629,7 +668,7 @@ async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
             pass
         try:
             serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun, periodo="ANO")
-            if not serv_cached:
+            if not serv_cached and not perfil_periodo:
                 serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun)
             if serv_cached:
                 scols, srows = serv_cached

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -178,8 +178,19 @@ def _load_top_fornecedores_dated(params: dict):
 
 
 def _load_top_servidores(municipio: str, params: dict | None = None):
-    query = TOP_SERVIDORES_RISCO_DATED if params and "ano_mes_inicio" in params else TOP_SERVIDORES_RISCO
+    is_dated = bool(params and "ano_mes_inicio" in params)
+    query = TOP_SERVIDORES_RISCO_DATED if is_dated else TOP_SERVIDORES_RISCO
     qparams = params if params else {"municipio": municipio}
+    # IMPORTANTE: cache key DEVE incluir o range datado, caso contrario uma
+    # chamada all-time anterior poluia chamadas dated subsequentes (e
+    # vice-versa) — a cached_query bate so pela key. cached_query so cobre
+    # all-time; dated cai para execute_query direto (igual a
+    # _load_top_fornecedores_dated). Ver review gpt-5.5 PR #32.
+    if is_dated:
+        try:
+            return execute_query(query, qparams, timeout_sec=TIMEOUT_QUERY_HEAVY)
+        except (UndefinedTable, UndefinedColumn, QueryCanceled):
+            return _empty_top_servidores()
     try:
         return cached_query(
             f"serv:{municipio.casefold()}",
@@ -188,14 +199,18 @@ def _load_top_servidores(municipio: str, params: dict | None = None):
             timeout_sec=TIMEOUT_QUERY_HEAVY,
         )
     except QueryCanceled:
-        return [
-            "cpf_digitos_6", "nome_upper", "nome_servidor",
-            "municipios", "maior_salario", "cargo",
-            "qtd_empresas_socio", "cnpjs_socio",
-            "flag_conflito_interesses", "flag_multi_empresa",
-            "flag_bolsa_familia", "flag_duplo_vinculo_estado",
-            "flag_alto_salario_socio", "risco_score",
-        ], []
+        return _empty_top_servidores()
+
+
+def _empty_top_servidores():
+    return [
+        "cpf_digitos_6", "nome_upper", "nome_servidor",
+        "municipios", "maior_salario", "cargo",
+        "qtd_empresas_socio", "cnpjs_socio",
+        "flag_conflito_interesses", "flag_multi_empresa",
+        "flag_bolsa_familia", "flag_duplo_vinculo_estado",
+        "flag_alto_salario_socio", "risco_score",
+    ], []
 
 
 def _get_query_def(query_id: str):

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -668,29 +668,29 @@ async function bootstrapCityReport(municipio, uf, dataInicio, dataFim) {
         _loadHeatmap(municipio);
     }
 
-    // Update hero/insight when date-filtered
-    if (_isDateFiltered()) {
-        // Show loading placeholders to avoid flash of all-time data
-        const el = id => document.getElementById(id);
-        ['heroQtdEmpenhos', 'heroTotalPago', 'heroQtdFornecedores'].forEach(id => {
-            if (el(id)) el(id).textContent = '...';
-        });
-        ['insightPctPago', 'insightPctSemLicit', 'insightPctDispensa', 'insightPctFolha'].forEach(id => {
-            if (el(id)) el(id).textContent = '...';
-        });
-        if (el('insightGapFinanceiro')) el('insightGapFinanceiro').textContent = '';
-        if (el('progressPctPago')) el('progressPctPago').style.width = '0%';
-        if (el('barEmpenhado')) el('barEmpenhado').textContent = '...';
-        if (el('barPago')) el('barPago').textContent = '...';
-        if (el('barFillPago')) el('barFillPago').style.width = '0%';
+    // Hero/insights/KPI strip + narrativa SEMPRE refrescam apos o boot.
+    // Antes, isso era gated em `_isDateFiltered()`, mas como SSR agora pinta
+    // em ANO (default 'Ano atual'), clicar 'Tudo' (sem datas) deixava a hero
+    // e a KPI strip presas em ANO enquanto os paineis abaixo iam para
+    // all-time. Refrescar sempre garante consistencia em ambas as direcoes
+    // (ANO->Tudo e Tudo->ANO/Custom).
+    const el = id => document.getElementById(id);
+    ['heroQtdEmpenhos', 'heroTotalPago', 'heroQtdFornecedores'].forEach(id => {
+        if (el(id)) el(id).textContent = '...';
+    });
+    ['insightPctPago', 'insightPctSemLicit', 'insightPctDispensa', 'insightPctFolha'].forEach(id => {
+        if (el(id)) el(id).textContent = '...';
+    });
+    if (el('insightGapFinanceiro')) el('insightGapFinanceiro').textContent = '';
+    if (el('progressPctPago')) el('progressPctPago').style.width = '0%';
+    if (el('barEmpenhado')) el('barEmpenhado').textContent = '...';
+    if (el('barPago')) el('barPago').textContent = '...';
+    if (el('barFillPago')) el('barFillPago').style.width = '0%';
 
-        // Always fetch via /api/perfil (handles ANO cache + live fallback internally)
-        await _refreshPerfilLive(municipio, uf);
-        // KPIs hero, concentracao top-5 e nota de atencao tambem precisam respeitar
-        // o filtro temporal — re-renderiza a partir do endpoint /api/kpis (que usa
-        // cache pre-computado por warm_cache.py quando possivel).
-        await _refreshKpisLive(municipio, uf);
-    }
+    // /api/perfil retorna perfil + narrativa, ambos respeitando o periodo.
+    await _refreshPerfilLive(municipio, uf);
+    // /api/kpis retorna kpi strip + concentracao + score unificado.
+    await _refreshKpisLive(municipio, uf);
     // Sempre cabla cliques no card de top-5 concentracao (independente de filtro):
     // SSR ja renderizou a versao all-time, queremos que clique abra dialog.
     _wireConcentracaoClicks();
@@ -1529,15 +1529,32 @@ async function _refreshPerfilLive(municipio, uf) {
             body: JSON.stringify(_buildBody(municipio, uf)),
         });
         if (res.ok) {
-            const perfil = await res.json();
+            const data = await res.json();
+            // Compat: /api/perfil agora retorna {perfil, narrative}.
+            // Tolera o formato antigo (perfil flat) caso uma versao em cache do
+            // bundle JS antigo bata com um backend novo (ou vice-versa).
+            const perfil = (data && data.perfil) ? data.perfil : data;
             _updateHeroStats(perfil);
             _updateInsightCards(perfil);
+            if (data && data.narrative) {
+                _updateNarrative(data.narrative);
+            }
         } else {
             console.warn('perfil endpoint returned', res.status);
         }
     } catch (e) {
         console.warn('perfil fetch failed', e);
     }
+}
+
+function _updateNarrative(narrative) {
+    if (!narrative) return;
+    const block = document.getElementById('cityNarrative');
+    if (!block) return;
+    const cit = block.querySelector('.citizen-only');
+    const aud = block.querySelector('.auditor-only');
+    if (cit && typeof narrative.citizen === 'string') cit.innerHTML = narrative.citizen;
+    if (aud && typeof narrative.auditor === 'string') aud.innerHTML = narrative.auditor;
 }
 
 // ── Dialog navigation stack ─────────────────────────────────────

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v13';
+const CACHE_VERSION = 'tpb-v14';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -117,7 +117,7 @@
         </svg>
     </button>
     <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
-    <script src="/static/app.js?v=36"></script>
+    <script src="/static/app.js?v=37"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -341,6 +341,9 @@
                 Bordas vermelhas destacam meses com desvio acima de 2 sigmas da m&eacute;dia do munic&iacute;pio —
                 tipicamente fim de ano (queima de or&ccedil;amento) ou picos pr&eacute;-eleitorais.</span>
             </p>
+            <p class="text-sm text-muted" style="margin-top:0.35rem">
+                <em>Hist&oacute;rico completo &mdash; n&atilde;o responde ao filtro de per&iacute;odo acima.</em>
+            </p>
         </div>
     </div>
     <div class="heatmap-wrap">
@@ -494,13 +497,17 @@
 
 <script>
 document.addEventListener("DOMContentLoaded", () => {
-    const _di = document.getElementById('dateInicio')?.value || '';
-    const _df = document.getElementById('dateFim')?.value || '';
-    if (_di && _df) {
-        bootstrapCityReport({{ perfil.municipio|tojson }}, {{ (display_uf or 'PB')|tojson }}, _di, _df);
-    } else {
-        bootstrapCityReport({{ perfil.municipio|tojson }}, {{ (display_uf or 'PB')|tojson }});
-    }
+    // Default da UI eh "Ano atual": passa as datas direto da Jinja para o
+    // bootstrap. Antes a logica lia .value dos inputs, mas eles tem apenas
+    // data-iso-value nesse momento (a mascara so eh aplicada DENTRO do
+    // bootstrap), entao .value vinha vazio e _isDateFiltered() voltava false
+    // — deixando o JS pedir caches all-time apesar do filtro visivel.
+    bootstrapCityReport(
+        {{ perfil.municipio|tojson }},
+        {{ (display_uf or 'PB')|tojson }},
+        {{ default_data_inicio|tojson }},
+        {{ default_data_fim|tojson }}
+    );
 });
 // Close dialog on backdrop click
 document.getElementById('empresa-dialog')?.addEventListener('click', function(e) {


### PR DESCRIPTION
## Problema

A pagina `/search/cidade?q=...` exibe uma barra de filtro de data com default **'Ano atual'** (01/01 ate hoje), mas varios componentes ignoravam esse filtro e mostravam dados all-time. Exemplo reportado: card *'Empresas proibidas de contratar que receberam da prefeitura'* (Q65) mostrando linhas de 2019 mesmo com a pill 'Ano atual' ativa.

## Causa raiz

1. `bootstrapCityReport(municipio, uf)` era chamado **sem** `data_inicio`/`data_fim`, entao o estado JS comecava com `_dateInicio=null`/`_dateFim=null`. `_isDateFiltered()` retornava `false` e `/api/batch` era chamado **sem** `?periodo=ANO`, retornando o cache all-time. Como bonus, `_refreshPerfilLive` nao rodava — hero/insight ficavam parados nos valores SSR all-time.
2. SSR (`search_cidade`) sempre lia `read_web_cache('PERFIL', municipio)` (all-time) — primeiro paint nunca alinhava com o filtro default.
3. `pick_destaques` (cards do modo cidadao) so olhava o cache all-time.
4. `/api/batch` tinha um fallback obsoleto que devolvia `TOP_SERVIDORES` all-time quando faltava `ANO:TOP_SERVIDORES` — desde que `TOP_SERVIDORES_RISCO_DATED` existe e o warmer popula `ANO:TOP_SERVIDORES`, o fallback so contaminava a resposta.
5. Q65 (sql + sql_dated) so mostrava `dt_inicio_sancao`/`dt_final_sancao`. A sancao costuma ser antiga, dando impressao de que a linha era antiga, mesmo o empenho caindo dentro do filtro.
6. Heatmap eh intencionalmente all-time (comentario no JS), mas nao tinha label avisando o usuario.

## Mudancas

- **`web/templates/results/cidade.html`** — passa `default_data_inicio`/`default_data_fim` ao `bootstrapCityReport` para que o JS comece ja com 'Ano atual' aplicado; adiciona nota explicita no heatmap (*'Historico completo — nao responde ao filtro de periodo acima.'*).
- **`web/routes/cidade.py:search_cidade`** — carrega `ANO:PERFIL` e sobrepoe os campos sensiveis ao filtro (qtd_empenhos, total_pago, qtd_fornecedores, pct_*, etc.) no dict `perfil`, mantendo `risco_score`/`qtd_licitacoes` do all-time para a narrativa/ranking historicos.
- **`web/routes/cidade.py:pick_destaques`** — prioriza `read_web_cache(qid, municipio, periodo='ANO')` e cai para all-time so quando o ANO ainda nao foi populado.
- **`web/routes/cidade.py:/api/batch`** — remove o fallback all-time para `TOP_SERVIDORES`.
- **`web/queries/registry.py` (Q65)** — adiciona `primeiro_empenho_no_filtro` e `ultimo_empenho_no_filtro` (MIN/MAX de `data_empenho` dentro dos filtros) tanto em `sql_full` quanto em `sql_dated`, deixando explicito que os pagamentos caem no periodo do filtro.

## Fora de escopo (intencional)

- **Drill-down dialogs (fornecedor / servidor)**: continuam mostrando historico completo conforme decisao do autor da issue.
- **KPIs avancados (KPI strip / concentracao card / /api/kpis / preset buttons)**: nao existem nesta branch — fazem parte do PR `feat/cidade-kpi-investigativa`. Se aquele PR for mergeado, vale repassar a mesma logica de `ANO`-first para `_kpi_summary_payload`.

## Como validar

1. Deploy via `Actions → deploy.yml → etl_phase=web`.
2. Abrir `/search/cidade?q=Cabedelo` (ou outra cidade). Conferir:
   - Hero/insight ja aparecem com valores do ano corrente no primeiro paint (sem flash de all-time).
   - Cards Q## (incluindo Q65 'Empresas sancionadas') so mostram empenhos do ano corrente.
   - Card Q65 mostra colunas `primeiro_empenho_no_filtro`/`ultimo_empenho_no_filtro` com datas do ano atual.
   - Heatmap exibe nota 'Historico completo — nao responde ao filtro'.
   - Trocar filtro para 'Todos os periodos' continua funcionando.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>