### PR TITLE
fix(frontend): priorizar achados e acessibilidade

### DIFF
--- a/web/kpis/cidade.py
+++ b/web/kpis/cidade.py
@@ -354,7 +354,8 @@ def compute_cidade_kpis(
     ctx = _build_context(perfil, fornecedores, servidores)
 
     rendered: list[dict] = []
-    for kdef in CIDADE_KPIS:
+    severity_rank = {"red": 0, "yellow": 1, "neutral": 2}
+    for idx, kdef in enumerate(CIDADE_KPIS):
         result = kdef.compute(ctx)
         rendered.append({
             "id": kdef.id,
@@ -362,8 +363,12 @@ def compute_cidade_kpis(
             "label_auditor": kdef.label_auditor,
             "href": kdef.href,
             "tooltip": kdef.tooltip,
+            "_order": idx,
             **result,
         })
+    rendered.sort(key=lambda k: (severity_rank.get(k.get("severity"), 2), k["_order"]))
+    for k in rendered:
+        k.pop("_order", None)
 
     # Score unificado live (mesma formula da MV mv_municipio_pb_kpi_score,
     # mas calculado a partir dos dados ja filtrados por periodo). Quando o

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -239,6 +239,7 @@ function initCredibilityDialog() {
     dialog.addEventListener('click', (e) => {
         if (e.target === dialog) dialog.close();
     });
+    dialog.querySelector('.dialog-close')?.addEventListener('click', () => dialog.close());
 }
 
 
@@ -436,6 +437,7 @@ function initDenunciaDialog() {
     dialog.addEventListener('click', (e) => {
         if (e.target === dialog) dialog.close();
     });
+    dialog.querySelector('.dialog-close')?.addEventListener('click', () => dialog.close());
 }
 
 
@@ -536,6 +538,11 @@ function setupAutocomplete(inputId, listId, endpoint, onSelect) {
     const list = document.getElementById(listId);
     const status = document.getElementById('cidade-status');
     if (!input || !list) return;
+    input.setAttribute('role', input.getAttribute('role') || 'combobox');
+    input.setAttribute('aria-autocomplete', 'list');
+    input.setAttribute('aria-controls', list.id || listId);
+    input.setAttribute('aria-expanded', 'false');
+    list.setAttribute('role', list.getAttribute('role') || 'listbox');
 
     let timer = null;
     let highlightedIndex = -1;
@@ -546,6 +553,8 @@ function setupAutocomplete(inputId, listId, endpoint, onSelect) {
         list.innerHTML = '';
         list.classList.remove('open');
         highlightedIndex = -1;
+        input.setAttribute('aria-expanded', 'false');
+        input.removeAttribute('aria-activedescendant');
     };
 
     const renderSuggestions = () => {
@@ -558,16 +567,24 @@ function setupAutocomplete(inputId, listId, endpoint, onSelect) {
 
         suggestions.forEach((item, index) => {
             const li = document.createElement('li');
+            const optionId = `${listId}-option-${index}`;
+            li.id = optionId;
             li.textContent = item;
             li.className = 'ac-item';
+            li.setAttribute('role', 'option');
+            li.setAttribute('aria-selected', index === highlightedIndex ? 'true' : 'false');
             li.addEventListener('mousedown', (event) => {
                 event.preventDefault();
                 commitSelection(item);
             });
-            if (index === highlightedIndex) li.classList.add('selected');
+            if (index === highlightedIndex) {
+                li.classList.add('selected');
+                input.setAttribute('aria-activedescendant', optionId);
+            }
             list.appendChild(li);
         });
         list.classList.add('open');
+        input.setAttribute('aria-expanded', 'true');
     };
 
     const commitSelection = (value) => {
@@ -620,6 +637,10 @@ function setupAutocomplete(inputId, listId, endpoint, onSelect) {
             if (!suggestions.length) return;
             highlightedIndex = Math.max(highlightedIndex - 1, 0);
             renderSuggestions();
+        }
+
+        if (event.key === 'Escape') {
+            clearList();
         }
     });
 
@@ -813,8 +834,9 @@ function renderFindingCard(card, queryId, data, municipio) {
 }
 
 function buildResultTable(queryId, columns, rows, municipio) {
-    const headerCells = columns.map(c =>
-        `<th>${c.replace(/_/g, ' ')}</th>`
+    const columnLabels = columns.map(c => String(c || '').replace(/_/g, ' '));
+    const headerCells = columnLabels.map(c =>
+        `<th>${_esc(c)}</th>`
     ).join('');
 
     // Auto-detect clickable columns for dialog reuse
@@ -856,25 +878,32 @@ function buildResultTable(queryId, columns, rows, municipio) {
 
     const bodyRows = rows.map(row => {
         const cells = row.map((val, ci) => {
-            if (val === null || val === undefined) return '<td>-</td>';
-            if (typeof val === 'boolean') return `<td>${val ? 'Sim' : 'Nao'}</td>`;
-            if (Array.isArray(val)) return `<td>${val.join(', ')}</td>`;
             const col = columns[ci] || '';
+            const label = _esc(columnLabels[ci] || col);
+            const classes = [ci === 0 ? 'stack-title' : 'stack-meta'];
+            const isNumericColumn = col.startsWith('valor') || col.startsWith('total') || col === 'capital_social' ||
+                col === 'maior_salario' || col === 'salario' || col.startsWith('pct') || col.startsWith('qtd') ||
+                col === 'empenhos';
+            if (isNumericColumn && ci !== 0) classes.push('num');
+            const td = (html) => `<td data-label="${label}" class="${classes.join(' ')}">${html}</td>`;
+            if (val === null || val === undefined) return td('-');
+            if (typeof val === 'boolean') return td(val ? 'Sim' : 'Nao');
+            if (Array.isArray(val)) return td(val.map(item => _esc(item)).join(', '));
             if (typeof val === 'number' || (typeof val === 'string' && /^-?\d+(\.\d+)?$/.test(val))) {
                 const n = parseFloat(val);
                 if (!isNaN(n)) {
                     if (col.startsWith('valor') || col.startsWith('total') || col === 'capital_social' || col === 'maior_salario' || col === 'salario') {
-                        return `<td>${_shortBrl(n)}</td>`;
+                        return td(_shortBrl(n));
                     }
                     if (col.startsWith('pct')) {
-                        return `<td>${n.toFixed(1)}%</td>`;
+                        return td(`${n.toFixed(1)}%`);
                     }
                     if (col.startsWith('qtd') || col === 'empenhos') {
-                        return `<td>${_shortNum(n)}</td>`;
+                        return td(_shortNum(n));
                     }
                 }
             }
-            return `<td>${val}</td>`;
+            return td(_esc(val));
         }).join('');
 
         // Determine row highlight class for sanction severity
@@ -943,11 +972,11 @@ function buildResultTable(queryId, columns, rows, municipio) {
         </div>
         <div class="table-shell js-data-table" data-page-size="10">
             <div class="table-actions">
-                <input type="search" class="table-filter" placeholder="Filtrar nesta tabela">
+                <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar resultados" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" inputmode="search" enterkeyhint="search">
                 <p class="table-meta text-sm text-muted" data-table-meta></p>
             </div>
             <div class="tbl-wrap">
-                <table>
+                <table class="stack-mobile">
                     <thead><tr>${headerCells}</tr></thead>
                     <tbody>${bodyRows}</tbody>
                 </table>
@@ -989,7 +1018,12 @@ function _shortNum(v) {
 
 function _esc(v) {
     if (v === null || v === undefined) return '-';
-    return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    return String(v)
+        .replace(/&/g,'&amp;')
+        .replace(/</g,'&lt;')
+        .replace(/>/g,'&gt;')
+        .replace(/"/g,'&quot;')
+        .replace(/'/g,'&#39;');
 }
 
 function _fmtDate(v) {
@@ -1301,19 +1335,21 @@ function _renderKpiCardValue(kpi) {
         valHtml = _shortNumLocal(kpi.value);
     }
     if (kpi.value_suffix) {
-        valHtml += `<span class="kpi-card-suffix">${kpi.value_suffix}</span>`;
+        valHtml += `<span class="kpi-card-suffix">${_esc(kpi.value_suffix)}</span>`;
     }
     return valHtml;
 }
 
 function _updateKpiHeroStrip(kpis) {
     if (!Array.isArray(kpis)) return;
+    const orderedCards = [];
     kpis.forEach(kpi => {
         const card = document.getElementById(kpi.id);
         if (!card) return;
         // severity class
         card.classList.remove('severity-red', 'severity-yellow', 'severity-neutral');
         card.classList.add(`severity-${kpi.severity || 'neutral'}`);
+        card.dataset.kpiSeverity = kpi.severity || 'neutral';
         // value
         const valEl = card.querySelector('.kpi-card-value');
         if (valEl) valEl.innerHTML = _renderKpiCardValue(kpi);
@@ -1330,7 +1366,10 @@ function _updateKpiHeroStrip(kpis) {
         } else if (extraEl) {
             extraEl.remove();
         }
+        orderedCards.push(card);
     });
+    const grid = document.querySelector('.city-kpi-grid');
+    if (grid) orderedCards.forEach(card => grid.appendChild(card));
 }
 
 function _updateConcentracaoCard(topConcentracao, pctTop5, concentracaoRed) {
@@ -3254,6 +3293,7 @@ document.addEventListener('DOMContentLoaded', () => {
         dialog.addEventListener('close', () => { _dialogOnClose(); });
         const backBtn = dialog.querySelector('.dialog-back');
         if (backBtn) backBtn.addEventListener('click', () => { _dialogPop(); });
+        dialog.querySelector('.dialog-close')?.addEventListener('click', () => dialog.close());
         _initDialogSwipeToClose();
     }
 

--- a/web/static/mapa.js
+++ b/web/static/mapa.js
@@ -294,9 +294,14 @@
 
     function wireToggle() {
         document.querySelectorAll('.mt-btn').forEach(btn => {
+            btn.setAttribute('aria-pressed', btn.classList.contains('active') ? 'true' : 'false');
             btn.addEventListener('click', () => {
-                document.querySelectorAll('.mt-btn').forEach(b => b.classList.remove('active'));
+                document.querySelectorAll('.mt-btn').forEach(b => {
+                    b.classList.remove('active');
+                    b.setAttribute('aria-pressed', 'false');
+                });
                 btn.classList.add('active');
+                btn.setAttribute('aria-pressed', 'true');
                 state.metric = btn.dataset.metric;
                 const note = document.getElementById('mapa-cutoff-note');
                 if (note) {
@@ -307,18 +312,44 @@
         });
     }
 
-    async function init() {
-        const [geojsonRes, dataRes, popRes] = await Promise.all([
-            fetch('/static/geo/pb-municipios.geojson').then(r => r.json()),
-            fetch('/api/mapa/pb').then(r => r.json()),
-            fetch('/static/geo/pb-populacao.json').then(r => r.json()),
-        ]);
-        state.geojson = geojsonRes;
-        state.data = dataRes;
-        state.dataIdx = buildDataIndex(dataRes);
-        state.pop = popRes;
-        computeAllMetricBreaks();
+    async function fetchJson(url) {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`${url} retornou ${res.status}`);
+        return res.json();
+    }
 
+    function renderMapError(message) {
+        const el = document.getElementById('mapa-pb');
+        if (el) {
+            el.innerHTML = `<div class="mapa-error" role="status">${message}</div>`;
+        }
+        const legend = document.getElementById('mapa-legend');
+        if (legend) legend.innerHTML = '';
+    }
+
+    async function init() {
+        let dataWarning = false;
+        try {
+            state.geojson = await fetchJson('/static/geo/pb-municipios.geojson');
+            const [dataRes, popRes] = await Promise.allSettled([
+                fetchJson('/api/mapa/pb'),
+                fetchJson('/static/geo/pb-populacao.json'),
+            ]);
+            if (dataRes.status === 'fulfilled') {
+                state.data = dataRes.value;
+                state.dataIdx = buildDataIndex(dataRes.value);
+            } else {
+                state.data = {};
+                state.dataIdx = {};
+                dataWarning = true;
+            }
+            state.pop = popRes.status === 'fulfilled' ? popRes.value : {};
+        } catch (err) {
+            console.warn('mapa init failed', err);
+            renderMapError('Nao foi possivel carregar o mapa agora. Tente novamente em instantes.');
+            return;
+        }
+        computeAllMetricBreaks();
         const map = L.map('mapa-pb', {
             zoomControl: true,
             attributionControl: false,
@@ -344,6 +375,10 @@
         wireMetricDescToggle();
         renderLegend();
         renderMetricDesc();
+        if (dataWarning) {
+            const note = document.getElementById('mapa-cutoff-note');
+            if (note) note.textContent = 'Mapa carregado, mas os indicadores municipais nao responderam agora.';
+        }
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1398,6 +1398,17 @@ td.num {
     border: none;
     border-radius: 0;
 }
+.mapa-error {
+    display: grid;
+    place-items: center;
+    min-height: inherit;
+    padding: 1rem;
+    color: #cbd5e1;
+    text-align: center;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 12px;
+}
 .mapa-tooltip {
     background: #0b1220 !important;
     border: 1px solid #2a3a5a !important;
@@ -3457,6 +3468,23 @@ html.audit-mode .denuncia-cta { display: none; }
     gap: .65rem;
 }
 
+.priority-guide {
+    margin-top: 1rem;
+    border-left: 3px solid rgba(96, 165, 250, 0.7);
+}
+.priority-guide .card-title {
+    margin-bottom: .35rem;
+}
+.priority-links {
+    display: flex;
+    gap: .6rem;
+    flex-wrap: wrap;
+    margin-top: .8rem;
+}
+.priority-panels {
+    margin-top: 1rem;
+}
+
 .kpi-card {
     position: relative;
     display: flex;
@@ -3556,36 +3584,14 @@ body:not(.dark-page) .kpi-card.severity-neutral {
 body:not(.dark-page) .kpi-card.severity-neutral .kpi-card-value { color: #1e293b; }
 
 @media (max-width: 640px) {
-    .city-kpi-strip {
-        position: relative;
-    }
     .city-kpi-grid {
-        /* horizontal scroll-snap on mobile to avoid 7-card vertical pile */
-        display: flex;
+        grid-template-columns: 1fr;
         gap: .55rem;
-        overflow-x: auto;
-        scroll-snap-type: x mandatory;
-        scrollbar-width: none;
-        padding-bottom: .35rem;
-        -webkit-overflow-scrolling: touch;
-    }
-    .city-kpi-grid::-webkit-scrollbar { display: none; }
-    /* Right-edge fade gives a clear hint that more cards exist off-screen */
-    .city-kpi-strip::after {
-        content: "";
-        position: absolute;
-        top: 2.5rem;
-        right: 0;
-        bottom: 0;
-        width: 32px;
-        pointer-events: none;
-        background: linear-gradient(90deg, rgba(15,23,42,0) 0%, rgba(15,23,42,0.85) 100%);
     }
     .kpi-card {
-        flex: 0 0 75%;
-        min-width: 220px;
-        scroll-snap-align: start;
+        min-height: auto;
     }
+    .priority-links { display: grid; }
 }
 
 /* Bar chart fill colors used by concentracao card */

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v14';
+const CACHE_VERSION = 'tpb-v15';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -86,10 +86,10 @@
             </span>
         </div>
     </footer>
-    <dialog id="credibility-dialog" class="credibility-dialog">
+    <dialog id="credibility-dialog" class="credibility-dialog" aria-labelledby="credibility-dialog-title">
         <div class="dialog-header">
-            <h3 class="dialog-title">Fontes e atualiza&ccedil;&atilde;o dos dados</h3>
-            <button type="button" class="dialog-close" onclick="this.closest('dialog').close()">&times;</button>
+            <h3 class="dialog-title" id="credibility-dialog-title">Fontes e atualiza&ccedil;&atilde;o dos dados</h3>
+            <button type="button" class="dialog-close" aria-label="Fechar">&times;</button>
         </div>
         <div class="dialog-body">
             <p>O <strong>TransparenciaPB</strong> cruza dados p&uacute;blicos de fontes oficiais para mostrar como cada prefeitura da Para&iacute;ba usa o dinheiro p&uacute;blico.</p>
@@ -117,7 +117,7 @@
         </svg>
     </button>
     <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
-    <script src="/static/app.js?v=37"></script>
+    <script src="/static/app.js?v=38"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -36,8 +36,12 @@
                     inputmode="search"
                     enterkeyhint="search"
                     aria-label="Buscar municipio da Paraiba"
+                    role="combobox"
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-controls="aclist-cidade"
                 >
-                <ul class="ac-list" id="aclist-cidade"></ul>
+                <ul class="ac-list" id="aclist-cidade" role="listbox" aria-label="Sugestoes de municipios"></ul>
             </div>
             <p class="search-status" id="cidade-status" aria-live="polite"></p>
             <button type="button" id="useLocation" class="geo-btn" aria-label="Usar minha localiza&ccedil;&atilde;o">
@@ -55,24 +59,24 @@
 <section class="mapa-hero">
     <div class="mapa-header">
         <div class="mapa-toggle-row">
-            <div class="mapa-toggle" role="tablist">
-                <button class="mt-btn active" data-metric="risco" data-desc="Score composto 0-100 pontos que agrega 8 KPIs investigativos (pesos somam 100): empresas sancionadas que atingem o municipio (15 pts), servidores em CEAF/expulsoes federais (15 pts), concentracao top-5 fornecedores (15 pts), servidores socios de fornecedores municipais (14 pts), % do gasto pago para empresas de socios servidores (13 pts), fornecedores com situacao cadastral irregular (10 pts), servidores no Bolsa Familia com salario alto (10 pts) e fornecedores em CEIS/CNEP em qualquer abrangencia (8 pts). Cada KPI usa curva concava (1 caso ja eh sinal forte) ou linear (percentuais)." data-desc-lay="Nota de 0 a 100 que resume 8 sinais de atencao do municipio: empresas sancionadas recebendo, servidores expulsos da Adm Federal, dinheiro concentrado em poucas empresas, servidores donos de empresas que recebem da prefeitura, empresas inativas/baixadas recebendo, e servidores no Bolsa Familia com salario alto. Quanto maior, mais sinais acumulados.">
+            <div class="mapa-toggle" aria-label="Escolher indicador do mapa">
+                <button type="button" class="mt-btn active" aria-pressed="true" data-metric="risco" data-desc="Score composto 0-100 pontos que agrega 8 KPIs investigativos (pesos somam 100): empresas sancionadas que atingem o municipio (15 pts), servidores em CEAF/expulsoes federais (15 pts), concentracao top-5 fornecedores (15 pts), servidores socios de fornecedores municipais (14 pts), % do gasto pago para empresas de socios servidores (13 pts), fornecedores com situacao cadastral irregular (10 pts), servidores no Bolsa Familia com salario alto (10 pts) e fornecedores em CEIS/CNEP em qualquer abrangencia (8 pts). Cada KPI usa curva concava (1 caso ja eh sinal forte) ou linear (percentuais)." data-desc-lay="Nota de 0 a 100 que resume 8 sinais de atencao do municipio: empresas sancionadas recebendo, servidores expulsos da Adm Federal, dinheiro concentrado em poucas empresas, servidores donos de empresas que recebem da prefeitura, empresas inativas/baixadas recebendo, e servidores no Bolsa Familia com salario alto. Quanto maior, mais sinais acumulados.">
                     <span class="citizen-only">Nota de aten&ccedil;&atilde;o</span>
                     <span class="auditor-only">Score unificado</span>
                 </button>
-                <button class="mt-btn" data-metric="pct_irregulares" data-desc="% do valor pago pelo municipio a fornecedores com algum sinal de irregularidade: sancao ativa no CEIS/CNEP (ultimos 3 anos), divida ativa na PGFN ou situacao cadastral nao ativa na Receita Federal (inativa, baixada ou inapta)." data-desc-lay="% do dinheiro que a prefeitura pagou para empresas com problema: san&ccedil;&atilde;o ativa do governo federal, d&iacute;vida com impostos federais, ou situa&ccedil;&atilde;o irregular na Receita.">
+                <button type="button" class="mt-btn" aria-pressed="false" data-metric="pct_irregulares" data-desc="% do valor pago pelo municipio a fornecedores com algum sinal de irregularidade: sancao ativa no CEIS/CNEP (ultimos 3 anos), divida ativa na PGFN ou situacao cadastral nao ativa na Receita Federal (inativa, baixada ou inapta)." data-desc-lay="% do dinheiro que a prefeitura pagou para empresas com problema: san&ccedil;&atilde;o ativa do governo federal, d&iacute;vida com impostos federais, ou situa&ccedil;&atilde;o irregular na Receita.">
                     <span class="citizen-only">% para empresas irregulares</span>
                     <span class="auditor-only">% Irregulares</span>
                 </button>
-                <button class="mt-btn" data-metric="pct_sem_licitacao" data-desc="% dos empenhos do municipio realizados sem processo licitatorio formal - dispensa, inexigibilidade, numero de licitacao vazio/zerado ou modalidade 'sem licitacao'." data-desc-lay="% das compras da prefeitura em que n&atilde;o houve disputa entre fornecedores (dispensa ou inexigibilidade). Licitar &eacute; a regra; exce&ccedil;&otilde;es precisam ser justificadas.">
+                <button type="button" class="mt-btn" aria-pressed="false" data-metric="pct_sem_licitacao" data-desc="% dos empenhos do municipio realizados sem processo licitatorio formal - dispensa, inexigibilidade, numero de licitacao vazio/zerado ou modalidade 'sem licitacao'." data-desc-lay="% das compras da prefeitura em que n&atilde;o houve disputa entre fornecedores (dispensa ou inexigibilidade). Licitar &eacute; a regra; exce&ccedil;&otilde;es precisam ser justificadas.">
                     <span class="citizen-only">Compras sem licita&ccedil;&atilde;o</span>
                     <span class="auditor-only">Sem licitacao</span>
                 </button>
-                <button class="mt-btn" data-metric="pct_top5" data-desc="% do total pago que ficou concentrado nos 5 maiores fornecedores do municipio. Indica dependencia de poucos fornecedores e pode sinalizar possivel direcionamento de contratacoes." data-desc-lay="% do total pago que ficou com apenas 5 empresas. Quando poucas empresas concentram muito dinheiro, pode indicar depend&ecirc;ncia ou favorecimento.">
+                <button type="button" class="mt-btn" aria-pressed="false" data-metric="pct_top5" data-desc="% do total pago que ficou concentrado nos 5 maiores fornecedores do municipio. Indica dependencia de poucos fornecedores e pode sinalizar possivel direcionamento de contratacoes." data-desc-lay="% do total pago que ficou com apenas 5 empresas. Quando poucas empresas concentram muito dinheiro, pode indicar depend&ecirc;ncia ou favorecimento.">
                     <span class="citizen-only">Top 5 empresas concentram</span>
                     <span class="auditor-only">Concentracao top-5</span>
                 </button>
-                <button class="mt-btn" data-metric="pago_per_capita" data-desc="Total pago pelo municipio dividido pelo numero de habitantes (IBGE 2022). Util para comparar porte de gasto entre municipios de tamanhos diferentes." data-desc-lay="Total gasto pela prefeitura dividido pelo n&uacute;mero de moradores. Serve para comparar cidades de tamanhos diferentes.">
+                <button type="button" class="mt-btn" aria-pressed="false" data-metric="pago_per_capita" data-desc="Total pago pelo municipio dividido pelo numero de habitantes (IBGE 2022). Util para comparar porte de gasto entre municipios de tamanhos diferentes." data-desc-lay="Total gasto pela prefeitura dividido pelo n&uacute;mero de moradores. Serve para comparar cidades de tamanhos diferentes.">
                     <span class="citizen-only">Gasto por morador</span>
                     <span class="auditor-only">Per capita</span>
                 </button>
@@ -183,6 +187,5 @@
         requestPosition();
     });
 })();
-</script>
 </script>
 {% endblock %}

--- a/web/templates/mapa.html
+++ b/web/templates/mapa.html
@@ -11,12 +11,12 @@
             <span class="citizen-only">{{ municipio_total_pb | default(223, true) }} municipios da Paraiba coloridos pelo indicador escolhido. Clique em um municipio para ver o detalhe.</span>
             <span class="auditor-only">{{ municipio_total_pb | default(223, true) }} municipios pintados por indicador. Clique em um municipio para abrir o detalhe.</span>
         </p>
-        <div class="mapa-toggle" role="tablist">
-            <button class="mt-btn active" data-metric="risco" title="Score composto (0-100) combinando varios sinais"><span class="citizen-only">Risco</span><span class="auditor-only">Risco composto</span></button>
-            <button class="mt-btn" data-metric="pct_irregulares" title="% do pago a fornecedores sancionados, com divida PGFN ou inativos"><span class="citizen-only">% com sinais</span><span class="auditor-only">% Irregulares</span></button>
-            <button class="mt-btn" data-metric="pct_sem_licitacao" title="% de empenhos feitos sem licitacao"><span class="citizen-only">Sem licitacao</span><span class="auditor-only">Sem licitacao</span></button>
-            <button class="mt-btn" data-metric="pct_top5" title="% do pago concentrado nos top-5 fornecedores"><span class="citizen-only">Top 5 concentram</span><span class="auditor-only">Concentracao top-5</span></button>
-            <button class="mt-btn" data-metric="pago_per_capita" title="Total pago por habitante (IBGE 2022)"><span class="citizen-only">Por habitante</span><span class="auditor-only">Per capita</span></button>
+        <div class="mapa-toggle" aria-label="Escolher indicador do mapa">
+            <button type="button" class="mt-btn active" aria-pressed="true" data-metric="risco" title="Score composto (0-100) combinando varios sinais"><span class="citizen-only">Risco</span><span class="auditor-only">Risco composto</span></button>
+            <button type="button" class="mt-btn" aria-pressed="false" data-metric="pct_irregulares" title="% do pago a fornecedores sancionados, com divida PGFN ou inativos"><span class="citizen-only">% com sinais</span><span class="auditor-only">% Irregulares</span></button>
+            <button type="button" class="mt-btn" aria-pressed="false" data-metric="pct_sem_licitacao" title="% de empenhos feitos sem licitacao"><span class="citizen-only">Sem licitacao</span><span class="auditor-only">Sem licitacao</span></button>
+            <button type="button" class="mt-btn" aria-pressed="false" data-metric="pct_top5" title="% do pago concentrado nos top-5 fornecedores"><span class="citizen-only">Top 5 concentram</span><span class="auditor-only">Concentracao top-5</span></button>
+            <button type="button" class="mt-btn" aria-pressed="false" data-metric="pago_per_capita" title="Total pago por habitante (IBGE 2022)"><span class="citizen-only">Por habitante</span><span class="auditor-only">Per capita</span></button>
         </div>
         <p class="mapa-cutoff-note" id="mapa-cutoff-note">Municipios com menos de R$ 5 milhoes em empenhos aparecem em cinza (amostra pequena).</p>
     </div>

--- a/web/templates/partials/result_table.html
+++ b/web/templates/partials/result_table.html
@@ -47,7 +47,7 @@
             <p class="table-meta text-sm text-muted" data-table-meta></p>
         </div>
         <div class="tbl-wrap">
-            <table>
+            <table class="stack-mobile">
                 <thead>
                     <tr>
                         {% for col in columns %}
@@ -96,7 +96,11 @@
                         {% for col in columns %}
                         {% set value = row[col] %}
                         {% set cell_auditor_only = COLUMN_META.get(col, {}).get('auditor_only') %}
-                        <td{% if cell_auditor_only %} class="auditor-only"{% endif %}>
+                        {% set meta = COLUMN_META.get(col, {}) %}
+                        {% set citizen_label = meta.get('citizen') %}
+                        {% set auditor_label = meta.get('auditor') or (col|replace('_', ' ')|title) %}
+                        {% set data_label = citizen_label or auditor_label %}
+                        <td data-label="{{ data_label|clean_text }}" class="{% if cell_auditor_only %}auditor-only {% endif %}{% if loop.first %}stack-title{% else %}stack-meta{% endif %}">
                             {% if value is sameas true %}
                                 <span class="badge badge-red">Sim</span>
                             {% elif value is sameas false %}

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -118,7 +118,7 @@
     </header>
     <div class="city-kpi-grid">
         {% for k in kpis %}
-        <a href="{{ k.href }}" class="kpi-card severity-{{ k.severity }}" id="{{ k.id }}" data-kpi-link>
+        <a href="{{ k.href }}" class="kpi-card severity-{{ k.severity }}" id="{{ k.id }}" data-kpi-link data-kpi-severity="{{ k.severity }}">
             <span class="kpi-card-label">
                 <span class="citizen-only">{{ k.label_citizen }}</span>
                 <span class="auditor-only">{{ k.label_auditor }}</span>
@@ -135,6 +135,76 @@
     </div>
 </section>
 {% endif %}
+
+<section class="card priority-guide" aria-label="Por onde comecar">
+    <p class="eyebrow">
+        <span class="citizen-only">Comece por aqui</span>
+        <span class="auditor-only">Triagem rapida</span>
+    </p>
+    <h2 class="card-title">
+        <span class="citizen-only">Veja primeiro os achados que pedem atencao</span>
+        <span class="auditor-only">Principais alvos antes do relatorio completo</span>
+    </h2>
+    <p class="text-muted">
+        <span class="citizen-only">Para uma leitura rapida, comece pelas empresas e servidores abaixo. Depois use o mapa mensal, os graficos e o relatorio completo se quiser investigar mais.</span>
+        <span class="auditor-only">Os paineis abaixo trazem listas acionaveis antes dos blocos analiticos longos.</span>
+    </p>
+    <div class="priority-links">
+        <a href="#fornecedores" class="btn btn-primary btn-sm">Ver empresas primeiro</a>
+        <a href="#servidores" class="btn btn-outline btn-sm">Ver servidores com sinais</a>
+    </div>
+</section>
+
+<div class="two-col priority-panels">
+    <section class="card" id="fornecedores" style="grid-column: 1 / -1">
+        <div class="section-head">
+            <div>
+                <p class="eyebrow">
+                    <span class="citizen-only">Quem mais recebe dinheiro da prefeitura</span>
+                    <span class="auditor-only">Quem mais recebeu</span>
+                </p>
+                <h2 class="card-title">
+                    <span class="citizen-only">Principais empresas contratadas</span>
+                    <span class="auditor-only">Fornecedores que mais aparecem no municipio</span>
+                </h2>
+            </div>
+        </div>
+        <p class="text-muted mb-1">
+            <span class="citizen-only">Empresas que mais recebem dinheiro p&uacute;blico aqui. Toque em uma empresa para ver detalhes e se ela tem alguma <span class="term" data-tip="Problema cadastral: d&iacute;vida ativa com a Uni&atilde;o, situa&ccedil;&atilde;o irregular na Receita Federal, ou san&ccedil;&atilde;o ativa do governo federal (CEIS, CNEP ou Inidoneidade).">irregularidade</span>.</span>
+            <span class="auditor-only">Esta lista ajuda a identificar concentracao de pagamentos e checar se os nomes mais frequentes fazem sentido no contexto local.
+            Clique em um fornecedor para ver detalhes dos empenhos e situacao cadastral.</span>
+        </p>
+        <div class="async-card" data-async-panel="fornecedores">
+            <div class="skeleton-line"></div>
+            <div class="skeleton-line short"></div>
+        </div>
+    </section>
+
+    <section class="card" id="servidores" style="grid-column: 1 / -1">
+        <div class="section-head">
+            <div>
+                <p class="eyebrow">
+                    <span class="citizen-only">Servidores com sinais de aten&ccedil;&atilde;o</span>
+                    <span class="auditor-only">Pessoas para revisar</span>
+                </p>
+                <h2 class="card-title">
+                    <span class="citizen-only">Servidores que merecem uma segunda olhada</span>
+                    <span class="auditor-only">Servidores que merecem verifica&ccedil;&atilde;o adicional</span>
+                </h2>
+            </div>
+        </div>
+        <p class="text-muted mb-1">
+            <span class="citizen-only">Servidores da prefeitura com ind&iacute;cios cruzados — por exemplo, <span class="term" data-tip="Quando o servidor aparece como s&oacute;cio ou administrador de empresa, algo que a lei restringe.">v&iacute;nculo com empresas</span>, sal&aacute;rio em mais de um governo ao mesmo tempo, ou outro sinal incomum.</span>
+            <span class="auditor-only">Servidores municipais com sinais nos cruzamentos automaticos — vinculos societarios,
+            pagamentos estaduais simultaneos, beneficios sociais ou acumulacao atipica de indicadores.
+            Clique em um servidor para ver detalhes.</span>
+        </p>
+        <div class="async-card" data-async-panel="servidores">
+            <div class="skeleton-line"></div>
+            <div class="skeleton-line short"></div>
+        </div>
+    </section>
+</div>
 
 {# ── Card: Concentracao de fornecedores (barras horizontais) ── #}
 {% if top_concentracao %}
@@ -292,10 +362,10 @@
     </div>
 </section>
 
-<dialog id="denuncia-dialog" class="denuncia-dialog">
+<dialog id="denuncia-dialog" class="denuncia-dialog" aria-labelledby="denuncia-dialog-title">
     <div class="dialog-header">
-        <h3 class="dialog-title">Como denunciar irregularidades</h3>
-        <button type="button" class="dialog-close" onclick="this.closest('dialog').close()">&times;</button>
+        <h3 class="dialog-title" id="denuncia-dialog-title">Como denunciar irregularidades</h3>
+        <button type="button" class="dialog-close" aria-label="Fechar">&times;</button>
     </div>
     <div class="dialog-body">
         <p class="text-sm text-muted">Escolha o canal mais adequado ao tipo de irregularidade. Em caso de d&uacute;vida, o MP-PB &eacute; um bom ponto de partida.</p>
@@ -358,57 +428,6 @@
         </span>
     </div>
 </section>
-
-<div class="two-col">
-    <section class="card" id="fornecedores" style="grid-column: 1 / -1">
-        <div class="section-head">
-            <div>
-                <p class="eyebrow">
-                    <span class="citizen-only">Quem mais recebe dinheiro da prefeitura</span>
-                    <span class="auditor-only">Quem mais recebeu</span>
-                </p>
-                <h2 class="card-title">
-                    <span class="citizen-only">Principais empresas contratadas</span>
-                    <span class="auditor-only">Fornecedores que mais aparecem no municipio</span>
-                </h2>
-            </div>
-        </div>
-        <p class="text-muted mb-1">
-            <span class="citizen-only">Empresas que mais recebem dinheiro p&uacute;blico aqui. Toque em uma empresa para ver detalhes e se ela tem alguma <span class="term" data-tip="Problema cadastral: d&iacute;vida ativa com a Uni&atilde;o, situa&ccedil;&atilde;o irregular na Receita Federal, ou san&ccedil;&atilde;o ativa do governo federal (CEIS, CNEP ou Inidoneidade).">irregularidade</span>.</span>
-            <span class="auditor-only">Esta lista ajuda a identificar concentracao de pagamentos e checar se os nomes mais frequentes fazem sentido no contexto local.
-            Clique em um fornecedor para ver detalhes dos empenhos e situacao cadastral.</span>
-        </p>
-        <div class="async-card" data-async-panel="fornecedores">
-            <div class="skeleton-line"></div>
-            <div class="skeleton-line short"></div>
-        </div>
-    </section>
-
-    <section class="card" id="servidores" style="grid-column: 1 / -1">
-        <div class="section-head">
-            <div>
-                <p class="eyebrow">
-                    <span class="citizen-only">Servidores com sinais de aten&ccedil;&atilde;o</span>
-                    <span class="auditor-only">Pessoas para revisar</span>
-                </p>
-                <h2 class="card-title">
-                    <span class="citizen-only">Servidores que merecem uma segunda olhada</span>
-                    <span class="auditor-only">Servidores que merecem verifica&ccedil;&atilde;o adicional</span>
-                </h2>
-            </div>
-        </div>
-        <p class="text-muted mb-1">
-            <span class="citizen-only">Servidores da prefeitura com ind&iacute;cios cruzados — por exemplo, <span class="term" data-tip="Quando o servidor aparece como s&oacute;cio ou administrador de empresa, algo que a lei restringe.">v&iacute;nculo com empresas</span>, sal&aacute;rio em mais de um governo ao mesmo tempo, ou outro sinal incomum.</span>
-            <span class="auditor-only">Servidores municipais com sinais nos cruzamentos automaticos — vinculos societarios,
-            pagamentos estaduais simultaneos, beneficios sociais ou acumulacao atipica de indicadores.
-            Clique em um servidor para ver detalhes.</span>
-        </p>
-        <div class="async-card" data-async-panel="servidores">
-            <div class="skeleton-line"></div>
-            <div class="skeleton-line short"></div>
-        </div>
-    </section>
-</div>
 
 <section class="report-sections" id="relatorio">
     {% for section in report_sections %}
@@ -486,11 +505,11 @@
     {% endfor %}
 </section>
 
-<dialog id="empresa-dialog" class="empresa-dialog">
+<dialog id="empresa-dialog" class="empresa-dialog" aria-labelledby="empresa-dialog-title">
     <div class="dialog-header">
-        <button type="button" class="dialog-back" style="visibility:hidden" title="Voltar">&#8592;</button>
-        <h3 class="dialog-title">Empresas vinculadas</h3>
-        <button type="button" class="dialog-close" onclick="this.closest('dialog').close()">&times;</button>
+        <button type="button" class="dialog-back" style="visibility:hidden" title="Voltar" aria-label="Voltar">&#8592;</button>
+        <h3 class="dialog-title" id="empresa-dialog-title">Empresas vinculadas</h3>
+        <button type="button" class="dialog-close" aria-label="Fechar">&times;</button>
     </div>
     <div class="dialog-body"></div>
 </dialog>


### PR DESCRIPTION
## Resumo
- Prioriza achados acionaveis na pagina da cidade, trazendo fornecedores/servidores para antes de graficos e relatorio longo.
- Ordena KPIs por severidade e remove o carrossel horizontal mobile para evitar esconder alertas criticos.
- Escapa valores em tabelas JS, aplica stack-mobile nas tabelas genericas e melhora ARIA de busca, dialogs e controles do mapa.
- Adiciona fallback de erro para carregamento do mapa e remove o `</script>` duplicado da home.

## Validacao
- `python -m compileall web -q`
- `node --check web\\static\\app.js`
- `node --check web\\static\\mapa.js`
- `node --check web\\static\\sw.js`
- `git diff --check`
- Smoke HTTP: `/`, `/mapa`, `/glossario`, `/search/cidade?q=Jo%C3%A3o%20Pessoa`
- Checks de HTML renderizado para combobox/listbox, ausencia de `role="tablist"`, dialogs rotulados, prioridade antes do heatmap e remocao do `</script>` duplicado
- Revisao Opus 4.7: sem issues significativos