### PR TITLE
Prioriza alertas no topo da pagina de cidade

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -267,6 +267,7 @@ function initMobileDescriptions(root = document) {
     root.querySelectorAll('.mobile-desc-toggle[data-mobile-desc-next], .mobile-desc-toggle[data-mobile-desc-target]').forEach((btn) => {
         if (btn.dataset.enhanced === 'true') return;
         btn.dataset.enhanced = 'true';
+        const extraPanels = [];
         let panel = btn.dataset.mobileDescTarget
             ? document.getElementById(btn.dataset.mobileDescTarget)
             : btn.nextElementSibling;
@@ -278,6 +279,13 @@ function initMobileDescriptions(root = document) {
             panel = btn.closest('div, section, article')?.querySelector('.mobile-collapsible-desc') || panel;
         }
         if (!panel || !panel.classList.contains('mobile-collapsible-desc')) return;
+        if (btn.dataset.mobileDescExplainer) {
+            const explainer = document.getElementById(btn.dataset.mobileDescExplainer);
+            if (explainer) {
+                explainer.hidden = true;
+                extraPanels.push(explainer);
+            }
+        }
         panel.classList.remove('is-open');
         btn.setAttribute('aria-expanded', 'false');
         btn.addEventListener('click', (event) => {
@@ -285,6 +293,10 @@ function initMobileDescriptions(root = document) {
             event.stopPropagation();
             const willOpen = !panel.classList.contains('is-open');
             panel.classList.toggle('is-open', willOpen);
+            extraPanels.forEach((extraPanel) => {
+                extraPanel.hidden = !willOpen;
+                extraPanel.classList.toggle('is-open', willOpen);
+            });
             btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
         });
     });
@@ -1186,7 +1198,7 @@ function buildFornecedoresPanel(data) {
 
     return `<section class="result-block">
         <div class="result-toolbar"><div>
-            <h3 class="card-title">${dualLabel('Empresas que mais receberam da prefeitura', 'Maiores fornecedores do municipio')} ${mobileDescToggleHtml()}</h3>
+            <h3 class="card-title title-with-action"><span class="title-text">${dualLabel('Empresas que mais receberam da prefeitura', 'Maiores fornecedores do municipio')}</span> ${mobileDescToggleHtml()}</h3>
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Concentracao dos pagamentos e sinais de atencao de cada empresa. Toque em uma empresa para detalhes.</span><span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span></p>
             ${fornLegend}
         </div></div>
@@ -3306,7 +3318,7 @@ function buildServidoresPanel(data) {
 
     return `<section class="result-block">
         <div class="result-toolbar"><div>
-            <h3 class="card-title">${dualLabel('Servidores com sinais de atencao', 'Servidores com sinais de atencao')} ${mobileDescToggleHtml()}</h3>
+            <h3 class="card-title title-with-action"><span class="title-text">${dualLabel('Servidores com sinais de atencao', 'Servidores com sinais de atencao')}</span> ${mobileDescToggleHtml()}</h3>
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, salario em mais de um governo, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos para profissionais de saude.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, duplo vinculo com o estado, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite acumulacao para profissionais de saude.</span></p>
             ${servLegend}
         </div></div>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -330,9 +330,9 @@ function initTour() {
 
     const STEPS_CIDADE = [
         {
-            selector: '.city-narrative',
+            selector: '.city-risk-badge, .city-narrative',
             title: 'Resumo em 30 segundos',
-            text: 'Este par&aacute;grafo traduz os n&uacute;meros da cidade em linguagem simples. Clique nas palavras destacadas para ir direto &agrave; se&ccedil;&atilde;o relacionada.',
+            text: 'Aqui fica a nota de aten&ccedil;&atilde;o e um resumo curto da cidade. Clique nas palavras destacadas para ir direto &agrave; se&ccedil;&atilde;o relacionada.',
         },
         {
             selector: '.city-kpi-strip, .findings-list',
@@ -1390,18 +1390,20 @@ function _getDateFilterCopy() {
         return { headline: 'Periodo: todo o historico', clear: false };
     }
     if (preset === 'current-year') {
-        return { headline: `Ano atual: ${range}`, clear: true };
+        return { headline: `Periodo: ano atual (${range})`, clear: false };
     }
     if (preset === 'last-12m') {
-        return { headline: `Ultimos 12 meses: ${range}`, clear: true };
+        return { headline: `Periodo: ultimos 12 meses (${range})`, clear: false };
     }
     return { headline: `Periodo: ${range}`, clear: true };
 }
 
 function _syncDateFilterUI() {
     const btnLimpar = document.getElementById('btnLimparData');
+    const current = document.getElementById('dateFilterCurrent');
     const copy = _getDateFilterCopy();
     if (btnLimpar) btnLimpar.style.display = copy.clear ? '' : 'none';
+    if (current) current.textContent = copy.headline;
     document.querySelectorAll('[data-date-preset]').forEach((btn) => {
         btn.classList.toggle('is-active', btn.dataset.datePreset === _getDatePreset());
     });
@@ -1518,6 +1520,29 @@ function _updateKpiHeroStrip(kpis) {
     if (grid) orderedCards.forEach(card => grid.appendChild(card));
 }
 
+function _riskSummaryMeta(score) {
+    const n = Number(score);
+    if (!Number.isFinite(n)) return null;
+    if (n >= 70) return { level: 'red', label: 'Atencao alta' };
+    if (n >= 40) return { level: 'yellow', label: 'Atencao' };
+    return { level: 'green', label: 'Baixa atencao' };
+}
+
+function _updateRiskSummary(score) {
+    const meta = _riskSummaryMeta(score);
+    if (!meta) return;
+    const rounded = String(Math.round(Number(score)));
+    document.querySelectorAll('[data-risk-summary]').forEach(badge => {
+        badge.classList.remove('badge-red', 'badge-yellow', 'badge-green');
+        badge.classList.add(`badge-${meta.level}`);
+        const label = badge.querySelector('[data-risk-label]');
+        if (label) label.textContent = meta.label;
+        badge.querySelectorAll('[data-score-unificado]').forEach(el => {
+            el.textContent = rounded;
+        });
+    });
+}
+
 function _updateConcentracaoCard(topConcentracao, pctTop5, concentracaoRed) {
     const card = document.querySelector('.city-concentracao');
     if (!card) return;
@@ -1599,6 +1624,7 @@ async function _refreshKpisLive(municipio, uf) {
             document.querySelectorAll('[data-score-unificado]').forEach(el => {
                 el.textContent = data.score_unificado;
             });
+            _updateRiskSummary(data.score_unificado);
         }
     } catch (e) {
         console.warn('kpis fetch failed', e);

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -62,6 +62,10 @@ function dualLabel(citizen, auditor, opts) {
 // Expose globally for inline usage dentro de template literals
 window.dualLabel = dualLabel;
 
+function mobileDescToggleHtml() {
+    return `<button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false"><span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span><span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span></button>`;
+}
+
 // Remove o prefixo tecnico de codigo em strings como "04021602 - COMISSIONADOS SMN-1"
 // ou "5005 - Atencao Integral a Saude". Mantem a string original se nao houver prefixo.
 function _stripCodePrefix(s) {
@@ -254,6 +258,27 @@ function initExplainers() {
             panel.hidden = !willOpen;
             btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
             btn.classList.toggle('is-open', willOpen);
+        });
+    });
+}
+
+
+function initMobileDescriptions(root = document) {
+    root.querySelectorAll('.mobile-desc-toggle[data-mobile-desc-next], .mobile-desc-toggle[data-mobile-desc-target]').forEach((btn) => {
+        if (btn.dataset.enhanced === 'true') return;
+        btn.dataset.enhanced = 'true';
+        const panel = btn.dataset.mobileDescTarget
+            ? document.getElementById(btn.dataset.mobileDescTarget)
+            : btn.nextElementSibling;
+        if (!panel || !panel.classList.contains('mobile-collapsible-desc')) return;
+        panel.classList.remove('is-open');
+        btn.setAttribute('aria-expanded', 'false');
+        btn.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            const willOpen = !panel.classList.contains('is-open');
+            panel.classList.toggle('is-open', willOpen);
+            btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
         });
     });
 }
@@ -757,6 +782,7 @@ async function bootstrapCityReport(municipio, uf, dataInicio, dataFim) {
             fornPanel.innerHTML = buildFornecedoresPanel(batchData.TOP_FORNECEDORES);
             fornPanel.setAttribute('aria-busy', 'false');
             initDataTables(fornPanel);
+            initMobileDescriptions(fornPanel);
             initClickableRows(fornPanel);
         }
     } else {
@@ -769,6 +795,7 @@ async function bootstrapCityReport(municipio, uf, dataInicio, dataFim) {
             servPanel.innerHTML = buildServidoresPanel(servData);
             servPanel.setAttribute('aria-busy', 'false');
             initDataTables(servPanel);
+            initMobileDescriptions(servPanel);
             initClickableRows(servPanel);
         } else {
             panelPromises.push(loadAsyncPanel('servidores', municipio, uf));
@@ -834,6 +861,7 @@ async function bootstrapCityReport(municipio, uf, dataInicio, dataFim) {
                 card.classList.remove('loading');
                 card.setAttribute('aria-busy', 'false');
                 initDataTables(body);
+                initMobileDescriptions(body);
                 initClickableRows(body);
             } catch {
                 countEl.textContent = '—';
@@ -862,6 +890,7 @@ function renderFindingCard(card, queryId, data, municipio) {
     } else {
         body.innerHTML = buildResultTable(queryId, data.columns, data.rows, municipio);
         initDataTables(body);
+        initMobileDescriptions(body);
         initClickableRows(body);
     }
     body.classList.add('fade-in');
@@ -1151,7 +1180,8 @@ function buildFornecedoresPanel(data) {
     return `<section class="result-block">
         <div class="result-toolbar"><div>
             <h3 class="card-title">${dualLabel('Empresas que mais receberam da prefeitura', 'Maiores fornecedores do municipio')}</h3>
-            <p class="text-muted text-sm"><span class="citizen-only">Concentracao dos pagamentos e sinais de atencao de cada empresa. Toque em uma empresa para detalhes.</span><span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span></p>
+            ${mobileDescToggleHtml()}
+            <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Concentracao dos pagamentos e sinais de atencao de cada empresa. Toque em uma empresa para detalhes.</span><span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span></p>
             ${fornLegend}
         </div></div>
         <div class="table-shell js-data-table" data-page-size="10">
@@ -3271,7 +3301,8 @@ function buildServidoresPanel(data) {
     return `<section class="result-block">
         <div class="result-toolbar"><div>
             <h3 class="card-title">${dualLabel('Servidores com sinais de atencao', 'Servidores com sinais de atencao')}</h3>
-            <p class="text-muted text-sm"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, salario em mais de um governo, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos para profissionais de saude.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, duplo vinculo com o estado, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite acumulacao para profissionais de saude.</span></p>
+            ${mobileDescToggleHtml()}
+            <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, salario em mais de um governo, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos para profissionais de saude.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, duplo vinculo com o estado, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite acumulacao para profissionais de saude.</span></p>
             ${servLegend}
         </div></div>
         <div class="table-shell js-data-table" data-page-size="10">
@@ -3320,6 +3351,7 @@ async function loadAsyncPanel(panelName, municipio, uf) {
         panel.setAttribute('aria-busy', 'false');
         initDataTables(panel);
         initInteractiveToggles(panel);
+        initMobileDescriptions(panel);
         initClickableRows(panel);
     } catch {
         showPanelError('Nao foi possivel carregar este bloco agora.');
@@ -3592,6 +3624,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initTermTooltips();
     initCityNarrativeToggle();
     initNarrativeAnchors();
+    initMobileDescriptions(document);
     initAnchorAutoExpand();
     initExplainers();
     initCredibilityDialog();

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -63,7 +63,7 @@ function dualLabel(citizen, auditor, opts) {
 window.dualLabel = dualLabel;
 
 function mobileDescToggleHtml() {
-    return `<button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false"><span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span><span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span></button>`;
+    return `<button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>`;
 }
 
 // Remove o prefixo tecnico de codigo em strings como "04021602 - COMISSIONADOS SMN-1"
@@ -267,9 +267,16 @@ function initMobileDescriptions(root = document) {
     root.querySelectorAll('.mobile-desc-toggle[data-mobile-desc-next], .mobile-desc-toggle[data-mobile-desc-target]').forEach((btn) => {
         if (btn.dataset.enhanced === 'true') return;
         btn.dataset.enhanced = 'true';
-        const panel = btn.dataset.mobileDescTarget
+        let panel = btn.dataset.mobileDescTarget
             ? document.getElementById(btn.dataset.mobileDescTarget)
             : btn.nextElementSibling;
+        if (!panel || !panel.classList.contains('mobile-collapsible-desc')) {
+            const title = btn.closest('.card-title, .finding-title');
+            panel = title ? title.nextElementSibling : panel;
+        }
+        if (!panel || !panel.classList.contains('mobile-collapsible-desc')) {
+            panel = btn.closest('div, section, article')?.querySelector('.mobile-collapsible-desc') || panel;
+        }
         if (!panel || !panel.classList.contains('mobile-collapsible-desc')) return;
         panel.classList.remove('is-open');
         btn.setAttribute('aria-expanded', 'false');
@@ -1179,8 +1186,7 @@ function buildFornecedoresPanel(data) {
 
     return `<section class="result-block">
         <div class="result-toolbar"><div>
-            <h3 class="card-title">${dualLabel('Empresas que mais receberam da prefeitura', 'Maiores fornecedores do municipio')}</h3>
-            ${mobileDescToggleHtml()}
+            <h3 class="card-title">${dualLabel('Empresas que mais receberam da prefeitura', 'Maiores fornecedores do municipio')} ${mobileDescToggleHtml()}</h3>
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Concentracao dos pagamentos e sinais de atencao de cada empresa. Toque em uma empresa para detalhes.</span><span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span></p>
             ${fornLegend}
         </div></div>
@@ -3300,8 +3306,7 @@ function buildServidoresPanel(data) {
 
     return `<section class="result-block">
         <div class="result-toolbar"><div>
-            <h3 class="card-title">${dualLabel('Servidores com sinais de atencao', 'Servidores com sinais de atencao')}</h3>
-            ${mobileDescToggleHtml()}
+            <h3 class="card-title">${dualLabel('Servidores com sinais de atencao', 'Servidores com sinais de atencao')} ${mobileDescToggleHtml()}</h3>
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, salario em mais de um governo, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos para profissionais de saude.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, duplo vinculo com o estado, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite acumulacao para profissionais de saude.</span></p>
             ${servLegend}
         </div></div>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -233,7 +233,8 @@ function initAnchorAutoExpand() {
 
 
 function initExplainers() {
-    // Fase 4: "O que isso significa?" inline. Toggle com persistencia em localStorage.
+    // Fase 4: "O que isso significa?" inline. Sempre comeca fechado:
+    // explicacao aberta por padrao empurra os registros para baixo em mobile.
     const buttons = document.querySelectorAll('.explainer-btn[data-explainer-target]');
     if (!buttons.length) return;
     buttons.forEach(btn => {
@@ -241,12 +242,10 @@ function initExplainers() {
         const panel = document.getElementById(targetId);
         if (!panel) return;
         const key = `explainer:${targetId}`;
-        // Restaura estado salvo
-        if (localStorage.getItem(key) === 'open') {
-            panel.hidden = false;
-            btn.setAttribute('aria-expanded', 'true');
-            btn.classList.add('is-open');
-        }
+        panel.hidden = true;
+        btn.setAttribute('aria-expanded', 'false');
+        btn.classList.remove('is-open');
+        try { localStorage.removeItem(key); } catch (_) { /* quota/private mode */ }
         btn.addEventListener('click', (e) => {
             // Nao propaga para finding-head (evita toggle de collapse)
             e.stopPropagation();
@@ -255,10 +254,6 @@ function initExplainers() {
             panel.hidden = !willOpen;
             btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
             btn.classList.toggle('is-open', willOpen);
-            try {
-                if (willOpen) localStorage.setItem(key, 'open');
-                else localStorage.removeItem(key);
-            } catch (_) { /* quota/private mode */ }
         });
     });
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2245,6 +2245,9 @@ body {
     .mobile-collapsible-desc {
         display: none;
     }
+    .mobile-duplicate-desc {
+        display: none;
+    }
     .mobile-collapsible-desc.is-open {
         display: block;
     }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2090,9 +2090,6 @@ body {
     .city-title-row {
         gap: 0.7rem;
     }
-    .city-title-row .eyebrow {
-        margin-bottom: 0.35rem;
-    }
     .city-hero-actions {
         flex-direction: column;
         align-items: flex-end;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2090,6 +2090,9 @@ body {
     .city-title-row {
         gap: 0.7rem;
     }
+    .city-title-row .eyebrow {
+        margin-bottom: 0.35rem;
+    }
     .city-hero-actions {
         flex-direction: column;
         align-items: flex-end;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -440,28 +440,45 @@ body.dark-page.mapa-page .container {
 
 .city-hero {
     display: grid;
-    grid-template-columns: 1.8fr 1fr;
-    gap: 1rem;
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
     background: linear-gradient(135deg, rgba(255,255,255,0.98), rgba(239, 246, 255, 0.95));
 }
+.city-title-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.9rem;
+}
+.city-title-row > div:first-child { min-width: 0; }
 .city-title {
     font-size: 2.15rem;
     line-height: 1.08;
     margin-bottom: 0.5rem;
 }
 .city-subtitle { max-width: 760px; }
-.city-hero-copy .share-btn { margin-top: 0.85rem; }
 .city-hero-copy { min-width: 0; }
 .city-hero-actions {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 0.65rem;
-    margin: 0.45rem 0 0.8rem;
-}
-.city-hero-actions .rank-badge,
-.city-hero-actions .share-btn-inline {
+    justify-content: flex-end;
+    gap: 0.5rem;
     margin: 0;
+}
+.city-risk-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 36px;
+    padding: 0.38rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+.city-risk-score {
+    font-variant-numeric: tabular-nums;
 }
 
 .hero-stats {
@@ -1215,19 +1232,45 @@ td.num {
     text-decoration: none;
 }
 
-/* Date filter bar — linha discreta no topo */
+/* Date filter bar — recolhido para nao competir com os alertas principais */
 .date-filter-bar {
+    display: block;
+    padding: 0.45rem 0.75rem;
+    margin: 0.35rem 0 1rem;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: var(--surface);
+    font-size: 0.88rem;
+}
+.date-filter-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-height: 34px;
+    list-style: none;
+    cursor: pointer;
+}
+.date-filter-summary::-webkit-details-marker { display: none; }
+.date-filter-current {
+    font-weight: 700;
+    color: var(--text);
+}
+.date-filter-action {
+    color: var(--blue);
+    font-size: 0.82rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+.date-filter-panel {
     display: flex;
     align-items: center;
     gap: 0.6rem 1rem;
     flex-wrap: wrap;
     justify-content: space-between;
-    padding: 0.45rem 0.85rem;
-    margin: 0.4rem 0 0.9rem;
-    border: 1px solid var(--line);
-    border-radius: 10px;
-    background: var(--surface);
-    font-size: 0.88rem;
+    margin-top: 0.55rem;
+    padding-top: 0.55rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
 .date-filter-inputs {
     display: flex;
@@ -1872,6 +1915,8 @@ body.dark-page .dialog-header { border-bottom-color: var(--line); }
 
 /* Date filter bar */
 body.dark-page .date-filter-bar { background: rgba(15, 23, 42, 0.55); border-color: rgba(255,255,255,0.1); }
+body.dark-page .date-filter-panel { border-top-color: rgba(148, 163, 184, 0.18); }
+body.dark-page .date-filter-action { color: #93c5fd; }
 body.dark-page .date-field span { color: var(--muted); }
 body.dark-page .date-filter-label { color: rgba(226, 232, 240, 0.78); }
 
@@ -2042,11 +2087,30 @@ body {
     .city-title { font-size: 1.55rem; }
     .city-subtitle { font-size: 0.88rem; }
     .city-hero { gap: 0.8rem; padding: 1rem; }
-    .city-hero-actions { gap: 0.5rem; margin: 0.35rem 0 0.7rem; }
-    .city-hero-actions .rank-badge,
-    .city-hero-actions .share-btn-inline {
-        width: 100%;
+    .city-title-row {
+        gap: 0.7rem;
+    }
+    .city-title-row .eyebrow {
+        margin-bottom: 0.35rem;
+    }
+    .city-hero-actions {
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.4rem;
+    }
+    .city-risk-badge {
+        min-height: 34px;
+        padding: 0.32rem 0.58rem;
+        font-size: 0.72rem;
+    }
+    .share-btn.share-btn-icon {
+        width: 40px;
+        min-height: 40px;
+        padding: 0;
         justify-content: center;
+    }
+    .share-btn-icon .share-label {
+        display: none;
     }
     .hero-stats { grid-template-columns: repeat(3, 1fr); gap: 0.5rem; }
     .hero-stat { padding: 0.65rem 0.5rem; text-align: center; }
@@ -2064,10 +2128,18 @@ body {
     .insight-card { padding: 0.85rem; }
     .insight-value { font-size: 1.2rem; margin: 0.7rem 0 0.25rem; }
 
-    /* Date filter bar mobile: tudo empilhado mas ainda compacto */
+    /* Date filter mobile: compacto e so expande quando solicitado */
     .date-filter-bar {
-        gap: 0.45rem;
-        padding: 0.5rem 0.65rem;
+        padding: 0.45rem 0.65rem;
+    }
+    .date-filter-summary {
+        min-height: 40px;
+    }
+    .date-filter-panel {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 0.55rem;
+        justify-content: stretch;
     }
     .date-filter-inputs {
         flex-wrap: wrap;
@@ -3544,7 +3616,7 @@ html.audit-mode .denuncia-cta { display: none; }
    Substitui o antigo rank-badge no topo da pagina /search/cidade.
    ============================================================ */
 .city-kpi-strip {
-    margin: 1.25rem 0 1.5rem;
+    margin: 0.8rem 0 0.9rem;
 }
 .city-kpi-head {
     margin-bottom: .75rem;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -810,6 +810,13 @@ td.num {
     color: #334155;
 }
 
+.mobile-desc-toggle {
+    display: none;
+}
+.mobile-desc-hide {
+    display: none;
+}
+
 .result-block .card-title {
     font-size: 1.05rem;
     font-weight: 700;
@@ -2218,6 +2225,39 @@ body {
     .finding-summary {
         justify-content: space-between;
         text-align: left;
+    }
+    .mobile-collapsible-desc {
+        display: none;
+    }
+    .mobile-collapsible-desc.is-open {
+        display: block;
+    }
+    .mobile-desc-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 34px;
+        margin: 0.15rem 0 0.35rem;
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        border: 1px solid rgba(96, 165, 250, 0.28);
+        background: rgba(59, 130, 246, 0.1);
+        color: #bfdbfe;
+        font: inherit;
+        font-size: 0.78rem;
+        font-weight: 700;
+        cursor: pointer;
+    }
+    body:not(.dark-page) .mobile-desc-toggle {
+        background: #eff6ff;
+        color: #1d4ed8;
+        border-color: #bfdbfe;
+    }
+    .mobile-desc-toggle[aria-expanded="true"] .mobile-desc-show {
+        display: none;
+    }
+    .mobile-desc-toggle[aria-expanded="true"] .mobile-desc-hide {
+        display: inline;
     }
 
     /* Autocomplete: itens com tap target maior */

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2978,7 +2978,28 @@ body.dark-page .city-narrative-toggle:focus-visible {
         border-color: rgba(148, 163, 184, 0.15);
     }
     table.stack-mobile tbody tr.row-sancao {
-        border-left: 3px solid var(--red, #dc2626);
+        background: linear-gradient(90deg, rgba(239, 68, 68, 0.14), rgba(254, 242, 242, 0.98) 38%, var(--surface, #fff));
+        border-color: rgba(239, 68, 68, 0.42);
+        border-left: 4px solid var(--red, #dc2626);
+        box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+    }
+    table.stack-mobile tbody tr.row-sancao-leve {
+        background: linear-gradient(90deg, rgba(245, 158, 11, 0.16), rgba(255, 251, 235, 0.98) 38%, var(--surface, #fff));
+        border-color: rgba(245, 158, 11, 0.38);
+        border-left: 4px solid #f59e0b;
+        box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.08), 0 1px 2px rgba(15, 23, 42, 0.04);
+    }
+    body.dark-page table.stack-mobile tbody tr.row-sancao {
+        background: linear-gradient(90deg, rgba(127, 29, 29, 0.68), rgba(127, 29, 29, 0.34) 34%, rgba(15, 23, 42, 0.98));
+        border-color: rgba(248, 113, 113, 0.46);
+        border-left-color: #ef4444;
+        box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.12), 0 1px 2px rgba(0, 0, 0, 0.18);
+    }
+    body.dark-page table.stack-mobile tbody tr.row-sancao-leve {
+        background: linear-gradient(90deg, rgba(120, 53, 15, 0.68), rgba(120, 53, 15, 0.32) 34%, rgba(15, 23, 42, 0.98));
+        border-color: rgba(251, 191, 36, 0.42);
+        border-left-color: #f59e0b;
+        box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.12), 0 1px 2px rgba(0, 0, 0, 0.18);
     }
     /* Linha padrao: label a esquerda, valor a direita (mesma linha) */
     table.stack-mobile tbody td {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -3048,6 +3048,9 @@ body.dark-page .city-narrative-toggle:focus-visible {
     border-radius: 6px;
     animation: explainer-slide 0.22s ease-out;
 }
+.finding-explainer[hidden] {
+    display: none !important;
+}
 .finding-explainer p {
     margin: 0;
     font-size: 0.95rem;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -810,6 +810,22 @@ td.num {
     color: #334155;
 }
 
+.title-with-action {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    max-width: 100%;
+}
+
+.title-with-action .title-text {
+    min-width: 0;
+}
+
+.title-with-action .mobile-desc-toggle,
+.title-with-action .explainer-btn {
+    flex: 0 0 auto;
+}
+
 .mobile-desc-toggle {
     display: none;
 }
@@ -2186,9 +2202,12 @@ body {
     }
     .section-summary {
         width: 100%;
+        flex-direction: row;
         align-items: flex-start;
         text-align: left;
+        gap: 0.45rem;
     }
+    .section-summary .section-collapse-toggle { margin-left: auto; }
     .section-collapse-toggle { min-height: 40px; }
     .city-narrative {
         font-size: 0.95rem;
@@ -2249,6 +2268,20 @@ body {
         line-height: 1;
         cursor: pointer;
         vertical-align: middle;
+    }
+    .title-with-action {
+        display: flex;
+        align-items: center;
+        flex-wrap: nowrap;
+    }
+    .title-with-action .title-text {
+        flex: 1 1 auto;
+    }
+    .title-with-action .mobile-desc-toggle {
+        margin-left: 0.2rem;
+    }
+    .finding-title .explainer-btn {
+        display: none !important;
     }
     body:not(.dark-page) .mobile-desc-toggle {
         background: #eff6ff;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -813,9 +813,6 @@ td.num {
 .mobile-desc-toggle {
     display: none;
 }
-.mobile-desc-hide {
-    display: none;
-}
 
 .result-block .card-title {
     font-size: 1.05rem;
@@ -2236,28 +2233,32 @@ body {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        min-height: 34px;
-        margin: 0.15rem 0 0.35rem;
-        padding: 0.25rem 0.65rem;
+        width: 30px;
+        height: 30px;
+        min-width: 30px;
+        min-height: 30px;
+        margin-left: 0.35rem;
+        padding: 0;
         border-radius: 999px;
         border: 1px solid rgba(96, 165, 250, 0.28);
         background: rgba(59, 130, 246, 0.1);
         color: #bfdbfe;
         font: inherit;
-        font-size: 0.78rem;
+        font-size: 0.82rem;
         font-weight: 700;
+        line-height: 1;
         cursor: pointer;
+        vertical-align: middle;
     }
     body:not(.dark-page) .mobile-desc-toggle {
         background: #eff6ff;
         color: #1d4ed8;
         border-color: #bfdbfe;
     }
-    .mobile-desc-toggle[aria-expanded="true"] .mobile-desc-show {
-        display: none;
-    }
-    .mobile-desc-toggle[aria-expanded="true"] .mobile-desc-hide {
-        display: inline;
+    .mobile-desc-toggle[aria-expanded="true"] {
+        background: #2563eb;
+        border-color: #3b82f6;
+        color: #fff;
     }
 
     /* Autocomplete: itens com tap target maior */

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v22';
+const CACHE_VERSION = 'tpb-v23';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v20';
+const CACHE_VERSION = 'tpb-v21';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v18';
+const CACHE_VERSION = 'tpb-v19';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v21';
+const CACHE_VERSION = 'tpb-v22';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v17';
+const CACHE_VERSION = 'tpb-v18';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -7,7 +7,7 @@
 //
 // Bump CACHE_VERSION para invalidar caches antigos.
 
-const CACHE_VERSION = 'tpb-v19';
+const CACHE_VERSION = 'tpb-v20';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGES_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:title" content="{% block twitter_title %}{{ self.og_title() }}{% endblock %}">
     <meta name="twitter:description" content="{% block twitter_description %}{{ self.og_description() }}{% endblock %}">
-    <link rel="stylesheet" href="/static/style.css?v=53">
+    <link rel="stylesheet" href="/static/style.css?v=54">
     <script>
         // Aplica modo (cidadao/auditor) + tamanho de fonte ANTES do render para evitar flash
         (function(){

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:title" content="{% block twitter_title %}{{ self.og_title() }}{% endblock %}">
     <meta name="twitter:description" content="{% block twitter_description %}{{ self.og_description() }}{% endblock %}">
-    <link rel="stylesheet" href="/static/style.css?v=49">
+    <link rel="stylesheet" href="/static/style.css?v=50">
     <script>
         // Aplica modo (cidadao/auditor) + tamanho de fonte ANTES do render para evitar flash
         (function(){
@@ -124,7 +124,7 @@
     <script>
         window.COLUMN_META = {{ COLUMN_META | tojson }};
     </script>
-    <script src="/static/app.js?v=44"></script>
+    <script src="/static/app.js?v=45"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:title" content="{% block twitter_title %}{{ self.og_title() }}{% endblock %}">
     <meta name="twitter:description" content="{% block twitter_description %}{{ self.og_description() }}{% endblock %}">
-    <link rel="stylesheet" href="/static/style.css?v=52">
+    <link rel="stylesheet" href="/static/style.css?v=53">
     <script>
         // Aplica modo (cidadao/auditor) + tamanho de fonte ANTES do render para evitar flash
         (function(){

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:title" content="{% block twitter_title %}{{ self.og_title() }}{% endblock %}">
     <meta name="twitter:description" content="{% block twitter_description %}{{ self.og_description() }}{% endblock %}">
-    <link rel="stylesheet" href="/static/style.css?v=48">
+    <link rel="stylesheet" href="/static/style.css?v=49">
     <script>
         // Aplica modo (cidadao/auditor) + tamanho de fonte ANTES do render para evitar flash
         (function(){
@@ -124,7 +124,7 @@
     <script>
         window.COLUMN_META = {{ COLUMN_META | tojson }};
     </script>
-    <script src="/static/app.js?v=43"></script>
+    <script src="/static/app.js?v=44"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:title" content="{% block twitter_title %}{{ self.og_title() }}{% endblock %}">
     <meta name="twitter:description" content="{% block twitter_description %}{{ self.og_description() }}{% endblock %}">
-    <link rel="stylesheet" href="/static/style.css?v=51">
+    <link rel="stylesheet" href="/static/style.css?v=52">
     <script>
         // Aplica modo (cidadao/auditor) + tamanho de fonte ANTES do render para evitar flash
         (function(){
@@ -124,7 +124,7 @@
     <script>
         window.COLUMN_META = {{ COLUMN_META | tojson }};
     </script>
-    <script src="/static/app.js?v=46"></script>
+    <script src="/static/app.js?v=47"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:title" content="{% block twitter_title %}{{ self.og_title() }}{% endblock %}">
     <meta name="twitter:description" content="{% block twitter_description %}{{ self.og_description() }}{% endblock %}">
-    <link rel="stylesheet" href="/static/style.css?v=50">
+    <link rel="stylesheet" href="/static/style.css?v=51">
     <script>
         // Aplica modo (cidadao/auditor) + tamanho de fonte ANTES do render para evitar flash
         (function(){
@@ -124,7 +124,7 @@
     <script>
         window.COLUMN_META = {{ COLUMN_META | tojson }};
     </script>
-    <script src="/static/app.js?v=45"></script>
+    <script src="/static/app.js?v=46"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/web/templates/partials/result_table.html
+++ b/web/templates/partials/result_table.html
@@ -1,7 +1,7 @@
 <section class="result-block">
     <div class="result-toolbar">
         <div>
-            <h3 class="card-title">{{ title }} <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button></h3>
+            <h3 class="card-title title-with-action"><span class="title-text">{{ title }}</span> <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button></h3>
             <p class="text-muted text-sm mobile-collapsible-desc">
                 <span class="citizen-only">Use o filtro para procurar uma empresa, um nome ou uma palavra nesta tabela.</span>
                 <span class="auditor-only">Use o filtro para localizar nomes, empresas, documentos ou termos relevantes nesta tabela.</span>

--- a/web/templates/partials/result_table.html
+++ b/web/templates/partials/result_table.html
@@ -1,11 +1,7 @@
 <section class="result-block">
     <div class="result-toolbar">
         <div>
-            <h3 class="card-title">{{ title }}</h3>
-            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-                <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-                <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-            </button>
+            <h3 class="card-title">{{ title }} <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button></h3>
             <p class="text-muted text-sm mobile-collapsible-desc">
                 <span class="citizen-only">Use o filtro para procurar uma empresa, um nome ou uma palavra nesta tabela.</span>
                 <span class="auditor-only">Use o filtro para localizar nomes, empresas, documentos ou termos relevantes nesta tabela.</span>

--- a/web/templates/partials/result_table.html
+++ b/web/templates/partials/result_table.html
@@ -2,7 +2,11 @@
     <div class="result-toolbar">
         <div>
             <h3 class="card-title">{{ title }}</h3>
-            <p class="text-muted text-sm">
+            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+                <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+                <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+            </button>
+            <p class="text-muted text-sm mobile-collapsible-desc">
                 <span class="citizen-only">Use o filtro para procurar uma empresa, um nome ou uma palavra nesta tabela.</span>
                 <span class="auditor-only">Use o filtro para localizar nomes, empresas, documentos ou termos relevantes nesta tabela.</span>
             </p>

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -5,11 +5,8 @@
             <h3 class="card-title">
                 <span class="citizen-only">Empresas que mais receberam da prefeitura</span>
                 <span class="auditor-only">Maiores fornecedores do municipio</span>
+                <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
             </h3>
-            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-                <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-                <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-            </button>
             <p class="text-muted text-sm mobile-collapsible-desc">
                 <span class="citizen-only">Concentra&ccedil;&atilde;o dos pagamentos e sinais de aten&ccedil;&atilde;o de cada empresa. Toque em uma empresa para detalhes.</span>
                 <span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span>

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -6,7 +6,11 @@
                 <span class="citizen-only">Empresas que mais receberam da prefeitura</span>
                 <span class="auditor-only">Maiores fornecedores do municipio</span>
             </h3>
-            <p class="text-muted text-sm">
+            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+                <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+                <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+            </button>
+            <p class="text-muted text-sm mobile-collapsible-desc">
                 <span class="citizen-only">Concentra&ccedil;&atilde;o dos pagamentos e sinais de aten&ccedil;&atilde;o de cada empresa. Toque em uma empresa para detalhes.</span>
                 <span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span>
             </p>

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -2,9 +2,11 @@
 <section class="result-block">
     <div class="result-toolbar">
         <div>
-            <h3 class="card-title">
-                <span class="citizen-only">Empresas que mais receberam da prefeitura</span>
-                <span class="auditor-only">Maiores fornecedores do municipio</span>
+            <h3 class="card-title title-with-action">
+                <span class="title-text">
+                    <span class="citizen-only">Empresas que mais receberam da prefeitura</span>
+                    <span class="auditor-only">Maiores fornecedores do municipio</span>
+                </span>
                 <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
             </h3>
             <p class="text-muted text-sm mobile-collapsible-desc">

--- a/web/templates/partials/top_servidores.html
+++ b/web/templates/partials/top_servidores.html
@@ -6,7 +6,11 @@
                 <span class="citizen-only">Servidores com sinais de aten&ccedil;&atilde;o</span>
                 <span class="auditor-only">Servidores com sinais de atencao</span>
             </h3>
-            <p class="text-muted text-sm">
+            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+                <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+                <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+            </button>
+            <p class="text-muted text-sm mobile-collapsible-desc">
                 <span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: s&oacute;cio de empresa, sal&aacute;rio em mais de um governo, beneficio social irregular, ou acumula&ccedil;&atilde;o at&iacute;pica. A Constitui&ccedil;&atilde;o permite dois v&iacute;nculos para profissionais de sa&uacute;de.</span>
                 <span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos:
                 vinculo societario com fornecedores, duplo vinculo com o estado, recebimento de beneficio social

--- a/web/templates/partials/top_servidores.html
+++ b/web/templates/partials/top_servidores.html
@@ -2,9 +2,11 @@
 <section class="result-block">
     <div class="result-toolbar">
         <div>
-            <h3 class="card-title">
-                <span class="citizen-only">Servidores com sinais de aten&ccedil;&atilde;o</span>
-                <span class="auditor-only">Servidores com sinais de atencao</span>
+            <h3 class="card-title title-with-action">
+                <span class="title-text">
+                    <span class="citizen-only">Servidores com sinais de aten&ccedil;&atilde;o</span>
+                    <span class="auditor-only">Servidores com sinais de atencao</span>
+                </span>
                 <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
             </h3>
             <p class="text-muted text-sm mobile-collapsible-desc">

--- a/web/templates/partials/top_servidores.html
+++ b/web/templates/partials/top_servidores.html
@@ -5,11 +5,8 @@
             <h3 class="card-title">
                 <span class="citizen-only">Servidores com sinais de aten&ccedil;&atilde;o</span>
                 <span class="auditor-only">Servidores com sinais de atencao</span>
+                <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
             </h3>
-            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-                <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-                <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-            </button>
             <p class="text-muted text-sm mobile-collapsible-desc">
                 <span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: s&oacute;cio de empresa, sal&aacute;rio em mais de um governo, beneficio social irregular, ou acumula&ccedil;&atilde;o at&iacute;pica. A Constitui&ccedil;&atilde;o permite dois v&iacute;nculos para profissionais de sa&uacute;de.</span>
                 <span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos:

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -337,9 +337,11 @@
                 <span class="citizen-only">Onde investigar primeiro</span>
                 <span class="auditor-only">Indice de investigacao</span>
             </p>
-                <h2 class="card-title">
-                    <span class="citizen-only">Navegue pelos temas desta cidade</span>
-                    <span class="auditor-only">Temas e blocos do relatorio</span>
+                <h2 class="card-title title-with-action">
+                    <span class="title-text">
+                        <span class="citizen-only">Navegue pelos temas desta cidade</span>
+                        <span class="auditor-only">Temas e blocos do relatorio</span>
+                    </span>
                     <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
                 </h2>
                 <p class="text-muted mobile-collapsible-desc">
@@ -454,7 +456,6 @@
                 </p>
                 <h2 class="card-title">
                     {% if section.title_lay %}<span class="citizen-only">{{ section.title_lay|safe }}</span><span class="auditor-only">{{ section.title }}</span>{% else %}{{ section.title }}{% endif %}
-                    <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
                 </h2>
                 <p class="text-muted mobile-collapsible-desc">
                     {% if section.description_lay %}<span class="citizen-only">{{ section.description_lay|safe }}</span><span class="auditor-only">{{ section.description }}</span>{% else %}{{ section.description }}{% endif %}
@@ -477,10 +478,12 @@
             <section class="finding-card loading collapsed" data-query="{{ query.id }}" aria-busy="true">
                 <div class="finding-head">
                     <div>
-                        <h3 class="finding-title">
-                            {% if query.title_lay %}<span class="citizen-only">{{ query.title_lay|safe }}</span><span class="auditor-only">{{ query.title }}</span>{% else %}{{ query.title }}{% endif %}
+                        <h3 class="finding-title title-with-action">
+                            <span class="title-text">
+                                {% if query.title_lay %}<span class="citizen-only">{{ query.title_lay|safe }}</span><span class="auditor-only">{{ query.title }}</span>{% else %}{{ query.title }}{% endif %}
+                            </span>
                             {% if query.explainer_lay %}<button type="button" class="explainer-btn citizen-only" data-explainer-target="exp-{{ query.id }}" aria-expanded="false" aria-label="O que isso significa?" title="O que isso significa?">&#8505;</button>{% endif %}
-                            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
+                            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next{% if query.explainer_lay %} data-mobile-desc-explainer="exp-{{ query.id }}"{% endif %} aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
                         </h3>
                         <p class="text-sm text-muted mobile-collapsible-desc">
                             {% if query.description_lay %}<span class="citizen-only">{{ query.description_lay|safe }}</span><span class="auditor-only">{{ query.description }}</span>{% else %}{{ query.description }}{% endif %}

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -186,7 +186,7 @@
                 </h2>
             </div>
         </div>
-        <p class="text-muted mb-1 mobile-collapsible-desc">
+        <p class="text-muted mb-1 mobile-duplicate-desc">
             <span class="citizen-only">Empresas que mais recebem dinheiro p&uacute;blico aqui. Toque em uma empresa para ver detalhes e se ela tem alguma <span class="term" data-tip="Problema cadastral: d&iacute;vida ativa com a Uni&atilde;o, situa&ccedil;&atilde;o irregular na Receita Federal, ou san&ccedil;&atilde;o ativa do governo federal (CEIS, CNEP ou Inidoneidade).">irregularidade</span>.</span>
             <span class="auditor-only">Esta lista ajuda a identificar concentracao de pagamentos e checar se os nomes mais frequentes fazem sentido no contexto local.
             Clique em um fornecedor para ver detalhes dos empenhos e situacao cadastral.</span>
@@ -210,7 +210,7 @@
                 </h2>
             </div>
         </div>
-        <p class="text-muted mb-1 mobile-collapsible-desc">
+        <p class="text-muted mb-1 mobile-duplicate-desc">
             <span class="citizen-only">Servidores da prefeitura com ind&iacute;cios cruzados — por exemplo, <span class="term" data-tip="Quando o servidor aparece como s&oacute;cio ou administrador de empresa, algo que a lei restringe.">v&iacute;nculo com empresas</span>, sal&aacute;rio em mais de um governo ao mesmo tempo, ou outro sinal incomum.</span>
             <span class="auditor-only">Servidores municipais com sinais nos cruzamentos automaticos — vinculos societarios,
             pagamentos estaduais simultaneos, beneficios sociais ou acumulacao atipica de indicadores.
@@ -457,7 +457,7 @@
                 <h2 class="card-title">
                     {% if section.title_lay %}<span class="citizen-only">{{ section.title_lay|safe }}</span><span class="auditor-only">{{ section.title }}</span>{% else %}{{ section.title }}{% endif %}
                 </h2>
-                <p class="text-muted mobile-collapsible-desc">
+                <p class="text-muted">
                     {% if section.description_lay %}<span class="citizen-only">{{ section.description_lay|safe }}</span><span class="auditor-only">{{ section.description }}</span>{% else %}{{ section.description }}{% endif %}
                 </p>
             </div>

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -186,7 +186,11 @@
                 </h2>
             </div>
         </div>
-        <p class="text-muted mb-1">
+        <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+            <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+            <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+        </button>
+        <p class="text-muted mb-1 mobile-collapsible-desc">
             <span class="citizen-only">Empresas que mais recebem dinheiro p&uacute;blico aqui. Toque em uma empresa para ver detalhes e se ela tem alguma <span class="term" data-tip="Problema cadastral: d&iacute;vida ativa com a Uni&atilde;o, situa&ccedil;&atilde;o irregular na Receita Federal, ou san&ccedil;&atilde;o ativa do governo federal (CEIS, CNEP ou Inidoneidade).">irregularidade</span>.</span>
             <span class="auditor-only">Esta lista ajuda a identificar concentracao de pagamentos e checar se os nomes mais frequentes fazem sentido no contexto local.
             Clique em um fornecedor para ver detalhes dos empenhos e situacao cadastral.</span>
@@ -210,7 +214,11 @@
                 </h2>
             </div>
         </div>
-        <p class="text-muted mb-1">
+        <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+            <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+            <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+        </button>
+        <p class="text-muted mb-1 mobile-collapsible-desc">
             <span class="citizen-only">Servidores da prefeitura com ind&iacute;cios cruzados — por exemplo, <span class="term" data-tip="Quando o servidor aparece como s&oacute;cio ou administrador de empresa, algo que a lei restringe.">v&iacute;nculo com empresas</span>, sal&aacute;rio em mais de um governo ao mesmo tempo, ou outro sinal incomum.</span>
             <span class="auditor-only">Servidores municipais com sinais nos cruzamentos automaticos — vinculos societarios,
             pagamentos estaduais simultaneos, beneficios sociais ou acumulacao atipica de indicadores.
@@ -337,15 +345,19 @@
                 <span class="citizen-only">Onde investigar primeiro</span>
                 <span class="auditor-only">Indice de investigacao</span>
             </p>
-            <h2 class="card-title">
-                <span class="citizen-only">Navegue pelos temas desta cidade</span>
-                <span class="auditor-only">Temas e blocos do relatorio</span>
-            </h2>
-            <p class="text-muted">
-                <span class="citizen-only">Escolha um tema para abrir so os achados daquela area e evitar rolagem longa.</span>
-                <span class="auditor-only">Use o indice abaixo para expandir apenas a area desejada e escanear o relatorio com menos scroll.</span>
-            </p>
-        </div>
+                <h2 class="card-title">
+                    <span class="citizen-only">Navegue pelos temas desta cidade</span>
+                    <span class="auditor-only">Temas e blocos do relatorio</span>
+                </h2>
+                <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+                    <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+                    <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+                </button>
+                <p class="text-muted mobile-collapsible-desc">
+                    <span class="citizen-only">Escolha um tema para abrir so os achados daquela area e evitar rolagem longa.</span>
+                    <span class="auditor-only">Use o indice abaixo para expandir apenas a area desejada e escanear o relatorio com menos scroll.</span>
+                </p>
+            </div>
     </div>
     <div class="report-index">
         {% for section in report_sections %}
@@ -454,7 +466,11 @@
                 <h2 class="card-title">
                     {% if section.title_lay %}<span class="citizen-only">{{ section.title_lay|safe }}</span><span class="auditor-only">{{ section.title }}</span>{% else %}{{ section.title }}{% endif %}
                 </h2>
-                <p class="text-muted">
+                <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+                    <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+                    <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+                </button>
+                <p class="text-muted mobile-collapsible-desc">
                     {% if section.description_lay %}<span class="citizen-only">{{ section.description_lay|safe }}</span><span class="auditor-only">{{ section.description }}</span>{% else %}{{ section.description }}{% endif %}
                 </p>
             </div>
@@ -479,7 +495,11 @@
                             {% if query.title_lay %}<span class="citizen-only">{{ query.title_lay|safe }}</span><span class="auditor-only">{{ query.title }}</span>{% else %}{{ query.title }}{% endif %}
                             {% if query.explainer_lay %}<button type="button" class="explainer-btn citizen-only" data-explainer-target="exp-{{ query.id }}" aria-expanded="false" aria-label="O que isso significa?" title="O que isso significa?">&#8505;</button>{% endif %}
                         </h3>
-                        <p class="text-sm text-muted">
+                        <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
+                            <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
+                            <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
+                        </button>
+                        <p class="text-sm text-muted mobile-collapsible-desc">
                             {% if query.description_lay %}<span class="citizen-only">{{ query.description_lay|safe }}</span><span class="auditor-only">{{ query.description }}</span>{% else %}{{ query.description }}{% endif %}
                         </p>
                     </div>

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -186,10 +186,6 @@
                 </h2>
             </div>
         </div>
-        <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-            <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-            <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-        </button>
         <p class="text-muted mb-1 mobile-collapsible-desc">
             <span class="citizen-only">Empresas que mais recebem dinheiro p&uacute;blico aqui. Toque em uma empresa para ver detalhes e se ela tem alguma <span class="term" data-tip="Problema cadastral: d&iacute;vida ativa com a Uni&atilde;o, situa&ccedil;&atilde;o irregular na Receita Federal, ou san&ccedil;&atilde;o ativa do governo federal (CEIS, CNEP ou Inidoneidade).">irregularidade</span>.</span>
             <span class="auditor-only">Esta lista ajuda a identificar concentracao de pagamentos e checar se os nomes mais frequentes fazem sentido no contexto local.
@@ -214,10 +210,6 @@
                 </h2>
             </div>
         </div>
-        <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-            <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-            <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-        </button>
         <p class="text-muted mb-1 mobile-collapsible-desc">
             <span class="citizen-only">Servidores da prefeitura com ind&iacute;cios cruzados — por exemplo, <span class="term" data-tip="Quando o servidor aparece como s&oacute;cio ou administrador de empresa, algo que a lei restringe.">v&iacute;nculo com empresas</span>, sal&aacute;rio em mais de um governo ao mesmo tempo, ou outro sinal incomum.</span>
             <span class="auditor-only">Servidores municipais com sinais nos cruzamentos automaticos — vinculos societarios,
@@ -348,11 +340,8 @@
                 <h2 class="card-title">
                     <span class="citizen-only">Navegue pelos temas desta cidade</span>
                     <span class="auditor-only">Temas e blocos do relatorio</span>
+                    <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
                 </h2>
-                <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-                    <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-                    <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-                </button>
                 <p class="text-muted mobile-collapsible-desc">
                     <span class="citizen-only">Escolha um tema para abrir so os achados daquela area e evitar rolagem longa.</span>
                     <span class="auditor-only">Use o indice abaixo para expandir apenas a area desejada e escanear o relatorio com menos scroll.</span>
@@ -465,11 +454,8 @@
                 </p>
                 <h2 class="card-title">
                     {% if section.title_lay %}<span class="citizen-only">{{ section.title_lay|safe }}</span><span class="auditor-only">{{ section.title }}</span>{% else %}{{ section.title }}{% endif %}
+                    <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
                 </h2>
-                <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-                    <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-                    <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-                </button>
                 <p class="text-muted mobile-collapsible-desc">
                     {% if section.description_lay %}<span class="citizen-only">{{ section.description_lay|safe }}</span><span class="auditor-only">{{ section.description }}</span>{% else %}{{ section.description }}{% endif %}
                 </p>
@@ -494,11 +480,8 @@
                         <h3 class="finding-title">
                             {% if query.title_lay %}<span class="citizen-only">{{ query.title_lay|safe }}</span><span class="auditor-only">{{ query.title }}</span>{% else %}{{ query.title }}{% endif %}
                             {% if query.explainer_lay %}<button type="button" class="explainer-btn citizen-only" data-explainer-target="exp-{{ query.id }}" aria-expanded="false" aria-label="O que isso significa?" title="O que isso significa?">&#8505;</button>{% endif %}
+                            <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false" aria-label="Ver descri&ccedil;&atilde;o" title="Ver descri&ccedil;&atilde;o">?</button>
                         </h3>
-                        <button type="button" class="mobile-desc-toggle" data-mobile-desc-next aria-expanded="false">
-                            <span class="mobile-desc-show">Ver descri&ccedil;&atilde;o</span>
-                            <span class="mobile-desc-hide">Ocultar descri&ccedil;&atilde;o</span>
-                        </button>
                         <p class="text-sm text-muted mobile-collapsible-desc">
                             {% if query.description_lay %}<span class="citizen-only">{{ query.description_lay|safe }}</span><span class="auditor-only">{{ query.description }}</span>{% else %}{{ query.description }}{% endif %}
                         </p>

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -68,7 +68,6 @@
     <div class="city-hero-copy">
         <div class="city-title-row">
             <div>
-                <p class="eyebrow">Resumo de aten&ccedil;&atilde;o</p>
                 <h1 class="city-title">{{ perfil.municipio }} - PB</h1>
             </div>
             <div class="city-hero-actions">

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -68,6 +68,7 @@
     <div class="city-hero-copy">
         <div class="city-title-row">
             <div>
+                <p class="eyebrow">Resumo de aten&ccedil;&atilde;o</p>
                 <h1 class="city-title">{{ perfil.municipio }} - PB</h1>
             </div>
             <div class="city-hero-actions">
@@ -80,6 +81,7 @@
                 <button
                     type="button"
                     class="share-btn share-btn-icon"
+                    hidden
                     data-share
                     data-share-title="{{ perfil.municipio }} - PB | TransparenciaPB"
                     data-share-text="Panorama de transparencia de {{ perfil.municipio }} - PB"

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -78,21 +78,6 @@
                     <span class="city-risk-score"><strong data-score-unificado>{{ "%.0f"|format(score_num) }}</strong>/100</span>
                 </span>
                 {% endif %}
-                <button
-                    type="button"
-                    class="share-btn share-btn-icon"
-                    hidden
-                    data-share
-                    data-share-title="{{ perfil.municipio }} - PB | TransparenciaPB"
-                    data-share-text="Panorama de transparencia de {{ perfil.municipio }} - PB"
-                    aria-label="Compartilhar este municipio"
-                    title="Compartilhar"
-                >
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                        <path d="M4 12v7a1 1 0 001 1h14a1 1 0 001-1v-7M16 6l-4-4-4 4M12 2v13" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                    <span class="share-label">Compartilhar</span>
-                </button>
             </div>
         </div>
         <p class="city-subtitle">

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -49,48 +49,54 @@
 {% set total_pago = perfil.total_pago|default(0)|float %}
 {% set pct_pago = (total_pago / total_empenhado * 100) if total_empenhado else 0 %}
 {% set gap_financeiro = total_empenhado - total_pago %}
-
-<div class="date-filter-bar" id="dateFilterBar" role="group" aria-label="Filtro de periodo">
-    <div class="date-filter-inputs">
-        <label class="date-field"><span>De</span>
-            <input type="text" id="dateInicio" inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off" data-iso-value="{{ default_data_inicio }}">
-        </label>
-        <label class="date-field"><span>Ate</span>
-            <input type="text" id="dateFim" inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off" data-iso-value="{{ default_data_fim }}">
-        </label>
-        <button class="btn btn-primary btn-sm" id="btnFiltrarData">Filtrar</button>
-        <p class="date-filter-status text-sm text-muted" id="dateFilterStatus" aria-live="polite"></p>
-    </div>
-    <div class="date-filter-presets" role="group" aria-label="Atalhos de periodo">
-        <button type="button" class="btn btn-outline btn-sm" data-date-preset="all">Tudo</button>
-        <button type="button" class="btn btn-outline btn-sm is-active" data-date-preset="current-year">Ano atual</button>
-        <button type="button" class="btn btn-outline btn-sm" data-date-preset="last-12m">12 meses</button>
-        <button type="button" class="btn btn-link btn-sm" id="btnLimparData" style="display:none">Limpar</button>
-    </div>
-</div>
+{% set score_value = score_unificado if score_unificado is not none else perfil.risco_score %}
+{% if score_value is not none %}
+    {% set score_num = score_value|float %}
+    {% if score_num >= 70 %}
+        {% set score_level = 'red' %}
+        {% set score_label = 'Aten&ccedil;&atilde;o alta' %}
+    {% elif score_num >= 40 %}
+        {% set score_level = 'yellow' %}
+        {% set score_label = 'Aten&ccedil;&atilde;o' %}
+    {% else %}
+        {% set score_level = 'green' %}
+        {% set score_label = 'Baixa aten&ccedil;&atilde;o' %}
+    {% endif %}
+{% endif %}
 
 <section class="city-hero card">
     <div class="city-hero-copy">
-        <p class="eyebrow">Panorama do municipio</p>
-        <h1 class="city-title">{{ perfil.municipio }} - PB</h1>
-        <div class="city-hero-actions">
-            <button
-                type="button"
-                class="share-btn share-btn-inline"
-                data-share
-                data-share-title="{{ perfil.municipio }} - PB | TransparenciaPB"
-                data-share-text="Panorama de transparencia de {{ perfil.municipio }} - PB"
-                aria-label="Compartilhar este municipio"
-            >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path d="M4 12v7a1 1 0 001 1h14a1 1 0 001-1v-7M16 6l-4-4-4 4M12 2v13" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Compartilhar
-            </button>
+        <div class="city-title-row">
+            <div>
+                <p class="eyebrow">Resumo de aten&ccedil;&atilde;o</p>
+                <h1 class="city-title">{{ perfil.municipio }} - PB</h1>
+            </div>
+            <div class="city-hero-actions">
+                {% if score_value is not none %}
+                <span class="city-risk-badge badge-{{ score_level }}" data-risk-summary>
+                    <span data-risk-label>{{ score_label|safe }}</span>
+                    <span class="city-risk-score"><strong data-score-unificado>{{ "%.0f"|format(score_num) }}</strong>/100</span>
+                </span>
+                {% endif %}
+                <button
+                    type="button"
+                    class="share-btn share-btn-icon"
+                    data-share
+                    data-share-title="{{ perfil.municipio }} - PB | TransparenciaPB"
+                    data-share-text="Panorama de transparencia de {{ perfil.municipio }} - PB"
+                    aria-label="Compartilhar este municipio"
+                    title="Compartilhar"
+                >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <path d="M4 12v7a1 1 0 001 1h14a1 1 0 001-1v-7M16 6l-4-4-4 4M12 2v13" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                    <span class="share-label">Compartilhar</span>
+                </button>
+            </div>
         </div>
         <p class="city-subtitle">
-            <span class="citizen-only">Veja como a prefeitura de {{ perfil.municipio }} usa o dinheiro p&uacute;blico — com quem gasta, se h&aacute; sinais de irregularidade, e onde v&atilde;o os maiores valores.</span>
-            <span class="auditor-only">Esta pagina resume os principais sinais de atencao encontrados nas despesas do municipio e organiza os achados por tema para facilitar a investigacao.</span>
+            <span class="citizen-only">Veja os principais sinais de risco nos gastos de {{ perfil.municipio }}.</span>
+            <span class="auditor-only">Resumo dos sinais investigativos prioritarios nas despesas do municipio.</span>
         </p>
         {% if narrative %}
         <div class="city-narrative-block" id="cityNarrativeBlock">
@@ -100,29 +106,6 @@
             </p>
         </div>
         {% endif %}
-    </div>
-    <div class="hero-stats">
-        <div class="hero-stat">
-            <span class="hero-stat-value" id="heroQtdEmpenhos">{{ perfil.qtd_empenhos|default(0)|short_number }}</span>
-            <span class="hero-stat-label">
-                <span class="citizen-only"><span class="term" data-tip="Empenho: reserva or&ccedil;ament&aacute;ria feita pela prefeitura para pagar despesas futuras.">gastos previstos</span></span>
-                <span class="auditor-only">despesas analisadas</span>
-            </span>
-        </div>
-        <div class="hero-stat">
-            <span class="hero-stat-value" id="heroTotalPago">{{ total_pago|short_brl }}</span>
-            <span class="hero-stat-label">
-                <span class="citizen-only">dinheiro que j&aacute; saiu do cofre</span>
-                <span class="auditor-only">pagos ao todo</span>
-            </span>
-        </div>
-        <div class="hero-stat">
-            <span class="hero-stat-value" id="heroQtdFornecedores">{{ perfil.qtd_fornecedores|default(0)|short_number }}</span>
-            <span class="hero-stat-label">
-                <span class="citizen-only">empresas contratadas</span>
-                <span class="auditor-only">fornecedores distintos</span>
-            </span>
-        </div>
     </div>
 </section>
 
@@ -158,6 +141,31 @@
     </div>
 </section>
 {% endif %}
+
+<details class="date-filter-bar" id="dateFilterBar">
+    <summary class="date-filter-summary">
+        <span class="date-filter-current" id="dateFilterCurrent">Per&iacute;odo: ano atual</span>
+        <span class="date-filter-action">Alterar per&iacute;odo</span>
+    </summary>
+    <div class="date-filter-panel" role="group" aria-label="Filtro de periodo">
+        <div class="date-filter-inputs">
+            <label class="date-field"><span>De</span>
+                <input type="text" id="dateInicio" inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off" data-iso-value="{{ default_data_inicio }}">
+            </label>
+            <label class="date-field"><span>Ate</span>
+                <input type="text" id="dateFim" inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off" data-iso-value="{{ default_data_fim }}">
+            </label>
+            <button class="btn btn-primary btn-sm" id="btnFiltrarData">Filtrar</button>
+            <p class="date-filter-status text-sm text-muted" id="dateFilterStatus" aria-live="polite"></p>
+        </div>
+        <div class="date-filter-presets" role="group" aria-label="Atalhos de periodo">
+            <button type="button" class="btn btn-outline btn-sm" data-date-preset="all">Tudo</button>
+            <button type="button" class="btn btn-outline btn-sm is-active" data-date-preset="current-year">Ano atual</button>
+            <button type="button" class="btn btn-outline btn-sm" data-date-preset="last-12m">12 meses</button>
+            <button type="button" class="btn btn-link btn-sm" id="btnLimparData" style="display:none">Limpar</button>
+        </div>
+    </div>
+</details>
 
 <section class="card priority-guide" aria-label="Por onde comecar">
     <p class="eyebrow">
@@ -534,7 +542,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // bootstrap. Antes a logica lia .value dos inputs, mas eles tem apenas
     // data-iso-value nesse momento (a mascara so eh aplicada DENTRO do
     // bootstrap), entao .value vinha vazio e _isDateFiltered() voltava false
-    // — deixando o JS pedir caches all-time apesar do filtro visivel.
+    // — deixando o JS pedir caches all-time apesar do filtro padrao.
     bootstrapCityReport(
         {{ perfil.municipio|tojson }},
         {{ (display_uf or 'PB')|tojson }},


### PR DESCRIPTION
## Resumo
- remove os cards duplicados do hero da pagina de cidade
- adiciona badge de atencao ao lado do titulo
- move os sinais investigativos para antes do filtro de periodo
- deixa o filtro de periodo recolhido e esconde Limpar para presets

## Validacao
- python -m compileall web -q
- node --check web\\static\\app.js
- GET http://127.0.0.1:8000/search/cidade?q=Campina%20Grande retornou 200
- Playwright MCP em 430x932 confirmou hero e alertas no primeiro viewport, com filtro abaixo da dobra