### PR TITLE
Auto-resize VM por etl_phase + pg-autotune + OIDC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Forcar LF em scripts/units que rodam em Linux na VM, mesmo se editados no Windows.
+# Sem isso, bash/systemd quebram silenciosamente em caracteres `\r`.
+*.sh        text eol=lf
+*.service   text eol=lf
+*.conf      text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.py        text eol=lf
+*.sql       text eol=lf
+deploy/nginx-cruza.conf text eol=lf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,23 @@
 name: Deploy to Azure VM
 
-# Runs directly on the VM via self-hosted runner (installed by setup-runner.yml).
-# Full live logs with the GitHub self-hosted runner max timeout (5 days / 7200 min).
+# Pipeline em 3 jobs:
+#   1. preflight  (github-hosted, OIDC) — resize VM up se etl_phase != web
+#   2. deploy     (self-hosted na VM) — ETL/SQL/web
+#   3. postflight (github-hosted, OIDC) — resize VM down se etl_phase != web
 #
 # Required secrets:
-#   DB_PASSWORD - PostgreSQL password
-#   ENV_FILE    - Contents of .env file
+#   DB_PASSWORD            - PostgreSQL password
+#   ENV_FILE               - Contents of .env file
+#   VM_HOST                - VM IP/hostname (used pelo preflight pra checar SSH)
+#   AZURE_CLIENT_ID        - OIDC: app registration clientId
+#   AZURE_TENANT_ID        - OIDC: tenant
+#   AZURE_SUBSCRIPTION_ID  - OIDC: subscription com a VM
 #
 # First-time setup:
-#   1. Create an Ubuntu VM (tested on Azure Standard_D4s_v3, 16GB RAM)
+#   1. Create an Ubuntu VM (tested on Azure Standard_B4as_v2, 16GB RAM)
 #   2. Attach a data disk mounted at /data (400GB+)
 #   3. Create user 'govbr' with SSH key access
-#   4. Set repo secrets: VM_HOST, VM_SSH_KEY, DB_PASSWORD, ENV_FILE
+#   4. Set repo secrets above (DB_PASSWORD, ENV_FILE, VM_HOST, AZURE_*)
 #   5. Run the "Setup Self-Hosted Runner" workflow (once)
 #   6. Run this workflow with etl_phase=all
 
@@ -33,11 +39,113 @@ on:
         type: boolean
         default: false
 
+# OIDC federado pro Azure (sem secrets de SP, sem expiracao).
+permissions:
+  id-token: write
+  contents: read
+
+# Lock global: apenas 1 run em voo por vez nessa VM. Sem isso, dois disparos
+# concorrentes podem fazer az vm deallocate/resize um sobre o outro e quebrar o
+# banco (que leva DIAS para reconstruir do zero).
+concurrency:
+  group: deploy-vm-govbr
+  cancel-in-progress: false
+
 env:
   PROJECT_DIR: /home/govbr/govbr-project
+  AZURE_RG: RG-GOVBR-NCUS
+  AZURE_VM: vm-govbr
+  # B2as_v2: 2 vCPU, 8GB  ~$55/mes  — adequado para servir web
+  # B4as_v2: 4 vCPU, 16GB ~$108/mes — necessario para ETL/views pesados
+  VM_SIZE_WEB: Standard_B2as_v2
+  VM_SIZE_ETL: Standard_B4as_v2
 
 jobs:
+  # ─────────────────────────────────────────────────────────────────────
+  # PREFLIGHT: redimensiona a VM para o tamanho adequado ao etl_phase
+  # ─────────────────────────────────────────────────────────────────────
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      target_size: ${{ steps.decide.outputs.target_size }}
+    steps:
+      - name: Decide target VM size
+        id: decide
+        run: |
+          if [ "${{ inputs.etl_phase }}" = "web" ]; then
+            echo "target_size=${{ env.VM_SIZE_WEB }}" >> "$GITHUB_OUTPUT"
+            echo "etl_phase=web → target=${{ env.VM_SIZE_WEB }} (8GB)"
+          else
+            echo "target_size=${{ env.VM_SIZE_ETL }}" >> "$GITHUB_OUTPUT"
+            echo "etl_phase=${{ inputs.etl_phase }} → target=${{ env.VM_SIZE_ETL }} (16GB)"
+          fi
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resize VM to target size
+        run: |
+          set -e
+          TARGET="${{ steps.decide.outputs.target_size }}"
+          CURRENT=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query hardwareProfile.vmSize -o tsv)
+          POWER=$(az vm get-instance-view -g "$AZURE_RG" -n "$AZURE_VM" \
+            --query "instanceView.statuses[?contains(code, 'PowerState')].code | [0]" -o tsv)
+
+          echo "Current size:  $CURRENT"
+          echo "Target size:   $TARGET"
+          echo "Power state:   $POWER"
+
+          if [ "$CURRENT" = "$TARGET" ]; then
+            echo "VM ja esta no tamanho correto."
+            if [ "$POWER" != "PowerState/running" ]; then
+              echo "VM esta $POWER, ligando..."
+              az vm start -g "$AZURE_RG" -n "$AZURE_VM"
+            fi
+          else
+            # Valida que o target SKU esta disponivel ANTES de deallocate.
+            # Sem isso, um SKU indisponivel deixa a VM parada e a producao no chao.
+            AVAILABLE=$(az vm list-vm-resize-options -g "$AZURE_RG" -n "$AZURE_VM" --query "[].name" -o tsv)
+            if ! echo "$AVAILABLE" | grep -qx "$TARGET"; then
+              echo "::error::Tamanho $TARGET indisponivel nessa VM/regiao no momento."
+              echo "Disponiveis:"; echo "$AVAILABLE"
+              exit 1
+            fi
+
+            echo "Resize: $CURRENT → $TARGET"
+            az vm deallocate -g "$AZURE_RG" -n "$AZURE_VM"
+
+            if ! az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$TARGET"; then
+              echo "::warning::Resize falhou, restaurando para $CURRENT..."
+              az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$CURRENT" || true
+              az vm start -g "$AZURE_RG" -n "$AZURE_VM" || true
+              echo "::error::Resize para $TARGET falhou — VM restaurada para $CURRENT"
+              exit 1
+            fi
+
+            az vm start -g "$AZURE_RG" -n "$AZURE_VM"
+          fi
+
+          # Aguarda SSH responder (runner systemd reconecta sozinho assim que sobe)
+          echo "Aguardando VM ficar reachable em SSH (porta 22)..."
+          for i in $(seq 1 30); do
+            if timeout 5 bash -c "</dev/tcp/${{ secrets.VM_HOST }}/22" 2>/dev/null; then
+              echo "VM reachable apos ${i} tentativas (~$((i*10))s)"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::warning::SSH nao respondeu em 5 minutos — runner pode demorar pra conectar"
+
+  # ─────────────────────────────────────────────────────────────────────
+  # DEPLOY: roda DENTRO da VM via self-hosted runner
+  # ─────────────────────────────────────────────────────────────────────
   deploy:
+    needs: preflight
     runs-on: [self-hosted, linux, azure]
     timeout-minutes: 7200  # GitHub self-hosted runner hard limit (5 days)
 
@@ -104,8 +212,10 @@ jobs:
             sudo -u postgres psql -c "ALTER USER govbr WITH PASSWORD '${{ secrets.DB_PASSWORD }}';"
             sudo -u postgres psql -d govbr -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
 
-            # Tuning for 16GB RAM
-            echo -e "shared_buffers = 4GB\neffective_cache_size = 12GB\nwork_mem = 512MB\nmaintenance_work_mem = 1GB\nmax_wal_size = 4GB\ncheckpoint_completion_target = 0.9\nrandom_page_cost = 1.1" | sudo tee /etc/postgresql/16/main/conf.d/tuning.conf > /dev/null
+            # Tuning inicial hardcoded (sera sobrescrito pelo step "Apply PostgreSQL auto-tuning"
+            # logo abaixo, que detecta a RAM real da VM). Mantido aqui apenas para que o postgres
+            # consiga subir pela primeira vez sem depender de ordem de execucao.
+            echo -e "shared_buffers = 2GB\neffective_cache_size = 6GB\nwork_mem = 64MB\nmaintenance_work_mem = 512MB\nmax_wal_size = 4GB\ncheckpoint_completion_target = 0.9\nrandom_page_cost = 1.1" | sudo tee /etc/postgresql/16/main/conf.d/tuning.conf > /dev/null
 
             sudo sed -i 's/local\s\+all\s\+all\s\+peer/local all all md5/' /etc/postgresql/16/main/pg_hba.conf
             sudo systemctl restart postgresql
@@ -147,6 +257,45 @@ jobs:
           pip install -e ".[web]" -q
 
           echo "=== Code deployed. Data dir: $DATA ==="
+
+      # ── Apply PostgreSQL auto-tuning based on detected RAM ──
+      # Idempotente: roda em todo deploy. Detecta RAM via /proc/meminfo e ajusta
+      # shared_buffers / effective_cache / work_mem / maintenance_work_mem.
+      # Tambem instala um systemd unit (pg-autotune.service) + drop-in que torna
+      # ele DEPENDENCIA HARD do postgres, garantindo re-tuning automatico apos
+      # resize de VM (preflight/postflight).
+      - name: Apply PostgreSQL auto-tuning
+        run: |
+          set -euo pipefail
+          cd ${{ env.PROJECT_DIR }}
+
+          sudo install -m 0755 deploy/pg-autotune.sh /usr/local/bin/pg-autotune.sh
+          sudo install -m 0644 deploy/pg-autotune.service /etc/systemd/system/pg-autotune.service
+
+          # Drop-in que faz postgresql@16-main.service depender de pg-autotune.service.
+          sudo mkdir -p /etc/systemd/system/postgresql@16-main.service.d
+          sudo install -m 0644 deploy/pg-autotune-pg-dropin.conf \
+            /etc/systemd/system/postgresql@16-main.service.d/99-autotune.conf
+
+          sudo systemctl daemon-reload
+          sudo systemctl enable pg-autotune.service
+
+          # Captura hash do tuning antes/depois para decidir se precisa restart.
+          # IMPORTANT: pg-autotune.sh nao escreve timestamp no arquivo, entao o
+          # hash so muda se a RAM detectada mudou (ex: apos resize de VM).
+          OLD_HASH=$(sudo md5sum /etc/postgresql/16/main/conf.d/tuning.conf 2>/dev/null | awk '{print $1}' || echo "none")
+          sudo /usr/local/bin/pg-autotune.sh
+          NEW_HASH=$(sudo md5sum /etc/postgresql/16/main/conf.d/tuning.conf | awk '{print $1}')
+
+          if [ "$OLD_HASH" != "$NEW_HASH" ]; then
+            echo "Tuning mudou ($OLD_HASH → $NEW_HASH), reiniciando postgres..."
+            sudo systemctl restart postgresql
+          else
+            echo "Tuning inalterado, no-op."
+          fi
+
+          # Mostra config atual para audit log
+          sudo cat /etc/postgresql/16/main/conf.d/tuning.conf
 
       # ── Verify disk space ──
       - name: Verify disk space
@@ -226,10 +375,17 @@ jobs:
           cd ${{ env.PROJECT_DIR }}
           source venv/bin/activate
           echo "=== Applying SQL changes (indices, normalization, views) ==="
-          echo "NOTA: etl.01_schema NÃO é executado aqui — ele faz DROP+CREATE e apagaria dados existentes"
-          python -m etl.10_indices 2>&1 || true
-          python -m etl.15_normalizar 2>&1 || true
-          python -m etl.21_views 2>&1 || true
+          echo "NOTA: etl.01_schema NAO eh executado aqui — ele faz DROP+CREATE e apagaria dados existentes"
+
+          # 10_indices: nao-idempotente (CREATE INDEX falha se ja existe). Soft-fail.
+          python -m etl.10_indices 2>&1 || echo "::warning::etl.10_indices falhou (provavelmente ja aplicado)"
+
+          # 15_normalizar: usa ADD COLUMN IF NOT EXISTS, idempotente. Soft-fail por seguranca.
+          python -m etl.15_normalizar 2>&1 || echo "::warning::etl.15_normalizar falhou (provavelmente ja aplicado)"
+
+          # 21_views: dropa+recria todas as MVs. SE ESSE FALHAR, queremos hard-fail
+          # para que o postflight NAO faca downsize da VM (deixa em 16GB para retomar).
+          python -m etl.21_views 2>&1
 
       # ── Specific phase ──
       - name: "ETL: Phase ${{ inputs.etl_phase }}"
@@ -246,7 +402,7 @@ jobs:
       - name: Run queries
         if: inputs.etl_phase != 'web'
         run: |
-          set -e
+          set -euo pipefail
           cd ${{ env.PROJECT_DIR }}
           source venv/bin/activate
           echo "=== Running all queries ==="
@@ -294,3 +450,71 @@ jobs:
           cd ${{ env.PROJECT_DIR }}
           source venv/bin/activate
           python3 -m etl.verify 2>/dev/null || echo "Verify script not available"
+
+  # ─────────────────────────────────────────────────────────────────────
+  # POSTFLIGHT: redimensiona a VM de volta para o tamanho web (B2as_v2)
+  # apos um deploy de ETL/SQL bem-sucedido. Mantem o estado "limpo" da VM
+  # otimizado para servir web (~$55/mes vs ~$108/mes do tamanho ETL).
+  #
+  # IMPORTANT: so roda quando deploy succeeded — se o ETL falhou no meio,
+  # mantemos a VM no tamanho grande para retomar sem outro resize.
+  # ─────────────────────────────────────────────────────────────────────
+  postflight:
+    needs: deploy
+    if: success() && inputs.etl_phase != 'web'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resize VM down to web-serving size
+        run: |
+          set -e
+          CURRENT=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query hardwareProfile.vmSize -o tsv)
+          TARGET="$VM_SIZE_WEB"
+
+          echo "Current size: $CURRENT"
+          echo "Target size:  $TARGET"
+
+          if [ "$CURRENT" = "$TARGET" ]; then
+            echo "VM ja esta no tamanho web. Nada a fazer."
+            exit 0
+          fi
+
+          # Valida disponibilidade antes de deallocate.
+          AVAILABLE=$(az vm list-vm-resize-options -g "$AZURE_RG" -n "$AZURE_VM" --query "[].name" -o tsv)
+          if ! echo "$AVAILABLE" | grep -qx "$TARGET"; then
+            echo "::error::Tamanho $TARGET indisponivel — abortando downsize, VM continua em $CURRENT"
+            exit 1
+          fi
+
+          echo "Downsize: $CURRENT → $TARGET"
+          az vm deallocate -g "$AZURE_RG" -n "$AZURE_VM"
+
+          if ! az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$TARGET"; then
+            echo "::warning::Resize falhou, restaurando para $CURRENT..."
+            az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$CURRENT" || true
+            az vm start -g "$AZURE_RG" -n "$AZURE_VM" || true
+            echo "::error::Downsize para $TARGET falhou — VM restaurada para $CURRENT"
+            exit 1
+          fi
+
+          az vm start -g "$AZURE_RG" -n "$AZURE_VM"
+
+          # Aguarda SSH responder antes de declarar sucesso.
+          echo "Aguardando VM ficar reachable em SSH apos downsize..."
+          for i in $(seq 1 30); do
+            if timeout 5 bash -c "</dev/tcp/${{ secrets.VM_HOST }}/22" 2>/dev/null; then
+              echo "VM reachable apos ${i} tentativas (~$((i*10))s)"
+              echo "Resize concluido. pg-autotune.service vai re-tunar postgres no boot."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::SSH nao respondeu em 5 minutos apos downsize — VM pode estar com problema"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -118,14 +118,49 @@ Todos os municipios da PB recebem perfil completo com insight cards, servidores 
 
 ### VM Azure (producao)
 
-| Componente | Especificacao | Custo |
-|---|---|---|
-| VM | Standard_B4as_v2 (4 vCPU, 16GB RAM) | ~US$110/mes |
-| Disco | 512GB Standard SSD (`/data`) | ~US$38/mes |
-| Regiao | North Central US | |
-| **Total** | | **~US$148/mes** |
+A VM **muda de tamanho automaticamente** dependendo do trabalho — `B2as_v2` (8GB) para servir web normalmente, `B4as_v2` (16GB) durante ETL/views pesados. Ver secao [Auto-resize de VM](#auto-resize-de-vm) abaixo.
+
+| Componente | Spec | Custo/mes (USD) | Custo/mes (BRL ~5.6) |
+|---|---|---|---|
+| **VM web** (`B2as_v2`, 2 vCPU, 8GB) | uso 100% do mes | ~$55 | ~R$ 308 |
+| **VM ETL** (`B4as_v2`, 4 vCPU, 16GB) | uso pontual (~$1.80/dia extra) | $54-108 (variavel) | R$ 300-600 |
+| Disco dados (`/data`) | 512GB Standard SSD | ~$38 | ~R$ 213 |
+| Disco OS | 32GB Standard SSD | ~$2.40 | ~R$ 13 |
+| IP publico estatico | Standard | ~$4 | ~R$ 22 |
+| Bandwidth | trafego web normal | ~$1 | ~R$ 6 |
+| **Total tipico (apenas web)** | | **~$100** | **~R$ 562** |
+| **Total com 1 ETL/mes** | | **~$115** | **~R$ 645** |
+
+> Cabe nos **$150/mes de credito Azure** (Visual Studio Enterprise) com folga de ~$35-50.
+> Regiao: **North Central US**. Resource group: `RG-GOVBR-NCUS`. VM: `vm-govbr`.
 
 O disco de 512GB armazena tanto o PostgreSQL (~248GB) quanto os dados brutos de download (~230GB no pico). Para caber no disco, o ETL **limpa automaticamente os CSVs brutos** apos cada fase completar com sucesso (`run_all.py`). Diretorios compartilhados entre fases (ex: `rfb/`, `tse/`) so sao removidos quando todas as fases dependentes completam.
+
+### Auto-resize de VM
+
+O workflow `deploy.yml` tem 3 jobs:
+
+```
+preflight (github-hosted, OIDC) → deploy (self-hosted na VM) → postflight (github-hosted, OIDC)
+```
+
+| etl_phase | Preflight: tamanho | Postflight: tamanho final |
+|---|---|---|
+| `web` | B2as_v2 (8GB) — sem mudanca se ja estiver | (nenhum) |
+| `all`, `sql`, `N` | B4as_v2 (16GB) — resize up se necessario | B2as_v2 (8GB) — resize down se deploy succeeded |
+
+**O que acontece:**
+1. **Preflight** redimensiona a VM para o tamanho adequado (`az vm deallocate → resize → start`).
+2. **Deploy** roda no self-hosted runner DENTRO da VM. O step `Apply PostgreSQL auto-tuning` detecta a RAM atual e ajusta `shared_buffers / effective_cache / work_mem / maintenance_work_mem` em `tuning.conf`. Reinicia o postgres se a config mudou.
+3. **Postflight** so roda em `etl_phase != web` E quando o deploy succeeded. Faz downsize de volta para o tamanho web. No proximo boot da VM, `pg-autotune.service` (systemd oneshot, `Before=postgresql.service`) re-tuna o postgres antes dele subir.
+
+**Quando o ETL falha no meio**, postflight nao roda — a VM fica em B4as_v2 (16GB) para voce poder retomar com `etl_phase=N` sem outro resize.
+
+**Tuning detectado automaticamente** (formulas Postgres-best-practices):
+- `shared_buffers` = 25% RAM
+- `effective_cache_size` = 75% RAM
+- `work_mem` = RAM / 128
+- `maintenance_work_mem` = 6% RAM (cap 1GB)
 
 ## Deploy (1 click)
 
@@ -137,11 +172,44 @@ O deploy roda via **GitHub Actions self-hosted runner** instalado na VM.
 2. **Fork** deste repositorio
 3. **Secrets obrigatorios** (Settings > Secrets > Actions):
    - `VM_HOST` — IP ou hostname da VM
-   - `VM_SSH_KEY` — chave SSH privada do usuario `govbr`
    - `DB_PASSWORD` — senha do PostgreSQL
    - `ENV_FILE` — conteudo do `.env` (ver `.env.example`)
-4. **Secret opcional**:
-   - `RUNNER_ADMIN_TOKEN` — PAT para instalar/reparar o self-hosted runner
+   - `AZURE_CLIENT_ID` — clientId do AD app para OIDC (auto-resize)
+   - `AZURE_TENANT_ID` — tenantId Azure
+   - `AZURE_SUBSCRIPTION_ID` — subscription com a VM
+4. **Secrets opcionais** (apenas para `setup-runner.yml`, nao usados no deploy):
+   - `VM_SSH_KEY` — chave SSH privada do usuario `govbr` (instalacao/reparo do runner)
+   - `RUNNER_ADMIN_TOKEN` — PAT para registrar/atualizar o self-hosted runner
+
+**Setup do OIDC para auto-resize** (1x, ~5min):
+
+```bash
+# Cria AD app + service principal + role no resource group + federated credential
+az ad app create --display-name govbr-deploy-github-oidc
+APP_ID=<appId-retornado>
+az ad sp create --id $APP_ID
+SP_ID=$(az ad sp show --id $APP_ID --query id -o tsv)
+az role assignment create \
+  --assignee-object-id $SP_ID \
+  --assignee-principal-type ServicePrincipal \
+  --role "Virtual Machine Contributor" \
+  --scope /subscriptions/<SUB_ID>/resourceGroups/<RG>
+
+# Federated credential trustando workflow_dispatch da branch main
+az ad app federated-credential create --id $APP_ID --parameters '{
+  "name": "github-deploy-main",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:<OWNER>/<REPO>:ref:refs/heads/main",
+  "audiences": ["api://AzureADTokenExchange"]
+}'
+
+# Adiciona secrets no GitHub
+gh secret set AZURE_CLIENT_ID --body "$APP_ID"
+gh secret set AZURE_TENANT_ID --body "$(az account show --query tenantId -o tsv)"
+gh secret set AZURE_SUBSCRIPTION_ID --body "<SUB_ID>"
+```
+
+O service principal so tem permissao de mexer em VMs/discos do resource group especifico — nao acessa outras subscriptions, billing, etc.
 
 ### Execucao
 
@@ -157,14 +225,14 @@ O workflow instala PostgreSQL 16, Python, Tor (fallback para downloads bloqueado
 
 ### Opcoes do deploy
 
-| Parametro | Descricao |
-|---|---|
-| `etl_phase=all` | ETL completo (download + carga + indices + views) |
-| `etl_phase=sql` | Apenas indices, normalizacao e views (sem schema destrutivo) |
-| `etl_phase=web` | Sync de codigo apenas (git pull + reinicia web services) |
-| `etl_phase=N` | Retomar a partir da fase N (ex: `19` para TCE-PB) |
-| `skip_download=true` | Pular downloads, usar dados ja existentes na VM |
-| `clean=true` | Limpar estado anterior (apaga tabelas, re-ETL do zero) |
+| Parametro | Descricao | Tamanho VM |
+|---|---|---|
+| `etl_phase=all` | ETL completo (download + carga + indices + views) | B4as_v2 (16GB) |
+| `etl_phase=sql` | Apenas indices, normalizacao e views (sem schema destrutivo) | B4as_v2 (16GB) |
+| `etl_phase=web` | Sync de codigo apenas (git pull + reinicia web services) | B2as_v2 (8GB) |
+| `etl_phase=N` | Retomar a partir da fase N (ex: `19` para TCE-PB) | B4as_v2 (16GB) |
+| `skip_download=true` | Pular downloads, usar dados ja existentes na VM | (sem mudanca) |
+| `clean=true` | Limpar estado anterior (apaga tabelas, re-ETL do zero) | (sem mudanca) |
 
 ### Uso local
 

--- a/TODO.md
+++ b/TODO.md
@@ -136,12 +136,16 @@
 - 115+ queries em queries/*.sql, 26 relatorios validos em relatorios/
 
 ### VM Azure
-- **Standard_B4as_v2** (4 vCPU, 16GB RAM) — North Central US
+- **B2as_v2** (2 vCPU, 8GB RAM, ~$55/mes) — uso normal (servir web)
+- **B4as_v2** (4 vCPU, 16GB RAM, ~$108/mes) — durante ETL/views (auto-resize via deploy.yml)
 - Disco: 512GB Standard SSD em /data (PostgreSQL 248GB + dados brutos ~105GB apos limpeza)
-- Budget: ~US$150/mes
-- SSH: `ssh -i /tmp/azure_vm_key govbr@52.162.207.186`
-- Workflows: `deploy.yml` (ETL + web services), `setup-runner.yml` (runner 1x)
-- Secrets: `VM_HOST`, `VM_SSH_KEY`, `DB_PASSWORD`, `ENV_FILE`, `RUNNER_ADMIN_TOKEN`
+- IP estatico: 52.162.207.186 (~$4/mes)
+- Budget: ~US$150/mes (creditos Visual Studio Enterprise)
+- **Custo tipico:** ~$100/mes so web, ~$115/mes com 1 ETL completo
+- Resource group: `RG-GOVBR-NCUS`. VM name: `vm-govbr`. Subscription: `90676d79-a73b-462d-bdd6-2b4c738237f5`
+- SSH: `ssh -i C:\Users\lucas\.ssh\azure_vm.txt govbr@52.162.207.186` (read-only debug)
+- Workflows: `deploy.yml` (preflight resize → ETL → postflight resize), `setup-runner.yml` (runner 1x)
+- Secrets: `VM_HOST`, `VM_SSH_KEY`, `DB_PASSWORD`, `ENV_FILE`, `RUNNER_ADMIN_TOKEN`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
 
 ### Frontend web
 - **Stack**: FastAPI + Jinja2 + vanilla JS, PostgreSQL

--- a/deploy/pg-autotune-pg-dropin.conf
+++ b/deploy/pg-autotune-pg-dropin.conf
@@ -1,0 +1,8 @@
+[Unit]
+# Faz pg-autotune.service uma DEPENDENCIA HARD do postgres no boot.
+# Sem isso, Before=/After= sao apenas ordenacao, e o postgres pode subir
+# se pg-autotune.service falhar ou nao estiver enabled. Com Requires=,
+# o postgres tambem falha se a tuning nao for aplicada — comportamento
+# desejado apos resize automatico de VM (preflight/postflight).
+Requires=pg-autotune.service
+After=pg-autotune.service

--- a/deploy/pg-autotune.service
+++ b/deploy/pg-autotune.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=PostgreSQL auto-tune based on detected RAM
+Documentation=file:///home/govbr/govbr-project/deploy/pg-autotune.sh
+# Roda no boot antes do postgres. A garantia de que o postgres NAO vai subir
+# antes desse servico nao depende deste Before= — depende do drop-in
+# 99-autotune.conf (em postgresql@16-main.service.d/) que adiciona
+# Requires=pg-autotune.service. Esse drop-in eh instalado pelo step
+# "Apply PostgreSQL auto-tuning" do deploy.yml.
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/pg-autotune.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/pg-autotune.sh
+++ b/deploy/pg-autotune.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# pg-autotune: ajusta o tuning do PostgreSQL automaticamente com base na RAM detectada.
+#
+# Roda em duas situacoes:
+#   1. Sob demanda durante deploys (chamado pelo workflow apos resize de VM).
+#   2. No boot do sistema, via pg-autotune.service (Before=postgresql.service)
+#      garantindo que o postgres sobe ja com a config correta apos resize.
+#
+# Formulas conservadoras (Postgres best-practices):
+#   shared_buffers       = 25% RAM
+#   effective_cache_size = 75% RAM
+#   work_mem             = RAM / 128 (cap min 8MB)
+#   maintenance_work_mem = 6% RAM (cap min 64MB, max 1GB)
+#
+# Settings fixos que nao dependem de RAM ficam no final.
+
+set -euo pipefail
+
+TOTAL_KB=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
+TOTAL_MB=$(( TOTAL_KB / 1024 ))
+
+# Defensivo: se deteccao falhou por algum motivo, assume 8GB.
+if [ "$TOTAL_MB" -lt 1024 ]; then
+    echo "pg-autotune: WARNING memoria detectada=${TOTAL_MB}MB, usando fallback 8192MB"
+    TOTAL_MB=8192
+fi
+
+SHARED_BUFFERS_MB=$(( TOTAL_MB / 4 ))
+EFFECTIVE_CACHE_MB=$(( TOTAL_MB * 3 / 4 ))
+
+WORK_MEM_MB=$(( TOTAL_MB / 128 ))
+[ "$WORK_MEM_MB" -lt 8 ] && WORK_MEM_MB=8
+
+MAINT_MB=$(( TOTAL_MB * 6 / 100 ))
+[ "$MAINT_MB" -gt 1024 ] && MAINT_MB=1024
+[ "$MAINT_MB" -lt 64 ] && MAINT_MB=64
+
+CONF_DIR=/etc/postgresql/16/main/conf.d
+TARGET="$CONF_DIR/tuning.conf"
+
+mkdir -p "$CONF_DIR"
+
+cat > "$TARGET" <<EOF
+# Auto-gerado por pg-autotune.sh com base na RAM detectada (${TOTAL_MB}MB)
+shared_buffers = ${SHARED_BUFFERS_MB}MB
+effective_cache_size = ${EFFECTIVE_CACHE_MB}MB
+work_mem = ${WORK_MEM_MB}MB
+maintenance_work_mem = ${MAINT_MB}MB
+max_wal_size = 4GB
+checkpoint_completion_target = 0.9
+random_page_cost = 1.1
+EOF
+
+echo "pg-autotune: tuning aplicado para ${TOTAL_MB}MB de RAM"
+echo "  shared_buffers=${SHARED_BUFFERS_MB}MB effective_cache_size=${EFFECTIVE_CACHE_MB}MB"
+echo "  work_mem=${WORK_MEM_MB}MB maintenance_work_mem=${MAINT_MB}MB"


### PR DESCRIPTION
## Resumo

Workflow `deploy.yml` agora redimensiona a VM automaticamente conforme a fase do ETL:
- `etl_phase=web` → VM em `B2as_v2` (8GB, ~$55/mes) — uso normal
- `etl_phase=all|sql|N` → resize up para `B4as_v2` (16GB, ~$108/mes), faz o ETL, depois resize down

Cabe nos **$150/mes de credito** Azure (Visual Studio Enterprise).

## Arquitetura (3 jobs)

1. **preflight** (github-hosted, OIDC): decide tamanho alvo, valida SKU disponivel, deallocate → resize → start. Rollback automatico se resize falhar.
2. **deploy** (self-hosted na VM): fluxo original + novo step `Apply PostgreSQL auto-tuning` que detecta RAM e ajusta tuning.conf.
3. **postflight** (github-hosted, OIDC): downsize para `B2as_v2` apenas quando `etl_phase != web` E `deploy.result == success`. Se ETL falhar, VM fica em 16GB para retomar.

## pg-autotune

- `deploy/pg-autotune.sh`: detecta RAM via `/proc/meminfo` e ajusta:
  - `shared_buffers` = 25% RAM
  - `effective_cache_size` = 75% RAM
  - `work_mem` = RAM/128
  - `maintenance_work_mem` = 6% RAM (cap 1GB)
- `deploy/pg-autotune.service`: systemd oneshot.
- `deploy/pg-autotune-pg-dropin.conf`: drop-in para `postgresql@16-main.service` com `Requires=pg-autotune.service` — torna pg-autotune dependencia HARD, garante postgres nunca sobe com tuning errado apos resize.

## Hardening (post-rubber-duck)

- `concurrency: deploy-vm-govbr` (cancel-in-progress: false) — bloqueia 2 runs na mesma VM.
- `21_views` removido o `|| true`: hard-fail propaga, postflight skipa downsize.
- `Run queries` com `set -o pipefail` (evita `tail` mascarar falhas).
- Resize tem rollback (restore para tamanho original se falhar) e valida SKU disponivel ANTES de deallocate.
- pg-autotune.sh nao escreve timestamp (hash determinstico, restart so quando RAM muda).
- `.gitattributes` forca LF em `*.sh`/`*.service`/`*.conf` (evita CRLF Windows quebrar bash na VM Linux).

## OIDC ja configurado

- AD app: `govbr-deploy-github-oidc` (clientId `651fcd04-29f4-4cab-9264-14c9b766c4ae`)
- SP role: `Virtual Machine Contributor` scope `/subscriptions/.../resourceGroups/RG-GOVBR-NCUS`
- Federated cred: `repo:lucasdiniz/govbr-cruza-dados:ref:refs/heads/main`
- Secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`

## Apos merge

Disparar deploy com `etl_phase=sql` para retomar o run #60 (que falhou em `21_views` step 70/82 quando os creditos expiraram).
