### PR TITLE
deploy: warm_cache via systemd oneshot + opt-in queries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,16 @@ on:
         required: false
         type: boolean
         default: false
+      warm_cache:
+        description: 'Roda warm_cache (1 ciclo, ~20h em B4). AUTO apos etl_phase!=web. Para etl_phase=web use este input. Forca preflight=B4 + downsize no fim.'
+        required: false
+        type: boolean
+        default: false
+      run_queries:
+        description: 'Roda etl.run_queries (analises de fraude, ~30min). Default false — relatorios/ podem ser regerados localmente.'
+        required: false
+        type: boolean
+        default: false
 
 # OIDC federado pro Azure (sem secrets de SP, sem expiracao).
 permissions:
@@ -73,12 +83,16 @@ jobs:
       - name: Decide target VM size
         id: decide
         run: |
-          if [ "${{ inputs.etl_phase }}" = "web" ]; then
+          # Resize UP para B4 (16GB) sempre que houver trabalho pesado:
+          #   - qualquer etl_phase != web (ETL/SQL/N usam mais RAM e CPU)
+          #   - warm_cache=true (1 ciclo de warm leva ~20h, beneficia muito de B4)
+          # Caso contrario (etl_phase=web sem warm), mantem B2 (8GB) para economizar.
+          if [ "${{ inputs.etl_phase }}" = "web" ] && [ "${{ inputs.warm_cache }}" != "true" ]; then
             echo "target_size=${{ env.VM_SIZE_WEB }}" >> "$GITHUB_OUTPUT"
-            echo "etl_phase=web → target=${{ env.VM_SIZE_WEB }} (8GB)"
+            echo "etl_phase=web warm_cache=false → target=${{ env.VM_SIZE_WEB }} (8GB, code sync)"
           else
             echo "target_size=${{ env.VM_SIZE_ETL }}" >> "$GITHUB_OUTPUT"
-            echo "etl_phase=${{ inputs.etl_phase }} → target=${{ env.VM_SIZE_ETL }} (16GB)"
+            echo "trabalho pesado (etl_phase=${{ inputs.etl_phase }} warm_cache=${{ inputs.warm_cache }}) → target=${{ env.VM_SIZE_ETL }} (16GB)"
           fi
 
       - name: Azure login (OIDC)
@@ -152,6 +166,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # ── Stop legacy warm-cache daemon FIRST ──
+      # Antes de qualquer trabalho pesado (ETL, migracoes), garantimos que o
+      # antigo daemon `cruza-warm-cache --loop` (Type=simple) NAO esteja rodando
+      # e disputando I/O. Roda incondicionalmente para tornar a transicao para
+      # oneshot idempotente: a falha do is-active eh tratada via `|| true`.
+      - name: Stop legacy warm-cache daemon
+        run: |
+          set +e
+          if systemctl is-active --quiet cruza-warm-cache; then
+            echo "Parando cruza-warm-cache antigo..."
+            sudo systemctl stop cruza-warm-cache
+          fi
+          if systemctl is-enabled --quiet cruza-warm-cache; then
+            echo "Desabilitando cruza-warm-cache antigo..."
+            sudo systemctl disable cruza-warm-cache
+          fi
+          # Mata qualquer processo orfao rodando warm_cache --loop diretamente.
+          sudo pkill -f 'warm_cache.*--loop' 2>/dev/null || true
+          exit 0
 
       # ── Clean previous failed state (manual trigger only) ──
       - name: Clean previous state
@@ -398,9 +432,9 @@ jobs:
           echo "=== ETL from phase ${{ inputs.etl_phase }} ==="
           python -m etl.run_all "${{ inputs.etl_phase }}" 2>&1
 
-      # ── Run fraud queries ──
+      # ── Run fraud queries (opt-in, demora ~30min) ──
       - name: Run queries
-        if: inputs.etl_phase != 'web'
+        if: inputs.run_queries == true && inputs.etl_phase != 'web'
         run: |
           set -euo pipefail
           cd ${{ env.PROJECT_DIR }}
@@ -427,20 +461,60 @@ jobs:
           sudo nginx -t && sudo systemctl reload nginx
           sudo systemctl enable nginx
 
-          # Install systemd services
+          # Install systemd services. cruza-warm-cache eh oneshot (sem [Install]):
+          # apenas o arquivo eh copiado, sem enable/start. Disparado pelo step
+          # "Warm cache" abaixo via systemctl start (que respeita o EnvironmentFile
+          # e User=govbr da unidade).
           sudo cp deploy/cruza-web.service /etc/systemd/system/
           sudo cp deploy/cruza-warm-cache.service /etc/systemd/system/
           sudo systemctl daemon-reload
-          sudo systemctl enable cruza-web cruza-warm-cache
+          sudo systemctl enable cruza-web
 
-          # Restart services to pick up new code
+          # Restart cruza-web to pick up new code.
           sudo systemctl restart cruza-web
-          sudo systemctl restart cruza-warm-cache
 
           echo "=== Web services deployed ==="
           systemctl is-active nginx && echo "nginx: RUNNING" || echo "nginx: FAILED"
           systemctl is-active cruza-web && echo "cruza-web: RUNNING" || echo "cruza-web: FAILED"
-          systemctl is-active cruza-warm-cache && echo "cruza-warm-cache: RUNNING" || echo "cruza-warm-cache: FAILED"
+          echo "cruza-warm-cache: oneshot instalado (executado sob demanda)"
+
+      # ── Warm cache (oneshot, ~20h em B4) ──
+      # Auto: roda apos etl_phase=all ou sql (dados mudaram, queries mudaram).
+      # Manual: roda em qualquer etl_phase quando warm_cache=true (incluindo
+      # phase=N e phase=web).
+      # Para etl_phase=N evitamos rodar automaticamente — rerodar uma fase
+      # pontual nao necessariamente justifica 20h de warm. Usuario opta-in
+      # explicitamente via warm_cache=true.
+      #
+      # continue-on-error: deixa postflight rodar mesmo se warm falhou
+      # parcialmente (warm_cache.py exit 1 quando >5% das queries falham).
+      # Postflight ainda executa downsize, evitando deixar VM em B4 ($108/mes)
+      # quando ETL succeeded mas warm teve issues. Falhas sao visiveis via
+      # job result no GitHub UI.
+      - name: Warm cache
+        if: |
+          inputs.warm_cache == true ||
+          inputs.etl_phase == 'all' ||
+          inputs.etl_phase == 'sql'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          echo "=== Warming web_cache table (esperado ~20h em B4as_v2 16GB) ==="
+          echo "Inicio: $(date -Iseconds)"
+          # systemctl start --wait com Type=oneshot bloqueia ate o ExecStart
+          # terminar e propaga exit code do processo. Usa EnvironmentFile,
+          # User=govbr, journal logging — tudo da unidade.
+          sudo systemctl start --wait cruza-warm-cache
+          STATUS=$?
+          echo "Fim:    $(date -Iseconds)"
+          sudo systemctl status cruza-warm-cache --no-pager --lines=20 || true
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::warning::cruza-warm-cache encerrou com falha (>5% queries falharam)"
+            # Re-emite o exit code para o GitHub Actions marcar o step como failed,
+            # mas continue-on-error garante que postflight ainda roda.
+            exit "$STATUS"
+          fi
+          echo "=== Cache warming complete ==="
 
       # ── Verify ──
       - name: Verify database
@@ -453,15 +527,24 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────
   # POSTFLIGHT: redimensiona a VM de volta para o tamanho web (B2as_v2)
-  # apos um deploy de ETL/SQL bem-sucedido. Mantem o estado "limpo" da VM
+  # sempre que a preflight fez upsize. Mantem o estado "limpo" da VM
   # otimizado para servir web (~$55/mes vs ~$108/mes do tamanho ETL).
   #
-  # IMPORTANT: so roda quando deploy succeeded — se o ETL falhou no meio,
-  # mantemos a VM no tamanho grande para retomar sem outro resize.
+  # Roda mesmo se o "Warm cache" falhou parcialmente (continue-on-error
+  # no step do warm garante que o deploy job sai com sucesso). A condicao
+  # `always() + needs.deploy.result != cancelled/skipped` evita o caso onde
+  # ETL falhou de verdade no meio (a VM fica em B4 para o usuario retomar
+  # com etl_phase=N sem mais um resize).
+  #
+  # A condicao deve ESPELHAR a logica do preflight "Decide target VM size":
+  # se preflight fez upsize, postflight tenta downsize.
   # ─────────────────────────────────────────────────────────────────────
   postflight:
     needs: deploy
-    if: success() && inputs.etl_phase != 'web'
+    if: |
+      always() &&
+      needs.deploy.result == 'success' &&
+      (inputs.etl_phase != 'web' || inputs.warm_cache == true)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/README.md
+++ b/README.md
@@ -144,23 +144,42 @@ O workflow `deploy.yml` tem 3 jobs:
 preflight (github-hosted, OIDC) → deploy (self-hosted na VM) → postflight (github-hosted, OIDC)
 ```
 
-| etl_phase | Preflight: tamanho | Postflight: tamanho final |
-|---|---|---|
-| `web` | B2as_v2 (8GB) — sem mudanca se ja estiver | (nenhum) |
-| `all`, `sql`, `N` | B4as_v2 (16GB) — resize up se necessario | B2as_v2 (8GB) — resize down se deploy succeeded |
+| Cenario | Preflight | Steps no deploy | Postflight |
+|---|---|---|---|
+| `etl_phase=web` (default) | B2as_v2 (8GB) | sync code, restart cruza-web | (nenhum) |
+| `etl_phase=web warm_cache=true` | B4as_v2 (16GB) | sync + warm_cache (~20h) | downsize → B2as_v2 |
+| `etl_phase=all` | B4as_v2 (16GB) | ETL completo + warm_cache (auto) | downsize → B2as_v2 |
+| `etl_phase=sql` | B4as_v2 (16GB) | indices/normalizar/views + warm_cache (auto) | downsize → B2as_v2 |
+| `etl_phase=N` | B4as_v2 (16GB) | ETL phase N (warm NAO eh auto, use warm_cache=true) | downsize → B2as_v2 |
+| `etl_phase=N run_queries=true warm_cache=true` | B4as_v2 (16GB) | ETL + queries + warm_cache | downsize → B2as_v2 |
 
 **O que acontece:**
-1. **Preflight** redimensiona a VM para o tamanho adequado (`az vm deallocate → resize → start`).
-2. **Deploy** roda no self-hosted runner DENTRO da VM. O step `Apply PostgreSQL auto-tuning` detecta a RAM atual e ajusta `shared_buffers / effective_cache / work_mem / maintenance_work_mem` em `tuning.conf`. Reinicia o postgres se a config mudou.
-3. **Postflight** so roda em `etl_phase != web` E quando o deploy succeeded. Faz downsize de volta para o tamanho web. No proximo boot da VM, `pg-autotune.service` (systemd oneshot, `Before=postgresql.service`) re-tuna o postgres antes dele subir.
+1. **Preflight** redimensiona a VM (`az vm deallocate → resize → start`). Valida disponibilidade do SKU antes e faz rollback se resize falhar.
+2. **Deploy** roda no self-hosted runner DENTRO da VM. O step `Apply PostgreSQL auto-tuning` detecta a RAM atual e ajusta `shared_buffers / effective_cache / work_mem / maintenance_work_mem`. Os steps de ETL/queries/warm sao opt-in conforme inputs.
+3. **Postflight** so roda quando preflight fez upsize E deploy succeeded. Faz downsize de volta para `B2as_v2`. No proximo boot da VM, `pg-autotune.service` re-tuna o postgres antes dele subir.
 
-**Quando o ETL falha no meio**, postflight nao roda — a VM fica em B4as_v2 (16GB) para voce poder retomar com `etl_phase=N` sem outro resize.
+**Quando o deploy falha no meio**, postflight nao roda — a VM fica em B4as_v2 (16GB) para voce retomar com `etl_phase=N` sem outro resize.
 
 **Tuning detectado automaticamente** (formulas Postgres-best-practices):
 - `shared_buffers` = 25% RAM
 - `effective_cache_size` = 75% RAM
 - `work_mem` = RAM / 128
 - `maintenance_work_mem` = 6% RAM (cap 1GB)
+
+### Cache warming (web_cache table)
+
+A tabela `web_cache` armazena resultados pre-computados das queries do frontend (FastAPI le diretamente dela em vez de rodar SQL pesado em request time). Os dados das tabelas mudam APENAS quando o ETL roda, entao o warm-cache foi simplificado:
+
+- `cruza-warm-cache.service` eh `Type=oneshot` e **NAO** tem `[Install]` section (nao auto-inicia no boot).
+- Roda 1 ciclo completo (`python -m web.warm_cache --daemon` sem `--loop`) e termina.
+- Workflow dispara via `sudo systemctl start --wait cruza-warm-cache` — bloqueia ate completar e propaga exit code.
+- Auto-disparado apos `etl_phase=all` ou `etl_phase=sql` (dados/queries mudaram).
+- Para `etl_phase=N` ou `etl_phase=web`: opt-in via input `warm_cache=true`.
+- Disparo manual na VM: `sudo systemctl start cruza-warm-cache`.
+
+O processo retorna exit 1 quando >5% das queries falham, sinalizando warm parcial. O deploy job marca o step como failed mas o `continue-on-error` garante que o postflight ainda faz downsize da VM (evita deixar B4 ligada por engano). Logs ficam disponiveis via `journalctl -u cruza-warm-cache`.
+
+Tempo esperado: **~20h em B4as_v2 (16GB)** por ciclo completo de 224 municipios PB.
 
 ## Deploy (1 click)
 
@@ -225,14 +244,22 @@ O workflow instala PostgreSQL 16, Python, Tor (fallback para downloads bloqueado
 
 ### Opcoes do deploy
 
-| Parametro | Descricao | Tamanho VM |
-|---|---|---|
-| `etl_phase=all` | ETL completo (download + carga + indices + views) | B4as_v2 (16GB) |
-| `etl_phase=sql` | Apenas indices, normalizacao e views (sem schema destrutivo) | B4as_v2 (16GB) |
-| `etl_phase=web` | Sync de codigo apenas (git pull + reinicia web services) | B2as_v2 (8GB) |
-| `etl_phase=N` | Retomar a partir da fase N (ex: `19` para TCE-PB) | B4as_v2 (16GB) |
-| `skip_download=true` | Pular downloads, usar dados ja existentes na VM | (sem mudanca) |
-| `clean=true` | Limpar estado anterior (apaga tabelas, re-ETL do zero) | (sem mudanca) |
+| Input | Descricao | Default | VM size |
+|---|---|---|---|
+| `etl_phase=all` | ETL completo (download + carga + indices + views) + warm_cache auto | — | B4as_v2 (16GB) |
+| `etl_phase=sql` | Apenas indices, normalizacao e views + warm_cache auto | — | B4as_v2 (16GB) |
+| `etl_phase=web` | Sync de codigo + restart web services | — | B2as_v2 (8GB) |
+| `etl_phase=N` | Retomar a partir da fase N (ex: `19` para TCE-PB). Warm NAO auto. | — | B4as_v2 (16GB) |
+| `warm_cache=true` | Forca warm_cache em qualquer etl_phase (~20h em B4) | `false` | B4as_v2 (16GB) |
+| `run_queries=true` | Roda etl.run_queries (~30min) apos ETL — analises de fraude | `false` | (sem mudanca) |
+| `skip_download=true` | Pular downloads, usar dados ja existentes na VM | `false` | (sem mudanca) |
+| `clean=true` | Limpar estado anterior (apaga tabelas, re-ETL do zero) | `false` | (sem mudanca) |
+
+**Cenarios tipicos:**
+- `etl_phase=web` (sozinho): rapido (~5min), sem warm_cache. Use para deploy de mudancas frontend que nao afetam queries.
+- `etl_phase=web warm_cache=true`: deploy + re-warming (~20h em B4). Use apos mudancas em `web/queries/registry.py`.
+- `etl_phase=all`: ETL completo + warm_cache automatico. Use para reload completo dos dados.
+- `etl_phase=19`: retoma fase 19 sem warm. Adicione `warm_cache=true` se a fase reabastecer dados que afetam o cache.
 
 ### Uso local
 

--- a/deploy/cruza-warm-cache.service
+++ b/deploy/cruza-warm-cache.service
@@ -1,16 +1,25 @@
 [Unit]
-Description=Cruza Dados - Cache Warmer
+Description=Cruza Dados - Cache Warmer (oneshot, executado sob demanda)
 After=postgresql.service network.target
 Wants=postgresql.service
 
 [Service]
-Type=simple
+# Type=oneshot: o systemctl start bloqueia ate o processo terminar e a unidade
+# vai para "inactive (dead)" apos sucesso. Permite rodar como step de deploy
+# que precisa esperar a conclusao antes de prosseguir (postflight resize down).
+Type=oneshot
 User=govbr
 WorkingDirectory=/home/govbr/govbr-project
 EnvironmentFile=/home/govbr/govbr-project/.env
-ExecStart=/home/govbr/govbr-project/venv/bin/python -u -m web.warm_cache --daemon --loop
-Restart=always
-RestartSec=30
+# --daemon (sem --loop) roda 1 ciclo completo e termina. Atualizar todos os
+# municipios PB pode demorar varias horas; sem timeout aqui.
+ExecStart=/home/govbr/govbr-project/venv/bin/python -u -m web.warm_cache --daemon
+TimeoutStartSec=0
+StandardOutput=journal
+StandardError=journal
 
-[Install]
-WantedBy=multi-user.target
+# SEM secao [Install]: a unidade NAO eh auto-iniciada no boot. Eh disparada
+# apenas explicitamente pelo deploy.yml ou por sysadmin via:
+#   sudo systemctl start cruza-warm-cache
+# Os dados das tabelas mudam apenas quando o ETL roda, entao warm-cache eh
+# uma operacao pos-ETL, nao um daemon continuo.

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -8,9 +8,17 @@ cp deploy/cruza-web.service /etc/systemd/system/
 cp deploy/cruza-warm-cache.service /etc/systemd/system/
 
 systemctl daemon-reload
-systemctl enable cruza-web cruza-warm-cache
-systemctl start cruza-web cruza-warm-cache
 
-echo "Services instalados e iniciados:"
+# cruza-web roda como daemon continuo (Type=simple). Habilita e inicia.
+systemctl enable cruza-web
+systemctl start cruza-web
+
+# cruza-warm-cache eh oneshot (NAO tem [Install] section). Nao auto-inicia
+# nem eh enabled. Disparado on-demand via:
+#   sudo systemctl start cruza-warm-cache
+# Tipicamente eh disparado pelo workflow deploy.yml apos ETL.
+
+echo "Services instalados:"
 systemctl status cruza-web --no-pager -l
-systemctl status cruza-warm-cache --no-pager -l
+echo ""
+echo "cruza-warm-cache: instalado mas NAO iniciado (oneshot, on-demand)."

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -446,21 +446,42 @@ def main():
     if args.daemon:
         print(f"Daemon mode: {len(municipios_pb)} PB municipios.")
         cycle = 0
+        last_fail_pct = 0.0
         while True:
             cycle += 1
             t0 = time.time()
             ok, fail = run_one_cycle(cycle)
             elapsed = time.time() - t0
-            print(f"=== Ciclo {cycle} completo: {ok} ok, {fail} fail ({elapsed/60:.1f}min) ===")
+            total = ok + fail
+            last_fail_pct = (fail / total * 100) if total > 0 else 0.0
+            print(
+                f"=== Ciclo {cycle} completo: {ok} ok, {fail} fail "
+                f"({last_fail_pct:.1f}%, {elapsed/60:.1f}min) ==="
+            )
             if not args.loop:
                 print("Ciclo unico finalizado (use --loop para repetir).")
                 break
             print(f"Proximo ciclo em {PAUSE_BETWEEN_CYCLES}s...")
             time.sleep(PAUSE_BETWEEN_CYCLES)
+
+        # Falha o processo se taxa de falha >5% em ciclo unico (--daemon sem --loop).
+        # Isso permite ao deploy.yml detectar warm parcial e nao mascarar como sucesso.
+        # Em modo --loop nao falhamos: o intuito eh continuar tentando.
+        if not args.loop and last_fail_pct > 5.0:
+            print(
+                f"ERRO: taxa de falha {last_fail_pct:.1f}% > 5% — exit 1",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     else:
         print(f"Processando {len(municipios_pb)} PB municipios...")
         ok, fail = run_one_cycle()
-        print(f"Completo: {ok} ok, {fail} fail")
+        total = ok + fail
+        fail_pct = (fail / total * 100) if total > 0 else 0.0
+        print(f"Completo: {ok} ok, {fail} fail ({fail_pct:.1f}%)")
+        if fail_pct > 5.0:
+            print(f"ERRO: taxa de falha {fail_pct:.1f}% > 5% — exit 1", file=sys.stderr)
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Resumo

Refatora warm_cache de daemon contínuo (`Type=simple --loop`) para `Type=oneshot` disparado pelo deploy. Resolve a contenção de I/O que causava timeouts em Q67 dated no B2as_v2.

## Por que

O daemon antigo rodava 24/7 e disputava I/O com o site (e com o próprio ETL durante deploys). No B2as_v2 (8GB, Standard SSD = 500 IOPS) isso era inviável — Q67 dated timeout em 90s.

Como os dados das tabelas mudam **apenas quando o ETL roda**, warm-cache contínuo é desnecessário. Bastam disparos pós-ETL.

## Mudanças

### `cruza-warm-cache.service` → oneshot
- Sem `[Install]` section: não auto-inicia no boot.
- Roda 1 ciclo (`--daemon` sem `--loop`) e termina.
- `TimeoutStartSec=0`: aceita as ~20h de execução.

### `deploy.yml`
1. **Novo step "Stop legacy warm-cache daemon" como PRIMEIRO do deploy job.** Para o daemon antigo *antes* do ETL, evitando contenção durante toda a pipeline.
2. **Novo step "Warm cache"** dispara via `sudo systemctl start --wait cruza-warm-cache` em vez de python direto. Ganha `EnvironmentFile`, `User=govbr`, journal logging.
3. **`continue-on-error: true` no warm + postflight com `always()`** — garante downsize da VM mesmo em warm parcial. Evita deixar VM em B4 ($108/mês) por bug no warm.
4. **Auto-warm SÓ em `etl_phase=all|sql`.** Para `etl_phase=N` o usuário opta-in via `warm_cache=true` — evita 20h surpresa em rerun de fase pontual.
5. **Novo input `run_queries`** (default `false`): `etl.run_queries` (~30min) agora é opt-in.

### `web/warm_cache.py`
- `main()` retorna `sys.exit(1)` quando >5% das queries falham. Permite ao deploy detectar warm parcial e marcar como failed (visível no GitHub UI), em vez de mascarar como sucesso.

### `deploy/setup.sh`
- Removido `enable/start` de `cruza-warm-cache` (sem `[Install]` faria warn).

## Origem dos fixes

Dois rubber-duck reviews em paralelo (Opus 4.7 + GPT-5.5) — convergiram em:
- exit code do warm não refletindo falhas (mascarava success)
- migration order (daemon antigo continuava rodando durante ETL)
- dead systemd unit (workflow rodava python direto)
- postflight gating muito coarse (warm fail = VM grande indefinidamente)
- auto-warm em `etl_phase=N` é cirurgicamente errado

## Verificações

- ✅ YAML válido
- ✅ Python AST válido (`web/warm_cache.py`)
- ✅ `etl/config.py:8` faz `load_dotenv()` (env vars carregam corretas no step)
- ✅ Arquivos com LF (não CRLF Windows)

## Cenários após merge

| Trigger | Auto-warm? |
|---|---|
| `etl_phase=all` | ✅ |
| `etl_phase=sql` | ✅ |
| `etl_phase=N` (resume) | ❌ (opt-in) |
| `etl_phase=web` | ❌ (opt-in) |
| Manual: `sudo systemctl start cruza-warm-cache` na VM | ✅ |

## Out of scope (follow-up)

- Cache generation/staging promotion (refactor maior em `web_cache` table)
- Connection cleanup nos workers do ThreadPoolExecutor
- Log truncation handling (4MB soft limit do GitHub Actions)
