### PR TITLE
deploy: dynamic disk SKU swap (Standard<->Premium) + ReadOnly caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,16 @@ env:
   # B4as_v2: 4 vCPU, 16GB ~$108/mes — necessario para ETL/views pesados
   VM_SIZE_WEB: Standard_B2as_v2
   VM_SIZE_ETL: Standard_B4as_v2
+  # Disco de dados (PostgreSQL ~248GB).
+  # Standard SSD E20: ~$38/mes, 500 IOPS, 100 MB/s — ok para servir web.
+  # Premium SSD P20:  ~$73/mes, 2300 IOPS, 150 MB/s + ReadOnly host caching
+  # (~4GB RAM da host como cache) — necessario para ETL/warm pesados.
+  # Como o disco eh cobrado POR HORA, swappar StandardSSD<->Premium nas
+  # transicoes de tamanho da VM custa ~$0.05/h extra durante operacoes
+  # pesadas, em vez de $35/mes always-on.
+  DATA_DISK: disk-govbr-data
+  DISK_SKU_LIGHT: StandardSSD_LRS
+  DISK_SKU_HEAVY: Premium_LRS
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────
@@ -79,20 +89,24 @@ jobs:
     timeout-minutes: 15
     outputs:
       target_size: ${{ steps.decide.outputs.target_size }}
+      target_disk_sku: ${{ steps.decide.outputs.target_disk_sku }}
     steps:
-      - name: Decide target VM size
+      - name: Decide target VM size and disk SKU
         id: decide
         run: |
           # Resize UP para B4 (16GB) sempre que houver trabalho pesado:
           #   - qualquer etl_phase != web (ETL/SQL/N usam mais RAM e CPU)
           #   - warm_cache=true (1 ciclo de warm leva ~20h, beneficia muito de B4)
           # Caso contrario (etl_phase=web sem warm), mantem B2 (8GB) para economizar.
+          # Disco segue a VM: Premium para trabalho pesado, Standard para web.
           if [ "${{ inputs.etl_phase }}" = "web" ] && [ "${{ inputs.warm_cache }}" != "true" ]; then
             echo "target_size=${{ env.VM_SIZE_WEB }}" >> "$GITHUB_OUTPUT"
-            echo "etl_phase=web warm_cache=false → target=${{ env.VM_SIZE_WEB }} (8GB, code sync)"
+            echo "target_disk_sku=${{ env.DISK_SKU_LIGHT }}" >> "$GITHUB_OUTPUT"
+            echo "etl_phase=web warm_cache=false → B2 + Standard SSD (web)"
           else
             echo "target_size=${{ env.VM_SIZE_ETL }}" >> "$GITHUB_OUTPUT"
-            echo "trabalho pesado (etl_phase=${{ inputs.etl_phase }} warm_cache=${{ inputs.warm_cache }}) → target=${{ env.VM_SIZE_ETL }} (16GB)"
+            echo "target_disk_sku=${{ env.DISK_SKU_HEAVY }}" >> "$GITHUB_OUTPUT"
+            echo "trabalho pesado → B4 + Premium SSD (16GB, 2300 IOPS)"
           fi
 
       - name: Azure login (OIDC)
@@ -102,45 +116,93 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resize VM to target size
+      - name: Resize VM and convert data disk SKU
         run: |
           set -e
-          TARGET="${{ steps.decide.outputs.target_size }}"
-          CURRENT=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query hardwareProfile.vmSize -o tsv)
+          TARGET_SIZE="${{ steps.decide.outputs.target_size }}"
+          TARGET_DISK_SKU="${{ steps.decide.outputs.target_disk_sku }}"
+
+          CURRENT_SIZE=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query hardwareProfile.vmSize -o tsv)
+          CURRENT_DISK_SKU=$(az disk show -g "$AZURE_RG" -n "$DATA_DISK" --query sku.name -o tsv)
+          CURRENT_CACHING=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query "storageProfile.dataDisks[?name=='$DATA_DISK'].caching | [0]" -o tsv)
           POWER=$(az vm get-instance-view -g "$AZURE_RG" -n "$AZURE_VM" \
             --query "instanceView.statuses[?contains(code, 'PowerState')].code | [0]" -o tsv)
 
-          echo "Current size:  $CURRENT"
-          echo "Target size:   $TARGET"
-          echo "Power state:   $POWER"
+          echo "Current VM size:   $CURRENT_SIZE"
+          echo "Target VM size:    $TARGET_SIZE"
+          echo "Current disk SKU:  $CURRENT_DISK_SKU"
+          echo "Target disk SKU:   $TARGET_DISK_SKU"
+          echo "Current caching:   $CURRENT_CACHING"
+          echo "Power state:       $POWER"
 
-          if [ "$CURRENT" = "$TARGET" ]; then
-            echo "VM ja esta no tamanho correto."
+          # Decide se algum trabalho eh necessario (idempotencia: skip se ja correto)
+          NEEDS_RESIZE="false"
+          NEEDS_DISK_CHANGE="false"
+          NEEDS_CACHING_FIX="false"
+          [ "$CURRENT_SIZE" != "$TARGET_SIZE" ] && NEEDS_RESIZE="true"
+          [ "$CURRENT_DISK_SKU" != "$TARGET_DISK_SKU" ] && NEEDS_DISK_CHANGE="true"
+          # ReadOnly caching no data disk acelera muito leituras de pgfn_divida
+          # e tce_pb_despesa (host caching ~4GB RAM da maquina hospedeira).
+          # Idempotente: setado uma vez, persiste.
+          [ "$CURRENT_CACHING" != "ReadOnly" ] && NEEDS_CACHING_FIX="true"
+
+          if [ "$NEEDS_RESIZE" = "false" ] && [ "$NEEDS_DISK_CHANGE" = "false" ] && [ "$NEEDS_CACHING_FIX" = "false" ]; then
+            echo "Tudo ja esta no estado correto."
             if [ "$POWER" != "PowerState/running" ]; then
               echo "VM esta $POWER, ligando..."
               az vm start -g "$AZURE_RG" -n "$AZURE_VM"
             fi
           else
-            # Valida que o target SKU esta disponivel ANTES de deallocate.
-            # Sem isso, um SKU indisponivel deixa a VM parada e a producao no chao.
-            AVAILABLE=$(az vm list-vm-resize-options -g "$AZURE_RG" -n "$AZURE_VM" --query "[].name" -o tsv)
-            if ! echo "$AVAILABLE" | grep -qx "$TARGET"; then
-              echo "::error::Tamanho $TARGET indisponivel nessa VM/regiao no momento."
-              echo "Disponiveis:"; echo "$AVAILABLE"
-              exit 1
+            # Valida disponibilidade do tamanho ANTES de deallocate
+            if [ "$NEEDS_RESIZE" = "true" ]; then
+              AVAILABLE=$(az vm list-vm-resize-options -g "$AZURE_RG" -n "$AZURE_VM" --query "[].name" -o tsv)
+              if ! echo "$AVAILABLE" | grep -qx "$TARGET_SIZE"; then
+                echo "::error::Tamanho $TARGET_SIZE indisponivel."
+                echo "Disponiveis:"; echo "$AVAILABLE"
+                exit 1
+              fi
             fi
 
-            echo "Resize: $CURRENT → $TARGET"
+            # VM precisa ser deallocated para: resize, disk SKU change, e mudanca de caching.
+            echo "Deallocating VM..."
             az vm deallocate -g "$AZURE_RG" -n "$AZURE_VM"
 
-            if ! az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$TARGET"; then
-              echo "::warning::Resize falhou, restaurando para $CURRENT..."
-              az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$CURRENT" || true
-              az vm start -g "$AZURE_RG" -n "$AZURE_VM" || true
-              echo "::error::Resize para $TARGET falhou — VM restaurada para $CURRENT"
-              exit 1
+            # 1. Resize VM (com rollback)
+            if [ "$NEEDS_RESIZE" = "true" ]; then
+              echo "Resize VM: $CURRENT_SIZE → $TARGET_SIZE"
+              if ! az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$TARGET_SIZE"; then
+                echo "::warning::Resize VM falhou, restaurando para $CURRENT_SIZE..."
+                az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$CURRENT_SIZE" || true
+                az vm start -g "$AZURE_RG" -n "$AZURE_VM" || true
+                echo "::error::Resize VM para $TARGET_SIZE falhou — VM restaurada"
+                exit 1
+              fi
             fi
 
+            # 2. Convert disk SKU. Azure limita a 2 mudancas por disco/24h —
+            # se atingir o limite, prossegue com o disco atual (warm rodara
+            # mais lento mas funciona).
+            if [ "$NEEDS_DISK_CHANGE" = "true" ]; then
+              echo "Disk SKU: $CURRENT_DISK_SKU → $TARGET_DISK_SKU"
+              if ! az disk update -g "$AZURE_RG" -n "$DATA_DISK" --sku "$TARGET_DISK_SKU"; then
+                echo "::warning::Conversao de disco falhou (provavelmente atingiu limite 2/24h)."
+                echo "::warning::Prosseguindo com SKU atual: $CURRENT_DISK_SKU"
+                echo "::warning::Performance pode ser inferior ao esperado."
+              fi
+            fi
+
+            # 3. Set caching ReadOnly no data disk (idempotente).
+            #    Azure CLI moderno: az vm update aceita `--set` no path do storageProfile.
+            if [ "$NEEDS_CACHING_FIX" = "true" ]; then
+              echo "Setting caching to ReadOnly on $DATA_DISK..."
+              # Encontra o LUN do disco para usar no --set
+              LUN=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query "storageProfile.dataDisks[?name=='$DATA_DISK'].lun | [0]" -o tsv)
+              az vm update -g "$AZURE_RG" -n "$AZURE_VM" \
+                --set "storageProfile.dataDisks[$LUN].caching=ReadOnly" \
+                || echo "::warning::Falha ao setar caching ReadOnly — prosseguindo"
+            fi
+
+            echo "Starting VM..."
             az vm start -g "$AZURE_RG" -n "$AZURE_VM"
           fi
 
@@ -555,41 +617,70 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resize VM down to web-serving size
+      - name: Resize VM down and convert disk SKU back
         run: |
           set -e
-          CURRENT=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query hardwareProfile.vmSize -o tsv)
-          TARGET="$VM_SIZE_WEB"
+          TARGET_SIZE="$VM_SIZE_WEB"
+          TARGET_DISK_SKU="$DISK_SKU_LIGHT"
 
-          echo "Current size: $CURRENT"
-          echo "Target size:  $TARGET"
+          CURRENT_SIZE=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query hardwareProfile.vmSize -o tsv)
+          CURRENT_DISK_SKU=$(az disk show -g "$AZURE_RG" -n "$DATA_DISK" --query sku.name -o tsv)
 
-          if [ "$CURRENT" = "$TARGET" ]; then
-            echo "VM ja esta no tamanho web. Nada a fazer."
+          echo "Current VM size:   $CURRENT_SIZE"
+          echo "Target VM size:    $TARGET_SIZE"
+          echo "Current disk SKU:  $CURRENT_DISK_SKU"
+          echo "Target disk SKU:   $TARGET_DISK_SKU"
+
+          NEEDS_RESIZE="false"
+          NEEDS_DISK_CHANGE="false"
+          [ "$CURRENT_SIZE" != "$TARGET_SIZE" ] && NEEDS_RESIZE="true"
+          [ "$CURRENT_DISK_SKU" != "$TARGET_DISK_SKU" ] && NEEDS_DISK_CHANGE="true"
+
+          if [ "$NEEDS_RESIZE" = "false" ] && [ "$NEEDS_DISK_CHANGE" = "false" ]; then
+            echo "VM ja esta no tamanho web e disco no SKU correto. Nada a fazer."
             exit 0
           fi
 
-          # Valida disponibilidade antes de deallocate.
-          AVAILABLE=$(az vm list-vm-resize-options -g "$AZURE_RG" -n "$AZURE_VM" --query "[].name" -o tsv)
-          if ! echo "$AVAILABLE" | grep -qx "$TARGET"; then
-            echo "::error::Tamanho $TARGET indisponivel — abortando downsize, VM continua em $CURRENT"
-            exit 1
+          # Valida disponibilidade antes de deallocate
+          if [ "$NEEDS_RESIZE" = "true" ]; then
+            AVAILABLE=$(az vm list-vm-resize-options -g "$AZURE_RG" -n "$AZURE_VM" --query "[].name" -o tsv)
+            if ! echo "$AVAILABLE" | grep -qx "$TARGET_SIZE"; then
+              echo "::error::Tamanho $TARGET_SIZE indisponivel — abortando, VM continua em $CURRENT_SIZE"
+              exit 1
+            fi
           fi
 
-          echo "Downsize: $CURRENT → $TARGET"
+          echo "Deallocating VM..."
           az vm deallocate -g "$AZURE_RG" -n "$AZURE_VM"
 
-          if ! az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$TARGET"; then
-            echo "::warning::Resize falhou, restaurando para $CURRENT..."
-            az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$CURRENT" || true
-            az vm start -g "$AZURE_RG" -n "$AZURE_VM" || true
-            echo "::error::Downsize para $TARGET falhou — VM restaurada para $CURRENT"
-            exit 1
+          # 1. Resize VM down (com rollback)
+          if [ "$NEEDS_RESIZE" = "true" ]; then
+            echo "Downsize: $CURRENT_SIZE → $TARGET_SIZE"
+            if ! az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$TARGET_SIZE"; then
+              echo "::warning::Resize falhou, restaurando para $CURRENT_SIZE..."
+              az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$CURRENT_SIZE" || true
+              az vm start -g "$AZURE_RG" -n "$AZURE_VM" || true
+              echo "::error::Downsize para $TARGET_SIZE falhou — VM restaurada"
+              exit 1
+            fi
           fi
 
+          # 2. Downgrade disk SKU. Se atingir limite Azure (2/24h), falha eh
+          # benigna: disco fica em Premium ($35/mes extra) ate o proximo
+          # postflight. Nao bloqueamos o downsize da VM por causa disso.
+          if [ "$NEEDS_DISK_CHANGE" = "true" ]; then
+            echo "Disk SKU: $CURRENT_DISK_SKU → $TARGET_DISK_SKU"
+            if ! az disk update -g "$AZURE_RG" -n "$DATA_DISK" --sku "$TARGET_DISK_SKU"; then
+              echo "::warning::Conversao de disco falhou (provavelmente atingiu limite 2/24h)."
+              echo "::warning::Disco permanece em $CURRENT_DISK_SKU."
+              echo "::warning::Sera convertido no proximo deploy ou manualmente."
+            fi
+          fi
+
+          echo "Starting VM..."
           az vm start -g "$AZURE_RG" -n "$AZURE_VM"
 
-          # Aguarda SSH responder antes de declarar sucesso.
+          # Aguarda SSH responder antes de declarar sucesso
           echo "Aguardando VM ficar reachable em SSH apos downsize..."
           for i in $(seq 1 30); do
             if timeout 5 bash -c "</dev/tcp/${{ secrets.VM_HOST }}/22" 2>/dev/null; then

--- a/README.md
+++ b/README.md
@@ -118,25 +118,29 @@ Todos os municipios da PB recebem perfil completo com insight cards, servidores 
 
 ### VM Azure (producao)
 
-A VM **muda de tamanho automaticamente** dependendo do trabalho — `B2as_v2` (8GB) para servir web normalmente, `B4as_v2` (16GB) durante ETL/views pesados. Ver secao [Auto-resize de VM](#auto-resize-de-vm) abaixo.
+A VM e o disco mudam de SKU automaticamente conforme o trabalho. Custos sao prorateados por hora pelo Azure, entao Premium SSD so cobra durante operacoes pesadas (~24h/mes), nao always-on.
 
-| Componente | Spec | Custo/mes (USD) | Custo/mes (BRL ~5.6) |
+| Componente | Spec leve (web) | Spec pesado (ETL/warm) | Custo/hora dif |
 |---|---|---|---|
-| **VM web** (`B2as_v2`, 2 vCPU, 8GB) | uso 100% do mes | ~$55 | ~R$ 308 |
-| **VM ETL** (`B4as_v2`, 4 vCPU, 16GB) | uso pontual (~$1.80/dia extra) | $54-108 (variavel) | R$ 300-600 |
-| Disco dados (`/data`) | 512GB Standard SSD | ~$38 | ~R$ 213 |
-| Disco OS | 32GB Standard SSD | ~$2.40 | ~R$ 13 |
-| IP publico estatico | Standard | ~$4 | ~R$ 22 |
-| Bandwidth | trafego web normal | ~$1 | ~R$ 6 |
-| **Total tipico (apenas web)** | | **~$100** | **~R$ 562** |
-| **Total com 1 ETL/mes** | | **~$115** | **~R$ 645** |
+| **VM** | B2as_v2 (2 vCPU, 8GB) | B4as_v2 (4 vCPU, 16GB) | +$0.07/h |
+| **Data disk** | Standard SSD E20 (500 IOPS) | Premium SSD P20 (2300 IOPS + ReadOnly host caching ~16GB) | +$0.05/h |
+| **Caching** | sempre ReadOnly | sempre ReadOnly | $0 |
 
-> Cabe nos **$150/mes de credito Azure** (Visual Studio Enterprise) com folga de ~$35-50.
-> Regiao: **North Central US**. Resource group: `RG-GOVBR-NCUS`. VM: `vm-govbr`.
+| Custo mensal estimado | USD | BRL (~5.6) |
+|---|---|---|
+| **Web base** (B2 + Standard SSD + IP + bandwidth) | ~$100 | ~R$ 562 |
+| **+ 1 ETL/mes** (~24h em B4 + Premium): | +$3 | +R$ 17 |
+| **+ 1 warm/mes** (~6h em B4 + Premium, com Premium acelerando 4x): | +$1 | +R$ 6 |
+| **Total tipico** | **~$104** | **~R$ 585** |
+
+> Cabe nos **$150/mes de credito Azure** (Visual Studio Enterprise) com folga de ~$45.
+> Regiao: **North Central US**. Resource group: `RG-GOVBR-NCUS`. VM: `vm-govbr`. Data disk: `disk-govbr-data`.
+
+⚠️ **Limite Azure:** disco aceita no maximo 2 mudancas de SKU por 24h. Se rodar 2 deploys com etl/warm no mesmo dia, o segundo upgrade falha — fica em Standard SSD por algumas horas (warm sera mais lento, mas funciona). Workflow detecta e segue.
 
 O disco de 512GB armazena tanto o PostgreSQL (~248GB) quanto os dados brutos de download (~230GB no pico). Para caber no disco, o ETL **limpa automaticamente os CSVs brutos** apos cada fase completar com sucesso (`run_all.py`). Diretorios compartilhados entre fases (ex: `rfb/`, `tse/`) so sao removidos quando todas as fases dependentes completam.
 
-### Auto-resize de VM
+### Auto-resize de VM (e disco)
 
 O workflow `deploy.yml` tem 3 jobs:
 
@@ -146,19 +150,27 @@ preflight (github-hosted, OIDC) → deploy (self-hosted na VM) → postflight (g
 
 | Cenario | Preflight | Steps no deploy | Postflight |
 |---|---|---|---|
-| `etl_phase=web` (default) | B2as_v2 (8GB) | sync code, restart cruza-web | (nenhum) |
-| `etl_phase=web warm_cache=true` | B4as_v2 (16GB) | sync + warm_cache (~20h) | downsize → B2as_v2 |
-| `etl_phase=all` | B4as_v2 (16GB) | ETL completo + warm_cache (auto) | downsize → B2as_v2 |
-| `etl_phase=sql` | B4as_v2 (16GB) | indices/normalizar/views + warm_cache (auto) | downsize → B2as_v2 |
-| `etl_phase=N` | B4as_v2 (16GB) | ETL phase N (warm NAO eh auto, use warm_cache=true) | downsize → B2as_v2 |
-| `etl_phase=N run_queries=true warm_cache=true` | B4as_v2 (16GB) | ETL + queries + warm_cache | downsize → B2as_v2 |
+| `etl_phase=web` (default) | B2 + Standard SSD | sync code, restart cruza-web | (nenhum) |
+| `etl_phase=web warm_cache=true` | **B4 + Premium SSD** | sync + warm_cache (~5-7h em Premium) | downsize → B2 + Standard |
+| `etl_phase=all` | **B4 + Premium SSD** | ETL completo + warm_cache (auto) | downsize → B2 + Standard |
+| `etl_phase=sql` | **B4 + Premium SSD** | indices/normalizar/views + warm_cache (auto) | downsize → B2 + Standard |
+| `etl_phase=N` | **B4 + Premium SSD** | ETL phase N (warm NAO eh auto) | downsize → B2 + Standard |
 
-**O que acontece:**
-1. **Preflight** redimensiona a VM (`az vm deallocate → resize → start`). Valida disponibilidade do SKU antes e faz rollback se resize falhar.
+**O que acontece em cada job:**
+
+1. **Preflight** redimensiona a VM e o disco juntos numa unica deallocation:
+   - `az vm deallocate`
+   - `az vm resize` (se tamanho diferente)
+   - `az disk update --sku` (se SKU diferente — gracioso ao limite de 2 mudancas/24h)
+   - `az vm update --set ...caching=ReadOnly` (se caching diferente — idempotente, configurado uma vez)
+   - `az vm start`
+   - Aguarda SSH na porta 22
+
 2. **Deploy** roda no self-hosted runner DENTRO da VM. O step `Apply PostgreSQL auto-tuning` detecta a RAM atual e ajusta `shared_buffers / effective_cache / work_mem / maintenance_work_mem`. Os steps de ETL/queries/warm sao opt-in conforme inputs.
-3. **Postflight** so roda quando preflight fez upsize E deploy succeeded. Faz downsize de volta para `B2as_v2`. No proximo boot da VM, `pg-autotune.service` re-tuna o postgres antes dele subir.
 
-**Quando o deploy falha no meio**, postflight nao roda — a VM fica em B4as_v2 (16GB) para voce retomar com `etl_phase=N` sem outro resize.
+3. **Postflight** so roda quando preflight fez upsize E deploy succeeded. Faz downsize VM + disco numa unica deallocation. Se o downgrade do disco falhar (limite 2/24h), a VM ainda eh redimensionada — disco fica em Premium ate o proximo deploy ($35/mes extra durante esse periodo).
+
+**Quando o deploy falha no meio**, postflight nao roda — VM e disco ficam grandes para voce retomar com `etl_phase=N` sem outro resize.
 
 **Tuning detectado automaticamente** (formulas Postgres-best-practices):
 - `shared_buffers` = 25% RAM

--- a/TODO.md
+++ b/TODO.md
@@ -136,15 +136,17 @@
 - 115+ queries em queries/*.sql, 26 relatorios validos em relatorios/
 
 ### VM Azure
-- **B2as_v2** (2 vCPU, 8GB RAM, ~$55/mes) — uso normal (servir web)
-- **B4as_v2** (4 vCPU, 16GB RAM, ~$108/mes) — durante ETL/views (auto-resize via deploy.yml)
-- Disco: 512GB Standard SSD em /data (PostgreSQL 248GB + dados brutos ~105GB apos limpeza)
+- **B2as_v2** (2 vCPU, 8GB, ~$55/mes) + Standard SSD E20 ($38/mes) — uso normal (servir web)
+- **B4as_v2** (4 vCPU, 16GB, ~$108/mes) + Premium SSD P20 ($73/mes, ReadOnly host caching) — durante ETL/warm
+- VM e disco mudam de SKU juntos via deploy.yml (preflight upsize, postflight downsize)
+- Disco Premium so cobra durante operacoes pesadas (~$3/mes vs $35/mes always-on)
+- Limite Azure: 2 mudancas de SKU de disco por 24h — workflow detecta e prossegue se atingir
 - IP estatico: 52.162.207.186 (~$4/mes)
 - Budget: ~US$150/mes (creditos Visual Studio Enterprise)
-- **Custo tipico:** ~$100/mes so web, ~$115/mes com 1 ETL completo
-- Resource group: `RG-GOVBR-NCUS`. VM name: `vm-govbr`. Subscription: `90676d79-a73b-462d-bdd6-2b4c738237f5`
+- **Custo tipico:** ~$104/mes (web + 1 ETL + 1 warm)
+- Resource group: `RG-GOVBR-NCUS`. VM: `vm-govbr`. Data disk: `disk-govbr-data`. Subscription: `90676d79-a73b-462d-bdd6-2b4c738237f5`
 - SSH: `ssh -i C:\Users\lucas\.ssh\azure_vm.txt govbr@52.162.207.186` (read-only debug)
-- Workflows: `deploy.yml` (preflight resize → ETL → postflight resize), `setup-runner.yml` (runner 1x)
+- Workflows: `deploy.yml` (preflight resize + disk SKU → ETL → postflight resize back), `setup-runner.yml` (runner 1x)
 - Secrets: `VM_HOST`, `VM_SSH_KEY`, `DB_PASSWORD`, `ENV_FILE`, `RUNNER_ADMIN_TOKEN`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
 
 ### Frontend web


### PR DESCRIPTION
## Resumo

Estende o auto-resize: agora `preflight`/`postflight` mudam o SKU do disco de dados junto com a VM. Standard SSD ($38/mês, 500 IOPS) durante web, Premium SSD P20 ($73/mês, 2300 IOPS + ReadOnly host caching) durante ETL/warm. Custo prorateado por hora pelo Azure.

## Por que

Q67 dated estava timing out porque Standard SSD = 500 IOPS + caching=None. Cada leitura de `pgfn_divida` (40M rows) ia direto pro disco, latência ~10ms. **Speedup esperado de Premium P20 + ReadOnly caching: 4-7x em queries do warm.**

## Custo

| Estratégia | Custo extra |
|---|---|
| Always-on Premium | +$35/mês |
| **SKU swap (este PR)** | **+$1-3/mês** (~24h em Premium/mês) |

Cabe nos $150 com folga de ~$45.

## Implementação

`.github/workflows/deploy.yml`:
- `env`: adiciona `DATA_DISK`, `DISK_SKU_LIGHT`, `DISK_SKU_HEAVY`
- Preflight `Decide target VM size and disk SKU` produz 2 outputs (`target_size` + `target_disk_sku`)
- Preflight `Resize VM and convert data disk SKU`: orquestra **deallocate → resize VM → disk update --sku → set caching=ReadOnly → start** numa única deallocation. Idempotente.
- Postflight `Resize VM down and convert disk SKU back`: simétrico.

## Tratamento de falhas

| Falha | Comportamento |
|---|---|
| Resize VM | Restaura tamanho original + start. Hard fail. |
| Disk SKU change (limite 2/24h Azure) | Prossegue com SKU atual. Logs warning. Warm vai mais lento mas roda. |
| Caching change | Logs warning, prossegue. Idempotente nos próximos deploys. |
| Postflight downgrade falha | VM ainda é redimensionada. Disco fica em Premium até próximo deploy. |

## Permissões

Service Principal `govbr-deploy-github-oidc` já tem role `Virtual Machine Contributor` no RG, que inclui `Microsoft.Compute/disks/write` — sem mudanças de permissão necessárias.

## Out of scope (próximos)

- Otimização de queries específicas (Q67 dated) — ataque alternativo, baixa prioridade após Premium SSD
- Generations/staging para `web_cache` — refactor maior

## Verificações

- ✅ YAML válido
- ✅ Role check: `disks/write` confirmado em "Virtual Machine Contributor"
- ✅ B4as_v2 supports PremiumIO=True (verificado anteriormente)
