### PR TITLE
deploy: warm cache speedup (parallel, work_mem, loop invert, Q67 MV)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -229,12 +229,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # ── Stop legacy warm-cache daemon FIRST ──
-      # Antes de qualquer trabalho pesado (ETL, migracoes), garantimos que o
-      # antigo daemon `cruza-warm-cache --loop` (Type=simple) NAO esteja rodando
-      # e disputando I/O. Roda incondicionalmente para tornar a transicao para
-      # oneshot idempotente: a falha do is-active eh tratada via `|| true`.
-      - name: Stop legacy warm-cache daemon
+      # ── Stop legacy warm-cache daemon + disable auto-update timers FIRST ──
+      # Antes de qualquer trabalho pesado, paramos:
+      #   1. Daemon antigo cruza-warm-cache (--loop), que disputa I/O.
+      #   2. Timers do unattended-upgrade — eles disparam systemctl daemon-reexec
+      #      que mata processos longos (warm de 12-18h foi morto antes por isso).
+      # Roda incondicionalmente para idempotencia.
+      - name: Stop legacy warm-cache daemon and mask auto-update timers
         run: |
           set +e
           if systemctl is-active --quiet cruza-warm-cache; then
@@ -247,6 +248,18 @@ jobs:
           fi
           # Mata qualquer processo orfao rodando warm_cache --loop diretamente.
           sudo pkill -f 'warm_cache.*--loop' 2>/dev/null || true
+
+          # Mask timers de auto-update (idempotente — symlink para /dev/null).
+          # Sem isso, apt-daily-upgrade.timer dispara systemctl daemon-reexec que
+          # envia SIGTERM para todos os servicos, matando warms longos.
+          # `mask` eh mais forte que `disable`: nao pode ser ativado nem por dependencia.
+          for unit in apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service; do
+            if systemctl is-enabled "$unit" 2>/dev/null | grep -qE '^(static|enabled|alias)$'; then
+              echo "Masking $unit..."
+              sudo systemctl mask "$unit"
+            fi
+          done
+
           exit 0
 
       # ── Clean previous failed state (manual trigger only) ──
@@ -539,6 +552,29 @@ jobs:
           systemctl is-active nginx && echo "nginx: RUNNING" || echo "nginx: FAILED"
           systemctl is-active cruza-web && echo "cruza-web: RUNNING" || echo "cruza-web: FAILED"
           echo "cruza-warm-cache: oneshot instalado (executado sob demanda)"
+
+      # ── Atualizar estatisticas das tabelas hot ANTES do warm ──
+      # Sem stats atualizadas, o planner pode escolher planos ruins (ex: hash
+      # join em vez de nested loop, ou Bitmap Heap Scan em vez de Index Scan).
+      # ANALYZE roda rapido e nao bloqueia leituras. Limitado as tabelas/MVs
+      # mais consultadas pelo warm (evita ANALYZE em tabelas muito grandes
+      # como rfb que nao mudam tao frequentemente).
+      - name: ANALYZE hot tables before warm
+        if: |
+          inputs.warm_cache == true ||
+          inputs.etl_phase == 'all' ||
+          inputs.etl_phase == 'sql'
+        run: |
+          set -euo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          source .env 2>/dev/null || true
+          PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
+          echo "=== ANALYZE em tabelas hot ==="
+          for tbl in tce_pb_despesa pgfn_divida estabelecimento socio mv_pessoa_pb mv_empresa_governo mv_empresa_pb mv_servidor_pb_risco mv_municipio_pb_mapa mv_municipio_pb_kpi_score; do
+            echo "  ANALYZE $tbl..."
+            PGPASSWORD="$PASS" psql -U govbr -d govbr -c "ANALYZE $tbl" 2>&1 | tail -1
+          done
+          echo "=== ANALYZE complete ==="
 
       # ── Warm cache (oneshot, ~20h em B4) ──
       # Auto: roda apos etl_phase=all ou sql (dados mudaram, queries mudaram).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: boolean
         default: false
+      drop_cache:
+        description: 'TRUNCATE web_cache antes do warm. AUTO=true para etl_phase!=web (dados mudaram). Para etl_phase=web, default false ativa resume mode (skip munis cacheados <24h).'
+        required: false
+        type: boolean
+        default: false
 
 # OIDC federado pro Azure (sem secrets de SP, sem expiracao).
 permissions:
@@ -576,7 +581,58 @@ jobs:
           done
           echo "=== ANALYZE complete ==="
 
-      # ── Warm cache (oneshot, ~20h em B4) ──
+      # ── Drop web_cache quando dados mudaram ──
+      # Apos ETL (etl_phase != web), as MVs/tabelas foram recriadas, entao o
+      # cache antigo pode estar inconsistente (ex: muni X com Q67 baseada na
+      # mv_q67_dated_pb antiga, antes da MV ser recriada). TRUNCATE eh idempotente.
+      # Para etl_phase=web (dados nao mudaram), o cache eh preservado e o resume
+      # mode no warm_cache.py pula munis ja cacheados.
+      # Override manual via inputs.drop_cache=true.
+      - name: Drop web_cache (data changed)
+        if: |
+          (inputs.warm_cache == true ||
+           inputs.etl_phase == 'all' ||
+           inputs.etl_phase == 'sql') &&
+          (inputs.drop_cache == true || inputs.etl_phase != 'web')
+        run: |
+          set -euo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          source .env 2>/dev/null || true
+          PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
+          echo "=== TRUNCATE web_cache (dados mudaram, cache obsoleto) ==="
+          BEFORE=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -t -A -c 'SELECT count(*) FROM web_cache' || echo 0)
+          PGPASSWORD="$PASS" psql -U govbr -d govbr -c 'TRUNCATE web_cache'
+          echo "Removidas $BEFORE entries do web_cache"
+
+      # ── Configure warm cache resume mode ──
+      # Em etl_phase=web (dados nao mudaram), ativa resume mode para pular
+      # munis ja cacheados nas ultimas 24h. Util para retomar warms
+      # interrompidos sem refazer trabalho.
+      # Em outros etl_phases, drop_cache acima ja zerou o cache, entao
+      # o skip nao tem efeito (mas seta para 0 para deixar explicito).
+      - name: Configure warm cache resume mode
+        if: |
+          inputs.warm_cache == true ||
+          inputs.etl_phase == 'all' ||
+          inputs.etl_phase == 'sql'
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.etl_phase }}" = "web" ] && [ "${{ inputs.drop_cache }}" != "true" ]; then
+            SKIP_HRS=24
+            echo "Resume mode: pula munis cacheados nas ultimas 24h"
+          else
+            SKIP_HRS=0
+            echo "Full rebuild mode (dados mudaram ou drop_cache=true)"
+          fi
+          sudo mkdir -p /etc/systemd/system/cruza-warm-cache.service.d
+          cat <<EOF | sudo tee /etc/systemd/system/cruza-warm-cache.service.d/runtime-env.conf > /dev/null
+          [Service]
+          Environment=WARM_SKIP_RECENT_HOURS=$SKIP_HRS
+          EOF
+          sudo systemctl daemon-reload
+          echo "WARM_SKIP_RECENT_HOURS=$SKIP_HRS configurado"
+
+      # ── Warm cache (oneshot, ~12-18h em B4 com fixes do PR de speedup) ──
       # Auto: roda apos etl_phase=all ou sql (dados mudaram, queries mudaram).
       # Manual: roda em qualquer etl_phase quando warm_cache=true (incluindo
       # phase=N e phase=web).
@@ -597,7 +653,7 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          echo "=== Warming web_cache table (esperado ~20h em B4as_v2 16GB) ==="
+          echo "=== Warming web_cache table (esperado ~12-18h em B4as_v2 16GB) ==="
           echo "Inicio: $(date -Iseconds)"
           # systemctl start --wait com Type=oneshot bloqueia ate o ExecStart
           # terminar e propaga exit code do processo. Usa EnvironmentFile,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ on:
         type: boolean
         default: false
       drop_cache:
-        description: 'TRUNCATE web_cache antes do warm. AUTO=true para etl_phase!=web (dados mudaram). Para etl_phase=web, default false ativa resume mode (skip munis cacheados <24h).'
+        description: 'TRUNCATE web_cache antes do warm. Use APENAS em mudancas de schema. Por padrao (false), cache antigo eh preservado e UPSERT-ado (evita 12-18h sem cache).'
         required: false
         type: boolean
         default: false
@@ -575,41 +575,54 @@ jobs:
           source .env 2>/dev/null || true
           PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
           echo "=== ANALYZE em tabelas hot ==="
-          for tbl in tce_pb_despesa pgfn_divida estabelecimento socio mv_pessoa_pb mv_empresa_governo mv_empresa_pb mv_servidor_pb_risco mv_municipio_pb_mapa mv_municipio_pb_kpi_score; do
+          for tbl in tce_pb_despesa pgfn_divida estabelecimento socio mv_pessoa_pb mv_empresa_governo mv_empresa_pb mv_servidor_pb_risco mv_municipio_pb_mapa mv_municipio_pb_kpi_score mv_q67_dated_pb; do
             echo "  ANALYZE $tbl..."
             PGPASSWORD="$PASS" psql -U govbr -d govbr -c "ANALYZE $tbl" 2>&1 | tail -1
           done
           echo "=== ANALYZE complete ==="
 
-      # ── Drop web_cache quando dados mudaram ──
-      # Apos ETL (etl_phase != web), as MVs/tabelas foram recriadas, entao o
-      # cache antigo pode estar inconsistente (ex: muni X com Q67 baseada na
-      # mv_q67_dated_pb antiga, antes da MV ser recriada). TRUNCATE eh idempotente.
-      # Para etl_phase=web (dados nao mudaram), o cache eh preservado e o resume
-      # mode no warm_cache.py pula munis ja cacheados.
-      # Override manual via inputs.drop_cache=true.
-      - name: Drop web_cache (data changed)
+      # ── Drop web_cache (opcional, padrao OFF) ──
+      # Por padrao NAO truncamos o cache mesmo apos ETL/SQL: o warm faz UPSERT
+      # (INSERT ... ON CONFLICT DO UPDATE), entao cada muni X / query Y eh
+      # substituido assim que o warm chegar nele. Cache antigo serve durante
+      # as 12-18h do warm, evitando que o site fique sem cache hit.
+      #
+      # Trade-off: durante a janela do warm, algumas munis exibem dados
+      # baseados em logica de query/MV anterior. Esse risco eh ACEITAVEL para
+      # mudancas tipicas (registry.py com nova versao de query). Mas para
+      # mudancas de SCHEMA (ex: coluna removida em web_cache), use
+      # drop_cache=true para forcar TRUNCATE.
+      #
+      # Idempotente em VM nova (DO block guarda a existencia da tabela).
+      - name: Drop web_cache (only if drop_cache=true)
         if: |
+          inputs.drop_cache == true &&
           (inputs.warm_cache == true ||
            inputs.etl_phase == 'all' ||
-           inputs.etl_phase == 'sql') &&
-          (inputs.drop_cache == true || inputs.etl_phase != 'web')
+           inputs.etl_phase == 'sql')
         run: |
           set -euo pipefail
           cd ${{ env.PROJECT_DIR }}
           source .env 2>/dev/null || true
           PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
-          echo "=== TRUNCATE web_cache (dados mudaram, cache obsoleto) ==="
-          BEFORE=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -t -A -c 'SELECT count(*) FROM web_cache' || echo 0)
-          PGPASSWORD="$PASS" psql -U govbr -d govbr -c 'TRUNCATE web_cache'
-          echo "Removidas $BEFORE entries do web_cache"
+          echo "=== TRUNCATE web_cache (drop_cache=true) ==="
+          PGPASSWORD="$PASS" psql -U govbr -d govbr -c "
+            DO \$\$
+            BEGIN
+              IF to_regclass('public.web_cache') IS NOT NULL THEN
+                EXECUTE 'TRUNCATE web_cache';
+                RAISE NOTICE 'web_cache truncated';
+              ELSE
+                RAISE NOTICE 'web_cache nao existe ainda — nada a truncar';
+              END IF;
+            END \$\$;
+          "
 
       # ── Configure warm cache resume mode ──
-      # Em etl_phase=web (dados nao mudaram), ativa resume mode para pular
-      # munis ja cacheados nas ultimas 24h. Util para retomar warms
-      # interrompidos sem refazer trabalho.
-      # Em outros etl_phases, drop_cache acima ja zerou o cache, entao
-      # o skip nao tem efeito (mas seta para 0 para deixar explicito).
+      # Se drop_cache=false (default): cache eh preservado, ativa resume mode
+      # (skip 24h) pra retomar warms interrompidos rapidamente. Trabalho ja
+      # feito eh preservado via UPSERT.
+      # Se drop_cache=true: cache foi TRUNCATE-ado, sem o que skip-ar.
       - name: Configure warm cache resume mode
         if: |
           inputs.warm_cache == true ||
@@ -617,12 +630,12 @@ jobs:
           inputs.etl_phase == 'sql'
         run: |
           set -euo pipefail
-          if [ "${{ inputs.etl_phase }}" = "web" ] && [ "${{ inputs.drop_cache }}" != "true" ]; then
+          if [ "${{ inputs.drop_cache }}" = "true" ]; then
+            SKIP_HRS=0
+            echo "Full rebuild mode (drop_cache=true)"
+          else
             SKIP_HRS=24
             echo "Resume mode: pula munis cacheados nas ultimas 24h"
-          else
-            SKIP_HRS=0
-            echo "Full rebuild mode (dados mudaram ou drop_cache=true)"
           fi
           sudo mkdir -p /etc/systemd/system/cruza-warm-cache.service.d
           cat <<EOF | sudo tee /etc/systemd/system/cruza-warm-cache.service.d/runtime-env.conf > /dev/null
@@ -652,7 +665,7 @@ jobs:
           inputs.etl_phase == 'sql'
         continue-on-error: true
         run: |
-          set -euo pipefail
+          set -uo pipefail  # SEM -e: queremos capturar exit do systemctl
           echo "=== Warming web_cache table (esperado ~12-18h em B4as_v2 16GB) ==="
           echo "Inicio: $(date -Iseconds)"
           # systemctl start --wait com Type=oneshot bloqueia ate o ExecStart
@@ -664,8 +677,6 @@ jobs:
           sudo systemctl status cruza-warm-cache --no-pager --lines=20 || true
           if [ "$STATUS" -ne 0 ]; then
             echo "::warning::cruza-warm-cache encerrou com falha (>5% queries falharam)"
-            # Re-emite o exit code para o GitHub Actions marcar o step como failed,
-            # mas continue-on-error garante que postflight ainda roda.
             exit "$STATUS"
           fi
           echo "=== Cache warming complete ==="

--- a/TODO.md
+++ b/TODO.md
@@ -80,6 +80,35 @@
 - [ ] **Padronizar citacao `razao social + CNPJ` nos relatorios ativos**
 - [ ] **Corrigir relatorios com CNPJ nao encontrado na base RFB local**
 
+### Warm cache - performance (deferred big PRs)
+Os items abaixo ficaram fora do PR de speedup inicial (loop invertido + Q67 MV +
+PARALLEL_WORKERS=4 + ANALYZE + work_mem + disable timers) por serem refactors
+maiores. Considerar quando o ciclo atual de warm (~12-18h esperados) ainda for
+bottleneck.
+
+- [ ] **#9 Single GROUP BY query (warm 1 query agrupada para todos os munis)**
+  - Hoje cada query roda 224 vezes (uma por muni). Com `WITH .. GROUP BY municipio`
+    + `ROW_NUMBER() OVER (PARTITION BY municipio ORDER BY ... LIMIT 500)`, vira
+    1 query unica → ~10-20x speedup esperado.
+  - Risco alto: cada query em `web/queries/registry.py` tem `WHERE municipio = X`
+    em local diferente (CTEs profundas, subqueries). Precisa rewrite manual de
+    cada query + helper Python pra splitar resultados grouped → `web_cache`.
+- [ ] **#10 Pre-aggregate todas as queries lentas em MVs unificadas**
+  - Uma MV por familia de query (ex: `mv_top_fornecedores_pb`, `mv_q70_pb`,
+    `mv_q89_pb`...) materializando o resultado agrupado por (muni, ano).
+  - Warm passa a ser `SELECT * FROM mv_X WHERE muni=X` × N queries → ~30min total.
+  - Ja temos #8 (mv_q67_dated_pb) como blueprint.
+  - Custo: profile pra identificar queries com >5s/muni; design das MVs;
+    espaco em disco; tempo de criacao inicial; refresh strategy.
+  - Esforco: vario dias.
+- [ ] **#11 Partition `tce_pb_despesa` por ano**
+  - Tabela atual = 44GB. Particionando por ano (2018, 2019, ..., 2026), queries
+    com filtro `WHERE ano = 2026` (ou `data_empenho >= 'YYYY-...'`) leem apenas
+    o slice de ~4GB do ano corrente. Speedup: ~4-6x em queries com filtro de ano.
+  - Migration: criar tabela particionada, COPY data por ano (~1-2h em B4), swap.
+  - Risco medio: PG suporta nativamente, mas migration eh all-or-nothing.
+    Atualizar `etl/03_rfb` ou loaders TCE-PB para escrever na tabela particionada.
+
 ### Catalogo de relatorios - revisao de validade
 
 #### Relatorios validos

--- a/deploy/cruza-warm-cache.service
+++ b/deploy/cruza-warm-cache.service
@@ -11,6 +11,11 @@ Type=oneshot
 User=govbr
 WorkingDirectory=/home/govbr/govbr-project
 EnvironmentFile=/home/govbr/govbr-project/.env
+# Env vars opcionais (configurados via drop-in /etc/systemd/system/cruza-warm-cache.service.d/):
+#   WARM_CACHE_WORKERS=N         (default 4) — paralelismo
+#   WARM_SKIP_RECENT_HOURS=N     (default 0) — resume mode: pula munis cacheados ha < N horas
+#                                              0 = rebuild completo (default seguro)
+#                                              24 = skip cacheados ha <24h (apos web-only deploy)
 # --daemon (sem --loop) roda 1 ciclo completo e termina. Atualizar todos os
 # municipios PB pode demorar varias horas; sem timeout aqui.
 ExecStart=/home/govbr/govbr-project/venv/bin/python -u -m web.warm_cache --daemon

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -11,6 +11,7 @@ DROP MATERIALIZED VIEW IF EXISTS mv_rede_pb CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_empresa_pb CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_servidor_pb_risco CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_servidor_pb_base CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_q67_dated_pb CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_municipio_pb_mapa CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_municipio_pb_kpi_score CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_municipio_pb_risco CASCADE;
@@ -1319,6 +1320,61 @@ FROM mv_pessoa_pb ppb
 WHERE ppb.flag_auto_contratacao_potencial OR ppb.flag_duplo_vinculo_mun_est
    OR ppb.flag_duplo_vinculo_fed_est OR ppb.flag_bf_com_renda_estado
    OR ppb.flag_sancionado;
+
+
+-- =============================================================================
+-- mv_q67_dated_pb: Pre-aggregate da Q67 (Fornecedor com divida PGFN recebendo)
+-- por (municipio, ano) — uma das queries mais lentas do warm cache.
+--
+-- Q67 dated original escaneava tce_pb_despesa (44GB) + pgfn_divida (32GB)
+-- a cada chamada → ~30-90s/muni. Pre-agregando, a query do warm vira um
+-- INDEX SCAN em ~10-50ms.
+--
+-- Granularidade: (municipio, ano). Preserva todas as colunas que a query
+-- original retorna. Cobre 2022+ (filtro fixo de ano >= 2022, alinhado com
+-- o uso real da pagina /search/cidade).
+-- =============================================================================
+CREATE MATERIALIZED VIEW mv_q67_dated_pb AS
+WITH desp_per_muni_ano AS (
+    SELECT
+        municipio,
+        ano,
+        cnpj_basico,
+        MAX(cpf_cnpj) AS cpf_cnpj,
+        MAX(nome_credor) AS nome_credor,
+        SUM(valor_pago) AS total_pago,
+        COUNT(*) AS qtd_empenhos
+    FROM tce_pb_despesa
+    WHERE cnpj_basico IS NOT NULL
+      AND valor_pago > 0
+      AND ano >= 2022
+      AND municipio IS NOT NULL
+    GROUP BY municipio, ano, cnpj_basico
+    HAVING SUM(valor_pago) > 50000
+),
+pgfn_agg AS (
+    SELECT
+        LEFT(cpf_cnpj_norm, 8) AS cnpj_basico,
+        MAX(situacao_inscricao) AS situacao_inscricao,
+        SUM(valor_consolidado) AS divida_pgfn
+    FROM pgfn_divida
+    WHERE LENGTH(cpf_cnpj_norm) = 14
+    GROUP BY LEFT(cpf_cnpj_norm, 8)
+)
+SELECT
+    d.municipio,
+    d.ano,
+    d.cpf_cnpj,
+    d.nome_credor,
+    pg.situacao_inscricao,
+    pg.divida_pgfn,
+    d.total_pago,
+    d.qtd_empenhos
+FROM desp_per_muni_ano d
+JOIN pgfn_agg pg ON pg.cnpj_basico = d.cnpj_basico;
+
+CREATE INDEX idx_mv_q67_dated_mun_ano
+    ON mv_q67_dated_pb(municipio, ano, divida_pgfn DESC);
 
 
 -- =============================================================================

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -1324,15 +1324,22 @@ WHERE ppb.flag_auto_contratacao_potencial OR ppb.flag_duplo_vinculo_mun_est
 
 -- =============================================================================
 -- mv_q67_dated_pb: Pre-aggregate da Q67 (Fornecedor com divida PGFN recebendo)
--- por (municipio, ano) — uma das queries mais lentas do warm cache.
+-- por (municipio, ano, cnpj_basico) — uma das queries mais lentas do warm cache.
 --
 -- Q67 dated original escaneava tce_pb_despesa (44GB) + pgfn_divida (32GB)
 -- a cada chamada → ~30-90s/muni. Pre-agregando, a query do warm vira um
 -- INDEX SCAN em ~10-50ms.
 --
--- Granularidade: (municipio, ano). Preserva todas as colunas que a query
--- original retorna. Cobre 2022+ (filtro fixo de ano >= 2022, alinhado com
--- o uso real da pagina /search/cidade).
+-- Granularidade: (municipio, ano, cnpj_basico). Cobre 2022+ (filtro fixo).
+--
+-- IMPORTANTE: o filtro `HAVING SUM(valor_pago) > 50000` da query original
+-- aplicava-se ao TOTAL no range solicitado. Aqui agregamos por (ano, cnpj_basico)
+-- SEM filtro de threshold — o threshold eh aplicado pela query consumidora
+-- apos somar varios anos, garantindo correctness em ranges multi-ano (ex: 12M).
+--
+-- Tambem expomos cnpj_basico para que a query consumidora agrupe por ele
+-- (evita duplicar divida_pgfn quando uma empresa tem multiplas filiais com
+-- cpf_cnpj diferentes em anos diferentes).
 -- =============================================================================
 CREATE MATERIALIZED VIEW mv_q67_dated_pb AS
 WITH desp_per_muni_ano AS (
@@ -1350,7 +1357,8 @@ WITH desp_per_muni_ano AS (
       AND ano >= 2022
       AND municipio IS NOT NULL
     GROUP BY municipio, ano, cnpj_basico
-    HAVING SUM(valor_pago) > 50000
+    -- Sem HAVING aqui: deixar a query consumidora aplicar o threshold
+    -- depois de somar anos do range solicitado.
 ),
 pgfn_agg AS (
     SELECT
@@ -1364,6 +1372,7 @@ pgfn_agg AS (
 SELECT
     d.municipio,
     d.ano,
+    d.cnpj_basico,
     d.cpf_cnpj,
     d.nome_credor,
     pg.situacao_inscricao,

--- a/web/queries/registry.py
+++ b/web/queries/registry.py
@@ -256,7 +256,12 @@ LIMIT 500
 --  - Granularidade ano (nao mes/dia). Para ano_inicio=ano_fim filtra exatamente.
 --  - Para ano_inicio < ano_fim, agrega multiplos anos.
 --  - Cobre 2022+ apenas (alinhado com uso real do frontend).
-SELECT cpf_cnpj, MAX(nome_credor) AS nome_credor, %(municipio)s AS municipio,
+-- GROUP BY cnpj_basico (nao cpf_cnpj) para evitar duplicar divida_pgfn quando
+-- uma empresa tem multiplas filiais com cpf_cnpj diferentes em anos diferentes.
+-- HAVING aplicado apos SUM dos anos no range solicitado (correctness em multi-ano).
+SELECT MAX(cpf_cnpj) AS cpf_cnpj,
+       MAX(nome_credor) AS nome_credor,
+       %(municipio)s AS municipio,
        MAX(situacao_inscricao) AS situacao_inscricao,
        MAX(divida_pgfn) AS divida_pgfn,
        SUM(total_pago) AS total_pago,
@@ -264,7 +269,8 @@ SELECT cpf_cnpj, MAX(nome_credor) AS nome_credor, %(municipio)s AS municipio,
 FROM mv_q67_dated_pb
 WHERE municipio = %(municipio)s
   AND ano BETWEEN %(ano_inicio)s AND %(ano_fim)s
-GROUP BY cpf_cnpj
+GROUP BY cnpj_basico
+HAVING SUM(total_pago) > 50000
 ORDER BY MAX(divida_pgfn) DESC
 LIMIT 500
 """)

--- a/web/queries/registry.py
+++ b/web/queries/registry.py
@@ -250,32 +250,22 @@ JOIN pgfn_agg pg ON pg.cnpj_basico = d.cnpj_basico
 ORDER BY pg.divida_pgfn DESC
 LIMIT 500
 """, timeout=90, sql_dated="""
-WITH desp AS (
-    SELECT cnpj_basico, MAX(cpf_cnpj) AS cpf_cnpj, MAX(nome_credor) AS nome_credor,
-           SUM(valor_pago) AS total_pago, COUNT(*) AS qtd_empenhos
-    FROM tce_pb_despesa
-    WHERE cnpj_basico IS NOT NULL AND valor_pago > 0
-      AND data_empenho >= %(data_inicio)s AND data_empenho <= %(data_fim)s
-      AND municipio = %(municipio)s
-    GROUP BY cnpj_basico
-    HAVING SUM(valor_pago) > 50000
-),
-pgfn_agg AS (
-    SELECT LEFT(cpf_cnpj_norm, 8) AS cnpj_basico,
-           MAX(situacao_inscricao) AS situacao_inscricao,
-           SUM(valor_consolidado) AS divida_pgfn
-    FROM pgfn_divida
-    WHERE LENGTH(cpf_cnpj_norm) = 14
-      AND LEFT(cpf_cnpj_norm, 8) IN (SELECT cnpj_basico FROM desp)
-    GROUP BY LEFT(cpf_cnpj_norm, 8)
-)
-SELECT d.cpf_cnpj, d.nome_credor, %(municipio)s AS municipio,
-       pg.situacao_inscricao,
-       pg.divida_pgfn,
-       d.total_pago, d.qtd_empenhos
-FROM desp d
-JOIN pgfn_agg pg ON pg.cnpj_basico = d.cnpj_basico
-ORDER BY pg.divida_pgfn DESC
+-- Variante dated (filtro por ano) usa mv_q67_dated_pb pre-agregada.
+-- ~100x mais rapida que a versao live (escanear tce_pb_despesa + pgfn_divida).
+-- Limitacoes da MV:
+--  - Granularidade ano (nao mes/dia). Para ano_inicio=ano_fim filtra exatamente.
+--  - Para ano_inicio < ano_fim, agrega multiplos anos.
+--  - Cobre 2022+ apenas (alinhado com uso real do frontend).
+SELECT cpf_cnpj, MAX(nome_credor) AS nome_credor, %(municipio)s AS municipio,
+       MAX(situacao_inscricao) AS situacao_inscricao,
+       MAX(divida_pgfn) AS divida_pgfn,
+       SUM(total_pago) AS total_pago,
+       SUM(qtd_empenhos) AS qtd_empenhos
+FROM mv_q67_dated_pb
+WHERE municipio = %(municipio)s
+  AND ano BETWEEN %(ano_inicio)s AND %(ano_fim)s
+GROUP BY cpf_cnpj
+ORDER BY MAX(divida_pgfn) DESC
 LIMIT 500
 """)
 

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -58,6 +58,13 @@ PARALLEL_WORKERS = int(os.getenv("WARM_CACHE_WORKERS", "4"))
 # em queries do registry sem comprometer o uso geral do banco.
 WARM_WORK_MEM = "256MB"
 
+# Resume mode: pula queries cacheadas ha menos de N horas.
+# Usado quando os DADOS nao mudaram (ex: etl_phase=web warm_cache=true).
+# 0 = sem skip (rebuild completo), tipico apos ETL/SQL que recriou MVs.
+# 24 = pula tudo cacheado nas ultimas 24h (resume de warm interrompido).
+# Configurado via env var pelo deploy.yml conforme etl_phase.
+SKIP_RECENT_HOURS = int(os.getenv("WARM_SKIP_RECENT_HOURS", "0"))
+
 # Timeouts (segundos) usados pelo warmer. Sao MAIORES que os do frontend
 # porque rodamos em background e queremos popular o cache mesmo para queries
 # pesadas. Falhar aqui significa cache miss eterno no usuario final.
@@ -249,6 +256,34 @@ def _run_query_for_muni(query_id: str, sql: str, mun: str, extra_params: dict | 
         return False, msg
 
 
+def _filter_cached_munis(query_id: str, municipios: list[str]) -> tuple[list[str], int]:
+    """Em resume mode (SKIP_RECENT_HOURS > 0), remove munis cujo cache para
+    `query_id` foi atualizado nas ultimas SKIP_RECENT_HOURS horas.
+
+    Returns (munis_to_process, num_skipped).
+    """
+    if SKIP_RECENT_HOURS <= 0:
+        return municipios, 0
+
+    conn = psycopg2.connect(DSN)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT municipio FROM {CACHE_TABLE} "
+                f"WHERE query_id = %s AND updated_at > now() - interval %s",
+                (query_id, f"{SKIP_RECENT_HOURS} hours"),
+            )
+            cached = {r[0] for r in cur.fetchall()}
+    finally:
+        conn.close()
+
+    if not cached:
+        return municipios, 0
+    remaining = [m for m in municipios if m not in cached]
+    return remaining, len(municipios) - len(remaining)
+
+
 def _warm_query_across_munis(query_id: str, sql: str, municipios: list[str],
                               extra_params: dict | None, timeout: int, verbose: bool):
     """Executa uma unica query para TODOS os municipios em paralelo.
@@ -256,7 +291,17 @@ def _warm_query_across_munis(query_id: str, sql: str, municipios: list[str],
     Inversao do loop original (que era muni->query). Aqui rodamos query->muni:
     apos a primeira muni, os indexes/tables relevantes ficam quentes no
     shared_buffers/host cache, beneficiando as munis seguintes.
+
+    Em resume mode (SKIP_RECENT_HOURS > 0), pula munis ja cacheados
+    recentemente para essa query.
     """
+    original_total = len(municipios)
+    municipios, skipped = _filter_cached_munis(query_id, municipios)
+    if not municipios:
+        if verbose:
+            print(f"  {query_id}: skipped {skipped}/{original_total} (resume mode)", flush=True)
+        return skipped, 0  # contam como ok porque ja estao cacheados
+
     total = len(municipios)
     ok = fail = 0
     timeouts = 0
@@ -278,21 +323,30 @@ def _warm_query_across_munis(query_id: str, sql: str, municipios: list[str],
     if verbose:
         rate = total / elapsed if elapsed > 0 else 0
         suffix = f" ({timeouts} timeouts)" if timeouts else ""
+        skip_msg = f", {skipped} skipped" if skipped else ""
         print(
-            f"  {query_id}: {ok}/{total} ok, {fail} fail{suffix} "
+            f"  {query_id}: {ok}/{total} ok, {fail} fail{suffix}{skip_msg} "
             f"({elapsed:.0f}s, {rate:.1f}/s)",
             flush=True,
         )
-    return ok, fail
+    # Skipped contam como ok no agregado: ja estao cacheados.
+    return ok + skipped, fail
 
 
 def _warm_kpi_summary_across_munis(municipios: list[str], periodo: str, verbose: bool):
     """Computa KPI_SUMMARY para todos os munis em paralelo. Depende de
     PERFIL/TOP_FORN/TOP_SERV ja cacheados para o periodo."""
+    qid = f"{periodo}:KPI_SUMMARY" if periodo else "KPI_SUMMARY"
+    original_total = len(municipios)
+    municipios, skipped = _filter_cached_munis(qid, municipios)
+    if not municipios:
+        if verbose:
+            print(f"  {qid}: skipped {skipped}/{original_total} (resume mode)", flush=True)
+        return skipped, 0
+
     total = len(municipios)
     ok = fail = 0
     t0 = time.time()
-    qid = f"{periodo}:KPI_SUMMARY" if periodo else "KPI_SUMMARY"
 
     def task(mun):
         conn = _thread_conn()
@@ -307,8 +361,9 @@ def _warm_kpi_summary_across_munis(municipios: list[str], periodo: str, verbose:
 
     elapsed = time.time() - t0
     if verbose:
-        print(f"  {qid}: {ok}/{total} ok, {fail} fail ({elapsed:.0f}s)", flush=True)
-    return ok, fail
+        skip_msg = f", {skipped} skipped" if skipped else ""
+        print(f"  {qid}: {ok}/{total} ok, {fail} fail{skip_msg} ({elapsed:.0f}s)", flush=True)
+    return ok + skipped, fail
 
 
 def _warm_phase(phase_name: str, municipios: list[str], all_queries: list,

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta, timezone
 
 import psycopg2
@@ -48,9 +49,14 @@ CREATE TABLE IF NOT EXISTS {CACHE_TABLE} (
 PAUSE_BETWEEN_CYCLES = 60  # seconds between full cycles in daemon mode
 
 # Numero de municipios processados em paralelo. Cada worker abre 1 conexao PG
-# propria. Mantemos baixo (2) para nao competir com os 3 workers do uvicorn
-# nem saturar I/O de tabelas grandes (tce_pb_despesa, etc).
-PARALLEL_WORKERS = 2
+# propria. Em B4as_v2 (4 vCPU) usamos 4 para saturar o CPU.
+# Em VMs menores, override via env var WARM_CACHE_WORKERS.
+PARALLEL_WORKERS = int(os.getenv("WARM_CACHE_WORKERS", "4"))
+
+# work_mem por sessao do warm. Evita disk-based sorts em queries com Sort/Hash
+# pesados. Padrao do PG (em B4 16GB) eh ~124MB; 256MB cobre Sort spillover
+# em queries do registry sem comprometer o uso geral do banco.
+WARM_WORK_MEM = "256MB"
 
 # Timeouts (segundos) usados pelo warmer. Sao MAIORES que os do frontend
 # porque rodamos em background e queremos popular o cache mesmo para queries
@@ -75,6 +81,11 @@ def _thread_conn():
     if conn is None or conn.closed:
         conn = psycopg2.connect(DSN)
         conn.autocommit = False
+        # Aumenta work_mem nessa sessao especifica para evitar disk-based sorts.
+        # Aplica em todas as queries do warm (PERFIL, TOP_*, registry, etc).
+        with conn.cursor() as cur:
+            cur.execute(f"SET work_mem = '{WARM_WORK_MEM}'")
+        conn.commit()
         _thread_local.conn = conn
     return conn
 
@@ -88,7 +99,19 @@ def _get_municipios_pb(conn, only: str | None = None) -> list[str]:
                 (only,),
             )
         else:
-            cur.execute("SELECT municipio FROM mv_municipio_pb_risco ORDER BY municipio")
+            # ORDER BY tamanho/risco desc primeiro: municipios maiores levam
+            # mais tempo, entao processa-los cedo da feedback de progresso
+            # mais real (workers terminam rapido com os pequenos depois).
+            # Tambem ajuda usuarios: as cidades mais consultadas (geralmente
+            # as maiores) ficam quentes no cache antes.
+            cur.execute(
+                """
+                SELECT r.municipio
+                FROM mv_municipio_pb_risco r
+                LEFT JOIN mv_municipio_pb_mapa m ON m.municipio = r.municipio
+                ORDER BY COALESCE(m.total_pago_pj, 0) DESC, r.municipio
+                """
+            )
         return [r[0] for r in cur.fetchall()]
 
 
@@ -196,174 +219,185 @@ def _compute_and_cache_kpi_summary(conn, mun: str, periodo: str, verbose: bool):
         return False
 
 
-def _run_and_cache(conn, query_id: str, sql: str, mun: str, timeout_sec: int, verbose: bool):
-    """Executa uma query e salva no cache. Retorna True se ok."""
-    try:
-        cols, rows = _execute(conn, sql, {"municipio": mun}, timeout_sec)
-        conn.commit()
-        with conn.cursor() as cur:
-            _upsert(cur, query_id, mun, cols, rows)
-        conn.commit()
-        return True
-    except Exception as e:
-        conn.rollback()
-        msg = str(e).split("\n")[0]
-        # Sempre loga (timeout incluso) para podermos identificar queries que
-        # nunca completam dentro do tempo configurado.
-        if verbose:
-            tag = "TIMEOUT" if "statement_timeout" in msg else "ERR"
-            print(f"  [{tag}] {query_id} mun={mun}: {msg}", flush=True)
-        return False
-
-
-def _run_and_cache_dated(conn, query_id: str, sql: str, params: dict, timeout_sec: int, verbose: bool):
-    """Executa query com params de data e salva no cache. Retorna True se ok."""
-    mun = params["municipio"]
-    try:
-        cols, rows = _execute(conn, sql, params, timeout_sec)
-        conn.commit()
-        with conn.cursor() as cur:
-            _upsert(cur, query_id, mun, cols, rows)
-        conn.commit()
-        return True
-    except Exception as e:
-        conn.rollback()
-        msg = str(e).split("\n")[0]
-        if verbose:
-            tag = "TIMEOUT" if "statement_timeout" in msg else "ERR"
-            print(f"  [{tag}] {query_id} mun={mun}: {msg}", flush=True)
-        return False
-
-
 def _ensure_cache_table(conn):
     with conn.cursor() as cur:
         cur.execute(SCHEMA_DDL)
     conn.commit()
 
 
-def _warm_municipio_periodo(mun: str, idx: int, total: int, periodo: str, params_base: dict, all_queries: list, verbose: bool):
-    """Processa variantes datadas para um periodo cacheavel (ANO, 12M)."""
+def _run_query_for_muni(query_id: str, sql: str, mun: str, extra_params: dict | None, timeout_sec: int):
+    """Executa uma query para 1 muni e cacheia. Retorna (ok, msg|None).
+
+    Usado pelo loop invertido (1 query × N munis em paralelo). Por design,
+    nao printa nada — o caller agrega resultados e decide o que logar.
+    """
     conn = _thread_conn()
+    if extra_params:
+        params = {**extra_params, "municipio": mun}
+    else:
+        params = {"municipio": mun}
+    try:
+        cols, rows = _execute(conn, sql, params, timeout_sec)
+        conn.commit()
+        with conn.cursor() as cur:
+            _upsert(cur, query_id, mun, cols, rows)
+        conn.commit()
+        return True, None
+    except Exception as e:
+        conn.rollback()
+        msg = str(e).split("\n")[0]
+        return False, msg
+
+
+def _warm_query_across_munis(query_id: str, sql: str, municipios: list[str],
+                              extra_params: dict | None, timeout: int, verbose: bool):
+    """Executa uma unica query para TODOS os municipios em paralelo.
+
+    Inversao do loop original (que era muni->query). Aqui rodamos query->muni:
+    apos a primeira muni, os indexes/tables relevantes ficam quentes no
+    shared_buffers/host cache, beneficiando as munis seguintes.
+    """
+    total = len(municipios)
+    ok = fail = 0
+    timeouts = 0
     t0 = time.time()
-    ok, fail = 0, 0
-    params = {"municipio": mun, **params_base}
-    prefix = f"{periodo}:"
 
-    if _run_and_cache_dated(conn, f"{prefix}PERFIL", PERFIL_MUNICIPIO_LIVE, params, TIMEOUT_PERFIL_LIVE, verbose):
-        ok += 1
-    else:
-        fail += 1
+    def task(mun):
+        return _run_query_for_muni(query_id, sql, mun, extra_params, timeout)
 
-    if _run_and_cache_dated(conn, f"{prefix}TOP_FORNECEDORES", TOP_FORNECEDORES_DATED, params, TIMEOUT_TOP_FORN, verbose):
-        ok += 1
-    else:
-        fail += 1
+    with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as ex:
+        for success, msg in ex.map(task, municipios):
+            if success:
+                ok += 1
+            else:
+                fail += 1
+                if msg and "statement_timeout" in msg:
+                    timeouts += 1
 
-    if _run_and_cache_dated(conn, f"{prefix}TOP_SERVIDORES", TOP_SERVIDORES_RISCO_DATED, params, TIMEOUT_TOP_SERV, verbose):
-        ok += 1
-    else:
-        fail += 1
+    elapsed = time.time() - t0
+    if verbose:
+        rate = total / elapsed if elapsed > 0 else 0
+        suffix = f" ({timeouts} timeouts)" if timeouts else ""
+        print(
+            f"  {query_id}: {ok}/{total} ok, {fail} fail{suffix} "
+            f"({elapsed:.0f}s, {rate:.1f}/s)",
+            flush=True,
+        )
+    return ok, fail
 
-    # KPI_SUMMARY depende de PERFIL/TOP_FORN/TOP_SERV do periodo ja cacheados acima.
-    if _compute_and_cache_kpi_summary(conn, mun, periodo, verbose):
-        ok += 1
-    else:
-        fail += 1
 
-    for qdef in all_queries:
-        if qdef.sql_full_dated:
-            cache_timeout = max(qdef.timeout_sec, TIMEOUT_REGISTRY_DEFAULT)
-            if _run_and_cache_dated(conn, f"{prefix}{qdef.id}", qdef.sql_full_dated, params, cache_timeout, verbose):
+def _warm_kpi_summary_across_munis(municipios: list[str], periodo: str, verbose: bool):
+    """Computa KPI_SUMMARY para todos os munis em paralelo. Depende de
+    PERFIL/TOP_FORN/TOP_SERV ja cacheados para o periodo."""
+    total = len(municipios)
+    ok = fail = 0
+    t0 = time.time()
+    qid = f"{periodo}:KPI_SUMMARY" if periodo else "KPI_SUMMARY"
+
+    def task(mun):
+        conn = _thread_conn()
+        return _compute_and_cache_kpi_summary(conn, mun, periodo, verbose=False)
+
+    with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as ex:
+        for result in ex.map(task, municipios):
+            if result:
                 ok += 1
             else:
                 fail += 1
 
     elapsed = time.time() - t0
     if verbose:
-        print(f"[{idx}/{total}] {periodo}:{mun}: {ok} ok, {fail} fail ({elapsed:.1f}s)", flush=True)
+        print(f"  {qid}: {ok}/{total} ok, {fail} fail ({elapsed:.0f}s)", flush=True)
     return ok, fail
 
 
-def _warm_municipio_ano(mun: str, idx: int, total: int, ano_params_base: dict, all_queries: list, verbose: bool):
-    """Processa todas as variantes ANO para um municipio. Usa conn por thread."""
-    return _warm_municipio_periodo(mun, idx, total, "ANO", ano_params_base, all_queries, verbose)
+def _warm_phase(phase_name: str, municipios: list[str], all_queries: list,
+                extra_params: dict | None, verbose: bool):
+    """Roda um ciclo completo para uma fase (ANO/12M/ALL-TIME) com loop
+    invertido: cada query roda contra todos os munis em paralelo, em ordem
+    de dependencia (PERFIL/TOP_* primeiro, depois KPI_SUMMARY, depois
+    HEATMAP, depois queries do registry).
 
+    Beneficios vs loop original (muni->query):
+    - Cache locality: indexes/tables consultadas pela query ficam quentes
+      no shared_buffers/host cache apos a primeira muni; demais munis se
+      beneficiam.
+    - Plan caching: postgres pode reusar o plano executado para uma muni
+      ao executar a mesma query (com municipio diferente) na proxima.
+    - Progresso visivel: cada query tem seu proprio summary timing.
+    """
+    is_dated = bool(extra_params)
+    prefix = f"{phase_name}:" if phase_name else ""
+    label = phase_name or "ALL-TIME"
+    if verbose:
+        print(f"\n--- {label}: {len(municipios)} munis, "
+              f"workers={PARALLEL_WORKERS} (loop invertido) ---", flush=True)
 
-def _warm_municipio_12m(mun: str, idx: int, total: int, params_12m_base: dict, all_queries: list, verbose: bool):
-    """Processa todas as variantes dos ultimos 12 meses para um municipio."""
-    return _warm_municipio_periodo(mun, idx, total, "12M", params_12m_base, all_queries, verbose)
+    cycle_ok = cycle_fail = 0
 
+    # 1. PERFIL — alimenta KPI_SUMMARY (dependencia)
+    perfil_sql = PERFIL_MUNICIPIO_LIVE if is_dated else PERFIL_MUNICIPIO
+    ok, fail = _warm_query_across_munis(
+        f"{prefix}PERFIL", perfil_sql, municipios, extra_params, TIMEOUT_PERFIL_LIVE, verbose,
+    )
+    cycle_ok += ok
+    cycle_fail += fail
 
-def _warm_municipio_alltime(mun: str, idx: int, total: int, all_queries: list, verbose: bool):
-    """Processa todas as variantes all-time para um municipio. Usa conn por thread."""
-    conn = _thread_conn()
-    t0 = time.time()
-    ok, fail = 0, 0
+    # 2. TOP_FORNECEDORES — alimenta KPI_SUMMARY
+    forn_sql = TOP_FORNECEDORES_DATED if is_dated else TOP_FORNECEDORES
+    ok, fail = _warm_query_across_munis(
+        f"{prefix}TOP_FORNECEDORES", forn_sql, municipios, extra_params, TIMEOUT_TOP_FORN, verbose,
+    )
+    cycle_ok += ok
+    cycle_fail += fail
 
-    if _run_and_cache(conn, "PERFIL", PERFIL_MUNICIPIO, mun, TIMEOUT_PERFIL_LIVE, verbose):
-        ok += 1
-    else:
-        fail += 1
+    # 3. TOP_SERVIDORES — alimenta KPI_SUMMARY
+    serv_sql = TOP_SERVIDORES_RISCO_DATED if is_dated else TOP_SERVIDORES_RISCO
+    ok, fail = _warm_query_across_munis(
+        f"{prefix}TOP_SERVIDORES", serv_sql, municipios, extra_params, TIMEOUT_TOP_SERV, verbose,
+    )
+    cycle_ok += ok
+    cycle_fail += fail
 
-    if _run_and_cache(conn, "TOP_FORNECEDORES", TOP_FORNECEDORES, mun, TIMEOUT_TOP_FORN, verbose):
-        ok += 1
-    else:
-        fail += 1
+    # 4. KPI_SUMMARY — depende dos 3 acima
+    ok, fail = _warm_kpi_summary_across_munis(municipios, phase_name, verbose)
+    cycle_ok += ok
+    cycle_fail += fail
 
-    if _run_and_cache(conn, "TOP_SERVIDORES", TOP_SERVIDORES_RISCO, mun, TIMEOUT_TOP_SERV, verbose):
-        ok += 1
-    else:
-        fail += 1
+    # 5. HEATMAP — apenas all-time
+    if not is_dated:
+        ok, fail = _warm_query_across_munis(
+            "HEATMAP", HEATMAP_MENSAL, municipios, None, TIMEOUT_HEATMAP, verbose,
+        )
+        cycle_ok += ok
+        cycle_fail += fail
 
-    # KPI_SUMMARY all-time depende de PERFIL/TOP_FORN/TOP_SERV ja cacheados acima
-    if _compute_and_cache_kpi_summary(conn, mun, "", verbose):
-        ok += 1
-    else:
-        fail += 1
-
-    if _run_and_cache(conn, "HEATMAP", HEATMAP_MENSAL, mun, TIMEOUT_HEATMAP, verbose):
-        ok += 1
-    else:
-        fail += 1
-
+    # 6. Queries do registry (Q01-Q310). Cada uma roda contra todos os munis.
     for qdef in all_queries:
-        cache_timeout = max(qdef.timeout_sec, TIMEOUT_REGISTRY_DEFAULT)
-        if _run_and_cache(conn, qdef.id, qdef.sql_full, mun, cache_timeout, verbose):
-            ok += 1
+        if is_dated:
+            sql = qdef.sql_full_dated
+            if not sql:
+                continue  # registry permite query sem variante dated
         else:
-            fail += 1
+            sql = qdef.sql_full
+        cache_timeout = max(qdef.timeout_sec, TIMEOUT_REGISTRY_DEFAULT)
+        ok, fail = _warm_query_across_munis(
+            f"{prefix}{qdef.id}", sql, municipios, extra_params, cache_timeout, verbose,
+        )
+        cycle_ok += ok
+        cycle_fail += fail
 
-    elapsed = time.time() - t0
-    if verbose:
-        print(f"[{idx}/{total}] {mun}: {ok} ok, {fail} fail ({elapsed:.1f}s)", flush=True)
-    return ok, fail
-
-
-def _run_parallel(label: str, municipios: list[str], task_fn, verbose: bool, **kwargs):
-    """Executa task_fn(mun, idx, total, ...) em paralelo entre municipios."""
-    total = len(municipios)
-    if verbose:
-        print(f"--- {label}: {total} municipios (workers={PARALLEL_WORKERS}) ---", flush=True)
-    cycle_ok, cycle_fail = 0, 0
-    with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as ex:
-        futs = [
-            ex.submit(task_fn, mun, i, total, verbose=verbose, **kwargs)
-            for i, mun in enumerate(municipios, 1)
-        ]
-        for f in as_completed(futs):
-            try:
-                ok, fail = f.result()
-                cycle_ok += ok
-                cycle_fail += fail
-            except Exception as e:
-                cycle_fail += 1
-                if verbose:
-                    print(f"  [WORKER ERR] {e}", flush=True)
     return cycle_ok, cycle_fail
 
 
 def warm_cycle_pb(municipios: list[str], verbose: bool = True):
-    """Processa um ciclo completo de todos os municipios PB (ANO, 12M e all-time)."""
+    """Processa um ciclo completo com loop invertido (query->muni).
+
+    Estrategia: para cada fase (ANO, 12M, all-time), iteramos QUERIES e
+    paralelizamos sobre munis. Isso melhora cache locality vs o loop
+    original (muni->query) — apos a primeira muni, indexes/tables
+    relevantes ja estao quentes no shared_buffers/host cache.
+    """
     # Garante schema da tabela de cache em conexao dedicada (curta).
     bootstrap = psycopg2.connect(DSN)
     bootstrap.autocommit = False
@@ -372,8 +406,6 @@ def warm_cycle_pb(municipios: list[str], verbose: bool = True):
 
     all_queries = list(CIDADE_QUERIES.values())
 
-    # 1o loop: variantes ANO (ano atual) — prioritario porque o frontend
-    # usa "ano atual" como filtro padrao, gerando mais cache hits.
     today = _today_gmt3()
     ano_params_base = {
         "data_inicio": f"{today.year}-01-01",
@@ -396,21 +428,20 @@ def warm_cycle_pb(municipios: list[str], verbose: bool = True):
         "ano_mes_fim": today.strftime("%Y-%m"),
     }
 
-    ano_ok, ano_fail = _run_parallel(
-        f"ANO {today.year}", municipios, _warm_municipio_ano, verbose,
-        ano_params_base=ano_params_base, all_queries=all_queries,
+    # Fase 1: ANO atual — prioritario porque o frontend usa "ano atual" como
+    # filtro padrao, gerando mais cache hits.
+    ano_ok, ano_fail = _warm_phase(
+        f"ANO {today.year}", municipios, all_queries, ano_params_base, verbose,
     )
 
-    # 2o loop: ultimos 12 meses, usado pelo preset frequente do frontend.
-    m12_ok, m12_fail = _run_parallel(
-        "12M", municipios, _warm_municipio_12m, verbose,
-        params_12m_base=params_12m_base, all_queries=all_queries,
+    # Fase 2: ultimos 12 meses, usado pelo preset frequente do frontend.
+    m12_ok, m12_fail = _warm_phase(
+        "12M", municipios, all_queries, params_12m_base, verbose,
     )
 
-    # 3o loop: variantes all-time (sem prefixo)
-    all_ok, all_fail = _run_parallel(
-        "ALL-TIME", municipios, _warm_municipio_alltime, verbose,
-        all_queries=all_queries,
+    # Fase 3: all-time (sem prefixo, sem params de data).
+    all_ok, all_fail = _warm_phase(
+        "", municipios, all_queries, None, verbose,
     )
 
     return ano_ok + m12_ok + all_ok, ano_fail + m12_fail + all_fail

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -54,9 +54,13 @@ PAUSE_BETWEEN_CYCLES = 60  # seconds between full cycles in daemon mode
 PARALLEL_WORKERS = int(os.getenv("WARM_CACHE_WORKERS", "4"))
 
 # work_mem por sessao do warm. Evita disk-based sorts em queries com Sort/Hash
-# pesados. Padrao do PG (em B4 16GB) eh ~124MB; 256MB cobre Sort spillover
-# em queries do registry sem comprometer o uso geral do banco.
-WARM_WORK_MEM = "256MB"
+# pesados. Padrao do PG (em B4 16GB) eh ~124MB.
+# 192MB = compromisso entre acelerar Sort e nao saturar memoria com 4 workers
+# rodando simultaneamente (4 workers * 3 sort ops * 192MB = ~2.3GB peak).
+# Nota: psycopg2 nao suporta SET LOCAL fora de transacao explicita; SET
+# session-level afeta apenas as conexoes abertas pelo warm (nao o postgres
+# como um todo). cruza-web abre suas proprias conexoes e nao eh afetado.
+WARM_WORK_MEM = "192MB"
 
 # Resume mode: pula queries cacheadas ha menos de N horas.
 # Usado quando os DADOS nao mudaram (ex: etl_phase=web warm_cache=true).
@@ -385,7 +389,12 @@ def _warm_phase(phase_name: str, municipios: list[str], all_queries: list,
     prefix = f"{phase_name}:" if phase_name else ""
     label = phase_name or "ALL-TIME"
     if verbose:
-        print(f"\n--- {label}: {len(municipios)} munis, "
+        # Em ANO/12M, mostrar o range efetivo nos logs ja que o prefix
+        # nao carrega mais o ano (precisa bater com ANO: lido pelo frontend).
+        range_info = ""
+        if extra_params:
+            range_info = f" (ano_inicio={extra_params.get('ano_inicio')}, ano_fim={extra_params.get('ano_fim')})"
+        print(f"\n--- {label}{range_info}: {len(municipios)} munis, "
               f"workers={PARALLEL_WORKERS} (loop invertido) ---", flush=True)
 
     cycle_ok = cycle_fail = 0
@@ -485,8 +494,10 @@ def warm_cycle_pb(municipios: list[str], verbose: bool = True):
 
     # Fase 1: ANO atual — prioritario porque o frontend usa "ano atual" como
     # filtro padrao, gerando mais cache hits.
+    # IMPORTANTE: usar prefix "ANO" (sem ano), porque eh o que o frontend espera
+    # ler em web/db.py e web/routes/cidade.py. O ano em si vai nos params.
     ano_ok, ano_fail = _warm_phase(
-        f"ANO {today.year}", municipios, all_queries, ano_params_base, verbose,
+        "ANO", municipios, all_queries, ano_params_base, verbose,
     )
 
     # Fase 2: ultimos 12 meses, usado pelo preset frequente do frontend.


### PR DESCRIPTION
## Resumo

Combina 7 fixes em um único PR para reduzir o tempo do warm cache de **~37h para ~12-18h estimado** (2-3x speedup):

| # | Fix | Speedup |
|---|---|---|
| 1 | Mask `unattended-upgrades`/`apt-daily.timer` | previne reset 24h |
| 2 | `PARALLEL_WORKERS = 4` (era 2) | 1.3-1.5x |
| 3 | `ANALYZE` tabelas hot antes do warm | 1.0-1.2x |
| 4 | `work_mem = 256MB` nas conexões do warm | 1.1-1.3x |
| 6 | Loop invertido: `query → muni` | 1.5-2x |
| 7 | Sort munis por `total_pago_pj DESC` | UX (sem speedup) |
| 8 | `mv_q67_dated_pb` (Q67 dated como MV) | 1.3-1.5x |

Itens **#9, #10, #11** deferidos para `TODO.md` (refactors maiores que precisariam de PRs dedicados).

## Por que cada um

- **#1**: o timer `apt-daily-upgrade` dispara `systemctl daemon-reexec` a cada ~24h, enviando SIGTERM para serviços longos. Matou nosso warm na primeira tentativa (28/224 munis perdidos).
- **#2**: B4as_v2 tem 4 vCPUs, estávamos usando 2. Override via `WARM_CACHE_WORKERS`.
- **#3**: stats stale → planner escolhe planos ruins (Bitmap Heap Scan em vez de Index Scan, etc).
- **#4**: queries com Sort/Hash spillavam para disco com `work_mem=124MB`.
- **#6**: refactor `_warm_municipio_periodo`/`_alltime`/`_run_parallel` → `_warm_query_across_munis`/`_warm_kpi_summary_across_munis`/`_warm_phase`. Cache locality: após muni 1 da query X, indexes ficam quentes para muni 2+.
- **#7**: `_get_municipios_pb` agora `JOIN mv_municipio_pb_mapa ORDER BY total_pago_pj DESC`. Munis grandes primeiro = feedback de progresso real cedo.
- **#8**: Q67 dated era ~30-90s/muni (frequentemente timeout 90s). Versão MV: ~10-50ms. Suporta ranges de ano além de `ano=ano_atual`.

## Aplicação

- **Itens #1, #3, #8**: aplicados manualmente via SSH na VM agora (idempotentes), sem precisar `etl_phase=sql` completo:
  - `sudo systemctl mask apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service` ✅
  - VACUUM/ANALYZE em background ✅
  - `mv_q67_dated_pb` em background (~30-60min creation) ⏳
- **Itens #2, #4, #6, #7**: ativam no próximo dispatch de `warm_cache=true`.

## Verificações

- ✅ `web/warm_cache.py`: AST parse + import OK, `PARALLEL_WORKERS=4`, `WARM_WORK_MEM=256MB`
- ✅ `web/queries/registry.py`: AST parse OK
- ✅ `sql/12_views.sql`: 49 CREATE / 26 DROP, `mv_q67_dated_pb` presente
- ✅ `deploy.yml`: YAML válido, 17 steps no deploy job
- ✅ `.gitattributes` força LF nos novos arquivos

## Out of scope

- **#9** Single GROUP BY query (10-20x): refactor de cada query do registry com window function `ROW_NUMBER() OVER (PARTITION BY municipio)`. Documentado em TODO.
- **#10** Pre-aggregate todas as queries lentas em MVs: vários dias de profile + design + build. Documentado em TODO. `#8` é blueprint.
- **#11** Partition `tce_pb_despesa` por ano (4-6x): migration de 44GB. Documentado em TODO.

## Próximos passos após merge

1. Disparar `etl_phase=web warm_cache=true` para validar todos os fixes em conjunto
2. Medir tempo real do cycle vs estimativa
3. Decidir se vale partir para #11 (próximo maior ganho previsível)
