### PR TITLE
warm_cache: cast cpf_cnpj para bpchar(14) — fix do Hash Right Join

### DIFF
--- a/web/queries/cidade.py
+++ b/web/queries/cidade.py
@@ -262,7 +262,7 @@ PERFIL_MUNICIPIO_PNCP = None  # deprecated: non-PB removed from frontend
 TOP_FORNECEDORES = """
 WITH top_forn AS (
     SELECT d.cnpj_basico, d.nome_credor,
-           MAX(d.cpf_cnpj) AS cpf_cnpj,
+           MAX(d.cpf_cnpj)::bpchar(14) AS cpf_cnpj,
            SUM(d.valor_pago) AS total_pago,
            COUNT(DISTINCT d.numero_empenho) AS qtd_empenhos
     FROM tce_pb_despesa d
@@ -351,7 +351,7 @@ ORDER BY q.abrangencia_sancao_info IS NOT NULL DESC, q.total_pago DESC
 TOP_FORNECEDORES_FALLBACK = """
 WITH top_forn AS (
     SELECT d.cnpj_basico, d.nome_credor,
-           MAX(d.cpf_cnpj) AS cpf_cnpj,
+           MAX(d.cpf_cnpj)::bpchar(14) AS cpf_cnpj,
            SUM(d.valor_pago) AS total_pago,
            COUNT(DISTINCT d.numero_empenho) AS qtd_empenhos
     FROM tce_pb_despesa d
@@ -458,7 +458,7 @@ ORDER BY q.abrangencia_sancao_info IS NOT NULL DESC, q.total_pago DESC
 TOP_FORNECEDORES_DATED = """
 WITH top_forn AS (
     SELECT d.cnpj_basico, d.nome_credor,
-           MAX(d.cpf_cnpj) AS cpf_cnpj,
+           MAX(d.cpf_cnpj)::bpchar(14) AS cpf_cnpj,
            SUM(d.valor_pago) AS total_pago,
            COUNT(DISTINCT d.numero_empenho) AS qtd_empenhos
     FROM tce_pb_despesa d
@@ -548,7 +548,7 @@ ORDER BY q.abrangencia_sancao_info IS NOT NULL DESC, q.total_pago DESC
 TOP_FORNECEDORES_FALLBACK_DATED = """
 WITH top_forn AS (
     SELECT d.cnpj_basico, d.nome_credor,
-           MAX(d.cpf_cnpj) AS cpf_cnpj,
+           MAX(d.cpf_cnpj)::bpchar(14) AS cpf_cnpj,
            SUM(d.valor_pago) AS total_pago,
            COUNT(DISTINCT d.numero_empenho) AS qtd_empenhos
     FROM tce_pb_despesa d


### PR DESCRIPTION
## Resumo

Fix de **1250x speedup** na query TOP_FORNECEDORES (todas variantes) com mudança mínima: ::bpchar(14) cast no \MAX(cpf_cnpj)\.

## Problema

\TOP_FORNECEDORES_DATED\ (e variantes) timeout em ~30s/muni durante o warm cache. Investigação mostrou que o gargalo NÃO era o CTE inicial (rápido, 60-300ms), mas o **outer LEFT JOIN com estabelecimento**:

\\\
Hash Right Join (actual time=497..26767ms)
  Hash Cond: ((est.cnpj_completo)::text = tf.cpf_cnpj)
  -> Parallel Index Only Scan estabelecimento (rows=23621334)
\\\

Postgres fazia **Full Scan dos 29M rows do estabelecimento** + Hash Right Join, em vez de Nested Loop Index Lookup nas 200 linhas de top_forn.

## Causa raiz

Type mismatch:
- \stabelecimento.cnpj_completo\ é \pchar(14)\
- \	op_forn.cpf_cnpj\ saía como \	ext\ (resultado de \MAX(varchar)\)

O cast implícito \(est.cnpj_completo)::text = tf.cpf_cnpj\ impedia uso direto do índice por valor.

## Fix

\MAX(d.cpf_cnpj)::bpchar(14) AS cpf_cnpj\ no CTE de cada query (4 lugares):

| Query | Antes | Depois |
|---|---|---|
| TOP_FORNECEDORES | (não medido) | (mesma melhoria esperada) |
| TOP_FORNECEDORES_FALLBACK | (não medido) | idem |
| **TOP_FORNECEDORES_DATED** | **25s** | **20ms** |
| TOP_FORNECEDORES_FALLBACK_DATED | idem | idem |

## Testes manuais

- ✅ Cuitegi (muni pequeno): 21ms
- ✅ João Pessoa (muni grande): 73ms
- ✅ 4 munis em paralelo: 60ms cada
- ✅ Query FULL com todos os JOINs e EXISTS: 21ms

## O que NÃO está incluído

Investigação inicial criou uma MV \mv_tce_pb_credor_mun_mes\ (4.4M rows, 980MB) para pre-agregar tce_pb_despesa. **Removida** porque acelerava só o CTE inicial (que já era rápido), não o gargalo real. \mv_q67_dated_pb\ (do PR #41) é mantida — ataca caso diferente (Q67 dated).

## Próximos passos após merge

1. \tl_phase=web warm_cache=true drop_cache=true\ para reaplicar o cache com queries corretas
2. ETA esperado do warm: muito mais rápido (~3-6h vs 14-18h)