### PR TITLE
fix(MVs): municipio NULL fantasma + sancoes_base alinhado a 2022+

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,8 +11,8 @@
 - [ ] **Atualizar labels/legendas do mapa** (`web/static/mapa.js:6-13`) — label "Risco composto (0-100)" → "Nota de atencao (0-100)" alinhando com `/search/cidade`. Recalibrar breaks (62/65/69/73/77 calibrados ao TCE legado) apos deploy. Atualizar descricao do filtro no popover `?` mencionando os 8 KPIs componentes
 - [ ] **PERF: socio_por_municipio reagrega tce_pb_despesa desnecessariamente** (`sql/12_views.sql`) — apesar de `_tmp_conflito` materializar relacao similar. Refresh fica mais caro. Opcional
 - [ ] **MAINT: MV duplica formula de sql_score_expression()** — a expressao inline em `sql/12_views.sql` deveria vir de `web/kpis/municipio_pb.py:sql_score_expression()` via placeholder no `etl/21_views.py` para garantir single source of truth. Hoje sao identicas, mas drift silencioso eh possivel
-- [ ] **`sancoes_base` filtra 3 anos vs `desp_eventos` 2022+** (`sql/12_views.sql`) — pode subcontar sancoes que estavam vigentes em 2022 mas terminaram em 2022. Considerar alargar filtro de sancoes para `>= '2022-01-01'`
-- [ ] **Deploy MV unificada em prod (PR #31)** — disparar `deploy.yml` com `etl_phase=18` quando Azure estiver OK. Recria todas MVs (drop CASCADE no topo do `sql/12_views.sql`) — vai criar `mv_municipio_pb_kpi_score` e atualizar `mv_municipio_pb_mapa`. **Obrigatorio antes de subir esta versao do app** — sem a MV, queries `PERFIL_MUNICIPIO`, `PB_MEDIAS`, `AUTOCOMPLETE_MUNICIPIO`, `PB_RANKING_SQL` e `og_image._fetch_perfil` falham com `UndefinedTable`
+- [x] **`sancoes_base` filtra 3 anos vs `desp_eventos` 2022+** (`sql/12_views.sql`) — corrigido: alinhado para `>= '2022-01-01'`. Antes excluia ~60 sancoes CEIS terminadas em 2022 cujos empenhos correspondentes estavam em desp_eventos
+- [x] **Deploy MV unificada em prod (PR #31)** — concluido: deploy.yml `etl_phase=18`/`etl_phase=sql` recria todas MVs incluindo `mv_municipio_pb_kpi_score` e `mv_municipio_pb_mapa`
 
 ### Pivot PB-first — novas visualizacoes e cruzamentos
 - [x] **Mapa coropletico PB** — 223 municipios pintados por metrica, 5 camadas (risco, % irregulares, % sem licitacao, top-5, per capita). Toggle, legenda, click navega para detalhe. Breaks calibrados aos percentis reais. Aliases TCE→IBGE para municipios renomeados
@@ -68,7 +68,7 @@
 - [x] **Deploy workflow corrigido** — `etl.01_schema` removido da fase `sql` (causava DROP+CREATE e perda de dados). Adicionada opcao `etl_phase=web` para sync de codigo sem reprocessar ETL
 - [x] **Nginx reverse proxy** — porta 80 → uvicorn 8000, gzip habilitado, config em `deploy/nginx-cruza.conf`
 - [ ] **ETL E2E em andamento** — run 24383758256 (`clean=true`, `etl_phase=all`), fase de download
-- [ ] **mv_fornecedor_pb_perfil ownership** — view criada por user `postgres`, app roda como `govbr`. Corrigir com `ALTER MATERIALIZED VIEW mv_fornecedor_pb_perfil OWNER TO govbr`
+- [x] **mv_fornecedor_pb_perfil ownership** — verificado em 2026-05-03: MV nao existe mais (renomeada/removida). TODO obsoleta
 - [x] **Auto-limpeza de CSVs implementada** — `run_all.py` agora remove CSVs brutos apos cada fase ETL bem-sucedida. Diretorios compartilhados (rfb, tse) so sao removidos quando todas as fases dependentes completam.
 - [x] **deploy.yml atualizado** — instala `.[web]`, copia systemd services, reinicia cruza-web e cruza-warm-cache apos deploy
 - [x] **Services systemd corrigidos** — paths atualizados para `/home/govbr/govbr-project` e `venv/` (matching deploy.yml)

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -257,6 +257,7 @@ servidor_mun AS (
     FROM tce_pb_servidor
     WHERE cpf_digitos_6 IS NOT NULL AND nome_upper IS NOT NULL
       AND ano_mes >= '2022-01'
+      AND municipio IS NOT NULL  -- evita falso flag de duplo vinculo via row sem atribuicao
       AND EXISTS (SELECT 1 FROM pf_base pf WHERE pf.cpf_digitos_6 = tce_pb_servidor.cpf_digitos_6)
     GROUP BY cpf_digitos_6, nome_upper
 ),
@@ -369,6 +370,7 @@ desp AS (
     JOIN empresa e ON e.cnpj_basico = d.cnpj_basico
         AND e.natureza_juridica NOT LIKE '1%'
     WHERE d.cnpj_basico IS NOT NULL AND d.ano >= 2022
+      AND d.municipio IS NOT NULL  -- ~35k rows fantasma sem atribuicao municipal
     GROUP BY d.municipio
 ),
 lic_proponente AS (
@@ -376,6 +378,7 @@ lic_proponente AS (
            COUNT(DISTINCT cpf_cnpj_proponente) AS num_proponentes
     FROM tce_pb_licitacao
     WHERE ano_licitacao >= 2022
+      AND municipio IS NOT NULL
     GROUP BY municipio, numero_licitacao
 ),
 lic AS (
@@ -390,6 +393,7 @@ receita AS (
            SUM(valor) FILTER (WHERE tipo_atualizacao_receita ILIKE 'Lançamento de Receita') AS receita_arrecadada
     FROM tce_pb_receita
     WHERE ano >= 2022
+      AND municipio IS NOT NULL
     GROUP BY municipio
 ),
 folha AS (
@@ -397,6 +401,7 @@ folha AS (
            SUM(valor_vantagem) AS total_folha
     FROM tce_pb_servidor
     WHERE ano_mes >= '2022-01'
+      AND municipio IS NOT NULL
     GROUP BY municipio
 )
 SELECT
@@ -455,6 +460,7 @@ SELECT cpf_digitos_6,
 FROM tce_pb_servidor
 WHERE cpf_digitos_6 IS NOT NULL AND nome_upper IS NOT NULL
   AND ano_mes >= '2022-01'
+  AND municipio IS NOT NULL  -- evita NULL no array `municipios` que propaga para mv_servidor_pb_risco
 GROUP BY cpf_digitos_6, nome_upper;
 
 CREATE UNIQUE INDEX idx_mv_srvb_cpf_nome ON mv_servidor_pb_base(cpf_digitos_6, nome_upper);
@@ -515,11 +521,13 @@ DROP TABLE IF EXISTS _tmp_se_unnest;
 
 -- 3a. Pre-agrega tce_pb_despesa por (cnpj_basico, municipio) UMA vez.
 -- Sem index: a unica leitura subsequente eh um Hash Join, que constroi
--- sua propria hashmap.
+-- sua propria hashmap. Filtro municipio IS NOT NULL eh free e descarta
+-- ~35k rows fantasma sem atribuicao municipal.
 CREATE TABLE _tmp_d_agg AS
 SELECT cnpj_basico, municipio, SUM(valor_pago) AS total_pago
 FROM tce_pb_despesa
 WHERE valor_pago > 0
+  AND municipio IS NOT NULL
 GROUP BY cnpj_basico, municipio;
 
 ANALYZE _tmp_d_agg;
@@ -669,7 +677,8 @@ tce_agg AS (
            SUM(valor_empenhado) AS total_empenhado,
            COUNT(*) AS qtd_empenhos,
            COUNT(DISTINCT municipio) AS qtd_municipios,
-           ARRAY_AGG(DISTINCT municipio ORDER BY municipio) AS municipios,
+           ARRAY_AGG(DISTINCT municipio ORDER BY municipio)
+              FILTER (WHERE municipio IS NOT NULL) AS municipios,
            COUNT(*) FILTER (WHERE numero_licitacao IS NULL OR numero_licitacao = '' OR numero_licitacao = '0' OR numero_licitacao = '000000000' OR modalidade_licitacao ILIKE '%sem licit%') AS qtd_sem_licitacao
     FROM tce_pb_despesa
     WHERE cnpj_basico IS NOT NULL AND valor_pago > 0
@@ -843,6 +852,7 @@ SELECT
 FROM tce_pb_despesa d
 JOIN empresa e ON e.cnpj_basico = d.cnpj_basico
 WHERE d.cnpj_basico IS NOT NULL AND d.valor_pago > 0
+  AND d.municipio IS NOT NULL  -- evita arestas com entidade NULL
 GROUP BY d.cnpj_basico, e.razao_social, d.municipio;
 
 -- Aresta 3: SERVIDOR_MUNICIPAL (pessoa → município)
@@ -857,7 +867,8 @@ SELECT DISTINCT
     srv.municipio, srv.municipio, srv.descricao_cargo
 FROM tce_pb_servidor srv
 WHERE srv.cpf_digitos_6 IS NOT NULL AND srv.nome_upper IS NOT NULL
-  AND srv.ano_mes >= '2022-01';
+  AND srv.ano_mes >= '2022-01'
+  AND srv.municipio IS NOT NULL;
 
 -- Aresta 4: CREDOR_ESTADUAL_PF (pessoa → estado)
 DROP TABLE IF EXISTS _tmp_rede_cred;
@@ -949,6 +960,7 @@ forn_mun AS MATERIALIZED (
     WHERE d.cnpj_basico IS NOT NULL
       AND d.ano >= 2022
       AND d.valor_pago > 0
+      AND d.municipio IS NOT NULL
     GROUP BY d.municipio, d.cnpj_basico
 ),
 top5 AS (
@@ -964,9 +976,13 @@ top5 AS (
     ) x
     GROUP BY municipio
 ),
--- Universo de sancoes vigentes nos ultimos 3 anos com escopo extraido.
--- Usado pelos dois KPIs de sancao abaixo. Filtro temporal aplicado depois
--- (na hora de joinar com data_empenho).
+-- Universo de sancoes vigentes em qualquer momento >= 2022-01-01.
+-- IMPORTANTE: alinhado com desp_eventos (ano >= 2022). Antes usava
+-- CURRENT_DATE - INTERVAL '3 years' como cutoff, o que excluia sancoes
+-- terminadas em 2022 mas cujos empenhos correspondentes ESTAVAM em
+-- desp_eventos (subcontagem de ~60 sancoes CEIS). Agora os dois lados
+-- usam a mesma janela temporal: tudo vigente em 2022+ e considerado.
+-- Filtro temporal por data_empenho aplicado depois (no join).
 sancoes_base AS MATERIALIZED (
     SELECT cnpj_basico, dt_inicio_sancao, dt_final_sancao,
            categoria_sancao, abrangencia_sancao,
@@ -978,7 +994,7 @@ sancoes_base AS MATERIALIZED (
                esfera_orgao_sancionador, orgao_sancionador
         FROM ceis_sancao
         WHERE LENGTH(cpf_cnpj_sancionado) = 14
-          AND (dt_final_sancao IS NULL OR dt_final_sancao >= CURRENT_DATE - INTERVAL '3 years')
+          AND (dt_final_sancao IS NULL OR dt_final_sancao >= '2022-01-01')
         UNION ALL
         SELECT LEFT(cpf_cnpj_sancionado, 8),
                dt_inicio_sancao, dt_final_sancao,
@@ -986,7 +1002,7 @@ sancoes_base AS MATERIALIZED (
                esfera_orgao_sancionador, orgao_sancionador
         FROM cnep_sancao
         WHERE LENGTH(cpf_cnpj_sancionado) = 14
-          AND (dt_final_sancao IS NULL OR dt_final_sancao >= CURRENT_DATE - INTERVAL '3 years')
+          AND (dt_final_sancao IS NULL OR dt_final_sancao >= '2022-01-01')
     ) u
 ),
 -- Empenhos brutos por (municipio, cnpj_basico, data_empenho) usados nos joins
@@ -998,6 +1014,7 @@ desp_eventos AS MATERIALIZED (
       AND d.ano >= 2022
       AND d.valor_pago > 0
       AND d.data_empenho IS NOT NULL
+      AND d.municipio IS NOT NULL
 ),
 -- Fornecedor com sancao APLICAVEL ao municipio na data do empenho.
 -- Aplicavel = inidoneidade OU acordo de leniencia (CNEP) OU abrangencia nacional
@@ -1198,6 +1215,7 @@ forn_mun AS MATERIALIZED (
     WHERE d.cnpj_basico IS NOT NULL
       AND d.ano >= 2022
       AND d.valor_pago > 0
+      AND d.municipio IS NOT NULL
     GROUP BY d.municipio, d.cnpj_basico
 ),
 hhi AS (


### PR DESCRIPTION
## Resumo

Dois fixes de severidade **HIGH** em MVs PB, identificados na auditoria de hoje:

1. `municipio NULL` fantasma em MVs PB (causa raiz, não workaround)
2. `sancoes_base` janela temporal alinhada com `desp_eventos` (correção de subcontagem)

## 1. municipio NULL fantasma

`tce_pb_despesa` tem **35.107 rows** com `municipio IS NULL` (empenhos sem atribuição municipal — prováveis despesas estaduais no dump). Esses rows leakeavam para múltiplas MVs, gerando **1 row "fantasma"** em `mv_municipio_pb_risco` e `mv_municipio_pb_mapa` (224 total / 223 distinct), o que quebra `warm_cache` (NOT NULL constraint em `web_cache.municipio`).

**Workaround atual** (`web/warm_cache.py:_get_municipios_pb` commit c8298b9) filtrava no Python. Agora atacamos a causa raiz no SQL.

Adicionado `WHERE municipio IS NOT NULL` em:
- `mv_municipio_pb_risco`: `desp`, `lic_proponente`, `receita`, `folha`
- `mv_municipio_pb_kpi_score`: `forn_mun`, `desp_eventos`
- `mv_municipio_pb_mapa`: `forn_mun`
- `mv_pessoa_pb.servidor_mun` ⬅️ rubber-duck: evita falso flag de duplo vínculo
- `mv_servidor_pb_base` ⬅️ rubber-duck: array `municipios` sem NULL elements
- `mv_empresa_pb.tce_agg.municipios` usa `FILTER (WHERE municipio IS NOT NULL)`
- `mv_rede_pb._tmp_rede_forn` e `_tmp_rede_srv` ⬅️ evita arestas com entidade=NULL
- `_tmp_d_agg` ⬅️ free filter

Workaround em Python ficará como belt-and-suspenders.

## 2. sancoes_base janela alinhada

`mv_municipio_pb_kpi_score.sancoes_base` usava `dt_final_sancao >= CURRENT_DATE - INTERVAL '3 years'` (~2023-05), mas `desp_eventos` usa `ano >= 2022`. Mismatch excluía **~60 sanções CEIS** terminadas em 2022 cujos empenhos correspondentes ESTAVAM em `desp_eventos`. Resultado: subcontagem do KPI `qtd_pago_irregular` que alimenta o mapa coroplético e o score unificado.

Fix: cutoff `>= '2022-01-01'` (alinhado com `desp_eventos`).

`cnpj_irregular` em `mv_municipio_pb_mapa` **MANTIDO** em 3 anos — uso diferente: marca "fornecedor irregular hoje" para o mapa, sem join temporal com `data_empenho`. Aqui 3-year é semanticamente correto.

## Validação

Rubber-duck independente revisou. Pegou **2 BLOCKING** (mv_pessoa_pb e mv_servidor_pb_base) + 4 non-blocking, todos aplicados.

## Aplicação

Os fixes só entram em vigor após próxima execução de `etl_phase=sql` (rebuild de todas MVs PB). Run 25286272593 em curso usa código anterior — vai precisar de novo deploy depois.
