### PR TITLE
feat(seo): P0 quick wins + P1 URLs amigaveis + /sobre + breadcrumbs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,29 @@ RESEND_API_KEY=
 RESEND_FROM=noreply@transparenciapb.org
 # Caixa que recebe as mensagens do form de contato.
 CONTATO_DEST=contato@transparenciapb.org
+
+# ─── SEO: verificacao de propriedade do site ───
+# Codigos vem dos dashboards de cada provedor. Coletar APOS o primeiro deploy
+# do site, registrar la, e copiar o token aqui (apenas a string, sem aspas
+# nem o <meta> wrapper). Re-deploy injeta as meta tags em todas as paginas.
+#
+# Google Search Console: https://search.google.com/search-console -> Adicionar
+#   propriedade -> URL prefix https://transparenciapb.org -> "Tag HTML" ->
+#   copiar valor de content="..."
+GOOGLE_SITE_VERIFICATION=
+#
+# Bing Webmaster Tools: https://www.bing.com/webmasters -> Add site ->
+#   "Meta tag" -> copiar valor de content="..."
+# (alimenta tambem DuckDuckGo, ChatGPT search, Yahoo)
+BING_SITE_VERIFICATION=
+
+# ─── SEO: IndexNow (notificacao de mudancas pra Bing/Yandex/Yahoo/Seznam) ───
+# Gerar chave 32+ chars com:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Apos setar, a rota /<key>.txt serve o arquivo de verificacao.
+# Submeter URLs com:
+#   python -m web.indexnow_submit
+INDEXNOW_KEY=
+# Origem completa do site (usada pelo indexnow_submit pra montar URLs).
+SITE_URL=https://transparenciapb.org
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -358,6 +358,19 @@ jobs:
           # Write .env from secrets
           echo "${{ secrets.ENV_FILE }}" > .env
 
+          # Append SEO secrets (mantidos separados do ENV_FILE pra
+          # rotacao independente sem precisar editar o .env todo).
+          # Cada um eh opcional — se nao setado, sai como linha vazia
+          # (NOME=) que o python os.environ.get trata como string vazia.
+          {
+            echo ""
+            echo "# --- SEO secrets (ver .env.example) ---"
+            echo "INDEXNOW_KEY=${{ secrets.INDEXNOW_KEY }}"
+            echo "SITE_URL=${{ secrets.SITE_URL }}"
+            echo "GOOGLE_SITE_VERIFICATION=${{ secrets.GOOGLE_SITE_VERIFICATION }}"
+            echo "BING_SITE_VERIFICATION=${{ secrets.BING_SITE_VERIFICATION }}"
+          } >> .env
+
           # Ensure data dir
           source .env
           DATA="${DATA_DIR:-/data/raw-data}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,6 +607,32 @@ jobs:
           systemctl is-active cruza-web && echo "cruza-web: RUNNING" || echo "cruza-web: FAILED"
           echo "cruza-warm-cache: oneshot instalado (executado sob demanda)"
 
+      # ── SEO: notificar IndexNow (Bing/Yandex/Yahoo/Seznam/Naver) ──
+      # Roda apos cruza-web restart pra que /<INDEXNOW_KEY>.txt esteja
+      # acessivel quando os crawlers vierem validar. Submissao usa o
+      # sitemap dinamico (web.routes.seo._build_sitemap_xml), que ja
+      # inclui as 223 cidades + paginas estaticas. Tolerante a falha:
+      # `continue-on-error: true` + `|| true` no script garantem que
+      # IndexNow flaky nao quebra o deploy. Skip silencioso se a env
+      # var INDEXNOW_KEY nao estiver no .env.
+      - name: SEO - IndexNow submit (Bing/Yandex/Yahoo)
+        if: inputs.etl_phase == 'web' || inputs.etl_phase == 'all'
+        continue-on-error: true
+        run: |
+          set -e
+          cd ${{ env.PROJECT_DIR }}
+          source venv/bin/activate
+          source .env 2>/dev/null || true
+          if [ -z "${INDEXNOW_KEY:-}" ]; then
+            echo "INDEXNOW_KEY nao setada no .env — skipping IndexNow submit"
+            exit 0
+          fi
+          echo "=== IndexNow submit (host=${SITE_URL:-https://transparenciapb.org}) ==="
+          # Aguarda alguns segundos pra garantir que o cruza-web reiniciou
+          # e a rota /<key>.txt esta servindo (caso crawlers validem na hora).
+          sleep 5
+          python -m web.indexnow_submit 2>&1 || echo "::warning::IndexNow submit falhou — verificar log acima"
+
       # ── Atualizar estatisticas das tabelas hot ANTES do warm ──
       # Sem stats atualizadas, o planner pode escolher planos ruins (ex: hash
       # join em vez de nested loop, ou Bitmap Heap Scan em vez de Index Scan).

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 node_modules/
 .claude/
 
+# Runtime cache de OG images (PIL gera on-demand em data/og_cache/)
+data/og_cache/
+
 # Assets estaticos do frontend nao sao ignorados
 !web/static/geo/*.json
 !web/static/geo/*.geojson

--- a/web/indexnow_submit.py
+++ b/web/indexnow_submit.py
@@ -1,0 +1,139 @@
+"""Submete URLs do sitemap ao IndexNow (Bing/Yandex/Yahoo/Seznam/Naver).
+
+IndexNow eh um protocolo aberto pra notificacao de mudancas de URL. Bing
+costuma indexar em horas (vs. semanas pelo crawler). NAO substitui o
+Google Search Console (Google ainda nao adotou IndexNow).
+
+Uso:
+    python -m web.indexnow_submit [--limit N] [--dry-run]
+
+Requer:
+    INDEXNOW_KEY        - chave 8-128 chars (gerar com secrets.token_urlsafe).
+    SITE_URL            - origem completa (default: https://transparenciapb.org).
+
+Como gerar a chave:
+    python -c "import secrets; print(secrets.token_urlsafe(32))"
+
+Apos setar INDEXNOW_KEY no .env, a rota /<key>.txt comeca a servir o
+arquivo de verificacao automaticamente. Confirme que esta acessivel:
+    curl https://transparenciapb.org/<sua-key>.txt
+
+Esse script reusa a logica do sitemap (web.routes.seo._build_sitemap_xml)
+pra extrair URLs e submete em batch ao endpoint do IndexNow.
+
+Recomendamos rodar:
+    1. Apos cada deploy de codigo (via deploy.yml ou systemd post-start)
+    2. Apos cada refresh de dados (warm cache concluido)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+log = logging.getLogger("indexnow")
+
+
+INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow"
+# IndexNow aceita ate 10.000 URLs por POST. Mantemos 500 por seguranca
+# (evita timeout em caso de erro do endpoint).
+BATCH_SIZE = 500
+
+
+def _extract_urls_from_sitemap(xml_text: str) -> list[str]:
+    """Parse simples (regex) das tags <loc>. Evita dependencia de XML
+    parser externo; sitemap eh pequeno e bem formado."""
+    return re.findall(r"<loc>([^<]+)</loc>", xml_text)
+
+
+def _submit_batch(host: str, key: str, urls: list[str], dry_run: bool) -> bool:
+    payload = {
+        "host": host,
+        "key": key,
+        "keyLocation": f"https://{host}/{key}.txt",
+        "urlList": urls,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    if dry_run:
+        log.info("[dry-run] POST %s (%d URLs)", INDEXNOW_ENDPOINT, len(urls))
+        return True
+    req = urllib.request.Request(
+        INDEXNOW_ENDPOINT,
+        data=body,
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "Accept": "application/json",
+            "User-Agent": "TransparenciaPB-IndexNow/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            status = resp.status
+            log.info("IndexNow response: HTTP %d (%d URLs)", status, len(urls))
+            return 200 <= status < 300
+    except urllib.error.HTTPError as e:
+        log.error("IndexNow HTTPError %d: %s", e.code, e.read().decode("utf-8", "replace")[:500])
+        return False
+    except urllib.error.URLError as e:
+        log.error("IndexNow URLError: %s", e.reason)
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Maximo de URLs a submeter (default: todas do sitemap)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Apenas mostra URLs que seriam submetidas, sem chamar IndexNow",
+    )
+    args = parser.parse_args()
+
+    key = os.environ.get("INDEXNOW_KEY", "").strip()
+    if not key:
+        log.error("INDEXNOW_KEY nao setada no .env. Aborte.")
+        return 2
+
+    site_url = os.environ.get("SITE_URL", "https://transparenciapb.org").strip().rstrip("/")
+    parsed = urlparse(site_url)
+    if not parsed.netloc:
+        log.error("SITE_URL invalida: %s", site_url)
+        return 2
+    host = parsed.netloc
+
+    # Gera sitemap localmente (mesma logica do endpoint /sitemap.xml).
+    # Importamos aqui pra evitar custo de DB se fizermos --dry-run sem env.
+    from web.routes.seo import _build_sitemap_xml
+    xml = _build_sitemap_xml(site_url)
+    urls = _extract_urls_from_sitemap(xml)
+    if args.limit:
+        urls = urls[: args.limit]
+
+    if not urls:
+        log.warning("Nenhuma URL extraida do sitemap. Aborte.")
+        return 1
+
+    log.info("Submetendo %d URL(s) ao IndexNow (host=%s)", len(urls), host)
+    ok = True
+    for i in range(0, len(urls), BATCH_SIZE):
+        batch = urls[i : i + BATCH_SIZE]
+        ok = _submit_batch(host, key, batch, args.dry_run) and ok
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/indexnow_submit.py
+++ b/web/indexnow_submit.py
@@ -28,6 +28,7 @@ Recomendamos rodar:
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import logging
 import os
@@ -52,8 +53,15 @@ BATCH_SIZE = 500
 
 def _extract_urls_from_sitemap(xml_text: str) -> list[str]:
     """Parse simples (regex) das tags <loc>. Evita dependencia de XML
-    parser externo; sitemap eh pequeno e bem formado."""
-    return re.findall(r"<loc>([^<]+)</loc>", xml_text)
+    parser externo; sitemap eh pequeno e bem formado.
+
+    IMPORTANTE: o conteudo eh entity-encoded (xml.sax.saxutils.escape em
+    seo.py:_build_sitemap_xml). Hoje URLs sao /cidade/<slug> e nao tem
+    `&`/`<`/`>`, mas se algum dia voltarmos a indexar URLs com query
+    string, html.unescape garante que `&amp;` vire `&` antes de submeter
+    pro IndexNow (que rejeitaria a URL malformada silenciosamente).
+    """
+    return [html.unescape(loc) for loc in re.findall(r"<loc>([^<]+)</loc>", xml_text)]
 
 
 def _submit_batch(host: str, key: str, urls: list[str], dry_run: bool) -> bool:

--- a/web/main.py
+++ b/web/main.py
@@ -253,6 +253,17 @@ except Exception:
 templates.env.globals["DATA_REFRESH_DATE"] = _data_refresh_br
 templates.env.globals["DATA_REFRESH_DATE_ISO"] = _data_refresh
 
+# SEO: verification meta tags (Search Console / Bing Webmaster Tools).
+# Codigos vem do dashboard de cada provedor; basta colar a string token.
+# Setar GOOGLE_SITE_VERIFICATION / BING_SITE_VERIFICATION no ENV_FILE
+# secret do GitHub Actions (e .env local pra dev). Ver SEO ops checklist.
+templates.env.globals["GOOGLE_SITE_VERIFICATION"] = os.environ.get(
+    "GOOGLE_SITE_VERIFICATION", ""
+).strip()
+templates.env.globals["BING_SITE_VERIFICATION"] = os.environ.get(
+    "BING_SITE_VERIFICATION", ""
+).strip()
+
 # JS load order. Each entry is a path relative to /static/js/, emitted as
 # an individual <script> tag in base.html. Order matters because the scripts
 # are plain (non-module) and rely on cross-file globals — files are loaded

--- a/web/main.py
+++ b/web/main.py
@@ -286,6 +286,7 @@ JS_FILES: list[str] = [
     # ES module web/static/js/md3/imports.js).
     "lib/md3-ready.js",
     "lib/dual-label.js",
+    "lib/slug.js",
     "lib/column-meta.js",
     "components/term-tooltip.js",
     "lib/expand-context.js",
@@ -341,7 +342,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "97"
+templates.env.globals["ASSET_VERSION"] = "98"
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -493,6 +494,13 @@ templates.env.globals["canonical_url"] = canonical_url
 templates.env.globals["is_dialog_state_url"] = is_dialog_state_url
 templates.env.globals["request_origin"] = _request_origin
 
+# Helper de slug pra URLs amigaveis (/cidade/<slug>). Mesma logica em
+# web/utils/slug.py garante que sitemap, links em HTML e a rota /cidade/{slug}
+# usem a forma canonica (acento removido, lowercase, hifens normalizados).
+from web.utils.slug import municipio_slug as _municipio_slug
+templates.env.globals["municipio_slug"] = _municipio_slug
+templates.env.filters["municipio_slug"] = _municipio_slug
+
 
 app.include_router(cidade_router)
 app.include_router(mapa_router)
@@ -575,3 +583,9 @@ async def service_worker():
 @app.get("/glossario")
 async def glossario(request: Request):
     return templates.TemplateResponse(request, "glossario.html")
+
+
+@app.get("/sobre")
+async def sobre(request: Request):
+    """Pagina /sobre: metodologia + fontes + limitacoes (E-E-A-T pra SEO)."""
+    return templates.TemplateResponse(request, "sobre.html")

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -9,7 +9,7 @@ import time
 from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Body, Query, Request
-from fastapi.responses import HTMLResponse, JSONResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel
 from psycopg2.errors import QueryCanceled, UndefinedTable, UndefinedColumn
 
@@ -626,11 +626,84 @@ def _render_partial(request: Request, template_name: str, context: dict):
     return templates.TemplateResponse(request, template_name, context)
 
 
+@router.get("/cidade/{slug}")
+async def cidade_by_slug(request: Request, slug: str):
+    """URL amigavel: /cidade/joao-pessoa.
+
+    Resolve slug -> nome canonico via web.utils.slug. Se slug recebido nao
+    eh canonico (ex: maiuscula, hifens duplos, com acento), responde 301
+    para a forma canonica pra evitar duplicate content.
+    """
+    from web.main import templates
+    from web.utils.slug import (
+        SlugLookupError,
+        municipio_slug,
+        slug_to_municipio,
+    )
+
+    try:
+        municipio = slug_to_municipio(slug)
+    except SlugLookupError:
+        # Cache vazio + DB indisponivel: 503 (nao 404). Crawler vai tentar
+        # de novo; transformar em 404 deindexava paginas validas.
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "300"},
+            content="Servico temporariamente indisponivel. Tente novamente em alguns minutos.",
+            media_type="text/plain; charset=utf-8",
+        )
+
+    if not municipio:
+        return templates.TemplateResponse(
+            request, "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+
+    # Canonicalizacao: se o slug recebido nao for o canonico (ex:
+    # /cidade/Joao-Pessoa, /cidade/joao--pessoa), 301 pra canonical.
+    canonical_slug = municipio_slug(municipio)
+    if canonical_slug and slug != canonical_slug:
+        return RedirectResponse(
+            url=f"/cidade/{canonical_slug}",
+            status_code=301,
+        )
+
+    return await _render_cidade(request, municipio)
+
+
 @router.get("/search/cidade")
 async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
-    from web.main import templates
+    """URL legada (busca por texto livre). Quando consegue resolver o termo
+    para uma cidade conhecida, faz 301 pra /cidade/<slug> (sinal SEO forte
+    de migracao). Fallback: renderiza pagina como antes (com 404 se
+    municipio nao existe na base)."""
+    from web.utils.slug import SlugLookupError, municipio_slug, slug_to_municipio
 
-    municipio, uf = _parse_municipio_uf(q)
+    municipio, _uf = _parse_municipio_uf(q)
+
+    # Tenta resolver via slug cache antes de redirecionar. Em SlugLookupError
+    # (cold start sem fallback), seguimos pro render direto — DB pode estar
+    # OK pra outras MVs mesmo se a slug cache falhou.
+    try:
+        canonical = slug_to_municipio(municipio_slug(municipio))
+    except SlugLookupError:
+        canonical = None
+
+    if canonical:
+        return RedirectResponse(
+            url=f"/cidade/{municipio_slug(canonical)}",
+            status_code=301,
+        )
+
+    # Termo nao bate com nenhuma cidade conhecida: render direto (404 templated)
+    return await _render_cidade(request, municipio)
+
+
+async def _render_cidade(request: Request, municipio: str):
+    """Renderiza pagina /cidade/<slug> ou /search/cidade?q=. Compartilhado
+    pelas duas rotas pra evitar duplicacao + risco de loop de redirect."""
+    from web.main import templates
 
     perfil = None
     try:

--- a/web/routes/og_image.py
+++ b/web/routes/og_image.py
@@ -203,3 +203,96 @@ async def og_cidade(slug: str):
     except Exception:
         pass
     return Response(content=png, media_type="image/png")
+
+
+def _render_home_png() -> bytes:
+    """OG card da home: marca + tagline + numero de municipios.
+
+    Aspect 1200x630 (recomendado pra Open Graph / Twitter Card large image).
+    """
+    W, H = 1200, 630
+    bg = (6, 10, 20)
+    accent = (96, 165, 250)
+    text_main = (243, 244, 246)
+    text_muted = (156, 163, 175)
+    text_strong = (255, 255, 255)
+
+    img = Image.new("RGB", (W, H), bg)
+    draw = ImageDraw.Draw(img)
+
+    # Gradiente sutil topo -> base (mesma vibe da hero da home)
+    for y in range(H):
+        a = int(30 * (1 - y / H))
+        r = max(0, min(255, 6 + a // 6))
+        g = max(0, min(255, 10 + a // 4))
+        b = max(0, min(255, 20 + a))
+        draw.rectangle([(0, y), (W, y + 1)], fill=(r, g, b))
+
+    # Barra lateral azul (consistente com /og/cidade/*.png em estado "neutro")
+    draw.rectangle([(0, 0), (14, H)], fill=accent)
+
+    # Marca topo
+    f_brand = _font(36)
+    draw.text((48, 56), "TransparenciaPB", font=f_brand, fill=accent)
+
+    # Headline (3 linhas pra evitar wrap)
+    f_h1_big = _font(72)
+    f_h1_small = _font(48)
+    draw.text((48, 130), "Como sua prefeitura", font=f_h1_big, fill=text_strong)
+    draw.text((48, 220), "gasta o dinheiro publico", font=f_h1_big, fill=text_strong)
+
+    # Subheadline
+    f_sub = _font(34)
+    draw.text(
+        (48, 330),
+        "223 municipios da Paraiba, cidade por cidade",
+        font=f_sub,
+        fill=text_main,
+    )
+
+    # Linha divisoria
+    draw.line([(48, 400), (W - 48, 400)], fill=(75, 85, 99), width=2)
+
+    # Tres pilares (fontes oficiais)
+    f_label = _font(22)
+    f_value = _font(26)
+    cols = [
+        ("Fontes oficiais", "TCE-PB, RFB, CGU"),
+        ("Cruzamentos", "Empresas e servidores"),
+        ("Cobertura", "223 prefeituras PB"),
+    ]
+    col_w = (W - 96) // 3
+    for i, (label, value) in enumerate(cols):
+        x = 48 + i * col_w
+        draw.text((x, 440), label, font=f_label, fill=text_muted)
+        draw.text((x, 470), value, font=f_value, fill=text_main)
+
+    # Footer
+    f_foot = _font(22)
+    draw.text(
+        (48, H - 56),
+        "transparenciapb.org  -  Dados abertos cruzados",
+        font=f_foot,
+        fill=text_muted,
+    )
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+@router.get("/og/home.png")
+async def og_home():
+    """OG image generica da home — usada como fallback em qualquer pagina
+    que nao sobrescreva o bloco og_image."""
+    if not _PIL_OK:
+        return Response(status_code=501, content="Pillow nao instalado")
+    cache_path = _CACHE_DIR / "_home.png"
+    if cache_path.exists() and (time.time() - cache_path.stat().st_mtime) < _TTL:
+        return FileResponse(cache_path, media_type="image/png")
+    png = _render_home_png()
+    try:
+        cache_path.write_bytes(png)
+    except Exception:
+        pass
+    return Response(content=png, media_type="image/png")

--- a/web/routes/og_image.py
+++ b/web/routes/og_image.py
@@ -6,7 +6,6 @@ import hashlib
 import io
 import os
 import time
-import unicodedata
 from pathlib import Path
 
 from fastapi import APIRouter, Response
@@ -29,9 +28,8 @@ _CACHE_DIR.mkdir(parents=True, exist_ok=True)
 _TTL = 24 * 3600
 
 
-def _norm_slug(name: str) -> str:
-    n = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
-    return "".join(c.lower() if c.isalnum() else "-" for c in n).strip("-")
+# Slug logic agora centralizada em web/utils/slug.py (mesma usada pelo
+# sitemap, rota /cidade/{slug} e JS lib/slug.js). Nao re-implementar aqui.
 
 
 def _font(size: int):
@@ -164,9 +162,19 @@ def _render_png(municipio: str, perfil: dict | None) -> bytes:
 
 @router.get("/og/cidade/{slug}.png")
 async def og_cidade(slug: str):
+    """OG card por municipio. Slug deve ser canonico (resolvido pela rota
+    /cidade/{slug} antes de injetar a URL na meta og:image). Se o slug nao
+    bater com nenhum municipio conhecido, gera card generico (titlecased)
+    pra nao quebrar previews em caso de cache miss bizarro.
+    """
     if not _PIL_OK:
         return Response(status_code=501, content="Pillow nao instalado")
-    safe_slug = _norm_slug(slug)
+    # Reutiliza o helper canonico (mesma logica do sitemap, da rota
+    # /cidade/{slug} e do JS lib/slug.js). Evita 4 normalizacoes
+    # divergentes que causam OG 404 em municipios com apostrofo/parenteses.
+    from web.utils.slug import municipio_slug, slug_to_municipio, SlugLookupError
+
+    safe_slug = municipio_slug(slug)
     if not safe_slug:
         return Response(status_code=400)
 
@@ -174,26 +182,16 @@ async def og_cidade(slug: str):
     if cache_path.exists() and (time.time() - cache_path.stat().st_mtime) < _TTL:
         return FileResponse(cache_path, media_type="image/png")
 
-    # Resolve slug -> nome de municipio (normalizado)
-    # Busca em mv_municipio_pb_risco por slug aproximado
-    sql = """
-        SELECT municipio FROM mv_municipio_pb_risco
-        WHERE lower(unaccent(replace(municipio, ' ', '-'))) = %(slug)s
-        LIMIT 1
-    """
+    # Resolve slug -> nome canonico via cache compartilhado. Em cold start
+    # (cache vazio + DB down) usamos o fallback titlecased pra ainda
+    # entregar PNG (preview de social media nunca deve 503).
     municipio = slug.replace("-", " ").title()
     try:
-        cols, rows = cached_query(
-            f"og:slug:{safe_slug}",
-            sql,
-            params={"slug": safe_slug},
-            timeout_sec=5,
-            ttl=CACHE_TTL,
-        )
-        if rows:
-            municipio = rows[0][0]
-    except Exception:
-        pass
+        resolved = slug_to_municipio(safe_slug)
+        if resolved:
+            municipio = resolved
+    except SlugLookupError:
+        pass  # cold start - usa fallback titlecased
 
     perfil = _fetch_perfil(municipio)
     png = _render_png(municipio, perfil)

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import secrets
 import time
 from typing import Any
 from xml.sax.saxutils import escape as xml_escape
@@ -15,6 +17,11 @@ from web import db
 
 router = APIRouter()
 _log = logging.getLogger("transparencia.seo")
+
+
+# IndexNow keys: 8-128 chars URL-safe. Pre-compilado pra rejeitar
+# paths nao-key sem comparacao (defesa contra probing).
+_INDEXNOW_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_\-]{8,128}$")
 
 
 # Cache em memória pra sitemap (gera lista de municípios uma vez por hora).
@@ -144,15 +151,31 @@ def _build_sitemap_xml(origin: str) -> str:
 
 @router.get("/sitemap.xml")
 async def sitemap_xml(request: Request) -> Response:
-    """Sitemap dinamico cached por 1h."""
+    """Sitemap dinamico cached por 1h.
+
+    Importante: NAO cacheamos sitemap parcial (sem URLs de cidade) — caso
+    contrario, uma falha transitoria de DB no primeiro hit pos-restart
+    serviria por 1h um sitemap incompleto a Google/IndexNow. Em build
+    parcial, servimos o resultado mas mantemos cache invalido para a
+    proxima request tentar de novo.
+    """
     origin = _site_origin(request)
     now = time.time()
     if _SITEMAP_CACHE["xml"] and (now - _SITEMAP_CACHE["ts"] < _SITEMAP_TTL):
         xml = _SITEMAP_CACHE["xml"]
     else:
         xml = _build_sitemap_xml(origin)
-        _SITEMAP_CACHE["xml"] = xml
-        _SITEMAP_CACHE["ts"] = now
+        # Heuristica simples: sitemap completo tem 100+ <url>; parcial
+        # (so paginas estaticas) tem ~5. Nao cachear parcial.
+        if xml.count("<url>") >= 100:
+            _SITEMAP_CACHE["xml"] = xml
+            _SITEMAP_CACHE["ts"] = now
+        else:
+            _log.warning(
+                "Sitemap parcial gerado (%d <url> entries) — nao cacheando, "
+                "proxima request tentara recarregar municipios",
+                xml.count("<url>"),
+            )
     return Response(
         content=xml,
         media_type="application/xml",
@@ -194,9 +217,26 @@ async def indexnow_key_file(key: str) -> PlainTextResponse:
 
     Esta rota tambem captura qualquer outro `.txt` no root (ex:
     /humans.txt, /security.txt) que ainda nao temos. Pra esses,
-    raise HTTPException(404) entrega o 404 templated normal."""
+    HTTPException(404) cai no handler global @app.exception_handler(404)
+    em main.py:522, que renderiza errors/404.html (UX consistente).
+
+    Defesa em profundidade:
+    - Validacao de regex no key recebido: rejeitamos paths que nao
+      poderiam ser IndexNow keys (8-128 chars URL-safe). Reduz superficie
+      de probing.
+    - Compare timing-safe via secrets.compare_digest: defesa contra
+      timing attacks que poderiam revelar caracteres da key (impacto baixo
+      ja que vazar a key apenas permite que 3rd party submeta URLs do
+      nosso dominio, mas e uma boa pratica barata).
+    """
     expected = os.environ.get("INDEXNOW_KEY", "").strip()
-    if not expected or key != expected:
+    if not expected:
+        raise HTTPException(status_code=404)
+    # IndexNow keys sao 8-128 chars URL-safe (alfanumerico + - + _).
+    # Qualquer coisa fora disso: 404 sem nem comparar.
+    if not _INDEXNOW_KEY_PATTERN.fullmatch(key):
+        raise HTTPException(status_code=404)
+    if not secrets.compare_digest(key, expected):
         raise HTTPException(status_code=404)
     return PlainTextResponse(
         expected,

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import Any
 from xml.sax.saxutils import escape as xml_escape
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse, Response
 
 from web import db
@@ -72,9 +73,25 @@ def _municipios_pb() -> list[str]:
         return []
 
 
+def _lastmod_iso() -> str:
+    """Data ISO (YYYY-MM-DD) usada como <lastmod> nas paginas de cidade.
+
+    Reflete a data de refresh dos dados (DATA_REFRESH_DATE_ISO env var,
+    setada por main.py). Quando os dados sao atualizados, novo deploy
+    com env var atualizada -> sitemap muda -> crawlers recrawl."""
+    val = os.environ.get("DATA_REFRESH_DATE", "").strip()
+    if val:
+        return val
+    # Fallback pro mesmo computo do main.py (hora local GMT-3)
+    from datetime import datetime, timedelta, timezone
+    return datetime.now(timezone(timedelta(hours=-3))).strftime("%Y-%m-%d")
+
+
 def _build_sitemap_xml(origin: str) -> str:
     """Gera <urlset> com homepage + paginas estaticas + paginas /search/cidade
-    pra cada municipio PB."""
+    pra cada municipio PB. Usa <lastmod> = data de refresh dos dados pra
+    sinalizar a Google quando paginas precisam ser recrawladas."""
+    lastmod = _lastmod_iso()
     parts: list[str] = []
     parts.append('<?xml version="1.0" encoding="UTF-8"?>')
     parts.append('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
@@ -89,6 +106,7 @@ def _build_sitemap_xml(origin: str) -> str:
     for path, prio, freq in static_pages:
         parts.append("  <url>")
         parts.append(f"    <loc>{xml_escape(origin)}{xml_escape(path)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
         parts.append(f"    <changefreq>{freq}</changefreq>")
         parts.append(f"    <priority>{prio}</priority>")
         parts.append("  </url>")
@@ -103,6 +121,7 @@ def _build_sitemap_xml(origin: str) -> str:
         loc = f"{origin}/search/cidade?q={encoded}"
         parts.append("  <url>")
         parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
         parts.append("    <changefreq>weekly</changefreq>")
         parts.append("    <priority>0.7</priority>")
         parts.append("  </url>")
@@ -126,4 +145,48 @@ async def sitemap_xml(request: Request) -> Response:
         content=xml,
         media_type="application/xml",
         headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# IndexNow (https://www.indexnow.org/)
+#
+# Protocolo aberto suportado por Bing, Yandex, Yahoo, Seznam, Naver. Permite
+# notificar mudancas de URL sem depender de crawler periodico (acelera
+# indexacao de novas paginas/cidades de poucos dias pra horas).
+#
+# Como funciona:
+#   1. Geramos um "key" (string opaca de 8-128 chars) e armazenamos em env
+#      var INDEXNOW_KEY. O mesmo key tambem precisa estar acessivel via HTTP
+#      em /<key>.txt no nosso dominio (rota abaixo) — isso prova que o site
+#      eh nosso.
+#   2. Submetemos URLs via POST a https://api.indexnow.org/indexnow ou GET
+#      a https://www.bing.com/indexnow?url=...&key=...
+#   3. IndexNow propaga pro Bing, Yandex, etc.
+#
+# Setup (no .env / ENV_FILE secret):
+#   INDEXNOW_KEY=<gerar via `python -c "import secrets; print(secrets.token_urlsafe(32))"`>
+#
+# Uso manual (apos deploy de conteudo novo): chamar
+#   python -m web.indexnow_submit
+# (ou triggar via admin endpoint se desejado).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/{key}.txt", response_class=PlainTextResponse)
+async def indexnow_key_file(key: str) -> PlainTextResponse:
+    """Serve o arquivo de verificacao do IndexNow em /<key>.txt.
+
+    IndexNow exige que GET /<key>.txt retorne EXATAMENTE o key como
+    body texto. Sem isso, motores de busca rejeitam as submissoes.
+
+    Esta rota tambem captura qualquer outro `.txt` no root (ex:
+    /humans.txt, /security.txt) que ainda nao temos. Pra esses,
+    raise HTTPException(404) entrega o 404 templated normal."""
+    expected = os.environ.get("INDEXNOW_KEY", "").strip()
+    if not expected or key != expected:
+        raise HTTPException(status_code=404)
+    return PlainTextResponse(
+        expected,
+        headers={"Cache-Control": "public, max-age=86400"},
     )

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -52,9 +52,14 @@ async def robots_txt(request: Request) -> PlainTextResponse:
     )
 
 
-def _municipios_pb() -> list[str]:
-    """Lista municípios PB ordenada por total_pago desc (mesma logica
-    do warm_cache pra alinhar prioridade). Retorna lista vazia em erro."""
+def _municipios_pb() -> list[tuple[str, str]]:
+    """Lista municipios PB ordenada por total_pago desc (mesma logica
+    do warm_cache pra alinhar prioridade). Retorna [(nome_canonico, slug), ...].
+
+    Reutiliza nomes do mv_municipio_pb_risco e o slug helper de
+    web.utils.slug pra garantir que sitemap, links no HTML e rota
+    /cidade/<slug> usam a MESMA forma canonica.
+    """
     sql = """
         SELECT r.municipio
         FROM mv_municipio_pb_risco r
@@ -63,11 +68,20 @@ def _municipios_pb() -> list[str]:
         ORDER BY COALESCE(m.total_pago_pj, 0) DESC, r.municipio
     """
     try:
+        from web.utils.slug import municipio_slug
         with db.get_conn() as conn:
             conn.autocommit = True
             with conn.cursor() as cur:
                 cur.execute(sql)
-                return [row[0] for row in cur.fetchall()]
+                out: list[tuple[str, str]] = []
+                seen: set[str] = set()
+                for (mun,) in cur.fetchall():
+                    slug = municipio_slug(mun)
+                    if not slug or slug in seen:
+                        continue
+                    seen.add(slug)
+                    out.append((str(mun), slug))
+                return out
     except Exception:
         _log.exception("Falha ao listar municipios PB pro sitemap")
         return []
@@ -100,6 +114,7 @@ def _build_sitemap_xml(origin: str) -> str:
     static_pages = [
         ("/", "1.0", "daily"),
         ("/mapa", "0.9", "daily"),
+        ("/sobre", "0.6", "monthly"),
         ("/glossario", "0.5", "monthly"),
         ("/contato", "0.4", "yearly"),
     ]
@@ -111,14 +126,11 @@ def _build_sitemap_xml(origin: str) -> str:
         parts.append(f"    <priority>{prio}</priority>")
         parts.append("  </url>")
 
-    # Pagina /search/cidade pra cada municipio PB
+    # Pagina /cidade/<slug> pra cada municipio PB. URLs amigaveis: substituem
+    # /search/cidade?q=... no sitemap. /search permanece funcional via 301.
     municipios = _municipios_pb()
-    for muni in municipios:
-        # Rota real eh /search/cidade?q=<NOME> (web/routes/cidade.py:629).
-        # _parse_municipio_uf assume PB sempre quando UF nao esta no string.
-        from urllib.parse import quote
-        encoded = quote(muni, safe="")
-        loc = f"{origin}/search/cidade?q={encoded}"
+    for _muni, slug in municipios:
+        loc = f"{origin}/cidade/{slug}"
         parts.append("  <url>")
         parts.append(f"    <loc>{xml_escape(loc)}</loc>")
         parts.append(f"    <lastmod>{lastmod}</lastmod>")

--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -72,6 +72,7 @@
 /* --- layer: pages --- */
 @import url("./pages/errors.css");
 @import url("./pages/glossario.css");
+@import url("./pages/sobre.css");
 @import url("./pages/contato.css");
 
 /* --- layer: utilities --- */

--- a/web/static/css/pages/sobre.css
+++ b/web/static/css/pages/sobre.css
@@ -1,0 +1,128 @@
+/* === pages/sobre.css === */
+/* Estilo da pagina /sobre. Reusa visual da glossario.css com algumas
+   aberturas pra long-form (lede, sections, cta). */
+@layer pages {
+    .sobre-page {
+        max-width: 820px;
+        margin: 24px auto;
+        padding: 0 18px;
+    }
+
+    .sobre-head {
+        margin-bottom: 28px;
+    }
+
+    .sobre-head .eyebrow {
+        margin: 0 0 6px;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--md-sys-color-primary);
+    }
+
+    .sobre-head h1 {
+        margin: 0 0 12px;
+        font-size: 32px;
+        font-weight: 700;
+        line-height: 1.2;
+    }
+
+    .sobre-head .lede {
+        margin: 0;
+        font-size: 17px;
+        line-height: 1.55;
+        color: var(--md-sys-color-on-surface);
+    }
+
+    .sobre-section {
+        margin-bottom: 32px;
+    }
+
+    .sobre-section h2 {
+        margin: 0 0 12px;
+        font-size: 22px;
+        font-weight: 700;
+        color: var(--md-sys-color-primary);
+        padding-bottom: 6px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    .sobre-section h3 {
+        margin: 16px 0 8px;
+        font-size: 17px;
+        font-weight: 600;
+    }
+
+    .sobre-section p,
+    .sobre-section li {
+        font-size: 15.5px;
+        line-height: 1.6;
+        color: var(--md-sys-color-on-surface);
+    }
+
+    .sobre-section ul {
+        padding-left: 22px;
+    }
+
+    .sobre-section li {
+        margin-bottom: 8px;
+    }
+
+    .sobre-section a {
+        color: var(--md-sys-color-primary);
+        text-decoration: underline;
+    }
+
+    .sobre-section a:hover {
+        text-decoration: none;
+    }
+
+    .sobre-cta {
+        display: flex;
+        gap: 12px;
+        margin-top: 32px;
+        padding-top: 20px;
+        border-top: 1px solid rgba(255, 255, 255, 0.12);
+        flex-wrap: wrap;
+    }
+
+    .sobre-cta .btn-primary,
+    .sobre-cta .btn-secondary {
+        padding: 10px 20px;
+        border-radius: var(--md-sys-shape-corner-medium);
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 15px;
+        transition: opacity 0.15s;
+    }
+
+    .sobre-cta .btn-primary {
+        background: var(--md-sys-color-primary);
+        color: var(--md-sys-color-on-primary);
+    }
+
+    .sobre-cta .btn-secondary {
+        background: var(--md-sys-color-surface-container);
+        color: var(--md-sys-color-on-surface);
+        border: 1px solid var(--md-sys-color-outline-variant);
+    }
+
+    .sobre-cta .btn-primary:hover,
+    .sobre-cta .btn-secondary:hover {
+        opacity: 0.9;
+        text-decoration: none;
+    }
+
+    @media (max-width: 640px) {
+        .sobre-page {
+            padding: 0 14px;
+            margin: 16px auto;
+        }
+        .sobre-head h1 {
+            font-size: 26px;
+        }
+        .sobre-section h2 {
+            font-size: 20px;
+        }
+    }
+}

--- a/web/static/js/components/autocomplete.js
+++ b/web/static/js/components/autocomplete.js
@@ -123,7 +123,14 @@ function setupAutocomplete(inputId, listId, endpoint, onSelect) {
 
 function initCidadeAutocomplete() {
     setupAutocomplete('ac-cidade', 'aclist-cidade', '/api/autocomplete/municipio', (value) => {
-        window.location.href = `/search/cidade?q=${encodeURIComponent(value)}`;
+        // URL amigavel: /cidade/<slug>. Fallback /search/cidade?q= se slugify
+        // nao estiver disponivel (defensivo: lib/slug.js carrega cedo no JS_FILES).
+        const slug = (typeof window.municipioSlug === 'function') ? window.municipioSlug(value) : '';
+        if (slug) {
+            window.location.href = `/cidade/${slug}`;
+        } else {
+            window.location.href = `/search/cidade?q=${encodeURIComponent(value)}`;
+        }
     });
 }
 

--- a/web/static/js/lib/slug.js
+++ b/web/static/js/lib/slug.js
@@ -1,0 +1,29 @@
+// === lib/slug.js ===
+// Espelha web/utils/slug.py:municipio_slug. Mantenha SINCRONIZADO!
+// Se mudar logica aqui, ajuste tambem o helper Python.
+//
+// Uso:
+//     window.municipioSlug("Joao Pessoa")  // "joao-pessoa"
+//
+// Diferenca proposital com Python: aqui aceitamos UTF-8 input dos usuarios
+// (typed e mostrado com acentos), removemos via NFKD + filtro ASCII.
+
+(function() {
+    'use strict';
+
+    function municipioSlug(name) {
+        if (!name) return '';
+        // Normalizacao NFKD: separa caracteres-base de marcas (acentos)
+        // depois remove qualquer codepoint na faixa de combining marks.
+        let s = String(name).normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+        s = s.toLowerCase();
+        // Espacos e hifens viram um unico hifen
+        s = s.replace(/[\s-]+/g, '-');
+        // Drop tudo que nao for [a-z0-9-]
+        s = s.replace(/[^a-z0-9-]+/g, '');
+        // Trim hifens das pontas
+        return s.replace(/^-+|-+$/g, '');
+    }
+
+    window.municipioSlug = municipioSlug;
+})();

--- a/web/static/js/pages/mapa.js
+++ b/web/static/js/pages/mapa.js
@@ -228,7 +228,12 @@
         layer.bindTooltip(tooltipHTML(feat), { sticky: true, className: 'mapa-tooltip' });
         layer.on('click', () => {
             const name = feat.properties.name;
-            window.location.href = `/search/cidade?q=${encodeURIComponent(name)}`;
+            const slug = (typeof window.municipioSlug === 'function') ? window.municipioSlug(name) : '';
+            if (slug) {
+                window.location.href = `/cidade/${slug}`;
+            } else {
+                window.location.href = `/search/cidade?q=${encodeURIComponent(name)}`;
+            }
         });
         layer.on('mouseover', () => layer.setStyle({ weight: 2, color: '#fff' }));
         layer.on('mouseout', () => state.layer.resetStyle(layer));

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -17,14 +17,29 @@
     {% set _canonical = canonical_url(request) if request else None %}
     {% if _canonical %}<link rel="canonical" href="{{ _canonical }}">{% endif %}
     {% if request and is_dialog_state_url(request) %}<meta name="robots" content="noindex,follow">{% endif %}
+    {# Search engine verification — codigos vem do Search Console / Bing
+       Webmaster Tools. Setar GOOGLE_SITE_VERIFICATION / BING_SITE_VERIFICATION
+       no .env (secret ENV_FILE no GitHub). Ver SEO operations checklist. #}
+    {% if GOOGLE_SITE_VERIFICATION %}<meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">{% endif %}
+    {% if BING_SITE_VERIFICATION %}<meta name="msvalidate.01" content="{{ BING_SITE_VERIFICATION }}">{% endif %}
     <meta property="og:site_name" content="TransparenciaPB">
     <meta property="og:type" content="{% block og_type %}website{% endblock %}">
     <meta property="og:title" content="{% block og_title %}TransparenciaPB{% endblock %}">
     <meta property="og:description" content="{% block og_description %}Transparencia e cruzamento de dados publicos dos 223 municipios da Paraiba.{% endblock %}">
     <meta property="og:locale" content="pt_BR">
     <meta property="og:url" content="{{ _canonical or (request.url if request else '') }}">
-    {% block og_image %}{% endblock %}
-    <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
+    {# OG image: paginas que tem imagem propria (cidade, relatorio) sobrescrevem
+       este bloco; default e a OG card generica da home (gerada por PIL em
+       /og/home.png). Garante preview em qualquer compartilhamento. #}
+    {% block og_image %}
+    <meta property="og:image" content="{{ request_origin(request) if request else '' }}/og/home.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:alt" content="TransparenciaPB — Dados publicos cruzados dos 223 municipios da Paraiba">
+    <meta name="twitter:image" content="{{ request_origin(request) if request else '' }}/og/home.png">
+    {% endblock %}
+    <meta name="twitter:card" content="{% block twitter_card %}summary_large_image{% endblock %}">
     <meta name="twitter:title" content="{% block twitter_title %}{{ self.og_title() }}{% endblock %}">
     <meta name="twitter:description" content="{% block twitter_description %}{{ self.og_description() }}{% endblock %}">
     {# JSON-LD: WebSite + Organization (sempre presente quando temos request).

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -183,6 +183,7 @@
                 Fontes: Portal da Transpar&ecirc;ncia, Receita Federal, CGU (CEIS/CNEP/CEAF), TCE-PB, dados.pb.gov.br, PNCP, PGFN, IBGE, TSE.
                 {% if DATA_REFRESH_DATE %}Dados atualizados em <strong>{{ DATA_REFRESH_DATE | default('', true) }}</strong>.{% endif %}
                 <button type="button" class="link-btn" id="credibilityOpen" aria-haspopup="dialog">Ver fontes e metodologia</button>
+                &middot; <a href="/sobre" class="footer-link">Sobre</a>
                 &middot; <a href="/glossario" class="footer-link">Gloss&aacute;rio</a>
                 &middot; <a href="/contato" class="footer-link">Contato</a>
                 &middot; <button type="button" id="tourRestart" class="link-btn footer-link" style="display:none">Como usar</button>

--- a/web/templates/glossario.html
+++ b/web/templates/glossario.html
@@ -1,5 +1,21 @@
 {% extends "base.html" %}
 {% block title %}Gloss&aacute;rio{% endblock %}
+{% block meta_description %}Glossario do TransparenciaPB: termos tecnicos de transparencia publica (CEIS, CNEP, empenho, dispensa, licitacao, PGFN, PNCP) traduzidos para linguagem cidad.{% endblock %}
+{% block og_title %}Glossario - TransparenciaPB{% endblock %}
+{% block og_description %}Termos tecnicos de transparencia publica traduzidos para linguagem cidad.{% endblock %}
+{% block json_ld_extra %}
+{% set _origin = request_origin(request) if request else '' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "TransparenciaPB", "item": "{{ _origin }}/"},
+    {"@type": "ListItem", "position": 2, "name": "Glossário", "item": "{{ _origin }}/glossario"}
+  ]
+}
+</script>
+{% endblock %}
 {% block content %}
 <section class="glossario-page">
   <header class="glossario-head">

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
-{% block title %}Cruza Dados - Paraiba{% endblock %}
+{% block title %}TransparenciaPB · Como sua prefeitura gasta o dinheiro publico{% endblock %}
+{% block meta_description %}TransparenciaPB cruza dados publicos dos 223 municipios da Paraiba: gastos das prefeituras, fornecedores irregulares, compras sem licitacao, servidores com conflito de interesse e concentracao de contratos. Fontes: TCE-PB, Receita Federal, CGU, Portal da Transparencia, PNCP.{% endblock %}
+{% block og_title %}TransparenciaPB · Dados publicos da Paraiba{% endblock %}
+{% block og_description %}Veja como cada uma das 223 prefeituras da Paraiba gasta o dinheiro publico: fornecedores, licitacoes, servidores, contratos. Cruzamento de dados oficiais.{% endblock %}
 {% block body_class %}mapa-page{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/vendor/leaflet/leaflet.css" />
@@ -9,8 +12,8 @@
     <div class="hero-dots" aria-hidden="true"></div>
     <div class="hero-content">
         <p class="eyebrow">
-            <span class="citizen-only">Paraiba &middot; cidade por cidade</span>
-            <span class="auditor-only">Paraiba &middot; dados abertos</span>
+            <span class="citizen-only">TransparenciaPB &middot; Para&iacute;ba &middot; cidade por cidade</span>
+            <span class="auditor-only">TransparenciaPB &middot; Para&iacute;ba &middot; dados abertos cruzados</span>
         </p>
         <h1>
             <span class="citizen-only">Descubra como sua prefeitura gasta o dinheiro p&uacute;blico</span>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -153,7 +153,12 @@
                     }
                     try { localStorage.setItem('last-city', city); } catch(_){}
                     setStatus(`Identificado: ${city}. Abrindo...`, 'ok');
-                    window.location.href = '/search/cidade?q=' + encodeURIComponent(city);
+                    {
+                        const _slug = (typeof window.municipioSlug === 'function') ? window.municipioSlug(city) : '';
+                        window.location.href = _slug
+                            ? `/cidade/${_slug}`
+                            : '/search/cidade?q=' + encodeURIComponent(city);
+                    }
                 } catch (err) {
                     setStatus('Nao conseguimos identificar o municipio. Tente pela busca.', 'warn');
                     btn.disabled = false;

--- a/web/templates/mapa.html
+++ b/web/templates/mapa.html
@@ -9,23 +9,34 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "Dataset",
-  "name": "Mapa de transparência da Paraíba",
-  "description": {{ ((_muni_total | string) ~ " municípios da Paraíba indexados por risco composto, % de fornecedores irregulares, % sem licitação, concentração top-5 e pagamento per capita.") | tojson }},
-  "url": "{{ origin }}/mapa",
-  "isAccessibleForFree": true,
-  "inLanguage": "pt-BR",
-  "creator": {"@id": "{{ origin }}/#organization"},
-  "license": "https://creativecommons.org/licenses/by/4.0/",
-  "spatialCoverage": {
-    "@type": "State",
-    "name": "Paraíba",
-    "alternateName": "PB",
-    "containedInPlace": {
-      "@type": "Country",
-      "name": "Brasil"
+  "@graph": [
+    {
+      "@type": "Dataset",
+      "name": "Mapa de transparência da Paraíba",
+      "description": {{ ((_muni_total | string) ~ " municípios da Paraíba indexados por risco composto, % de fornecedores irregulares, % sem licitação, concentração top-5 e pagamento per capita.") | tojson }},
+      "url": "{{ origin }}/mapa",
+      "isAccessibleForFree": true,
+      "inLanguage": "pt-BR",
+      "creator": {"@id": "{{ origin }}/#organization"},
+      "license": "https://creativecommons.org/licenses/by/4.0/",
+      "spatialCoverage": {
+        "@type": "State",
+        "name": "Paraíba",
+        "alternateName": "PB",
+        "containedInPlace": {
+          "@type": "Country",
+          "name": "Brasil"
+        }
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "TransparenciaPB", "item": "{{ origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": "Mapa Paraíba", "item": "{{ origin }}/mapa"}
+      ]
     }
-  }
+  ]
 }
 </script>
 {% endblock %}

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -4,17 +4,20 @@
 {% block og_title %}{{ municipio }} - PB | TransparenciaPB{% endblock %}
 {% block og_description %}Panorama de transparencia de {{ municipio }} - PB.{% endblock %}
 {% block twitter_card %}summary_large_image{% endblock %}
+{% set _slug = municipio | municipio_slug %}
 {% block og_image %}
-<meta property="og:image" content="/og/cidade/{{ municipio | replace(' ', '-') | lower }}.png">
+<meta property="og:image" content="{{ request_origin(request) if request else '' }}/og/cidade/{{ _slug }}.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta name="twitter:image" content="/og/cidade/{{ municipio | replace(' ', '-') | lower }}.png">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:alt" content="{{ municipio }} - Resumo TransparenciaPB">
+<meta name="twitter:image" content="{{ request_origin(request) if request else '' }}/og/cidade/{{ _slug }}.png">
 {% endblock %}
 {% block json_ld_extra %}
 {# JSON-LD adicional pra pagina de cidade: GovernmentOrganization (a
    prefeitura), Dataset (o relatorio), e BreadcrumbList (Home > Cidade). #}
 {% set origin = request_origin(request) if request else '' %}
-{% set page_url = origin + '/search/cidade?q=' + (municipio | urlencode) %}
+{% set page_url = origin + '/cidade/' + _slug %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -64,7 +67,8 @@
         {
           "@type": "ListItem",
           "position": 3,
-          "name": {{ municipio | tojson }}
+          "name": {{ municipio | tojson }},
+          "item": {{ page_url | tojson }}
         }
       ]
     }

--- a/web/templates/sobre.html
+++ b/web/templates/sobre.html
@@ -1,0 +1,164 @@
+{% extends "base.html" %}
+{% block title %}Sobre o TransparenciaPB{% endblock %}
+{% block meta_description %}TransparenciaPB cruza dados publicos oficiais (TCE-PB, Receita Federal, CGU, PNCP, Portal da Transparencia, dados.pb.gov.br) para tornar visivel como cada uma das 223 prefeituras da Paraiba gasta o dinheiro publico. Metodologia, fontes e limitacoes.{% endblock %}
+{% block og_title %}Sobre o TransparenciaPB - Metodologia e fontes{% endblock %}
+{% block og_description %}Como cruzamos dados oficiais para fiscalizar 223 prefeituras paraibanas. Metodologia transparente, fontes oficiais, codigo aberto.{% endblock %}
+{% block json_ld_extra %}
+{% set _origin = request_origin(request) if request else '' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "AboutPage",
+      "@id": "{{ _origin }}/sobre#aboutpage",
+      "url": "{{ _origin }}/sobre",
+      "name": "Sobre o TransparenciaPB",
+      "description": "Metodologia, fontes e limitacoes do TransparenciaPB",
+      "isPartOf": {"@id": "{{ _origin }}/#website"},
+      "about": {"@id": "{{ _origin }}/#organization"},
+      "inLanguage": "pt-BR"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "{{ _origin }}/sobre#breadcrumb",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ _origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": "Sobre", "item": "{{ _origin }}/sobre"}
+      ]
+    }
+  ]
+}
+</script>
+{% endblock %}
+{% block content %}
+<article class="sobre-page">
+  <header class="sobre-head">
+    <p class="eyebrow">Sobre o TransparenciaPB</p>
+    <h1>Dados publicos cruzados, em linguagem cidad&atilde;</h1>
+    <p class="lede">
+      O TransparenciaPB &eacute; uma ferramenta gratuita que cruza dados publicos
+      oficiais para mostrar como cada uma das <strong>223 prefeituras da Para&iacute;ba</strong>
+      gasta o dinheiro publico. Indicamos sinais de aten&ccedil;&atilde;o
+      &mdash; n&atilde;o conclus&otilde;es jur&iacute;dicas. Se algo aqui chamar
+      sua aten&ccedil;&atilde;o, leve a fonte original aos &oacute;rg&atilde;os
+      de controle (MP-PB, TCE-PB, CGU).
+    </p>
+  </header>
+
+  <section class="sobre-section" id="o-que-fazemos">
+    <h2>O que fazemos</h2>
+    <p>
+      Processamos cerca de <strong>350 milh&otilde;es de registros</strong> por
+      semana. Cruzamos por CPF e CNPJ:
+    </p>
+    <ul>
+      <li>Despesas, empenhos e contratos das prefeituras (TCE-PB, dados.pb.gov.br, PNCP).</li>
+      <li>Cadastro de empresas e s&oacute;cios (Receita Federal).</li>
+      <li>Empresas e servidores p&uacute;blicos sancionados (CEIS, CNEP, CEAF da CGU).</li>
+      <li>D&iacute;vidas com a Uni&atilde;o (PGFN).</li>
+      <li>Sal&aacute;rios e v&iacute;nculos federais (SIAPE, Portal da Transpar&ecirc;ncia).</li>
+      <li>Bolsa Fam&iacute;lia, candidatos e doadores eleitorais (TSE).</li>
+    </ul>
+    <p>
+      Para cada cidade, mostramos: maiores fornecedores e poss&iacute;veis
+      problemas (san&ccedil;&otilde;es, d&iacute;vidas, situa&ccedil;&atilde;o
+      cadastral irregular), conflitos de interesse (servidores que s&atilde;o
+      s&oacute;cios de quem recebe da prefeitura), compras sem licita&ccedil;&atilde;o,
+      concentra&ccedil;&atilde;o de gastos em poucos fornecedores e mais.
+    </p>
+  </section>
+
+  <section class="sobre-section" id="metodologia">
+    <h2>Metodologia</h2>
+    <h3>Cruzamento por documentos</h3>
+    <p>
+      Como cada fonte publica os dados em formato pr&oacute;prio &mdash; CPF
+      mascarado, CNPJ b&aacute;sico ou completo &mdash; normalizamos antes de
+      qualquer compara&ccedil;&atilde;o. Joins s&atilde;o sempre por <em>igualdade</em>
+      sobre os d&iacute;gitos normalizados (n&atilde;o por nome aproximado).
+    </p>
+    <h3>Score de aten&ccedil;&atilde;o (0-100)</h3>
+    <p>
+      A &quot;nota de aten&ccedil;&atilde;o&quot; combina 8 indicadores
+      (pesos somam 100): empresas sancionadas que recebem da prefeitura,
+      servidores em CEAF/expuls&otilde;es federais, concentra&ccedil;&atilde;o
+      top-5 fornecedores, servidores s&oacute;cios de fornecedores
+      municipais, % do gasto pago para empresas de s&oacute;cios servidores,
+      fornecedores com situa&ccedil;&atilde;o cadastral irregular,
+      servidores no Bolsa Fam&iacute;lia com sal&aacute;rio alto e
+      fornecedores em CEIS/CNEP. Cada indicador usa curva c&ocirc;ncava
+      (1 caso j&aacute; sinaliza aten&ccedil;&atilde;o) ou linear (percentuais).
+    </p>
+    <h3>Frequ&ecirc;ncia de atualiza&ccedil;&atilde;o</h3>
+    <p>
+      Os dados deste site s&atilde;o atualizados periodicamente a partir
+      dos arquivos abertos publicados pelas fontes oficiais. A data da
+      &uacute;ltima atualiza&ccedil;&atilde;o aparece no rodap&eacute; de
+      todas as p&aacute;ginas.
+    </p>
+  </section>
+
+  <section class="sobre-section" id="limitacoes">
+    <h2>Limita&ccedil;&otilde;es</h2>
+    <ul>
+      <li>
+        <strong>S&atilde;o ind&iacute;cios, n&atilde;o conclus&otilde;es.</strong>
+        Um servidor s&oacute;cio de uma empresa que recebe da prefeitura pode
+        ter v&aacute;rios contextos (her&oacute;i de heran&ccedil;a, contrato
+        legal de pequeno valor, etc.). Sempre verifique a fonte original
+        antes de tirar conclus&otilde;es.
+      </li>
+      <li>
+        <strong>Algumas fontes mascaram CPF.</strong> O Portal da Transpar&ecirc;ncia
+        mascara 6 d&iacute;gitos do meio e o dados.pb.gov.br mascara o
+        in&iacute;cio e o fim. Quando cruzamos masked com aberto, indicamos
+        explicitamente.
+      </li>
+      <li>
+        <strong>Dados podem ter erro de origem.</strong> Erros de digita&ccedil;&atilde;o
+        no TCE-PB (ex: CNPJ inv&aacute;lido) ou divergencias entre fontes
+        s&atilde;o filtrados, mas n&atilde;o garantimos cobertura total.
+      </li>
+      <li>
+        <strong>N&atilde;o substitui &oacute;rg&atilde;os de controle.</strong>
+        Suspeitas s&eacute;rias devem ser levadas a MP-PB, TCE-PB ou CGU,
+        que t&ecirc;m poder de investiga&ccedil;&atilde;o formal.
+      </li>
+    </ul>
+  </section>
+
+  <section class="sobre-section" id="fontes">
+    <h2>Fontes oficiais</h2>
+    <ul>
+      <li><a href="https://portaldatransparencia.gov.br/" target="_blank" rel="noopener">Portal da Transpar&ecirc;ncia</a> &mdash; execu&ccedil;&atilde;o or&ccedil;ament&aacute;ria federal, Bolsa Fam&iacute;lia, servidores SIAPE.</li>
+      <li><a href="https://www.gov.br/receitafederal/pt-br/assuntos/orientacao-tributaria/cadastros/consultas/dados-publicos-cnpj" target="_blank" rel="noopener">Receita Federal &mdash; CNPJ</a> &mdash; cadastro de empresas e s&oacute;cios.</li>
+      <li><a href="https://www.gov.br/cgu/pt-br/assuntos/transparencia-publica" target="_blank" rel="noopener">CGU</a> &mdash; CEIS, CNEP, CEAF.</li>
+      <li><a href="https://tce.pb.gov.br/" target="_blank" rel="noopener">TCE-PB</a> &mdash; despesas, licita&ccedil;&otilde;es e folha das prefeituras paraibanas.</li>
+      <li><a href="https://dados.pb.gov.br/" target="_blank" rel="noopener">dados.pb.gov.br</a> &mdash; dados abertos do Governo do Estado.</li>
+      <li><a href="https://pncp.gov.br/" target="_blank" rel="noopener">PNCP</a> &mdash; Portal Nacional de Contrata&ccedil;&otilde;es P&uacute;blicas.</li>
+      <li><a href="https://www.gov.br/pgfn/pt-br" target="_blank" rel="noopener">PGFN</a> &mdash; d&iacute;vida ativa da Uni&atilde;o.</li>
+      <li><a href="https://www.ibge.gov.br/" target="_blank" rel="noopener">IBGE</a> &mdash; dados dos munic&iacute;pios.</li>
+      <li><a href="https://www.tse.jus.br/" target="_blank" rel="noopener">TSE</a> &mdash; candidatos e doa&ccedil;&otilde;es eleitorais.</li>
+    </ul>
+  </section>
+
+  <section class="sobre-section" id="contato">
+    <h2>Contato e c&oacute;digo aberto</h2>
+    <p>
+      Encontrou um bug, dado errado ou sugest&atilde;o? Use a
+      <a href="/contato">p&aacute;gina de contato</a>. Toda devolutiva
+      &eacute; lida e respondida.
+    </p>
+    <p>
+      O c&oacute;digo deste projeto est&aacute; em
+      <a href="https://github.com/lucasdiniz/govbr-cruza-dados" target="_blank" rel="noopener">github.com/lucasdiniz/govbr-cruza-dados</a>.
+    </p>
+  </section>
+
+  <nav class="sobre-cta">
+    <a href="/" class="btn-primary">Voltar para o mapa</a>
+    <a href="/glossario" class="btn-secondary">Ver gloss&aacute;rio</a>
+  </nav>
+</article>
+{% endblock %}

--- a/web/utils/__init__.py
+++ b/web/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utilitarios compartilhados do app web."""

--- a/web/utils/slug.py
+++ b/web/utils/slug.py
@@ -1,0 +1,179 @@
+"""Helpers de slug pra URLs amigaveis de municipio.
+
+Geram e resolvem slugs como "joao-pessoa", "santa-rita", "campina-grande".
+Cache em memoria mapeia slug -> nome canonico (com acento) consultando
+mv_municipio_pb_risco. TTL 1h: nome canonico nao muda na pratica, mas
+permite recovery se cache fica stale apos refresh de dados.
+
+Uso:
+    from web.utils.slug import municipio_slug, slug_to_municipio, SlugLookupError
+
+    municipio_slug("Joao Pessoa")            # "joao-pessoa"
+    slug_to_municipio("joao-pessoa")         # "Joao Pessoa" (canonico)
+    slug_to_municipio("nao-existe")          # None
+    # Levanta SlugLookupError quando cache vazio + DB indisponivel.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+import unicodedata
+
+from web import db
+
+
+_log = logging.getLogger("transparencia.slug")
+
+
+class SlugLookupError(RuntimeError):
+    """Cache vazio + impossivel consultar o DB. Sinaliza erro de
+    infraestrutura (deve virar HTTP 503), nao slug inexistente (404)."""
+
+
+# Cache thread-safe: slug -> nome canonico. Carregado on-demand.
+_LOCK = threading.Lock()
+_CACHE: dict[str, str] = {}
+_CACHE_TS: float = 0.0
+_CACHE_TTL = 3600  # 1h
+
+# Regex pra colapsar runs de hifens/whitespace em um unico "-"
+_DASH_RUN = re.compile(r"[-\s]+")
+# Caracteres permitidos no slug final (alfanumericos ASCII + hifen)
+_NON_SLUG = re.compile(r"[^a-z0-9-]+")
+
+
+def municipio_slug(name: str) -> str:
+    """Converte nome de municipio em slug URL-safe.
+
+    >>> municipio_slug("Joao Pessoa")
+    'joao-pessoa'
+    >>> municipio_slug("Sao Joao do Rio do Peixe")
+    'sao-joao-do-rio-do-peixe'
+    >>> municipio_slug("D'Avila")
+    'davila'
+    >>> municipio_slug("  Espacos   demais  ")
+    'espacos-demais'
+    """
+    if not name:
+        return ""
+    # NFKD strip de acentos
+    n = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    n = n.lower()
+    # Espacos viram hifens, multi viram um so
+    n = _DASH_RUN.sub("-", n)
+    # Drop caracteres nao-slug (apostrofes, parenteses, etc.)
+    n = _NON_SLUG.sub("", n)
+    # Trim hifens das pontas
+    return n.strip("-")
+
+
+def _load_cache() -> dict[str, str]:
+    """Carrega slug -> nome canonico do banco.
+
+    Levanta a excecao original do psycopg2/db em erro de DB — caller
+    decide se ignora (stale cache) ou propaga (cold start).
+
+    ORDER BY municipio garante determinismo em colisoes (extremamente
+    improvaveis em PB, mas defensivo). Logamos warning quando 2 municipios
+    diferentes geram o mesmo slug pra detectar bugs de dados na MV.
+    """
+    sql = """
+        SELECT municipio FROM mv_municipio_pb_risco
+        WHERE municipio IS NOT NULL
+        ORDER BY municipio
+    """
+    cache: dict[str, str] = {}
+    with db.get_conn() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            for (mun,) in cur.fetchall():
+                if not mun:
+                    continue
+                slug = municipio_slug(mun)
+                if not slug:
+                    continue
+                if slug in cache and cache[slug] != mun:
+                    _log.warning(
+                        "Slug colision: %r mapeia tanto para %r quanto para %r — "
+                        "mantendo %r (ordem alfabetica). Verifique mv_municipio_pb_risco.",
+                        slug, cache[slug], mun, cache[slug],
+                    )
+                    continue
+                cache[slug] = str(mun)
+    return cache
+
+
+def _ensure_cache() -> dict[str, str]:
+    """Carrega ou recarrega o cache se TTL expirou. Thread-safe.
+
+    Politica:
+    - Cache fresco (TTL nao expirou) -> retorna sem ir ao DB.
+    - Cache expirado mas existe -> tenta recarregar; em erro, mantem stale
+      (nao penaliza usuario por refresh transitoriamente falho).
+    - Cache vazio + DB falha -> levanta SlugLookupError (cold start).
+    """
+    global _CACHE, _CACHE_TS
+    now = time.time()
+    if _CACHE and (now - _CACHE_TS) < _CACHE_TTL:
+        return _CACHE
+    with _LOCK:
+        # Re-check apos acquire (outro thread pode ter recarregado)
+        if _CACHE and (time.time() - _CACHE_TS) < _CACHE_TTL:
+            return _CACHE
+        try:
+            new_cache = _load_cache()
+        except Exception as exc:
+            if _CACHE:
+                # Stale-while-error: serve cache antigo, loga warning
+                _log.warning(
+                    "Falha ao recarregar slug cache (%s) — servindo cache antigo (%d entradas)",
+                    exc, len(_CACHE),
+                )
+                return _CACHE
+            # Cold start sem cache: erro de infra -> caller deve dar 503
+            _log.exception("Falha ao carregar slug cache (cold start, sem fallback)")
+            raise SlugLookupError(str(exc)) from exc
+        if new_cache:
+            _CACHE = new_cache
+            _CACHE_TS = time.time()
+            _log.info("Slug cache carregado: %d municipios", len(new_cache))
+        return _CACHE
+
+
+def slug_to_municipio(slug: str) -> str | None:
+    """Resolve slug -> nome canonico. None se slug nao existe.
+
+    Lookup tolerante: chamadores podem passar 'Joao-Pessoa', 'joao-pessoa',
+    'joão-pessoa' indistintamente — todos sao normalizados pra forma
+    canonica antes do lookup.
+
+    Levanta SlugLookupError quando cache vazio + DB indisponivel (caller
+    deve responder HTTP 503, nao 404).
+    """
+    if not slug:
+        return None
+    norm = municipio_slug(slug)
+    if not norm:
+        return None
+    cache = _ensure_cache()
+    return cache.get(norm)
+
+
+def invalidate_cache() -> None:
+    """Forca recarga no proximo lookup. Util pra testes / pos-refresh de dados."""
+    global _CACHE, _CACHE_TS
+    with _LOCK:
+        _CACHE = {}
+        _CACHE_TS = 0.0
+
+
+def all_municipios_slugged() -> dict[str, str]:
+    """Retorna copia do cache atual: slug -> nome canonico.
+
+    Para uso em sitemap (precisa enumerar todas as cidades + slug).
+    Levanta SlugLookupError no cold start sem fallback.
+    """
+    return dict(_ensure_cache())


### PR DESCRIPTION
## Por que

Site `transparenciapb.org` não aparece em busca por "transparenciapb" no Google. Auditoria identificou: SEO técnico já bom (robots.txt, sitemap, canonical, JSON-LD), mas faltam itens críticos pra crawl/indexação inicial. Este PR junta **P0 (quick wins)** e **P1 (URLs amigáveis + página /sobre + breadcrumbs)** num único deploy.

## P0 — Quick Wins

### Templates
- `base.html`: meta tags `google-site-verification` e `msvalidate.01` (lidas de env), og:image fallback `/og/home.png` (1200×630), `og:image:alt`, `summary_large_image` como Twitter card default.
- `index.html`: title rico (`Como sua prefeitura gasta o dinheiro publico`), meta description com keywords (`fornecedores irregulares`, `compras sem licitacao`, `servidores com conflito`...), og:title/description próprios, eyebrow com a marca `TransparenciaPB`.

### Rotas
- `GET /og/home.png`: card OG genérico renderizado por PIL, cacheado em disco.
- `GET /<INDEXNOW_KEY>.txt`: arquivo de verificação do IndexNow. 404 templated quando chave não bate, sem interferir com `/robots.txt`.

### Sitemap
- `<lastmod>` em todas as entradas, valor = `DATA_REFRESH_DATE` do env.

### Tooling
- `web/indexnow_submit.py`: CLI que extrai URLs do sitemap e POSTa em batch ao IndexNow. Notifica Bing/Yandex/Yahoo/Seznam/Naver.
- `.github/workflows/deploy.yml`: novo step "SEO - IndexNow submit" pós cruza-web restart, `continue-on-error: true`, skip silencioso se `INDEXNOW_KEY` não setada. Roda em `etl_phase=web` ou `all`.

### Config
- `.env.example`: documenta `GOOGLE_SITE_VERIFICATION`, `BING_SITE_VERIFICATION`, `INDEXNOW_KEY`, `SITE_URL`.

## P1 — URLs amigáveis + /sobre + Breadcrumbs

### URLs amigáveis (`/cidade/<slug>` substituindo `/search/cidade?q=...`)

- `web/utils/slug.py`: helpers `municipio_slug()` / `slug_to_municipio()` com cache em memória (1h TTL, thread-safe). `SlugLookupError` para cold start sem fallback (caller responde 503 em vez de transformar em 404 em massa).
- `web/routes/cidade.py`: nova rota `GET /cidade/{slug}`. Refatorado `search_cidade` extraindo `_render_cidade()` compartilhado (evita risco de loop redirect que rubber-duck pegou). Canonicalização: variantes (`Joao-Pessoa`, `joao--pessoa`) → 301 pra forma canônica. `/search/cidade?q=` passa a 301 quando resolve cidade conhecida; fallback para render direto (404 templated) em termos desconhecidos.
- `web/routes/seo.py`: sitemap usa `/cidade/<slug>`.
- `web/static/js/lib/slug.js`: espelha `municipio_slug` Python pra autocomplete/mapa/geo navegarem direto pra `/cidade/<slug>` (evita 1 redirect extra). 11 unit checks confirmam sincronia 100% Python ↔ JS.
- `web/templates/results/cidade.html`: og:image absoluto + page_url e og:image usando slug canônico via filtro `municipio_slug`. `BreadcrumbList` agora inclui URL no item da cidade.

### Página `/sobre` (E-E-A-T)
- `web/templates/sobre.html`: metodologia, fontes, limitações, contato. `AboutPage` + `BreadcrumbList` JSON-LD.
- `web/static/css/pages/sobre.css`: layout long-form + CTA buttons.
- `web/main.py`: `GET /sobre`. Sitemap inclui `/sobre` (prioridade 0.6).
- `web/templates/base.html`: link "Sobre" no footer.

### BreadcrumbList JSON-LD
- Adicionado em `/mapa`, `/glossario` (cidade e sobre já têm).

### Outros
- `ASSET_VERSION` 97 → 98 (novo `lib/slug.js`).
- `.gitignore`: `data/og_cache/` (PIL gera on-demand).

## Validação

40 smoke checks passando:
- **11 unit Python** (`municipio_slug`)
- **11 unit JS** (`municipioSlug` via Node) — sincronia 100% Python ↔ JS
- **7 cold-start (sem DB)** — 503/404 corretos
- **11 redirects + sitemap** (com cache mock)

Crítica do rubber-duck (Sonnet 4.7) aplicada integralmente:
- ✅ `_render_cidade()` compartilhado (evita loop)
- ✅ `RedirectResponse(..., status_code=301)` explícito
- ✅ Canonicalização de variantes de slug
- ✅ 503 em cold-start sem fallback (não 404)
- ✅ `ORDER BY municipio` + log de colisões

```bash
# Build/compile sanity
python -m compileall web -q

# Smoke (sem DB, exige fastapi.testclient)
python -c "
import os, time
os.environ['GOOGLE_SITE_VERIFICATION'] = 'g'
from web.utils import slug as s
s._CACHE = {'joao-pessoa': 'Joao Pessoa'}
s._CACHE_TS = time.time()
import web.routes.seo as seo
seo._SITEMAP_CACHE = {'ts': 0.0, 'xml': ''}
seo._municipios_pb = lambda: [(n, sg) for sg, n in s._CACHE.items()]
from fastapi.testclient import TestClient
from web.main import app
c = TestClient(app)
print('sobre:', c.get('/sobre').status_code)
print('cidade variant:', c.get('/cidade/Joao-Pessoa', follow_redirects=False).status_code)
print('search redirect:', c.get('/search/cidade?q=Joao%20Pessoa', follow_redirects=False).status_code)
print('sitemap has /sobre:', '/sobre' in c.get('/sitemap.xml').text)
print('sitemap has /cidade/joao-pessoa:', '/cidade/joao-pessoa' in c.get('/sitemap.xml').text)
"
```

## Setup pós-merge (você precisa fazer)

Detalhado no plan da sessão (`~/.copilot/session-state/.../plan.md`):

1. **Google Search Console** — registrar `transparenciapb.org`, copiar token, adicionar `GOOGLE_SITE_VERIFICATION` ao secret `ENV_FILE`, redeploy, verificar, submeter sitemap, pedir indexação manual de top URLs.
2. **Bing Webmaster Tools** — mesmo fluxo com `BING_SITE_VERIFICATION`.
3. **IndexNow** — gerar key (`python -c "import secrets; print(secrets.token_urlsafe(32))"`), setar `INDEXNOW_KEY` + `SITE_URL` no `ENV_FILE`, redeploy. O step novo no `deploy.yml` chama `web.indexnow_submit` automaticamente após restart.
4. **Outreach/backlinks** — imprensa PB, Open Knowledge BR, Transparência Brasil, redes sociais. **Sem isso, ranking continua limitado mesmo com SEO técnico perfeito** — pilar #1 pra Google.

## Não-objetivos

- Publicar relatórios em `relatorios/` no site (P2, fora de escopo por decisão do dono).
- Core Web Vitals (code-split Material Web, fonts preload). Próxima onda.

## Risk / rollback

- `/og/home.png` falha gracefully se PIL não estiver instalado (501).
- `/<key>.txt` retorna 404 templated se `INDEXNOW_KEY` não setada — não quebra nada.
- Step IndexNow no deploy tem `continue-on-error: true` — failure de rede com `api.indexnow.org` não quebra deploy.
- `/cidade/<slug>` cold-start (cache vazio + DB down) responde 503 com `Retry-After: 300` — Google não deindexa.
- `/search/cidade?q=` mantém comportamento antigo (404 templated) quando termo não resolve — clientes externos linkando pra essa URL continuam funcionando.

Rollback: `git revert acf2ec2..c55adee` desfaz tudo.
