### PR TITLE
fix(warm-cache): Q67 ALL-TIME usa mv_q67_dated_pb (timeout 600s+ -> ~50ms)

### DIFF
--- a/web/queries/registry.py
+++ b/web/queries/registry.py
@@ -223,31 +223,26 @@ _reg("Q67", "Fornecedor com divida PGFN recebendo",
      "Empresa com divida ativa na Uniao recebendo do municipio",
      "Fornecedores Irregulares",
      """
-WITH desp AS (
-    SELECT cnpj_basico, MAX(cpf_cnpj) AS cpf_cnpj, MAX(nome_credor) AS nome_credor,
-           SUM(valor_pago) AS total_pago, COUNT(*) AS qtd_empenhos
-    FROM tce_pb_despesa
-    WHERE cnpj_basico IS NOT NULL AND valor_pago > 0 AND ano >= 2022
-      AND municipio = %(municipio)s
-    GROUP BY cnpj_basico
-    HAVING SUM(valor_pago) > 50000
-),
-pgfn_agg AS (
-    SELECT LEFT(cpf_cnpj_norm, 8) AS cnpj_basico,
-           MAX(situacao_inscricao) AS situacao_inscricao,
-           SUM(valor_consolidado) AS divida_pgfn
-    FROM pgfn_divida
-    WHERE LENGTH(cpf_cnpj_norm) = 14
-      AND LEFT(cpf_cnpj_norm, 8) IN (SELECT cnpj_basico FROM desp)
-    GROUP BY LEFT(cpf_cnpj_norm, 8)
-)
-SELECT d.cpf_cnpj, d.nome_credor, %(municipio)s AS municipio,
-       pg.situacao_inscricao,
-       pg.divida_pgfn,
-       d.total_pago, d.qtd_empenhos
-FROM desp d
-JOIN pgfn_agg pg ON pg.cnpj_basico = d.cnpj_basico
-ORDER BY pg.divida_pgfn DESC
+-- ALL-TIME usa mv_q67_dated_pb (mesma MV da variante dated, sem filtro de ano).
+-- Antes desta fix a query rodava live sobre tce_pb_despesa + pgfn_divida e
+-- ultrapassava o timeout de 600s no warm cache para municipios grandes
+-- (Joao Pessoa, Campina Grande, Cabedelo, etc). A MV cobre ano >= 2022,
+-- que ja era o filtro implicito da query live ("ALL-TIME desde 2022").
+-- Equivalencia algebrica: SUM-de-SUM por ano = SUM total; MAX-de-MAX = MAX.
+-- divida_pgfn e situacao_inscricao usam MAX (nao SUM) porque o valor ja vem
+-- agregado por cnpj_basico na MV — somar duplicaria pelo numero de anos.
+SELECT MAX(cpf_cnpj) AS cpf_cnpj,
+       MAX(nome_credor) AS nome_credor,
+       %(municipio)s AS municipio,
+       MAX(situacao_inscricao) AS situacao_inscricao,
+       MAX(divida_pgfn) AS divida_pgfn,
+       SUM(total_pago) AS total_pago,
+       SUM(qtd_empenhos) AS qtd_empenhos
+FROM mv_q67_dated_pb
+WHERE municipio = %(municipio)s
+GROUP BY cnpj_basico
+HAVING SUM(total_pago) > 50000
+ORDER BY MAX(divida_pgfn) DESC
 LIMIT 500
 """, timeout=90, sql_dated="""
 -- Variante dated (filtro por ano) usa mv_q67_dated_pb pre-agregada.


### PR DESCRIPTION
## Problema

No ultimo deploy o warm cache reportou Q67 ALL-TIME timeout para 24 dos 28 municipios PB que precisaram refresh:

```
Q67: 4/28 ok, 24 fail, 195 skipped (4046s, 0.0/s)
FAIL Q67 Cabedelo: canceling statement due to statement timeout
FAIL Q67 João Pessoa: canceling statement due to statement timeout
FAIL Q67 Campina Grande: canceling statement due to statement timeout
... +21 outras (Santa Rita, Bayeux, Cajazeiras, Patos, Sousa, Guarabira, Queimadas, ...)
```

A variante dated (ANO/12M) ja usava `mv_q67_dated_pb` e voa em ~10-50ms (todas as 223 munis ANO/12M passaram). Mas a ALL-TIME (`sql_full`) ainda escaneava `tce_pb_despesa` (44GB) + `pgfn_divida` (32GB) live por municipio, batendo no timeout do warm de 600s para os munis grandes.

## Fix

Reescrever `sql_full` para reutilizar a MV `mv_q67_dated_pb` (mesmo padrao da `sql_dated`, sem `ano BETWEEN`). Equivalencia algebrica:

- Live filtrava `ano >= 2022`; MV materializa apenas `ano >= 2022` -> mesmo universo.
- `SUM(SUM por ano) = SUM total`; `COUNT(*) total = SUM(qtd_empenhos por ano)`.
- `MAX(MAX por ano) = MAX total` (cpf_cnpj, nome_credor).
- `divida_pgfn` e `situacao_inscricao` usam `MAX` (nao SUM) porque o valor ja vem agregado por `cnpj_basico` na MV — somar duplicaria pelo numero de anos.

Validado com rubber-duck (sem blockers de correctness).

## Como reaplicar em prod

Apos merge:

1. `etl_phase=web` no deploy.yml
2. `invalidate_cache_keys=Q67` (DELETE cirurgico no web_cache)
3. Warm cache vai re-popular Q67 ALL-TIME para todos os 223 munis usando a query rapida (~10-50ms cada).

## Files

- `web/queries/registry.py` (Q67 sql_full reescrito)