### PR TITLE
perf(seo): preconnect Google Fonts + bump HSTS 1d to 6 meses

### DIFF
--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -40,7 +40,9 @@ server {
 
     # Security headers tambem no www block — visitors via www.* recebem HSTS
     # imediatamente em vez de so na 2a requisicao apos o redirect.
-    add_header Strict-Transport-Security "max-age=86400" always;
+    # HSTS: 6 meses (15768000s). Pos-validacao subir pra 2 anos (63072000) +
+    # includeSubDomains + preload e submeter em https://hstspreload.org/.
+    add_header Strict-Transport-Security "max-age=15768000" always;
     add_header X-Content-Type-Options nosniff always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
 
@@ -73,13 +75,19 @@ server {
     add_header X-Frame-Options SAMEORIGIN always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), interest-cohort=()" always;
-    # HSTS: 1 dia inicial. Subir pra 6 meses (15768000) após validação.
-    add_header Strict-Transport-Security "max-age=86400" always;
+    # HSTS: 6 meses. Pos-validacao prolongada (~2 meses sem incidente HTTPS)
+    # subir pra 2 anos (63072000) + includeSubDomains + preload e submeter
+    # em https://hstspreload.org/. Manter conservador ate la pra permitir
+    # rollback rapido caso algum subpath precise de HTTP (ex: integracao).
+    add_header Strict-Transport-Security "max-age=15768000" always;
     # CSP em modo Report-Only: avisa de violações sem bloquear. Após
     # observar logs sem falsos positivos, mover pra Content-Security-Policy
     # ativo. unsafe-inline necessário porque temos inline scripts dinâmicos
     # (theme/font-size pre-render, COLUMN_META, cidade bootstrap).
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+    # Google Fonts: style-src precisa de fonts.googleapis.com (CSS) e
+    # font-src de fonts.gstatic.com (woff2). Sem isso, mover de Report-Only
+    # pra modo enforced quebraria as fontes.
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
 
     # Limite de upload
     client_max_body_size 10m;

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,6 +22,16 @@
        no .env (secret ENV_FILE no GitHub). Ver SEO operations checklist. #}
     {% if GOOGLE_SITE_VERIFICATION %}<meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">{% endif %}
     {% if BING_SITE_VERIFICATION %}<meta name="msvalidate.01" content="{{ BING_SITE_VERIFICATION }}">{% endif %}
+    {# Resource hints: a CSS de tipografia (typography.css) faz @import de
+       fonts.googleapis.com, que por sua vez baixa woff2 de fonts.gstatic.com.
+       Sem preconnect, o browser so descobre essas origens depois de parsear o
+       CSS — adiciona ~200-400ms de DNS+TLS no path critico do LCP. Preconnect
+       inicia o handshake ja no parse do <head>. crossorigin="" e necessario
+       em fonts.gstatic.com porque os fetches de woff2 sao CORS (font-face). #}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
     <meta property="og:site_name" content="TransparenciaPB">
     <meta property="og:type" content="{% block og_type %}website{% endblock %}">
     <meta property="og:title" content="{% block og_title %}TransparenciaPB{% endblock %}">


### PR DESCRIPTION
# perf(seo): preconnect Google Fonts + bump HSTS

Quick wins SEO/Web Vitals/security identificados no audit pos-merge do P0 SEO. Tres mudancas pequenas, baixo risco, ganho mensuravel.

## 1. Preconnect/DNS-prefetch pra Google Fonts (LCP win)

`web/static/css/tokens/typography.css:17` faz:

```css
@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500&family=Material+Symbols+Outlined&display=swap");
```

Isso baixa CSS de `fonts.googleapis.com` e woff2 de `fonts.gstatic.com`. Sem `preconnect`, o browser so descobre essas origens depois de parsear `index.css` -> `typography.css`. DNS+TCP+TLS handshake atrasa em ~200-400ms o primeiro byte da fonte, e como Roboto e variavel de texto critico, isso bate direto no **LCP** (metrica que Google usa pra ranking).

Adicionado em `base.html` no `<head>` (antes da tag `<link rel="stylesheet">` do bundle):

```html
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
<link rel="dns-prefetch" href="https://fonts.googleapis.com">
<link rel="dns-prefetch" href="https://fonts.gstatic.com">
```

Notas:
- `crossorigin=""` em gstatic e obrigatorio (woff2 sao fetches CORS por causa de `font-face`); sem isso o preconnect nao reusa a conexao TLS e vira no-op.
- `dns-prefetch` repetido como fallback pra browsers/proxies que ignoram preconnect (defesa em profundidade barata).
- Nao mexemos em typography.css. Migrar de @import pra `<link>` daria ganho marginal mas tem risco de FOUT/FOIT — mantemos pra outro PR caso queiramos.

## 2. HSTS: 1 dia -> 6 meses

`deploy/nginx-cruza.conf` tinha `max-age=86400` em ambos os blocks (apex + www) com TODO no comentario:

```
# HSTS: 1 dia inicial. Subir pra 6 meses (15768000) após validação.
```

Site esta estavel em HTTPS ha bastante tempo, entao subimos pro valor planejado. Mantemos **sem** `includeSubDomains` e **sem** `preload` por enquanto (proximo passo: validar 2 meses sem incidente, ai subir pra 2 anos + preload + submeter em https://hstspreload.org/).

SEO impact: marginal (Google ja confia em HTTPS), mas e signal de seguranca/maturidade que crawlers consideram.

## 3. CSP: whitelist fonts.googleapis.com + fonts.gstatic.com

CSP esta em **Report-Only**, mas a string nao incluia as origens do Google Fonts:

```
style-src 'self' 'unsafe-inline'
font-src 'self' data:
```

Resultado: report-uri logaria violacoes legitimas (ruido), e qualquer migracao futura pra enforced quebraria fontes. Adicionado:

```
style-src 'self' 'unsafe-inline' https://fonts.googleapis.com
font-src 'self' data: https://fonts.gstatic.com
```

Sem mudanca de comportamento hoje (continua Report-Only) — destrava migracao futura pra enforced.

## O que NAO foi feito

- **GZipMiddleware FastAPI**: skip. Nginx ja gzipa text/css/js/json/svg/manifest no apex block (linhas 64-69 nginx-cruza.conf, `gzip on; gzip_types ...`). Adicionar fastapi GZip duplicaria compressao e geraria headers conflitantes.

## Como testar

**Local sem deploy:** os arquivos `.html` e `.conf` sao validaveis sem rodar:

```bash
# 1. Validar nginx syntax (na VM ou container nginx local)
docker run --rm -v $(pwd)/deploy:/etc/nginx/conf.d:ro nginx:alpine nginx -t

# 2. Render do template (smoke):
python -c "from jinja2 import Environment, FileSystemLoader; \
  env = Environment(loader=FileSystemLoader('web/templates')); \
  print(env.get_template('base.html').render(request=None))" | head -50
```

**Pos-deploy:**

```bash
# Header HSTS:
curl -sI https://transparenciapb.org/ | grep -i strict-transport
# Esperado: Strict-Transport-Security: max-age=15768000

# Preconnect no HTML:
curl -s https://transparenciapb.org/ | grep -i preconnect
# Esperado: 2 linhas <link rel="preconnect" ...>

# CSP:
curl -sI https://transparenciapb.org/ | grep -i content-security
# Esperado: incluir fonts.googleapis.com e fonts.gstatic.com

# Web Vitals (rodar no PageSpeed Insights):
# https://pagespeed.web.dev/analysis?url=https%3A%2F%2Ftransparenciapb.org%2F
# Esperado: LCP melhora 200-400ms vs baseline antes do PR.
```

## Risco

Baixo. Mudancas sao headers HTTP e tags `<link>` que sao ignoradas se browser/proxy nao suportar. Rollback = revert do commit + redeploy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
