### PR TITLE
feat(seo): paginas /empresa/<cnpj> indexaveis + E-E-A-T sem Person

### DIFF
--- a/web/indexnow_submit.py
+++ b/web/indexnow_submit.py
@@ -34,6 +34,7 @@ import logging
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -165,9 +166,16 @@ def main() -> int:
 
     log.info("Submetendo %d URL(s) ao IndexNow (host=%s)", len(urls), host)
     ok = True
-    for i in range(0, len(urls), BATCH_SIZE):
+    # Sleep entre batches: IndexNow nao publica rate limits oficiais, mas
+    # apos onda de empresas (~5K-50K URLs) podemos bater limite implicito
+    # do Bing. 0.5s entre batches da margem de seguranca sem alongar muito
+    # o submit (50 batches = 25s adicional). Apenas em modo real, nao dry-run.
+    batch_indices = list(range(0, len(urls), BATCH_SIZE))
+    for idx, i in enumerate(batch_indices):
         batch = urls[i : i + BATCH_SIZE]
         ok = _submit_batch(host, key, batch, args.dry_run) and ok
+        if not args.dry_run and idx < len(batch_indices) - 1:
+            time.sleep(0.5)
 
     return 0 if ok else 1
 

--- a/web/main.py
+++ b/web/main.py
@@ -12,6 +12,7 @@ from fastapi.templating import Jinja2Templates
 
 from web import db
 from web.routes.cidade import router as cidade_router
+from web.routes.empresa import router as empresa_router
 from web.routes.mapa import router as mapa_router
 from web.routes.og_image import router as og_router
 from web.routes.contato import build_router as build_contato_router
@@ -503,6 +504,7 @@ templates.env.filters["municipio_slug"] = _municipio_slug
 
 
 app.include_router(cidade_router)
+app.include_router(empresa_router)
 app.include_router(mapa_router)
 app.include_router(og_router)
 app.include_router(build_contato_router(templates))

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -66,6 +66,9 @@ EMPRESA_SOCIOS_BY_BASICO = """
 
 # ─────────────────────────────────────────────────────────────────────────
 # Sancoes (CEIS / CNEP) e dividas (PGFN) — chave: cpf_cnpj_norm = 14 digitos
+# Usadas pelo dialog (cidade.py /api/fornecedor/detalhes), onde o usuario
+# clica num pagamento especifico do municipio e queremos as sancoes do
+# estabelecimento exato que recebeu aquele empenho.
 # ─────────────────────────────────────────────────────────────────────────
 
 EMPRESA_SANCOES_CEIS_BY_CNPJ = """
@@ -112,6 +115,56 @@ EMPRESA_LENIENCIA_EFEITOS_BY_ID = """
                         """
 
 # ─────────────────────────────────────────────────────────────────────────
+# Versoes _BY_BASICO — usadas pela pagina /empresa/{cnpj} (perfil agregado
+# da empresa raiz, alinhado com mv_empresa_pb que tambem agrega por
+# cnpj_basico). Garantem coerencia entre KPIs (que vem da MV agregada por
+# basico) e listagens detalhadas. Filtro `tipo_pessoa IN (PJ, ...)` evita
+# colisao de prefixo com CPFs (cpf=11 digitos vs cnpj=14, mas LEFT(.,8)
+# poderia bater com CPF cuja primeira metade coincide).
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_SANCOES_CEIS_BY_BASICO = """
+    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal,
+           abrangencia_sancao
+    FROM ceis_sancao
+    WHERE LEFT(cpf_cnpj_norm, 8) = %s
+      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+    ORDER BY dt_inicio_sancao DESC
+"""
+
+EMPRESA_SANCOES_CNEP_BY_BASICO = """
+    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal, valor_multa,
+           abrangencia_sancao
+    FROM cnep_sancao
+    WHERE LEFT(cpf_cnpj_norm, 8) = %s
+      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+    ORDER BY dt_inicio_sancao DESC
+"""
+
+EMPRESA_PGFN_BY_BASICO = """
+    SELECT numero_inscricao, situacao_inscricao,
+           receita_principal, valor_consolidado,
+           dt_inscricao, indicador_ajuizado
+    FROM pgfn_divida
+    WHERE LEFT(cpf_cnpj_norm, 8) = %s
+      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+    ORDER BY valor_consolidado DESC
+"""
+
+EMPRESA_LENIENCIA_BY_BASICO = """
+    SELECT al.cnpj_sancionado, al.razao_social_rfb, al.situacao_acordo,
+           al.orgao_sancionador, al.dt_inicio_acordo, al.dt_fim_acordo,
+           al.numero_processo, al.id_acordo
+    FROM acordo_leniencia al
+    WHERE LEFT(al.cnpj_norm, 8) = %s
+    ORDER BY al.dt_inicio_acordo DESC
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
 # Pagamentos publicos PB (agregados + por municipio + top elementos)
 # Usados apenas pela pagina /empresa/{cnpj}.
 # ─────────────────────────────────────────────────────────────────────────
@@ -122,23 +175,23 @@ EMPRESA_AGREGADOS_PB_BY_BASICO = """
     WHERE cnpj_basico = %s
 """
 
-EMPRESA_MUNICIPIOS_PAGANTES_BY_CNPJ = """
+EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO = """
     SELECT municipio,
            SUM(valor_pago) AS total_pago,
            COUNT(*) AS qtd_empenhos
     FROM tce_pb_despesa
-    WHERE cpf_cnpj = %s
+    WHERE cnpj_basico = %s
       AND valor_pago > 0
     GROUP BY municipio
     ORDER BY total_pago DESC
 """
 
-EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_CNPJ = """
+EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO = """
     SELECT elemento_despesa,
            SUM(valor_pago) AS total_elemento,
            COUNT(*) AS qtd
     FROM tce_pb_despesa
-    WHERE cpf_cnpj = %s
+    WHERE cnpj_basico = %s
       AND valor_pago > 0
     GROUP BY elemento_despesa
     ORDER BY SUM(valor_pago) DESC
@@ -150,6 +203,11 @@ EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_CNPJ = """
 # Inclui CNPJs com pagamentos PB relevantes (>= R$ 10k), em CEIS vigente
 # ou com divida PGFN > 0. Retorna (razao_social, cnpj_completo) onde
 # cnpj_completo = basico+ordem(0001)+dv da matriz.
+#
+# LIMIT 45000: protocolo sitemap.org permite ate 50.000 URLs por arquivo.
+# Cidades (~223) + estaticas (5) + 45k empresas = ~45.2k, com folga ate
+# o limite. Quando passarmos disso, implementar sitemap index com chunks
+# (TODO: web/routes/seo.py — sitemap-empresas-1.xml etc).
 # ─────────────────────────────────────────────────────────────────────────
 
 EMPRESAS_QUALIFICADAS_PARA_SITEMAP = """
@@ -165,4 +223,5 @@ EMPRESAS_QUALIFICADAS_PARA_SITEMAP = """
        OR epb.total_divida_pgfn > 0
     ORDER BY epb.total_pb_geral DESC NULLS LAST,
              epb.cnpj_basico
+    LIMIT 45000
 """

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -1,0 +1,168 @@
+"""SQL parametrizado para o perfil publico de empresa (/empresa/<cnpj>) e
+para o endpoint /api/fornecedor/detalhes (dialog).
+
+As 8 primeiras constantes (CEIS, CNEP, ESTABELECIMENTO, MATRIZ, SOCIOS,
+PGFN, LENIENCIA, EFEITOS) reproduzem byte-a-byte os SQLs que viviam
+inline em web/routes/cidade.py:1746-1992. Foram extraidas pra que a rota
+nova /empresa/{cnpj} consuma a mesma fonte canonica e o dialog continue
+identico.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cadastro RFB (estabelecimento + empresa)
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO = """
+                    SELECT
+                        est.situacao_cadastral, est.dt_situacao,
+                        est.cnpj_completo, est.cnae_principal,
+                        dcnae.descricao AS desc_cnae_principal,
+                        est.uf,
+                        COALESCE(dm.descricao, est.municipio) AS municipio,
+                        est.matriz_filial, est.nome_fantasia,
+                        est.dt_inicio_atividade,
+                        est.tipo_logradouro, est.logradouro, est.numero,
+                        est.complemento, est.bairro, est.cep,
+                        est.ddd1, est.telefone1, est.email,
+                        e.razao_social, e.capital_social, e.porte,
+                        e.natureza_juridica,
+                        dnj.descricao AS desc_natureza_juridica,
+                        e.ente_federativo
+                    FROM estabelecimento est
+                    LEFT JOIN empresa e ON e.cnpj_basico = est.cnpj_basico
+                    LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
+                    LEFT JOIN dom_cnae dcnae ON dcnae.codigo = est.cnae_principal
+                    LEFT JOIN dom_natureza_juridica dnj ON dnj.codigo = e.natureza_juridica
+                    WHERE est.cnpj_completo = %s
+                """
+
+EMPRESA_MATRIZ_BY_BASICO = """
+                        SELECT est.cnpj_completo,
+                               est.tipo_logradouro, est.logradouro, est.numero,
+                               est.complemento, est.bairro, est.cep,
+                               est.ddd1, est.telefone1, est.email,
+                               COALESCE(dm.descricao, est.municipio) AS municipio,
+                               est.uf, est.nome_fantasia,
+                               est.dt_inicio_atividade
+                        FROM estabelecimento est
+                        LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
+                        WHERE est.cnpj_basico = %s AND est.cnpj_ordem = '0001'
+                    """
+
+EMPRESA_SOCIOS_BY_BASICO = """
+                    SELECT s.tipo_socio, s.nome, s.cpf_cnpj_socio,
+                           s.qualificacao,
+                           dq.descricao AS desc_qualificacao,
+                           s.dt_entrada, s.pais, s.faixa_etaria,
+                           s.nome_representante, s.cpf_representante,
+                           s.qualif_representante,
+                           dqr.descricao AS desc_qualif_representante
+                    FROM socio s
+                    LEFT JOIN dom_qualificacao dq ON dq.codigo = s.qualificacao
+                    LEFT JOIN dom_qualificacao dqr ON dqr.codigo = s.qualif_representante
+                    WHERE s.cnpj_basico = %s
+                    ORDER BY s.tipo_socio, s.dt_entrada DESC
+                """
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sancoes (CEIS / CNEP) e dividas (PGFN) — chave: cpf_cnpj_norm = 14 digitos
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_SANCOES_CEIS_BY_CNPJ = """
+                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal,
+                           abrangencia_sancao
+                    FROM ceis_sancao
+                    WHERE cpf_cnpj_norm = %s
+                    ORDER BY dt_inicio_sancao DESC
+                """
+
+EMPRESA_SANCOES_CNEP_BY_CNPJ = """
+                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal, valor_multa,
+                           abrangencia_sancao
+                    FROM cnep_sancao
+                    WHERE cpf_cnpj_norm = %s
+                    ORDER BY dt_inicio_sancao DESC
+                """
+
+EMPRESA_PGFN_BY_CNPJ = """
+                    SELECT numero_inscricao, situacao_inscricao,
+                           receita_principal, valor_consolidado,
+                           dt_inscricao, indicador_ajuizado
+                    FROM pgfn_divida
+                    WHERE cpf_cnpj_norm = %s
+                    ORDER BY valor_consolidado DESC
+                """
+
+EMPRESA_LENIENCIA_BY_CNPJ = """
+                    SELECT al.cnpj_sancionado, al.razao_social_rfb, al.situacao_acordo,
+                           al.orgao_sancionador, al.dt_inicio_acordo, al.dt_fim_acordo,
+                           al.numero_processo, al.id_acordo
+                    FROM acordo_leniencia al
+                    WHERE al.cnpj_norm = %s
+                    ORDER BY al.dt_inicio_acordo DESC
+                """
+
+EMPRESA_LENIENCIA_EFEITOS_BY_ID = """
+                            SELECT efeito, complemento FROM acordo_efeito
+                            WHERE id_acordo = %s
+                        """
+
+# ─────────────────────────────────────────────────────────────────────────
+# Pagamentos publicos PB (agregados + por municipio + top elementos)
+# Usados apenas pela pagina /empresa/{cnpj}.
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_AGREGADOS_PB_BY_BASICO = """
+    SELECT *
+    FROM mv_empresa_pb
+    WHERE cnpj_basico = %s
+"""
+
+EMPRESA_MUNICIPIOS_PAGANTES_BY_CNPJ = """
+    SELECT municipio,
+           SUM(valor_pago) AS total_pago,
+           COUNT(*) AS qtd_empenhos
+    FROM tce_pb_despesa
+    WHERE cpf_cnpj = %s
+      AND valor_pago > 0
+    GROUP BY municipio
+    ORDER BY total_pago DESC
+"""
+
+EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_CNPJ = """
+    SELECT elemento_despesa,
+           SUM(valor_pago) AS total_elemento,
+           COUNT(*) AS qtd
+    FROM tce_pb_despesa
+    WHERE cpf_cnpj = %s
+      AND valor_pago > 0
+    GROUP BY elemento_despesa
+    ORDER BY SUM(valor_pago) DESC
+    LIMIT 5
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sitemap: empresas qualificadas (heuristica de filtro pra evitar ruido).
+# Inclui CNPJs com pagamentos PB relevantes (>= R$ 10k), em CEIS vigente
+# ou com divida PGFN > 0. Retorna (razao_social, cnpj_completo) onde
+# cnpj_completo = basico+ordem(0001)+dv da matriz.
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESAS_QUALIFICADAS_PARA_SITEMAP = """
+    SELECT
+        COALESCE(NULLIF(epb.razao_social, ''), 'Empresa ' || epb.cnpj_basico) AS razao_social,
+        est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo
+    FROM mv_empresa_pb epb
+    JOIN estabelecimento est
+        ON est.cnpj_basico = epb.cnpj_basico
+       AND est.cnpj_ordem = '0001'
+    WHERE epb.total_pb_geral >= 10000
+       OR epb.flag_ceis_vigente
+       OR epb.total_divida_pgfn > 0
+    ORDER BY epb.total_pb_geral DESC NULLS LAST,
+             epb.cnpj_basico
+"""

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -41,6 +41,16 @@ from web.queries.cidade import (
     TOP_SERVIDORES_RISCO,
     TOP_SERVIDORES_RISCO_DATED,
 )
+from web.queries.empresa import (
+    EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
+    EMPRESA_LENIENCIA_BY_CNPJ,
+    EMPRESA_LENIENCIA_EFEITOS_BY_ID,
+    EMPRESA_MATRIZ_BY_BASICO,
+    EMPRESA_PGFN_BY_CNPJ,
+    EMPRESA_SANCOES_CEIS_BY_CNPJ,
+    EMPRESA_SANCOES_CNEP_BY_CNPJ,
+    EMPRESA_SOCIOS_BY_BASICO,
+)
 from web.queries.registry import CIDADE_QUERIES, get_categories
 from web.kpis.cidade import compute_cidade_kpis
 
@@ -1743,15 +1753,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                 result["top_elementos"] = top_elementos
 
                 # Sancoes CEIS
-                cur.execute("""
-                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
-                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
-                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal,
-                           abrangencia_sancao
-                    FROM ceis_sancao
-                    WHERE cpf_cnpj_norm = %s
-                    ORDER BY dt_inicio_sancao DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_SANCOES_CEIS_BY_CNPJ, (cpf_cnpj,))
                 san_cols = [d[0] for d in cur.description]
                 san_rows = cur.fetchall()
                 sancoes = []
@@ -1764,15 +1766,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     sancoes.append(r)
 
                 # Sancoes CNEP
-                cur.execute("""
-                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
-                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
-                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal, valor_multa,
-                           abrangencia_sancao
-                    FROM cnep_sancao
-                    WHERE cpf_cnpj_norm = %s
-                    ORDER BY dt_inicio_sancao DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_SANCOES_CNEP_BY_CNPJ, (cpf_cnpj,))
                 cnep_cols = [d[0] for d in cur.description]
                 cnep_rows = cur.fetchall()
                 for row in cnep_rows:
@@ -1850,31 +1844,8 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                 # Situacao cadastral + dados cadastrais detalhados
                 # Retorna estabelecimento exato + matriz (cnpj_ordem='0001') para
                 # endereco/contato + dados da empresa (capital, porte, natureza).
-                est_where = "est.cnpj_completo = %s"
                 est_params = (cpf_cnpj,)
-                cur.execute(f"""
-                    SELECT
-                        est.situacao_cadastral, est.dt_situacao,
-                        est.cnpj_completo, est.cnae_principal,
-                        dcnae.descricao AS desc_cnae_principal,
-                        est.uf,
-                        COALESCE(dm.descricao, est.municipio) AS municipio,
-                        est.matriz_filial, est.nome_fantasia,
-                        est.dt_inicio_atividade,
-                        est.tipo_logradouro, est.logradouro, est.numero,
-                        est.complemento, est.bairro, est.cep,
-                        est.ddd1, est.telefone1, est.email,
-                        e.razao_social, e.capital_social, e.porte,
-                        e.natureza_juridica,
-                        dnj.descricao AS desc_natureza_juridica,
-                        e.ente_federativo
-                    FROM estabelecimento est
-                    LEFT JOIN empresa e ON e.cnpj_basico = est.cnpj_basico
-                    LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
-                    LEFT JOIN dom_cnae dcnae ON dcnae.codigo = est.cnae_principal
-                    LEFT JOIN dom_natureza_juridica dnj ON dnj.codigo = e.natureza_juridica
-                    WHERE {est_where}
-                """, est_params)
+                cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, est_params)
                 sit_cols = [d[0] for d in cur.description]
                 sit_rows = cur.fetchall()
                 if sit_rows:
@@ -1892,18 +1863,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                 cnpj_basico_int = cpf_cnpj[:8]
                 cnpj_ordem_int = cpf_cnpj[8:12]
                 if cnpj_ordem_int != '0001':
-                    cur.execute("""
-                        SELECT est.cnpj_completo,
-                               est.tipo_logradouro, est.logradouro, est.numero,
-                               est.complemento, est.bairro, est.cep,
-                               est.ddd1, est.telefone1, est.email,
-                               COALESCE(dm.descricao, est.municipio) AS municipio,
-                               est.uf, est.nome_fantasia,
-                               est.dt_inicio_atividade
-                        FROM estabelecimento est
-                        LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
-                        WHERE est.cnpj_basico = %s AND est.cnpj_ordem = '0001'
-                    """, (cnpj_basico_int,))
+                    cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico_int,))
                     mat_cols = [d[0] for d in cur.description]
                     mat_row = cur.fetchone()
                     if mat_row:
@@ -1914,20 +1874,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                         result["matriz"] = matriz
 
                 # Socios (CPFs vem mascarados pela RFB — seguro expor).
-                cur.execute("""
-                    SELECT s.tipo_socio, s.nome, s.cpf_cnpj_socio,
-                           s.qualificacao,
-                           dq.descricao AS desc_qualificacao,
-                           s.dt_entrada, s.pais, s.faixa_etaria,
-                           s.nome_representante, s.cpf_representante,
-                           s.qualif_representante,
-                           dqr.descricao AS desc_qualif_representante
-                    FROM socio s
-                    LEFT JOIN dom_qualificacao dq ON dq.codigo = s.qualificacao
-                    LEFT JOIN dom_qualificacao dqr ON dqr.codigo = s.qualif_representante
-                    WHERE s.cnpj_basico = %s
-                    ORDER BY s.tipo_socio, s.dt_entrada DESC
-                """, (cnpj_basico_int,))
+                cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico_int,))
                 soc_cols = [d[0] for d in cur.description]
                 soc_rows = cur.fetchall()
                 if soc_rows:
@@ -1941,14 +1888,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     result["socios"] = socios
 
                 # Divida PGFN
-                cur.execute("""
-                    SELECT numero_inscricao, situacao_inscricao,
-                           receita_principal, valor_consolidado,
-                           dt_inscricao, indicador_ajuizado
-                    FROM pgfn_divida
-                    WHERE cpf_cnpj_norm = %s
-                    ORDER BY valor_consolidado DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_PGFN_BY_CNPJ, (cpf_cnpj,))
                 pgfn_cols = [d[0] for d in cur.description]
                 pgfn_rows = cur.fetchall()
                 if pgfn_rows:
@@ -1964,14 +1904,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     result["pgfn"] = dividas
 
                 # Acordos de Leniencia
-                cur.execute("""
-                    SELECT al.cnpj_sancionado, al.razao_social_rfb, al.situacao_acordo,
-                           al.orgao_sancionador, al.dt_inicio_acordo, al.dt_fim_acordo,
-                           al.numero_processo, al.id_acordo
-                    FROM acordo_leniencia al
-                    WHERE al.cnpj_norm = %s
-                    ORDER BY al.dt_inicio_acordo DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_LENIENCIA_BY_CNPJ, (cpf_cnpj,))
                 al_cols = [d[0] for d in cur.description]
                 al_rows = cur.fetchall()
                 if al_rows:
@@ -1982,10 +1915,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                             if hasattr(v, 'isoformat'):
                                 a[k] = v.isoformat()
                         # Buscar efeitos do acordo
-                        cur.execute("""
-                            SELECT efeito, complemento FROM acordo_efeito
-                            WHERE id_acordo = %s
-                        """, (a["id_acordo"],))
+                        cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
                         ef_cols = [d[0] for d in cur.description]
                         ef_rows = cur.fetchall()
                         a["efeitos"] = [_row_to_dict(ef_cols, er) for er in ef_rows]

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -21,15 +21,15 @@ from web.db import execute_query, get_conn
 from web.queries.empresa import (
     EMPRESA_AGREGADOS_PB_BY_BASICO,
     EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
-    EMPRESA_LENIENCIA_BY_CNPJ,
+    EMPRESA_LENIENCIA_BY_BASICO,
     EMPRESA_LENIENCIA_EFEITOS_BY_ID,
     EMPRESA_MATRIZ_BY_BASICO,
-    EMPRESA_MUNICIPIOS_PAGANTES_BY_CNPJ,
-    EMPRESA_PGFN_BY_CNPJ,
-    EMPRESA_SANCOES_CEIS_BY_CNPJ,
-    EMPRESA_SANCOES_CNEP_BY_CNPJ,
+    EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO,
+    EMPRESA_PGFN_BY_BASICO,
+    EMPRESA_SANCOES_CEIS_BY_BASICO,
+    EMPRESA_SANCOES_CNEP_BY_BASICO,
     EMPRESA_SOCIOS_BY_BASICO,
-    EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_CNPJ,
+    EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO,
 )
 
 router = APIRouter()
@@ -116,93 +116,111 @@ async def empresa_perfil(request: Request, cnpj: str):
         agregados = _convert_row(_row_to_dict(agg_cols, agg_rows[0]))
 
         # 2. Cadastro RFB (estabelecimento + empresa) — chave: cnpj_completo.
+        # Detalhes (sancoes/divida/leniencia/pagamentos) sao consultados POR
+        # CNPJ_BASICO (8 digitos) pra coerencia com mv_empresa_pb que agrega
+        # por basico. URL e canonicalizada com 14 digitos da matriz mas a
+        # pagina representa a empresa raiz.
         with get_conn() as conn:
             conn.autocommit = True
             with conn.cursor() as cur:
                 cur.execute(f"SET statement_timeout = '{TIMEOUT_PROFILE * 1000}'")
+                # try/finally: garante RESET statement_timeout em qualquer
+                # caminho (404 cedo, exception, ou sucesso). Sem isso, a
+                # config de sessao vaza pra proxima request que pegar a
+                # mesma conexao do pool, podendo quebrar queries pesadas
+                # de outros endpoints. (Caught by GPT-5.5 review do PR #57.)
+                try:
+                    cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (canonical,))
+                    est_cols = [d[0] for d in cur.description]
+                    est_rows = cur.fetchall()
+                    if not est_rows:
+                        return templates.TemplateResponse(
+                            request,
+                            "errors/404.html",
+                            {"path": str(request.url.path)},
+                            status_code=404,
+                        )
+                    estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
 
-                cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (canonical,))
-                est_cols = [d[0] for d in cur.description]
-                est_rows = cur.fetchall()
-                if not est_rows:
-                    return templates.TemplateResponse(
-                        request,
-                        "errors/404.html",
-                        {"path": str(request.url.path)},
-                        status_code=404,
-                    )
-                estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
+                    # 3. Matriz (se a entidade nao for ela propria a matriz)
+                    matriz = None
+                    if cnpj_ordem != "0001":
+                        cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
+                        mat_cols = [d[0] for d in cur.description]
+                        mat_row = cur.fetchone()
+                        if mat_row:
+                            matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
 
-                # 3. Matriz (se a entidade nao for ela propria a matriz)
-                matriz = None
-                if cnpj_ordem != "0001":
-                    cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
-                    mat_cols = [d[0] for d in cur.description]
-                    mat_row = cur.fetchone()
-                    if mat_row:
-                        matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
-
-                # 4. Socios
-                cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
-                soc_cols = [d[0] for d in cur.description]
-                socios = [
-                    _convert_row(_row_to_dict(soc_cols, r))
-                    for r in cur.fetchall()
-                ]
-
-                # 5. Sancoes CEIS + CNEP
-                cur.execute(EMPRESA_SANCOES_CEIS_BY_CNPJ, (canonical,))
-                ceis_cols = [d[0] for d in cur.description]
-                sancoes = []
-                for r in cur.fetchall():
-                    item = _convert_row(_row_to_dict(ceis_cols, r))
-                    item["origem"] = "CEIS"
-                    sancoes.append(item)
-
-                cur.execute(EMPRESA_SANCOES_CNEP_BY_CNPJ, (canonical,))
-                cnep_cols = [d[0] for d in cur.description]
-                for r in cur.fetchall():
-                    item = _convert_row(_row_to_dict(cnep_cols, r))
-                    item["origem"] = "CNEP"
-                    sancoes.append(item)
-
-                # 6. PGFN
-                cur.execute(EMPRESA_PGFN_BY_CNPJ, (canonical,))
-                pg_cols = [d[0] for d in cur.description]
-                pgfn = [
-                    _convert_row(_row_to_dict(pg_cols, r))
-                    for r in cur.fetchall()
-                ]
-
-                # 7. Acordos de Leniencia + efeitos
-                cur.execute(EMPRESA_LENIENCIA_BY_CNPJ, (canonical,))
-                len_cols = [d[0] for d in cur.description]
-                acordos = []
-                for r in cur.fetchall():
-                    a = _convert_row(_row_to_dict(len_cols, r))
-                    cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
-                    ef_cols = [d[0] for d in cur.description]
-                    a["efeitos"] = [
-                        _row_to_dict(ef_cols, er) for er in cur.fetchall()
+                    # 4. Socios
+                    cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
+                    soc_cols = [d[0] for d in cur.description]
+                    socios = [
+                        _convert_row(_row_to_dict(soc_cols, r))
+                        for r in cur.fetchall()
                     ]
-                    acordos.append(a)
 
-                # 8. Municipios pagantes (PB) + top elementos
-                cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_CNPJ, (canonical,))
-                mp_cols = [d[0] for d in cur.description]
-                municipios_pagantes = [
-                    _convert_row(_row_to_dict(mp_cols, r))
-                    for r in cur.fetchall()
-                ]
+                    # 5. Sancoes CEIS + CNEP (por basico, todos estabelecimentos)
+                    cur.execute(EMPRESA_SANCOES_CEIS_BY_BASICO, (cnpj_basico,))
+                    ceis_cols = [d[0] for d in cur.description]
+                    sancoes = []
+                    for r in cur.fetchall():
+                        item = _convert_row(_row_to_dict(ceis_cols, r))
+                        item["origem"] = "CEIS"
+                        sancoes.append(item)
 
-                cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_CNPJ, (canonical,))
-                te_cols = [d[0] for d in cur.description]
-                top_elementos = [
-                    _convert_row(_row_to_dict(te_cols, r))
-                    for r in cur.fetchall()
-                ]
+                    cur.execute(EMPRESA_SANCOES_CNEP_BY_BASICO, (cnpj_basico,))
+                    cnep_cols = [d[0] for d in cur.description]
+                    for r in cur.fetchall():
+                        item = _convert_row(_row_to_dict(cnep_cols, r))
+                        item["origem"] = "CNEP"
+                        sancoes.append(item)
 
-                cur.execute("RESET statement_timeout")
+                    # 6. PGFN (por basico)
+                    cur.execute(EMPRESA_PGFN_BY_BASICO, (cnpj_basico,))
+                    pg_cols = [d[0] for d in cur.description]
+                    pgfn = [
+                        _convert_row(_row_to_dict(pg_cols, r))
+                        for r in cur.fetchall()
+                    ]
+
+                    # 7. Acordos de Leniencia + efeitos (por basico)
+                    cur.execute(EMPRESA_LENIENCIA_BY_BASICO, (cnpj_basico,))
+                    len_cols = [d[0] for d in cur.description]
+                    acordos = []
+                    for r in cur.fetchall():
+                        a = _convert_row(_row_to_dict(len_cols, r))
+                        cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
+                        ef_cols = [d[0] for d in cur.description]
+                        a["efeitos"] = [
+                            _row_to_dict(ef_cols, er) for er in cur.fetchall()
+                        ]
+                        acordos.append(a)
+
+                    # 8. Municipios pagantes (PB) + top elementos (por basico)
+                    cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO, (cnpj_basico,))
+                    mp_cols = [d[0] for d in cur.description]
+                    municipios_pagantes = [
+                        _convert_row(_row_to_dict(mp_cols, r))
+                        for r in cur.fetchall()
+                    ]
+
+                    cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO, (cnpj_basico,))
+                    te_cols = [d[0] for d in cur.description]
+                    top_elementos = [
+                        _convert_row(_row_to_dict(te_cols, r))
+                        for r in cur.fetchall()
+                    ]
+                finally:
+                    try:
+                        cur.execute("RESET statement_timeout")
+                    except Exception:
+                        # se conexao ja foi marcada como aborted, RESET
+                        # falha — tolerar porque putconn vai descartar a
+                        # conexao corrompida em vez de devolver ao pool.
+                        _log.warning(
+                            "RESET statement_timeout falhou (conexao "
+                            "provavelmente sera descartada pelo pool)"
+                        )
     except Exception:
         _log.exception("empresa perfil failed cnpj=%s", canonical)
         return Response(

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -1,0 +1,275 @@
+"""Rota publica /empresa/{cnpj} — perfil SEO de empresa.
+
+Renderiza pagina indexavel com cadastro RFB, sancoes, dividas, agregados
+de pagamentos publicos PB e municipios pagantes. Reaproveita as queries
+de web.queries.empresa (mesma fonte que o dialog usa em cidade.py).
+
+URL: /empresa/<14-digitos>. CNPJ formatado com mascara redireciona via
+404; entrada deve ser 14 digitos numericos puros (canonical).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse, Response
+
+from web.config import TIMEOUT_PROFILE
+from web.db import execute_query, get_conn
+from web.queries.empresa import (
+    EMPRESA_AGREGADOS_PB_BY_BASICO,
+    EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
+    EMPRESA_LENIENCIA_BY_CNPJ,
+    EMPRESA_LENIENCIA_EFEITOS_BY_ID,
+    EMPRESA_MATRIZ_BY_BASICO,
+    EMPRESA_MUNICIPIOS_PAGANTES_BY_CNPJ,
+    EMPRESA_PGFN_BY_CNPJ,
+    EMPRESA_SANCOES_CEIS_BY_CNPJ,
+    EMPRESA_SANCOES_CNEP_BY_CNPJ,
+    EMPRESA_SOCIOS_BY_BASICO,
+    EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_CNPJ,
+)
+
+router = APIRouter()
+_log = logging.getLogger("transparencia.empresa")
+
+_CNPJ_RE = re.compile(r"^\d{14}$")
+
+
+def _row_to_dict(cols, row):
+    return dict(zip(cols, row))
+
+
+def _convert(value):
+    if hasattr(value, "as_tuple"):  # Decimal
+        return float(value)
+    if hasattr(value, "isoformat"):  # date/datetime
+        return value.isoformat()
+    return value
+
+
+def _convert_row(d: dict) -> dict:
+    return {k: _convert(v) for k, v in d.items()}
+
+
+def _format_cnpj(cnpj14: str) -> str:
+    return f"{cnpj14[:2]}.{cnpj14[2:5]}.{cnpj14[5:8]}/{cnpj14[8:12]}-{cnpj14[12:14]}"
+
+
+def _normalize_cnpj_input(raw: str) -> str | None:
+    """Retorna 14 digitos puros (sem mascara) ou None se invalido."""
+    digits = re.sub(r"\D", "", raw or "")
+    if len(digits) != 14:
+        return None
+    return digits
+
+
+@router.get("/empresa/{cnpj}")
+async def empresa_perfil(request: Request, cnpj: str):
+    """Renderiza /empresa/<14-digits>. Redireciona para forma canonica
+    (14 digitos puros) se a entrada veio com mascara/pontos.
+    """
+    from web.main import templates
+
+    canonical = _normalize_cnpj_input(cnpj)
+    if not canonical:
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+    if cnpj != canonical:
+        return RedirectResponse(url=f"/empresa/{canonical}", status_code=301)
+
+    cnpj_basico = canonical[:8]
+    cnpj_ordem = canonical[8:12]
+
+    try:
+        # 1. Agregados PB (mv_empresa_pb) — chave: cnpj_basico.
+        # Se a empresa nao esta na MV, nao tem dados PB -> 404.
+        try:
+            agg_cols, agg_rows = execute_query(
+                EMPRESA_AGREGADOS_PB_BY_BASICO,
+                (cnpj_basico,),
+                timeout_sec=TIMEOUT_PROFILE,
+            )
+        except Exception:
+            # DB indisponivel: 503 transitorio (nao 404, pra evitar deindex).
+            return Response(
+                status_code=503,
+                headers={"Retry-After": "300"},
+                content="Servico temporariamente indisponivel. Tente novamente em alguns minutos.",
+                media_type="text/plain; charset=utf-8",
+            )
+
+        if not agg_rows:
+            return templates.TemplateResponse(
+                request,
+                "errors/404.html",
+                {"path": str(request.url.path)},
+                status_code=404,
+            )
+
+        agregados = _convert_row(_row_to_dict(agg_cols, agg_rows[0]))
+
+        # 2. Cadastro RFB (estabelecimento + empresa) — chave: cnpj_completo.
+        with get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(f"SET statement_timeout = '{TIMEOUT_PROFILE * 1000}'")
+
+                cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (canonical,))
+                est_cols = [d[0] for d in cur.description]
+                est_rows = cur.fetchall()
+                if not est_rows:
+                    return templates.TemplateResponse(
+                        request,
+                        "errors/404.html",
+                        {"path": str(request.url.path)},
+                        status_code=404,
+                    )
+                estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
+
+                # 3. Matriz (se a entidade nao for ela propria a matriz)
+                matriz = None
+                if cnpj_ordem != "0001":
+                    cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
+                    mat_cols = [d[0] for d in cur.description]
+                    mat_row = cur.fetchone()
+                    if mat_row:
+                        matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
+
+                # 4. Socios
+                cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
+                soc_cols = [d[0] for d in cur.description]
+                socios = [
+                    _convert_row(_row_to_dict(soc_cols, r))
+                    for r in cur.fetchall()
+                ]
+
+                # 5. Sancoes CEIS + CNEP
+                cur.execute(EMPRESA_SANCOES_CEIS_BY_CNPJ, (canonical,))
+                ceis_cols = [d[0] for d in cur.description]
+                sancoes = []
+                for r in cur.fetchall():
+                    item = _convert_row(_row_to_dict(ceis_cols, r))
+                    item["origem"] = "CEIS"
+                    sancoes.append(item)
+
+                cur.execute(EMPRESA_SANCOES_CNEP_BY_CNPJ, (canonical,))
+                cnep_cols = [d[0] for d in cur.description]
+                for r in cur.fetchall():
+                    item = _convert_row(_row_to_dict(cnep_cols, r))
+                    item["origem"] = "CNEP"
+                    sancoes.append(item)
+
+                # 6. PGFN
+                cur.execute(EMPRESA_PGFN_BY_CNPJ, (canonical,))
+                pg_cols = [d[0] for d in cur.description]
+                pgfn = [
+                    _convert_row(_row_to_dict(pg_cols, r))
+                    for r in cur.fetchall()
+                ]
+
+                # 7. Acordos de Leniencia + efeitos
+                cur.execute(EMPRESA_LENIENCIA_BY_CNPJ, (canonical,))
+                len_cols = [d[0] for d in cur.description]
+                acordos = []
+                for r in cur.fetchall():
+                    a = _convert_row(_row_to_dict(len_cols, r))
+                    cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
+                    ef_cols = [d[0] for d in cur.description]
+                    a["efeitos"] = [
+                        _row_to_dict(ef_cols, er) for er in cur.fetchall()
+                    ]
+                    acordos.append(a)
+
+                # 8. Municipios pagantes (PB) + top elementos
+                cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_CNPJ, (canonical,))
+                mp_cols = [d[0] for d in cur.description]
+                municipios_pagantes = [
+                    _convert_row(_row_to_dict(mp_cols, r))
+                    for r in cur.fetchall()
+                ]
+
+                cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_CNPJ, (canonical,))
+                te_cols = [d[0] for d in cur.description]
+                top_elementos = [
+                    _convert_row(_row_to_dict(te_cols, r))
+                    for r in cur.fetchall()
+                ]
+
+                cur.execute("RESET statement_timeout")
+    except Exception:
+        _log.exception("empresa perfil failed cnpj=%s", canonical)
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "300"},
+            content="Servico temporariamente indisponivel. Tente novamente em alguns minutos.",
+            media_type="text/plain; charset=utf-8",
+        )
+
+    razao_social = (
+        estabelecimento.get("razao_social")
+        or agregados.get("razao_social")
+        or estabelecimento.get("nome_fantasia")
+        or f"Empresa {cnpj_basico}"
+    )
+    cnpj_fmt = _format_cnpj(canonical)
+    total_pb_geral = float(agregados.get("total_pb_geral") or 0)
+    qtd_municipios = len(municipios_pagantes)
+    qtd_empenhos_pb = int(agregados.get("qtd_tce_empenhos") or 0) + int(
+        agregados.get("qtd_pb_empenhos") or 0
+    )
+    sancoes_vigentes = sum(
+        1
+        for s in sancoes
+        if not s.get("dt_final_sancao")
+        or str(s.get("dt_final_sancao")) >= "1900-01-01"  # placeholder; UI usa data
+    )
+    total_divida_pgfn = float(agregados.get("total_divida_pgfn") or 0)
+
+    # Meta description (150-160 chars). Mantemos curta e factual.
+    meta_parts = [
+        f"Perfil de {razao_social} (CNPJ {cnpj_fmt}) no TransparenciaPB."
+    ]
+    if total_pb_geral > 0:
+        meta_parts.append(
+            f"Recebido em PB: R$ {total_pb_geral:,.0f}".replace(",", ".")
+        )
+    if sancoes:
+        meta_parts.append(f"Sancoes: {len(sancoes)}.")
+    if total_divida_pgfn > 0:
+        meta_parts.append(
+            f"Divida PGFN: R$ {total_divida_pgfn:,.0f}".replace(",", ".")
+        )
+    meta_description = " ".join(meta_parts)[:300]
+
+    return templates.TemplateResponse(
+        request,
+        "results/empresa.html",
+        {
+            "cnpj": canonical,
+            "cnpj_basico": cnpj_basico,
+            "cnpj_ordem": cnpj_ordem,
+            "cnpj_fmt": cnpj_fmt,
+            "razao_social": razao_social,
+            "estabelecimento": estabelecimento,
+            "matriz": matriz,
+            "socios": socios,
+            "sancoes": sancoes,
+            "pgfn": pgfn,
+            "acordos_leniencia": acordos,
+            "agregados": agregados,
+            "municipios_pagantes": municipios_pagantes,
+            "top_elementos": top_elementos,
+            "kpi_total_pb": total_pb_geral,
+            "kpi_qtd_municipios": qtd_municipios,
+            "kpi_qtd_empenhos": qtd_empenhos_pb,
+            "kpi_total_divida_pgfn": total_divida_pgfn,
+            "meta_description": meta_description,
+        },
+    )

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -196,11 +196,17 @@ def _build_sitemap_xml(origin: str) -> str:
 async def sitemap_xml(request: Request) -> Response:
     """Sitemap dinamico cached por 1h.
 
-    Importante: NAO cacheamos sitemap parcial (sem URLs de cidade) — caso
-    contrario, uma falha transitoria de DB no primeiro hit pos-restart
-    serviria por 1h um sitemap incompleto a Google/IndexNow. Em build
-    parcial, servimos o resultado mas mantemos cache invalido para a
-    proxima request tentar de novo.
+    Importante: NAO cacheamos sitemap parcial (sem URLs de cidade ou
+    empresa) — caso contrario, uma falha transitoria de DB no primeiro
+    hit pos-restart serviria por 1h um sitemap incompleto a Google/IndexNow.
+    Em build parcial, servimos o resultado mas mantemos cache invalido
+    para a proxima request tentar de novo.
+
+    Heuristica de completude:
+    - Sitemap completo tem static (5) + cidades (~223) + empresas (>=1).
+    - Threshold combina: precisa de >= 100 cidades E >= 1 empresa.
+    - Se DB de empresas falhar mas cidades estao OK, recusa cache (a
+      proxima request reativa _empresas_pb).
     """
     origin = _site_origin(request)
     now = time.time()
@@ -208,16 +214,23 @@ async def sitemap_xml(request: Request) -> Response:
         xml = _SITEMAP_CACHE["xml"]
     else:
         xml = _build_sitemap_xml(origin)
-        # Heuristica simples: sitemap completo tem 100+ <url>; parcial
-        # (so paginas estaticas) tem ~5. Nao cachear parcial.
-        if xml.count("<url>") >= 100:
+        cidades_n = xml.count("/cidade/")
+        empresas_n = xml.count("/empresa/")
+        # Bookmark de completude: cidades >= 100 (entre 223 PB, threshold
+        # generoso pra sobreviver a flapping) E pelo menos 1 empresa
+        # qualificada. Se filtro de qualificacao algum dia retornar 0
+        # legitimamente, este check vira "nao cacheia, mas /sitemap.xml
+        # continua servindo build novo a cada request" — penalty aceitavel.
+        is_complete = cidades_n >= 100 and empresas_n >= 1
+        if is_complete:
             _SITEMAP_CACHE["xml"] = xml
             _SITEMAP_CACHE["ts"] = now
         else:
             _log.warning(
-                "Sitemap parcial gerado (%d <url> entries) — nao cacheando, "
-                "proxima request tentara recarregar municipios",
-                xml.count("<url>"),
+                "Sitemap parcial gerado (cidades=%d, empresas=%d) — nao "
+                "cacheando, proxima request tentara recarregar do DB",
+                cidades_n,
+                empresas_n,
             )
     return Response(
         content=xml,

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -94,6 +94,36 @@ def _municipios_pb() -> list[tuple[str, str]]:
         return []
 
 
+def _empresas_pb() -> list[tuple[str, str]]:
+    """Lista empresas qualificadas (heuristica em web.queries.empresa).
+    Retorna [(razao_social, cnpj_completo), ...]. Cnpj eh string de 14
+    digitos numericos puros (forma canonica usada pela rota /empresa/{cnpj}).
+    """
+    from web.queries.empresa import EMPRESAS_QUALIFICADAS_PARA_SITEMAP
+
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(EMPRESAS_QUALIFICADAS_PARA_SITEMAP)
+                out: list[tuple[str, str]] = []
+                seen: set[str] = set()
+                for razao, cnpj_completo in cur.fetchall():
+                    if not cnpj_completo:
+                        continue
+                    cnpj_str = str(cnpj_completo).strip()
+                    if len(cnpj_str) != 14 or not cnpj_str.isdigit():
+                        continue
+                    if cnpj_str in seen:
+                        continue
+                    seen.add(cnpj_str)
+                    out.append((str(razao or ""), cnpj_str))
+                return out
+    except Exception:
+        _log.exception("Falha ao listar empresas PB pro sitemap")
+        return []
+
+
 def _lastmod_iso() -> str:
     """Data ISO (YYYY-MM-DD) usada como <lastmod> nas paginas de cidade.
 
@@ -143,6 +173,19 @@ def _build_sitemap_xml(origin: str) -> str:
         parts.append(f"    <lastmod>{lastmod}</lastmod>")
         parts.append("    <changefreq>weekly</changefreq>")
         parts.append("    <priority>0.7</priority>")
+        parts.append("  </url>")
+
+    # Pagina /empresa/<cnpj> pra cada empresa qualificada (filtro em
+    # web.queries.empresa.EMPRESAS_QUALIFICADAS_PARA_SITEMAP). URL canonica
+    # usa 14 digitos numericos puros (sem mascara).
+    empresas = _empresas_pb()
+    for _razao, cnpj_completo in empresas:
+        loc = f"{origin}/empresa/{cnpj_completo}"
+        parts.append("  <url>")
+        parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
+        parts.append("    <changefreq>weekly</changefreq>")
+        parts.append("    <priority>0.5</priority>")
         parts.append("  </url>")
 
     parts.append("</urlset>")

--- a/web/static/js/components/fornecedor-dialog.js
+++ b/web/static/js/components/fornecedor-dialog.js
@@ -109,6 +109,7 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
             <div class="empresa-header">
                 <strong>${_esc(est.razao_social || fornecedorNome)}</strong>
                 <code class="auditor-only">${cnpjFmt}</code>
+                <a href="/empresa/${_esc(exactDoc)}" class="ext-link-inline" title="Ver perfil completo da empresa (pagina dedicada)">Ver perfil &#8599;</a>
             </div>
             <div class="empresa-details">
                 <span>${dualLabel('Cadastro:','Situacao:')} <span class="${sitClass}">${sit}</span>${isFilial ? ` <span class="badge badge-gray">${tipoFilial}</span>` : ''}</span>
@@ -166,6 +167,7 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
                 <div class="empresa-header">
                     <strong>${_esc(fornecedorNome || nomeCredor || 'Fornecedor')}</strong>
                     <code class="auditor-only">${cnpjFmt}</code>
+                    <a href="/empresa/${_esc(exactDoc)}" class="ext-link-inline" title="Ver perfil completo da empresa (pagina dedicada)">Ver perfil &#8599;</a>
                 </div>
                 <div class="empresa-details">
                     <span>Cadastro completo da empresa indisponivel na base RFB para este CNPJ.</span>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -81,7 +81,18 @@
           "name": "TransparenciaPB",
           "url": "{{ _origin }}/",
           "logo": "{{ _origin }}/static/icon-512.png",
-          "description": "Plataforma cidadã de cruzamento de dados públicos abertos da Paraíba"
+          "description": "Plataforma cidadã de cruzamento de dados públicos abertos da Paraíba",
+          "foundingDate": "2025",
+          "sameAs": [
+            "https://github.com/lucasdiniz/govbr-cruza-dados"
+          ],
+          "publishingPrinciples": "{{ _origin }}/sobre",
+          "knowsAbout": [
+            "Transparência pública",
+            "Dados abertos",
+            "Paraíba",
+            "Fiscalização cidadã"
+          ]
         }
       ]
     }

--- a/web/templates/contato.html
+++ b/web/templates/contato.html
@@ -3,6 +3,34 @@
 {% block meta_description %}Entre em contato com a equipe da TransparenciaPB — sugestoes, correcoes ou parcerias.{% endblock %}
 {% block og_title %}Contato — TransparenciaPB{% endblock %}
 {% block og_description %}Mande uma mensagem pra equipe da TransparenciaPB.{% endblock %}
+{% block json_ld_extra %}
+{% set _origin = request_origin(request) if request else '' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "ContactPage",
+      "@id": "{{ _origin }}/contato#contactpage",
+      "url": "{{ _origin }}/contato",
+      "name": "Contato — TransparenciaPB",
+      "description": "Canal de contato com a equipe da TransparenciaPB para sugestoes, correcoes e parcerias.",
+      "isPartOf": {"@id": "{{ _origin }}/#website"},
+      "about": {"@id": "{{ _origin }}/#organization"},
+      "inLanguage": "pt-BR"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "{{ _origin }}/contato#breadcrumb",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ _origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": "Contato", "item": "{{ _origin }}/contato"}
+      ]
+    }
+  ]
+}
+</script>
+{% endblock %}
 {% block content %}
 <section class="contato-page">
     <header class="contato-head">

--- a/web/templates/partials/empresa/_flags.html
+++ b/web/templates/partials/empresa/_flags.html
@@ -1,0 +1,33 @@
+{# Flags de risco visiveis (do mv_empresa_pb) #}
+{% set flags = [] %}
+{% if agregados.flag_capital_desproporcional %}
+    {% set flags = flags + [('Capital social desproporcional', 'Capital social muito baixo comparado ao volume recebido em pagamentos publicos. Pode indicar empresa fachada ou subdimensionada.')] %}
+{% endif %}
+{% if agregados.flag_multi_municipal %}
+    {% set flags = flags + [('Atua em 3+ municipios', 'Empresa recebeu pagamentos de tres ou mais prefeituras paraibanas. Padrao multi-municipal merece verificacao quando associado a outros indicios.')] %}
+{% endif %}
+{% if agregados.flag_predomina_sem_licitacao %}
+    {% set flags = flags + [('Predomina sem licitacao', 'Mais da metade dos empenhos foram registrados como dispensa, inexigibilidade ou sem numero de licitacao.')] %}
+{% endif %}
+{% if agregados.flag_inativa %}
+    {% set flags = flags + [('Cadastro inativo na RFB', 'Situacao cadastral na Receita Federal nao consta como Ativa.')] %}
+{% endif %}
+{% if agregados.flag_ceis_vigente %}
+    {% set flags = flags + [('Sancao vigente (CEIS)', 'Empresa esta no Cadastro de Empresas Inidoneas e Suspensas com sancao vigente.')] %}
+{% endif %}
+{% if flags %}
+<section class="empresa-section" id="sinais">
+    <h2>Sinais de atencao</h2>
+    <ul class="empresa-flags">
+        {% for label, descr in flags %}
+        <li class="empresa-flag-item">
+            <strong>{{ label }}</strong>
+            <span class="text-sm text-muted"> &mdash; {{ descr }}</span>
+        </li>
+        {% endfor %}
+    </ul>
+    <p class="text-sm text-muted">
+        Estes sinais sao automaticos e <em>nao</em> conclusoes juridicas. Sempre verifique a fonte original.
+    </p>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_hero.html
+++ b/web/templates/partials/empresa/_hero.html
@@ -1,0 +1,45 @@
+{# Hero: razao social + CNPJ + situacao cadastral + endereco sede #}
+{% set situacao = estabelecimento.situacao_cadastral %}
+{% set situacao_str = situacao|string if situacao is not none else '' %}
+{% set inativa = situacao_str != '2' %}
+<header class="empresa-hero">
+    <p class="eyebrow">Perfil de empresa</p>
+    <h1>{{ razao_social|clean_text }}</h1>
+    <p class="empresa-cnpj-line">
+        <code class="empresa-cnpj">CNPJ {{ cnpj_fmt }}</code>
+        {% if inativa %}
+            <span class="badge badge-red" title="Situacao cadastral diferente de Ativa na Receita Federal">Cadastro inativo / suspenso</span>
+        {% else %}
+            <span class="badge badge-green">Ativa na RFB</span>
+        {% endif %}
+        {% if estabelecimento.matriz_filial %}
+            <span class="text-sm text-muted">
+                {% if estabelecimento.matriz_filial|string == '1' %}Matriz{% else %}Filial{% endif %}
+            </span>
+        {% endif %}
+    </p>
+    {% if estabelecimento.nome_fantasia %}
+        <p class="text-muted">Nome fantasia: <strong>{{ estabelecimento.nome_fantasia|clean_text }}</strong></p>
+    {% endif %}
+    {% set logr = estabelecimento.logradouro or (matriz.logradouro if matriz else None) %}
+    {% set num = estabelecimento.numero or (matriz.numero if matriz else None) %}
+    {% set bai = estabelecimento.bairro or (matriz.bairro if matriz else None) %}
+    {% set mun = estabelecimento.municipio or (matriz.municipio if matriz else None) %}
+    {% set uf = estabelecimento.uf or (matriz.uf if matriz else None) %}
+    {% if logr or mun %}
+        <p class="empresa-endereco text-sm">
+            {% if estabelecimento.tipo_logradouro %}{{ estabelecimento.tipo_logradouro|clean_text }} {% endif %}
+            {% if logr %}{{ logr|clean_text }}{% endif %}{% if num %}, {{ num }}{% endif %}
+            {% if bai %} &mdash; {{ bai|clean_text }}{% endif %}
+            {% if mun %} &mdash; {{ mun|clean_text }}{% if uf %}/{{ uf }}{% endif %}{% endif %}
+        </p>
+    {% endif %}
+    {% if estabelecimento.desc_cnae_principal %}
+        <p class="text-sm text-muted">
+            Atividade principal (CNAE): {{ estabelecimento.desc_cnae_principal|clean_text }}
+        </p>
+    {% endif %}
+    {% if estabelecimento.dt_inicio_atividade %}
+        <p class="text-sm text-muted">Inicio de atividade: {{ estabelecimento.dt_inicio_atividade }}</p>
+    {% endif %}
+</header>

--- a/web/templates/partials/empresa/_leniencia.html
+++ b/web/templates/partials/empresa/_leniencia.html
@@ -1,0 +1,30 @@
+{# Acordos de leniencia (CGU) #}
+{% if acordos_leniencia %}
+<section class="empresa-section" id="leniencia">
+    <h2>Acordos de leniencia</h2>
+    <ul class="empresa-acordos">
+        {% for a in acordos_leniencia %}
+        <li class="empresa-acordo-item">
+            <p>
+                <span class="badge badge-blue">Leniencia &mdash; {{ a.situacao_acordo|clean_text or 'sem situacao' }}</span>
+                {% if a.orgao_sancionador %}<strong> {{ a.orgao_sancionador|clean_text }}</strong>{% endif %}
+            </p>
+            <p class="text-sm text-muted">
+                {% if a.dt_inicio_acordo %}Inicio: {{ a.dt_inicio_acordo }}{% endif %}
+                {% if a.dt_fim_acordo %} &mdash; fim: {{ a.dt_fim_acordo }}{% endif %}
+            </p>
+            {% if a.numero_processo %}
+            <p class="text-sm">Processo: <code>{{ a.numero_processo }}</code></p>
+            {% endif %}
+            {% if a.efeitos %}
+            <ul class="empresa-acordo-efeitos text-sm">
+                {% for ef in a.efeitos %}
+                <li><strong>{{ ef.efeito|clean_text }}</strong>{% if ef.complemento %} &mdash; {{ ef.complemento|clean_text }}{% endif %}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_municipios_pagantes.html
+++ b/web/templates/partials/empresa/_municipios_pagantes.html
@@ -1,0 +1,48 @@
+{# Lista de municipios PB que pagaram esta empresa #}
+{% if municipios_pagantes %}
+<section class="empresa-section" id="municipios-pagantes">
+    <h2>Municipios que pagaram esta empresa</h2>
+    <p class="text-sm text-muted">Pagamentos identificados no TCE-PB. Clique no municipio pra ver o panorama de transparencia.</p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile">
+            <thead>
+                <tr>
+                    <th>Municipio</th>
+                    <th class="text-right">Total pago</th>
+                    <th class="text-right">Empenhos</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for mp in municipios_pagantes %}
+                {% set _slug = mp.municipio | municipio_slug %}
+                <tr>
+                    <td data-label="Municipio">
+                        {% if _slug %}
+                            <a href="/cidade/{{ _slug }}">{{ mp.municipio|clean_text }}</a>
+                        {% else %}
+                            {{ mp.municipio|clean_text }}
+                        {% endif %}
+                    </td>
+                    <td data-label="Total pago" class="text-right num">{{ mp.total_pago|short_brl }}</td>
+                    <td data-label="Empenhos" class="text-right num">{{ mp.qtd_empenhos|short_number }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endif %}
+
+{% if top_elementos %}
+<section class="empresa-section" id="top-elementos">
+    <h2>Principais tipos de despesa</h2>
+    <ul class="empresa-elementos">
+        {% for el in top_elementos %}
+        <li>
+            <strong>{{ el.elemento_despesa|clean_text or 'Sem classificacao' }}</strong>
+            &mdash; {{ el.total_elemento|short_brl }} em {{ el.qtd|short_number }} empenhos
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_pgfn.html
+++ b/web/templates/partials/empresa/_pgfn.html
@@ -1,0 +1,39 @@
+{# Dividas ativas PGFN #}
+{% if pgfn %}
+<section class="empresa-section" id="pgfn">
+    <h2>Divida ativa da Uniao (PGFN)</h2>
+    <p class="text-sm text-muted">
+        Inscricoes da empresa em divida ativa federal. Total: <strong>{{ kpi_total_divida_pgfn|short_brl }}</strong>.
+    </p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile">
+            <thead>
+                <tr>
+                    <th>Inscricao</th>
+                    <th>Situacao</th>
+                    <th>Receita</th>
+                    <th class="text-right">Valor consolidado</th>
+                    <th>Inscricao em</th>
+                    <th>Ajuizado</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for d in pgfn %}
+                <tr>
+                    <td data-label="Inscricao"><code class="text-sm">{{ d.numero_inscricao }}</code></td>
+                    <td data-label="Situacao">{{ d.situacao_inscricao|clean_text }}</td>
+                    <td data-label="Receita">{{ d.receita_principal|clean_text }}</td>
+                    <td data-label="Valor" class="text-right num">{{ d.valor_consolidado|short_brl }}</td>
+                    <td data-label="Inscricao em">{{ d.dt_inscricao or '-' }}</td>
+                    <td data-label="Ajuizado">{{ d.indicador_ajuizado or '-' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <p class="text-sm">
+        Fonte oficial:
+        <a href="https://www.listadevedores.pgfn.gov.br/" target="_blank" rel="noopener nofollow">Lista de Devedores da PGFN</a>.
+    </p>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_resumo_pagamentos.html
+++ b/web/templates/partials/empresa/_resumo_pagamentos.html
@@ -1,0 +1,30 @@
+{# Resumo de pagamentos publicos PB (KPIs) #}
+{% if kpi_total_pb and kpi_total_pb > 0 %}
+<section class="empresa-section" id="resumo-pagamentos">
+    <h2>Pagamentos publicos na Paraiba</h2>
+    <div class="kpi-grid">
+        <div class="kpi-card">
+            <p class="kpi-label">Total recebido (PB)</p>
+            <p class="kpi-value">{{ kpi_total_pb|short_brl }}</p>
+            <p class="kpi-hint text-sm text-muted">Soma de empenhos pagos no TCE-PB + dados.pb (estado).</p>
+        </div>
+        <div class="kpi-card">
+            <p class="kpi-label">Municipios pagantes</p>
+            <p class="kpi-value">{{ kpi_qtd_municipios|short_number }}</p>
+            <p class="kpi-hint text-sm text-muted">Quantidade de prefeituras que pagaram esta empresa.</p>
+        </div>
+        <div class="kpi-card">
+            <p class="kpi-label">Empenhos</p>
+            <p class="kpi-value">{{ kpi_qtd_empenhos|short_number }}</p>
+            <p class="kpi-hint text-sm text-muted">Numero total de pagamentos publicos identificados.</p>
+        </div>
+        {% if kpi_total_divida_pgfn and kpi_total_divida_pgfn > 0 %}
+        <div class="kpi-card kpi-card-warn">
+            <p class="kpi-label">Divida ativa (PGFN)</p>
+            <p class="kpi-value">{{ kpi_total_divida_pgfn|short_brl }}</p>
+            <p class="kpi-hint text-sm text-muted">Tributos federais inscritos em divida ativa.</p>
+        </div>
+        {% endif %}
+    </div>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_sancoes.html
+++ b/web/templates/partials/empresa/_sancoes.html
@@ -1,0 +1,44 @@
+{# Sancoes CEIS + CNEP #}
+{% if sancoes %}
+<section class="empresa-section" id="sancoes">
+    <h2>Sancoes administrativas</h2>
+    <p class="text-sm text-muted">
+        Registros do CEIS e CNEP (CGU). Cada item indica orgao sancionador, periodo e fundamentacao legal.
+    </p>
+    <ul class="empresa-sancoes">
+        {% for s in sancoes %}
+        {% set vigente = (not s.dt_final_sancao) or (s.dt_final_sancao and s.dt_final_sancao >= DATA_REFRESH_DATE_ISO) %}
+        <li class="empresa-sancao-item {% if vigente %}is-vigente{% endif %}">
+            <p>
+                <span class="badge {% if vigente %}badge-red{% else %}badge-gray{% endif %}">
+                    {{ s.origem }}{% if vigente %} &mdash; vigente{% endif %}
+                </span>
+                <strong>{{ s.categoria_sancao|clean_text or 'Sancao' }}</strong>
+            </p>
+            <p class="text-sm text-muted">
+                {% if s.dt_inicio_sancao %}Inicio: {{ s.dt_inicio_sancao }}{% endif %}
+                {% if s.dt_final_sancao %} &mdash; fim: {{ s.dt_final_sancao }}{% else %} &mdash; sem data fim cadastrada{% endif %}
+            </p>
+            {% if s.orgao_sancionador %}
+            <p class="text-sm">Orgao sancionador: <strong>{{ s.orgao_sancionador|clean_text }}</strong>
+                {% if s.esfera_orgao_sancionador %} ({{ s.esfera_orgao_sancionador|clean_text }}){% endif %}
+            </p>
+            {% endif %}
+            {% if s.abrangencia_sancao %}
+            <p class="text-sm text-muted">Abrangencia: {{ s.abrangencia_sancao|clean_text }}</p>
+            {% endif %}
+            {% if s.fundamentacao_legal %}
+            <p class="text-sm text-muted">Fundamentacao: {{ s.fundamentacao_legal|clean_text }}</p>
+            {% endif %}
+            {% if s.valor_multa %}
+            <p class="text-sm">Valor da multa: {{ s.valor_multa|short_brl }}</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    <p class="text-sm">
+        Fonte oficial:
+        <a href="https://portaldatransparencia.gov.br/sancoes" target="_blank" rel="noopener nofollow">Portal da Transparencia &mdash; Sancoes</a>.
+    </p>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_socios.html
+++ b/web/templates/partials/empresa/_socios.html
@@ -1,0 +1,38 @@
+{# Quadro societario (CPFs vem mascarados pela RFB - seguro expor) #}
+{% if socios %}
+<section class="empresa-section" id="socios">
+    <h2>Quadro societario</h2>
+    <p class="text-sm text-muted">CPFs sao publicados parcialmente mascarados pela Receita Federal.</p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile">
+            <thead>
+                <tr>
+                    <th>Nome</th>
+                    <th>CPF/CNPJ</th>
+                    <th>Qualificacao</th>
+                    <th>Entrada</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for s in socios %}
+                <tr>
+                    <td data-label="Nome">{{ s.nome|clean_text }}</td>
+                    <td data-label="CPF/CNPJ"><code class="text-sm">{{ s.cpf_cnpj_socio or '-' }}</code></td>
+                    <td data-label="Qualificacao">{{ s.desc_qualificacao|clean_text or s.qualificacao or '-' }}</td>
+                    <td data-label="Entrada">{{ s.dt_entrada or '-' }}</td>
+                </tr>
+                {% if s.nome_representante %}
+                <tr class="empresa-rep-row">
+                    <td colspan="4" class="text-sm text-muted">
+                        Representante: <strong>{{ s.nome_representante|clean_text }}</strong>
+                        {% if s.cpf_representante %} &mdash; <code>{{ s.cpf_representante }}</code>{% endif %}
+                        {% if s.desc_qualif_representante %} &mdash; {{ s.desc_qualif_representante|clean_text }}{% endif %}
+                    </td>
+                </tr>
+                {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endif %}

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -48,7 +48,8 @@
                         data-fornecedor-cnpj="{{ f.cnpj_basico }}"
                         data-fornecedor-cpf-cnpj="{{ cnpj_completo_digits }}"
                         data-fornecedor-nome="{{ (f.razao_social or f.nome_credor)|clean_text }}"
-                        data-fornecedor-nome-credor="{{ f.nome_credor|clean_text }}">
+                        data-fornecedor-nome-credor="{{ f.nome_credor|clean_text }}"
+                        data-empresa-url="/empresa/{{ cnpj_completo_digits }}">
                     {% else %}
                     <tr class="row-detail-unavailable{{ row_extra }}" aria-disabled="true">
                     {% endif %}

--- a/web/templates/results/empresa.html
+++ b/web/templates/results/empresa.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+{% block title %}{{ razao_social|clean_text }} (CNPJ {{ cnpj_fmt }}){% endblock %}
+{% block meta_description %}{{ meta_description }}{% endblock %}
+{% block og_title %}{{ razao_social|clean_text }} - CNPJ {{ cnpj_fmt }} | TransparenciaPB{% endblock %}
+{% block og_description %}{{ meta_description }}{% endblock %}
+{% block og_type %}article{% endblock %}
+{% block json_ld_extra %}
+{% set origin = request_origin(request) if request else '' %}
+{% set page_url = origin + '/empresa/' + cnpj %}
+{% set logr = estabelecimento.logradouro or (matriz.logradouro if matriz else None) %}
+{% set num = estabelecimento.numero or (matriz.numero if matriz else None) %}
+{% set bai = estabelecimento.bairro or (matriz.bairro if matriz else None) %}
+{% set cep = estabelecimento.cep or (matriz.cep if matriz else None) %}
+{% set mun = estabelecimento.municipio or (matriz.municipio if matriz else None) %}
+{% set uf = estabelecimento.uf or (matriz.uf if matriz else None) %}
+{% set street_parts = [] %}
+{% if estabelecimento.tipo_logradouro %}{% set street_parts = street_parts + [estabelecimento.tipo_logradouro] %}{% endif %}
+{% if logr %}{% set street_parts = street_parts + [logr] %}{% endif %}
+{% set street_address = (street_parts | join(' ')) %}{% if num %}{% set street_address = street_address + ', ' + (num|string) %}{% endif %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": {{ (page_url ~ '#organization') | tojson }},
+      "name": {{ razao_social | clean_text | tojson }},
+      "url": {{ page_url | tojson }},
+      "identifier": [
+        {
+          "@type": "PropertyValue",
+          "propertyID": "CNPJ",
+          "value": {{ cnpj | tojson }}
+        }
+      ],
+      {% if estabelecimento.nome_fantasia %}"alternateName": {{ estabelecimento.nome_fantasia | clean_text | tojson }},{% endif %}
+      {% if estabelecimento.dt_inicio_atividade %}"foundingDate": {{ estabelecimento.dt_inicio_atividade | tojson }},{% endif %}
+      "address": {
+        "@type": "PostalAddress",
+        {% if street_address %}"streetAddress": {{ street_address | clean_text | tojson }},{% endif %}
+        {% if bai %}"addressLocality": {{ bai | clean_text | tojson }},{% endif %}
+        {% if mun %}"addressRegion": {{ ((mun ~ (', ' ~ uf if uf else '')) | clean_text) | tojson }},{% endif %}
+        {% if cep %}"postalCode": {{ cep | tojson }},{% endif %}
+        "addressCountry": "BR"
+      },
+      "sameAs": [
+        {{ ("https://cnpj.biz/" ~ cnpj) | tojson }},
+        {{ ("https://www.gov.br/receitafederal/pt-br/servicos/cadastro/cnpj/consultar-situacao-cadastral") | tojson }}
+      ]
+    },
+    {
+      "@type": "Dataset",
+      "name": {{ ("Perfil publico de " ~ razao_social ~ " (CNPJ " ~ cnpj_fmt ~ ")") | clean_text | tojson }},
+      "description": {{ meta_description | tojson }},
+      "url": {{ page_url | tojson }},
+      "isAccessibleForFree": true,
+      "inLanguage": "pt-BR",
+      "creator": {"@id": "{{ origin }}/#organization"},
+      "license": "https://creativecommons.org/licenses/by/4.0/",
+      "keywords": [
+        "CNPJ",
+        "transparencia publica",
+        "Paraiba",
+        "fornecedor publico",
+        "CEIS", "CNEP", "PGFN"
+      ],
+      "spatialCoverage": {
+        "@type": "Place",
+        "name": "Paraiba, Brasil"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": "Empresas", "item": "{{ origin }}/sobre"},
+        {"@type": "ListItem", "position": 3, "name": {{ razao_social | clean_text | tojson }}, "item": {{ page_url | tojson }} }
+      ]
+    }
+  ]
+}
+</script>
+{% endblock %}
+{% block content %}
+<article class="empresa-page">
+    {% include "partials/empresa/_hero.html" %}
+    {% include "partials/empresa/_resumo_pagamentos.html" %}
+    {% include "partials/empresa/_flags.html" %}
+    {% include "partials/empresa/_sancoes.html" %}
+    {% include "partials/empresa/_pgfn.html" %}
+    {% include "partials/empresa/_leniencia.html" %}
+    {% include "partials/empresa/_municipios_pagantes.html" %}
+    {% include "partials/empresa/_socios.html" %}
+
+    <section class="empresa-section empresa-fontes">
+        <h2>Fontes oficiais</h2>
+        <p class="text-sm text-muted">
+            Este perfil cruza dados publicos da Receita Federal (CNPJ), CGU (CEIS, CNEP, Acordos de Leniencia),
+            PGFN (divida ativa), TCE-PB (despesas municipais) e dados.pb.gov.br (orcamento estadual).
+            Todos os dados sao oficiais e publicos. Indicamos sinais de atencao &mdash; nao conclusoes juridicas.
+        </p>
+        <p class="text-sm">
+            <a href="/sobre">Metodologia e fontes</a> &middot;
+            <a href="/contato">Reportar correcao</a>
+        </p>
+    </section>
+</article>
+{% endblock %}

--- a/web/templates/results/empresa.html
+++ b/web/templates/results/empresa.html
@@ -37,9 +37,10 @@
       {% if estabelecimento.dt_inicio_atividade %}"foundingDate": {{ estabelecimento.dt_inicio_atividade | tojson }},{% endif %}
       "address": {
         "@type": "PostalAddress",
-        {% if street_address %}"streetAddress": {{ street_address | clean_text | tojson }},{% endif %}
-        {% if bai %}"addressLocality": {{ bai | clean_text | tojson }},{% endif %}
-        {% if mun %}"addressRegion": {{ ((mun ~ (', ' ~ uf if uf else '')) | clean_text) | tojson }},{% endif %}
+        {%- set street_with_neighborhood = (street_address ~ (' - ' ~ bai if bai else '')) | trim if street_address or bai else '' %}
+        {% if street_with_neighborhood %}"streetAddress": {{ street_with_neighborhood | clean_text | tojson }},{% endif %}
+        {% if mun %}"addressLocality": {{ mun | clean_text | tojson }},{% endif %}
+        {% if uf %}"addressRegion": {{ uf | tojson }},{% endif %}
         {% if cep %}"postalCode": {{ cep | tojson }},{% endif %}
         "addressCountry": "BR"
       },
@@ -55,7 +56,12 @@
       "url": {{ page_url | tojson }},
       "isAccessibleForFree": true,
       "inLanguage": "pt-BR",
-      "creator": {"@id": "{{ origin }}/#organization"},
+      "creator": {
+        "@type": "Organization",
+        "@id": "{{ origin }}/#organization",
+        "name": "TransparenciaPB",
+        "url": "{{ origin }}/"
+      },
       "license": "https://creativecommons.org/licenses/by/4.0/",
       "keywords": [
         "CNPJ",


### PR DESCRIPTION
## Objetivo

Tornar empresas (fornecedores publicos) **indexaveis** pelo Google. Hoje
elas vivem so dentro do dialog em `/cidade/<slug>` (URL nao indexavel).
Com /empresa/<14-digits>, multiplicamos paginas indexaveis em ~10x:
~13.5k empresas qualificadas vs 223 cidades.

Tambem reforca **E-E-A-T** (Experience-Expertise-Authoritativeness-Trust)
sem usar Person JSON-LD: Organization ganha foundingDate, sameAs (GitHub),
publishingPrinciples, knowsAbout. Pagina /contato vira ContactPage.

## Decisoes do user

- **URL**: `/empresa/<cnpj-14-digitos>` (numerico puro). Mascara redireciona 301.
- **Identidade autoral**: Anonymous / so "TransparenciaPB". **NAO** usa Person JSON-LD.
- **Sitemap volume**: empresas qualificadas (`total_pb_geral >= R$10k OR flag_ceis_vigente OR total_divida_pgfn > 0`).
- **Dialog atual**: nao foi refatorado nesta PR (segue funcional). Pagina nova reusa partials Jinja proprios.

## Mudancas

### Criados

- `web/queries/empresa.py` — 12 SQL constants compartilhadas entre /empresa e /api/fornecedor/detalhes.
  - 8 extraidas byte-a-byte de `cidade.py` (CEIS, CNEP, ESTABELECIMENTO, MATRIZ, SOCIOS, PGFN, LENIENCIA, EFEITOS) — elimina duplicacao.
  - 3 novas para a pagina (mv_empresa_pb, municipios pagantes, top elementos global).
  - 1 nova para sitemap (filtro de qualificacao).
- `web/routes/empresa.py` — rota `GET /empresa/{cnpj}`. Validacao 14 digitos, redirect canonico, 503 (nao 404) em DB indisponivel para evitar deindex.
- `web/templates/results/empresa.html` — pagina principal com Organization + Dataset + BreadcrumbList JSON-LD.
- `web/templates/partials/empresa/_*.html` — 8 partials (hero, resumo_pagamentos, flags, sancoes, pgfn, leniencia, municipios_pagantes, socios).

### Modificados

- `web/routes/cidade.py` — endpoint `/api/fornecedor/detalhes` agora importa SQL de `web.queries.empresa` (sem mudanca de logica nem comportamento).
- `web/routes/seo.py` — adiciona `_empresas_pb()` e injeta URLs `/empresa/<cnpj>` no sitemap (priority 0.5, weekly).
- `web/main.py` — registra `empresa_router`.
- `web/templates/base.html` — Organization JSON-LD ganha `foundingDate`, `sameAs`, `publishingPrinciples`, `knowsAbout` (E-E-A-T sem Person).
- `web/templates/contato.html` — adiciona `ContactPage` + `BreadcrumbList` JSON-LD.
- `web/templates/partials/top_fornecedores.html` — adiciona `data-empresa-url="/empresa/<cnpj>"` em rows com CNPJ valido (preparacao para link "Ver perfil completo" em PR futuro do dialog).

## Como testar pos-deploy

```bash
# Smoke uma empresa real
curl -s https://transparenciapb.org/empresa/12345678000190 | grep -i 'razao\|json-ld\|cnpj'

# Sitemap inclui /empresa/
curl -s https://transparenciapb.org/sitemap.xml | grep -c '/empresa/'

# CNPJ com mascara redireciona 301
curl -sI https://transparenciapb.org/empresa/12.345.678/0001-90

# Schema validator
# https://validator.schema.org/?url=https%3A%2F%2Ftransparenciapb.org%2Fempresa%2F12345678000190
```

Validar que `/api/fornecedor/detalhes` (dialog em /cidade) continua funcionando identico (mesma SQL extraida).

## Risco

- **Extracao de SQL**: as 8 queries movidas pra `queries/empresa.py` sao byte-equivalentes; comportamento do dialog deve permanecer identico. Compileall + render Jinja validados localmente.
- **Volume sitemap**: filtro garante <50k URLs (limite por sitemap.xml). Particionamento fica como follow-up se passar.
- **Cache**: rota nao usa `web_cache` ainda (TODO: adicionar TTL 24h em PR de followup; query agregada por `cnpj_basico` tem indice unico, lookup sub-ms).
- **404 vs 503**: empresa fora de `mv_empresa_pb` -> 404; falha de DB -> 503 com Retry-After 300 (mesma estrategia de /cidade/<slug>).

## Validacao

- `python -m compileall web -q` — sem erros.
- Render Jinja de `results/empresa.html`, `contato.html`, `base.html` — JSON-LD valido (todos blocks parseiam).
- Imports `web.routes.empresa` resolvem sem erro.

## Out-of-scope (proximos PRs)

- Migrar fornecedor-dialog.js para consumir as partials Jinja (atualmente duplicado).
- Cache web_cache TTL 24h para /empresa.
- Particionamento de sitemap se passar de 50k.
- Paginas /relatorios/<slug> indexaveis.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
