### PR TITLE
feat(seo): empresa pages cache-only + warmer + sitemap gated

### DIFF
--- a/.github/workflows/warm-empresas.yml
+++ b/.github/workflows/warm-empresas.yml
@@ -1,0 +1,133 @@
+name: Warm cache (empresas)
+
+# Pre-popula web_cache com perfil de cada /empresa/<cnpj>.
+# Pre-requisito pra ativar SITEMAP_INCLUDE_EMPRESAS=1 (sem cache, pagina
+# /empresa/<cnpj> retorna 503 — nunca executa as 8 queries inline).
+#
+# Esperado: ~30-90min para 45K empresas em B4 (4 workers paralelos).
+# Self-hosted runner (mesma VM) pra evitar SSH overhead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      preflight_b4:
+        description: 'Subir VM pra B4 antes de warm (recomendado — 4 workers paralelos saturam B2 facil)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+# Lock global compartilhado com deploy.yml — mesmo group key.
+concurrency:
+  group: deploy-vm-govbr
+  cancel-in-progress: false
+
+env:
+  PROJECT_DIR: /home/govbr/govbr-project
+  AZURE_RG: RG-GOVBR-NCUS
+  AZURE_VM: vm-govbr
+  VM_SIZE_WEB: Standard_B2as_v2
+  VM_SIZE_ETL: Standard_B4as_v2
+
+jobs:
+  preflight:
+    if: inputs.preflight_b4 == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resize VM to B4 if needed
+        run: |
+          set -euo pipefail
+          CURRENT=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query "hardwareProfile.vmSize" -o tsv)
+          if [ "$CURRENT" = "$VM_SIZE_ETL" ]; then
+            echo "VM ja em $VM_SIZE_ETL, skip resize"
+            exit 0
+          fi
+          echo "Resizing $AZURE_VM: $CURRENT -> $VM_SIZE_ETL"
+          az vm deallocate -g "$AZURE_RG" -n "$AZURE_VM"
+          az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$VM_SIZE_ETL"
+          az vm start -g "$AZURE_RG" -n "$AZURE_VM"
+          # Aguarda runner se reconectar
+          sleep 30
+
+  warm:
+    needs: [preflight]
+    if: always() && (needs.preflight.result == 'success' || needs.preflight.result == 'skipped')
+    runs-on: self-hosted
+    timeout-minutes: 180  # 3h cap (warming 45K empresas em ~60-90min normal)
+    steps:
+      - name: Pre-warm sanity check
+        run: |
+          cd ${{ env.PROJECT_DIR }}
+          source venv/bin/activate
+          source .env 2>/dev/null || true
+          # Confirma que mv_empresa_pb existe (pre-requisito do warmer).
+          PASS=$(grep -E '^POSTGRES_PASSWORD=' .env | cut -d= -f2-)
+          PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "SELECT COUNT(*) FROM mv_empresa_pb;" \
+            || (echo "::error::mv_empresa_pb nao existe — rode etl_phase=sql primeiro"; exit 1)
+
+      - name: Run empresa warmer
+        run: |
+          set -uo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          source venv/bin/activate
+          # set -a faz `source .env` exportar pro subprocesso (mesmo padrao
+          # do step IndexNow apos fix do PR #56).
+          set -a
+          source .env 2>/dev/null || true
+          set +a
+          echo "=== Empresa warmer started at $(date -Iseconds) ==="
+          python -m web.warm_cache --empresas
+          STATUS=$?
+          echo "=== Empresa warmer exit status: $STATUS ==="
+          exit $STATUS
+
+      - name: Cache stats
+        if: always()
+        run: |
+          cd ${{ env.PROJECT_DIR }}
+          PASS=$(grep -E '^POSTGRES_PASSWORD=' .env | cut -d= -f2-)
+          PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT 'EMPRESA_PERFIL rows: ' || COUNT(*)
+            FROM web_cache WHERE query_id = 'EMPRESA_PERFIL';
+          "
+          PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT 'oldest cache: ' || MIN(updated_at)::text || ' newest: ' || MAX(updated_at)::text
+            FROM web_cache WHERE query_id = 'EMPRESA_PERFIL';
+          "
+
+  postflight:
+    needs: [warm]
+    if: always() && needs.warm.result == 'success' && inputs.preflight_b4 == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resize VM down to B2
+        run: |
+          set -euo pipefail
+          CURRENT=$(az vm show -g "$AZURE_RG" -n "$AZURE_VM" --query "hardwareProfile.vmSize" -o tsv)
+          if [ "$CURRENT" = "$VM_SIZE_WEB" ]; then
+            echo "VM ja em $VM_SIZE_WEB, skip"
+            exit 0
+          fi
+          echo "Downsizing $AZURE_VM: $CURRENT -> $VM_SIZE_WEB"
+          az vm deallocate -g "$AZURE_RG" -n "$AZURE_VM"
+          az vm resize -g "$AZURE_RG" -n "$AZURE_VM" --size "$VM_SIZE_WEB"
+          az vm start -g "$AZURE_RG" -n "$AZURE_VM"

--- a/.github/workflows/warm-empresas.yml
+++ b/.github/workflows/warm-empresas.yml
@@ -149,7 +149,12 @@ jobs:
 
   postflight:
     needs: [warm]
-    if: always() && needs.warm.result == 'success' && inputs.preflight_b4 == true
+    # Downsize SEMPRE que preflight subiu, mesmo se warm falhou ou estourou
+    # timeout. VM em B4 sem trabalho ativo custa $108/mes vs $30 do B2.
+    # Se warm falhou parcialmente, cache esta degradado mas nao bloqueia
+    # operacao — re-trigger manual quando precisar (lock global do
+    # concurrency garante exclusao mutua).
+    if: always() && needs.warm.result != 'skipped' && inputs.preflight_b4 == true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/warm-empresas.yml
+++ b/.github/workflows/warm-empresas.yml
@@ -106,6 +106,47 @@ jobs:
             FROM web_cache WHERE query_id = 'EMPRESA_PERFIL';
           "
 
+      # E2E smoke test: pega 3 CNPJs warmed aleatorios e bate na rota
+      # /empresa/<cnpj> via cruza-web. Tem que retornar HTTP 200.
+      # Detecta bugs de serializacao (cache hit volta str em vez de dict
+      # — toda hit cairia em 503) que o warmer sozinho nao pega.
+      - name: E2E smoke test (warmed CNPJs returning 200, not 503)
+        if: success()
+        run: |
+          set -uo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          PASS=$(grep -E '^POSTGRES_PASSWORD=' .env | cut -d= -f2-)
+          # Pega 3 CNPJs warmed pra bater na rota local
+          CNPJS=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT municipio FROM web_cache
+            WHERE query_id = 'EMPRESA_PERFIL'
+            ORDER BY random() LIMIT 3;
+          ")
+          if [ -z "$CNPJS" ]; then
+            echo "::warning::Sem CNPJs cached pra smoke test"
+            exit 0
+          fi
+          FAIL=0
+          for cnpj in $CNPJS; do
+            # Bate via localhost:8000 (cruza-web) com Host header pra trigger
+            # da rota correta. -o /dev/null + -w pra so capturar status.
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time 10 \
+              -H "Host: transparenciapb.org" \
+              "http://127.0.0.1:8000/empresa/$cnpj")
+            if [ "$STATUS" = "200" ]; then
+              echo "  /empresa/$cnpj -> 200 OK"
+            else
+              echo "::error::/empresa/$cnpj -> $STATUS (esperado 200)"
+              FAIL=$((FAIL + 1))
+            fi
+          done
+          if [ "$FAIL" -gt 0 ]; then
+            echo "::error::E2E smoke test FAILED em $FAIL/3 CNPJs — cache pode estar mal-formado"
+            exit 1
+          fi
+          echo "E2E smoke test OK (3/3 CNPJs cached returning 200)"
+
   postflight:
     needs: [warm]
     if: always() && needs.warm.result == 'success' && inputs.preflight_b4 == true

--- a/web/indexnow_submit.py
+++ b/web/indexnow_submit.py
@@ -34,6 +34,7 @@ import logging
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -165,9 +166,16 @@ def main() -> int:
 
     log.info("Submetendo %d URL(s) ao IndexNow (host=%s)", len(urls), host)
     ok = True
-    for i in range(0, len(urls), BATCH_SIZE):
+    # Sleep entre batches: IndexNow nao publica rate limits oficiais, mas
+    # apos onda de empresas (~5K-50K URLs) podemos bater limite implicito
+    # do Bing. 0.5s entre batches da margem de seguranca sem alongar muito
+    # o submit (50 batches = 25s adicional). Apenas em modo real, nao dry-run.
+    batch_indices = list(range(0, len(urls), BATCH_SIZE))
+    for idx, i in enumerate(batch_indices):
         batch = urls[i : i + BATCH_SIZE]
         ok = _submit_batch(host, key, batch, args.dry_run) and ok
+        if not args.dry_run and idx < len(batch_indices) - 1:
+            time.sleep(0.5)
 
     return 0 if ok else 1
 

--- a/web/main.py
+++ b/web/main.py
@@ -12,6 +12,7 @@ from fastapi.templating import Jinja2Templates
 
 from web import db
 from web.routes.cidade import router as cidade_router
+from web.routes.empresa import router as empresa_router
 from web.routes.mapa import router as mapa_router
 from web.routes.og_image import router as og_router
 from web.routes.contato import build_router as build_contato_router
@@ -503,6 +504,7 @@ templates.env.filters["municipio_slug"] = _municipio_slug
 
 
 app.include_router(cidade_router)
+app.include_router(empresa_router)
 app.include_router(mapa_router)
 app.include_router(og_router)
 app.include_router(build_contato_router(templates))

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -118,9 +118,20 @@ EMPRESA_LENIENCIA_EFEITOS_BY_ID = """
 # Versoes _BY_BASICO — usadas pela pagina /empresa/{cnpj} (perfil agregado
 # da empresa raiz, alinhado com mv_empresa_pb que tambem agrega por
 # cnpj_basico). Garantem coerencia entre KPIs (que vem da MV agregada por
-# basico) e listagens detalhadas. Filtro `tipo_pessoa IN (PJ, ...)` evita
-# colisao de prefixo com CPFs (cpf=11 digitos vs cnpj=14, mas LEFT(.,8)
-# poderia bater com CPF cuja primeira metade coincide).
+# basico) e listagens detalhadas.
+#
+# Os filtros foram alinhados com os indices parciais existentes em
+# sql/19_indices_queries.sql:
+#   - CEIS/CNEP: idx_ceis/cnep_cnpj_basico_j ON (LEFT(cpf_cnpj_norm,8))
+#                WHERE tipo_pessoa = 'J' — usar `tipo_pessoa = 'J'` strict
+#                (CGU normaliza pra 'J', valor unico em pratica).
+#   - PGFN: idx_pgfn_cnpj_basico_norm ON (LEFT(cpf_cnpj_norm,8))
+#           WHERE LENGTH(cpf_cnpj_norm) = 14 — usar LENGTH=14 (exclui CPFs
+#           cujo prefixo de 8 caracteres poderia colidir).
+#   - LENIENCIA: tabela pequena (~80 acordos historicos), seq scan trivial.
+# Sem esses filtros casando com os indices, o warmer rodaria seq scan em
+# tabelas de milhoes de rows × 45K empresas — risco de derrubar o DB
+# justamente no rollout que deveria evitar isso (P1 do GPT 5.5 review).
 # ─────────────────────────────────────────────────────────────────────────
 
 EMPRESA_SANCOES_CEIS_BY_BASICO = """
@@ -130,7 +141,8 @@ EMPRESA_SANCOES_CEIS_BY_BASICO = """
            abrangencia_sancao
     FROM ceis_sancao
     WHERE LEFT(cpf_cnpj_norm, 8) = %s
-      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+      AND tipo_pessoa = 'J'
+      AND cpf_cnpj_norm IS NOT NULL
     ORDER BY dt_inicio_sancao DESC
 """
 
@@ -141,7 +153,8 @@ EMPRESA_SANCOES_CNEP_BY_BASICO = """
            abrangencia_sancao
     FROM cnep_sancao
     WHERE LEFT(cpf_cnpj_norm, 8) = %s
-      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+      AND tipo_pessoa = 'J'
+      AND cpf_cnpj_norm IS NOT NULL
     ORDER BY dt_inicio_sancao DESC
 """
 
@@ -151,7 +164,7 @@ EMPRESA_PGFN_BY_BASICO = """
            dt_inscricao, indicador_ajuizado
     FROM pgfn_divida
     WHERE LEFT(cpf_cnpj_norm, 8) = %s
-      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+      AND LENGTH(cpf_cnpj_norm) = 14
     ORDER BY valor_consolidado DESC
 """
 

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -1,0 +1,227 @@
+"""SQL parametrizado para o perfil publico de empresa (/empresa/<cnpj>) e
+para o endpoint /api/fornecedor/detalhes (dialog).
+
+As 8 primeiras constantes (CEIS, CNEP, ESTABELECIMENTO, MATRIZ, SOCIOS,
+PGFN, LENIENCIA, EFEITOS) reproduzem byte-a-byte os SQLs que viviam
+inline em web/routes/cidade.py:1746-1992. Foram extraidas pra que a rota
+nova /empresa/{cnpj} consuma a mesma fonte canonica e o dialog continue
+identico.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cadastro RFB (estabelecimento + empresa)
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO = """
+                    SELECT
+                        est.situacao_cadastral, est.dt_situacao,
+                        est.cnpj_completo, est.cnae_principal,
+                        dcnae.descricao AS desc_cnae_principal,
+                        est.uf,
+                        COALESCE(dm.descricao, est.municipio) AS municipio,
+                        est.matriz_filial, est.nome_fantasia,
+                        est.dt_inicio_atividade,
+                        est.tipo_logradouro, est.logradouro, est.numero,
+                        est.complemento, est.bairro, est.cep,
+                        est.ddd1, est.telefone1, est.email,
+                        e.razao_social, e.capital_social, e.porte,
+                        e.natureza_juridica,
+                        dnj.descricao AS desc_natureza_juridica,
+                        e.ente_federativo
+                    FROM estabelecimento est
+                    LEFT JOIN empresa e ON e.cnpj_basico = est.cnpj_basico
+                    LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
+                    LEFT JOIN dom_cnae dcnae ON dcnae.codigo = est.cnae_principal
+                    LEFT JOIN dom_natureza_juridica dnj ON dnj.codigo = e.natureza_juridica
+                    WHERE est.cnpj_completo = %s
+                """
+
+EMPRESA_MATRIZ_BY_BASICO = """
+                        SELECT est.cnpj_completo,
+                               est.tipo_logradouro, est.logradouro, est.numero,
+                               est.complemento, est.bairro, est.cep,
+                               est.ddd1, est.telefone1, est.email,
+                               COALESCE(dm.descricao, est.municipio) AS municipio,
+                               est.uf, est.nome_fantasia,
+                               est.dt_inicio_atividade
+                        FROM estabelecimento est
+                        LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
+                        WHERE est.cnpj_basico = %s AND est.cnpj_ordem = '0001'
+                    """
+
+EMPRESA_SOCIOS_BY_BASICO = """
+                    SELECT s.tipo_socio, s.nome, s.cpf_cnpj_socio,
+                           s.qualificacao,
+                           dq.descricao AS desc_qualificacao,
+                           s.dt_entrada, s.pais, s.faixa_etaria,
+                           s.nome_representante, s.cpf_representante,
+                           s.qualif_representante,
+                           dqr.descricao AS desc_qualif_representante
+                    FROM socio s
+                    LEFT JOIN dom_qualificacao dq ON dq.codigo = s.qualificacao
+                    LEFT JOIN dom_qualificacao dqr ON dqr.codigo = s.qualif_representante
+                    WHERE s.cnpj_basico = %s
+                    ORDER BY s.tipo_socio, s.dt_entrada DESC
+                """
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sancoes (CEIS / CNEP) e dividas (PGFN) — chave: cpf_cnpj_norm = 14 digitos
+# Usadas pelo dialog (cidade.py /api/fornecedor/detalhes), onde o usuario
+# clica num pagamento especifico do municipio e queremos as sancoes do
+# estabelecimento exato que recebeu aquele empenho.
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_SANCOES_CEIS_BY_CNPJ = """
+                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal,
+                           abrangencia_sancao
+                    FROM ceis_sancao
+                    WHERE cpf_cnpj_norm = %s
+                    ORDER BY dt_inicio_sancao DESC
+                """
+
+EMPRESA_SANCOES_CNEP_BY_CNPJ = """
+                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal, valor_multa,
+                           abrangencia_sancao
+                    FROM cnep_sancao
+                    WHERE cpf_cnpj_norm = %s
+                    ORDER BY dt_inicio_sancao DESC
+                """
+
+EMPRESA_PGFN_BY_CNPJ = """
+                    SELECT numero_inscricao, situacao_inscricao,
+                           receita_principal, valor_consolidado,
+                           dt_inscricao, indicador_ajuizado
+                    FROM pgfn_divida
+                    WHERE cpf_cnpj_norm = %s
+                    ORDER BY valor_consolidado DESC
+                """
+
+EMPRESA_LENIENCIA_BY_CNPJ = """
+                    SELECT al.cnpj_sancionado, al.razao_social_rfb, al.situacao_acordo,
+                           al.orgao_sancionador, al.dt_inicio_acordo, al.dt_fim_acordo,
+                           al.numero_processo, al.id_acordo
+                    FROM acordo_leniencia al
+                    WHERE al.cnpj_norm = %s
+                    ORDER BY al.dt_inicio_acordo DESC
+                """
+
+EMPRESA_LENIENCIA_EFEITOS_BY_ID = """
+                            SELECT efeito, complemento FROM acordo_efeito
+                            WHERE id_acordo = %s
+                        """
+
+# ─────────────────────────────────────────────────────────────────────────
+# Versoes _BY_BASICO — usadas pela pagina /empresa/{cnpj} (perfil agregado
+# da empresa raiz, alinhado com mv_empresa_pb que tambem agrega por
+# cnpj_basico). Garantem coerencia entre KPIs (que vem da MV agregada por
+# basico) e listagens detalhadas. Filtro `tipo_pessoa IN (PJ, ...)` evita
+# colisao de prefixo com CPFs (cpf=11 digitos vs cnpj=14, mas LEFT(.,8)
+# poderia bater com CPF cuja primeira metade coincide).
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_SANCOES_CEIS_BY_BASICO = """
+    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal,
+           abrangencia_sancao
+    FROM ceis_sancao
+    WHERE LEFT(cpf_cnpj_norm, 8) = %s
+      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+    ORDER BY dt_inicio_sancao DESC
+"""
+
+EMPRESA_SANCOES_CNEP_BY_BASICO = """
+    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
+           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
+           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal, valor_multa,
+           abrangencia_sancao
+    FROM cnep_sancao
+    WHERE LEFT(cpf_cnpj_norm, 8) = %s
+      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+    ORDER BY dt_inicio_sancao DESC
+"""
+
+EMPRESA_PGFN_BY_BASICO = """
+    SELECT numero_inscricao, situacao_inscricao,
+           receita_principal, valor_consolidado,
+           dt_inscricao, indicador_ajuizado
+    FROM pgfn_divida
+    WHERE LEFT(cpf_cnpj_norm, 8) = %s
+      AND tipo_pessoa IN ('PJ', 'Pessoa jurídica', 'J')
+    ORDER BY valor_consolidado DESC
+"""
+
+EMPRESA_LENIENCIA_BY_BASICO = """
+    SELECT al.cnpj_sancionado, al.razao_social_rfb, al.situacao_acordo,
+           al.orgao_sancionador, al.dt_inicio_acordo, al.dt_fim_acordo,
+           al.numero_processo, al.id_acordo
+    FROM acordo_leniencia al
+    WHERE LEFT(al.cnpj_norm, 8) = %s
+    ORDER BY al.dt_inicio_acordo DESC
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Pagamentos publicos PB (agregados + por municipio + top elementos)
+# Usados apenas pela pagina /empresa/{cnpj}.
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_AGREGADOS_PB_BY_BASICO = """
+    SELECT *
+    FROM mv_empresa_pb
+    WHERE cnpj_basico = %s
+"""
+
+EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO = """
+    SELECT municipio,
+           SUM(valor_pago) AS total_pago,
+           COUNT(*) AS qtd_empenhos
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %s
+      AND valor_pago > 0
+    GROUP BY municipio
+    ORDER BY total_pago DESC
+"""
+
+EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO = """
+    SELECT elemento_despesa,
+           SUM(valor_pago) AS total_elemento,
+           COUNT(*) AS qtd
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %s
+      AND valor_pago > 0
+    GROUP BY elemento_despesa
+    ORDER BY SUM(valor_pago) DESC
+    LIMIT 5
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sitemap: empresas qualificadas (heuristica de filtro pra evitar ruido).
+# Inclui CNPJs com pagamentos PB relevantes (>= R$ 10k), em CEIS vigente
+# ou com divida PGFN > 0. Retorna (razao_social, cnpj_completo) onde
+# cnpj_completo = basico+ordem(0001)+dv da matriz.
+#
+# LIMIT 45000: protocolo sitemap.org permite ate 50.000 URLs por arquivo.
+# Cidades (~223) + estaticas (5) + 45k empresas = ~45.2k, com folga ate
+# o limite. Quando passarmos disso, implementar sitemap index com chunks
+# (TODO: web/routes/seo.py — sitemap-empresas-1.xml etc).
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESAS_QUALIFICADAS_PARA_SITEMAP = """
+    SELECT
+        COALESCE(NULLIF(epb.razao_social, ''), 'Empresa ' || epb.cnpj_basico) AS razao_social,
+        est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo
+    FROM mv_empresa_pb epb
+    JOIN estabelecimento est
+        ON est.cnpj_basico = epb.cnpj_basico
+       AND est.cnpj_ordem = '0001'
+    WHERE epb.total_pb_geral >= 10000
+       OR epb.flag_ceis_vigente
+       OR epb.total_divida_pgfn > 0
+    ORDER BY epb.total_pb_geral DESC NULLS LAST,
+             epb.cnpj_basico
+    LIMIT 45000
+"""

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -41,6 +41,16 @@ from web.queries.cidade import (
     TOP_SERVIDORES_RISCO,
     TOP_SERVIDORES_RISCO_DATED,
 )
+from web.queries.empresa import (
+    EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
+    EMPRESA_LENIENCIA_BY_CNPJ,
+    EMPRESA_LENIENCIA_EFEITOS_BY_ID,
+    EMPRESA_MATRIZ_BY_BASICO,
+    EMPRESA_PGFN_BY_CNPJ,
+    EMPRESA_SANCOES_CEIS_BY_CNPJ,
+    EMPRESA_SANCOES_CNEP_BY_CNPJ,
+    EMPRESA_SOCIOS_BY_BASICO,
+)
 from web.queries.registry import CIDADE_QUERIES, get_categories
 from web.kpis.cidade import compute_cidade_kpis
 
@@ -1743,15 +1753,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                 result["top_elementos"] = top_elementos
 
                 # Sancoes CEIS
-                cur.execute("""
-                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
-                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
-                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal,
-                           abrangencia_sancao
-                    FROM ceis_sancao
-                    WHERE cpf_cnpj_norm = %s
-                    ORDER BY dt_inicio_sancao DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_SANCOES_CEIS_BY_CNPJ, (cpf_cnpj,))
                 san_cols = [d[0] for d in cur.description]
                 san_rows = cur.fetchall()
                 sancoes = []
@@ -1764,15 +1766,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     sancoes.append(r)
 
                 # Sancoes CNEP
-                cur.execute("""
-                    SELECT cpf_cnpj_norm AS cpf_cnpj_sancionado,
-                           categoria_sancao, dt_inicio_sancao, dt_final_sancao,
-                           orgao_sancionador, esfera_orgao_sancionador, fundamentacao_legal, valor_multa,
-                           abrangencia_sancao
-                    FROM cnep_sancao
-                    WHERE cpf_cnpj_norm = %s
-                    ORDER BY dt_inicio_sancao DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_SANCOES_CNEP_BY_CNPJ, (cpf_cnpj,))
                 cnep_cols = [d[0] for d in cur.description]
                 cnep_rows = cur.fetchall()
                 for row in cnep_rows:
@@ -1850,31 +1844,8 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                 # Situacao cadastral + dados cadastrais detalhados
                 # Retorna estabelecimento exato + matriz (cnpj_ordem='0001') para
                 # endereco/contato + dados da empresa (capital, porte, natureza).
-                est_where = "est.cnpj_completo = %s"
                 est_params = (cpf_cnpj,)
-                cur.execute(f"""
-                    SELECT
-                        est.situacao_cadastral, est.dt_situacao,
-                        est.cnpj_completo, est.cnae_principal,
-                        dcnae.descricao AS desc_cnae_principal,
-                        est.uf,
-                        COALESCE(dm.descricao, est.municipio) AS municipio,
-                        est.matriz_filial, est.nome_fantasia,
-                        est.dt_inicio_atividade,
-                        est.tipo_logradouro, est.logradouro, est.numero,
-                        est.complemento, est.bairro, est.cep,
-                        est.ddd1, est.telefone1, est.email,
-                        e.razao_social, e.capital_social, e.porte,
-                        e.natureza_juridica,
-                        dnj.descricao AS desc_natureza_juridica,
-                        e.ente_federativo
-                    FROM estabelecimento est
-                    LEFT JOIN empresa e ON e.cnpj_basico = est.cnpj_basico
-                    LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
-                    LEFT JOIN dom_cnae dcnae ON dcnae.codigo = est.cnae_principal
-                    LEFT JOIN dom_natureza_juridica dnj ON dnj.codigo = e.natureza_juridica
-                    WHERE {est_where}
-                """, est_params)
+                cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, est_params)
                 sit_cols = [d[0] for d in cur.description]
                 sit_rows = cur.fetchall()
                 if sit_rows:
@@ -1892,18 +1863,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                 cnpj_basico_int = cpf_cnpj[:8]
                 cnpj_ordem_int = cpf_cnpj[8:12]
                 if cnpj_ordem_int != '0001':
-                    cur.execute("""
-                        SELECT est.cnpj_completo,
-                               est.tipo_logradouro, est.logradouro, est.numero,
-                               est.complemento, est.bairro, est.cep,
-                               est.ddd1, est.telefone1, est.email,
-                               COALESCE(dm.descricao, est.municipio) AS municipio,
-                               est.uf, est.nome_fantasia,
-                               est.dt_inicio_atividade
-                        FROM estabelecimento est
-                        LEFT JOIN dom_municipio dm ON dm.codigo = est.municipio
-                        WHERE est.cnpj_basico = %s AND est.cnpj_ordem = '0001'
-                    """, (cnpj_basico_int,))
+                    cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico_int,))
                     mat_cols = [d[0] for d in cur.description]
                     mat_row = cur.fetchone()
                     if mat_row:
@@ -1914,20 +1874,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                         result["matriz"] = matriz
 
                 # Socios (CPFs vem mascarados pela RFB — seguro expor).
-                cur.execute("""
-                    SELECT s.tipo_socio, s.nome, s.cpf_cnpj_socio,
-                           s.qualificacao,
-                           dq.descricao AS desc_qualificacao,
-                           s.dt_entrada, s.pais, s.faixa_etaria,
-                           s.nome_representante, s.cpf_representante,
-                           s.qualif_representante,
-                           dqr.descricao AS desc_qualif_representante
-                    FROM socio s
-                    LEFT JOIN dom_qualificacao dq ON dq.codigo = s.qualificacao
-                    LEFT JOIN dom_qualificacao dqr ON dqr.codigo = s.qualif_representante
-                    WHERE s.cnpj_basico = %s
-                    ORDER BY s.tipo_socio, s.dt_entrada DESC
-                """, (cnpj_basico_int,))
+                cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico_int,))
                 soc_cols = [d[0] for d in cur.description]
                 soc_rows = cur.fetchall()
                 if soc_rows:
@@ -1941,14 +1888,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     result["socios"] = socios
 
                 # Divida PGFN
-                cur.execute("""
-                    SELECT numero_inscricao, situacao_inscricao,
-                           receita_principal, valor_consolidado,
-                           dt_inscricao, indicador_ajuizado
-                    FROM pgfn_divida
-                    WHERE cpf_cnpj_norm = %s
-                    ORDER BY valor_consolidado DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_PGFN_BY_CNPJ, (cpf_cnpj,))
                 pgfn_cols = [d[0] for d in cur.description]
                 pgfn_rows = cur.fetchall()
                 if pgfn_rows:
@@ -1964,14 +1904,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     result["pgfn"] = dividas
 
                 # Acordos de Leniencia
-                cur.execute("""
-                    SELECT al.cnpj_sancionado, al.razao_social_rfb, al.situacao_acordo,
-                           al.orgao_sancionador, al.dt_inicio_acordo, al.dt_fim_acordo,
-                           al.numero_processo, al.id_acordo
-                    FROM acordo_leniencia al
-                    WHERE al.cnpj_norm = %s
-                    ORDER BY al.dt_inicio_acordo DESC
-                """, (cpf_cnpj,))
+                cur.execute(EMPRESA_LENIENCIA_BY_CNPJ, (cpf_cnpj,))
                 al_cols = [d[0] for d in cur.description]
                 al_rows = cur.fetchall()
                 if al_rows:
@@ -1982,10 +1915,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                             if hasattr(v, 'isoformat'):
                                 a[k] = v.isoformat()
                         # Buscar efeitos do acordo
-                        cur.execute("""
-                            SELECT efeito, complemento FROM acordo_efeito
-                            WHERE id_acordo = %s
-                        """, (a["id_acordo"],))
+                        cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
                         ef_cols = [d[0] for d in cur.description]
                         ef_rows = cur.fetchall()
                         a["efeitos"] = [_row_to_dict(ef_cols, er) for er in ef_rows]

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -77,6 +77,31 @@ def _normalize_cnpj_input(raw: str) -> str | None:
     return digits
 
 
+def _calculate_cnpj_dv(basico: str, ordem: str) -> str:
+    """Computa os 2 digitos verificadores do CNPJ a partir de basico+ordem.
+
+    Algoritmo padrao da Receita Federal (modulo 11):
+    - DV1: soma ponderada dos primeiros 12 digitos com pesos
+      [5,4,3,2,9,8,7,6,5,4,3,2], depois (sum * 10) % 11 % 10.
+    - DV2: idem com 13 digitos e pesos [6,5,4,3,2,9,8,7,6,5,4,3,2].
+
+    Pure math, sem DB hit. Usado pra redirecionar /empresa/<filial> ->
+    /empresa/<matriz> sem precisar consultar estabelecimento (mantem o
+    invariant cache-only da rota).
+    """
+    digits = basico + ordem
+    if len(digits) != 12 or not digits.isdigit():
+        raise ValueError(f"basico+ordem invalido: {digits!r}")
+    weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    sum1 = sum(int(digits[i]) * weights1[i] for i in range(12))
+    dv1 = (sum1 * 10) % 11 % 10
+    digits2 = digits + str(dv1)
+    weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    sum2 = sum(int(digits2[i]) * weights2[i] for i in range(13))
+    dv2 = (sum2 * 10) % 11 % 10
+    return f"{dv1}{dv2}"
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Pipeline de computacao: roda as 8 queries e monta o dict de template.
 # Usado APENAS pelo warmer. Nao chamar da rota (custo alto, risco de pool
@@ -277,6 +302,26 @@ async def empresa_perfil(request: Request, cnpj: str):
         )
     if cnpj != canonical:
         return RedirectResponse(url=f"/empresa/{canonical}", status_code=301)
+
+    # Filial → matriz: o warmer popula cache so para a matriz (cnpj_ordem='0001')
+    # de cada cnpj_basico (mesma logica do sitemap). Se chegou aqui um CNPJ
+    # de filial (ordem != 0001), redireciona pra matriz canonica usando DV
+    # computado matematicamente (sem DB hit, mantem cache-only invariant).
+    # Sem isso, links do dialog de fornecedor que usam exactDoc da filial
+    # cairiam em 503 mesmo apos warmer rodar (caught by GPT-5.5 review #58).
+    cnpj_ordem = canonical[8:12]
+    if cnpj_ordem != "0001":
+        try:
+            matriz_dv = _calculate_cnpj_dv(canonical[:8], "0001")
+            matriz = canonical[:8] + "0001" + matriz_dv
+            return RedirectResponse(url=f"/empresa/{matriz}", status_code=301)
+        except ValueError:
+            return templates.TemplateResponse(
+                request,
+                "errors/404.html",
+                {"path": str(request.url.path)},
+                status_code=404,
+            )
 
     # Lookup no web_cache. Schema: (query_id=EMPRESA_PERFIL, municipio=cnpj),
     # rows[0][0] = dict completo serializado como JSONB.

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -1,8 +1,14 @@
 """Rota publica /empresa/{cnpj} — perfil SEO de empresa.
 
-Renderiza pagina indexavel com cadastro RFB, sancoes, dividas, agregados
-de pagamentos publicos PB e municipios pagantes. Reaproveita as queries
-de web.queries.empresa (mesma fonte que o dialog usa em cidade.py).
+ARQUITETURA pos-incidente do PR #57:
+- Rota e CACHE-ONLY: le de web_cache (chave EMPRESA_PERFIL:<cnpj>) e renderiza.
+- Cache miss = 503 com Retry-After (NAO faz live query — protege DB do
+  thundering herd que derrubou o site quando IndexNow notificou Bing sobre
+  45K URLs simultaneamente). Cache-miss-only e seguro porque empresas so
+  entram no sitemap depois de warmed.
+- A funcao `compute_empresa_perfil_dict` executa as 8 queries e monta o
+  dict completo. Eh chamada APENAS pelo warmer (web/warm_cache.py), nunca
+  inline na rota.
 
 URL: /empresa/<14-digitos>. CNPJ formatado com mascara redireciona via
 404; entrada deve ser 14 digitos numericos puros (canonical).
@@ -12,12 +18,13 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse, Response
 
 from web.config import TIMEOUT_PROFILE
-from web.db import execute_query, get_conn
+from web.db import execute_query, get_conn, read_web_cache
 from web.queries.empresa import (
     EMPRESA_AGREGADOS_PB_BY_BASICO,
     EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
@@ -36,6 +43,10 @@ router = APIRouter()
 _log = logging.getLogger("transparencia.empresa")
 
 _CNPJ_RE = re.compile(r"^\d{14}$")
+
+# Chave canonica usada em web_cache. Warmer e rota DEVEM usar exatamente
+# esta string. Mudancas exigem invalidar o cache existente.
+CACHE_QUERY_ID = "EMPRESA_PERFIL"
 
 
 def _row_to_dict(cols, row):
@@ -66,169 +77,125 @@ def _normalize_cnpj_input(raw: str) -> str | None:
     return digits
 
 
-@router.get("/empresa/{cnpj}")
-async def empresa_perfil(request: Request, cnpj: str):
-    """Renderiza /empresa/<14-digits>. Redireciona para forma canonica
-    (14 digitos puros) se a entrada veio com mascara/pontos.
+# ─────────────────────────────────────────────────────────────────────────
+# Pipeline de computacao: roda as 8 queries e monta o dict de template.
+# Usado APENAS pelo warmer. Nao chamar da rota (custo alto, risco de pool
+# exhaustion sob trafego de crawler).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class EmpresaNotFoundError(Exception):
+    """Empresa nao tem dados PB (nao em mv_empresa_pb) ou CNPJ invalido."""
+
+
+def compute_empresa_perfil_dict(cnpj_completo: str) -> dict[str, Any]:
+    """Executa as 8 queries e monta o dict completo do perfil.
+
+    Returns: dict pronto pra TemplateResponse.
+    Raises: EmpresaNotFoundError se empresa nao em mv_empresa_pb ou
+            cadastro RFB ausente. Outras exceptions sao do DB e propagam.
     """
-    from web.main import templates
+    if not _CNPJ_RE.fullmatch(cnpj_completo):
+        raise EmpresaNotFoundError(f"CNPJ invalido: {cnpj_completo}")
 
-    canonical = _normalize_cnpj_input(cnpj)
-    if not canonical:
-        return templates.TemplateResponse(
-            request,
-            "errors/404.html",
-            {"path": str(request.url.path)},
-            status_code=404,
-        )
-    if cnpj != canonical:
-        return RedirectResponse(url=f"/empresa/{canonical}", status_code=301)
+    cnpj_basico = cnpj_completo[:8]
+    cnpj_ordem = cnpj_completo[8:12]
 
-    cnpj_basico = canonical[:8]
-    cnpj_ordem = canonical[8:12]
+    # 1. Agregados PB (mv_empresa_pb) — chave: cnpj_basico.
+    agg_cols, agg_rows = execute_query(
+        EMPRESA_AGREGADOS_PB_BY_BASICO,
+        (cnpj_basico,),
+        timeout_sec=TIMEOUT_PROFILE,
+    )
+    if not agg_rows:
+        raise EmpresaNotFoundError(f"sem dados PB: {cnpj_completo}")
+    agregados = _convert_row(_row_to_dict(agg_cols, agg_rows[0]))
 
-    try:
-        # 1. Agregados PB (mv_empresa_pb) — chave: cnpj_basico.
-        # Se a empresa nao esta na MV, nao tem dados PB -> 404.
-        try:
-            agg_cols, agg_rows = execute_query(
-                EMPRESA_AGREGADOS_PB_BY_BASICO,
-                (cnpj_basico,),
-                timeout_sec=TIMEOUT_PROFILE,
-            )
-        except Exception:
-            # DB indisponivel: 503 transitorio (nao 404, pra evitar deindex).
-            return Response(
-                status_code=503,
-                headers={"Retry-After": "300"},
-                content="Servico temporariamente indisponivel. Tente novamente em alguns minutos.",
-                media_type="text/plain; charset=utf-8",
-            )
+    # 2. Cadastro RFB + 3-8 demais detalhes — uma transaction com todos
+    # os SELECTs. statement_timeout setado e resetado em try/finally pra
+    # nao vazar configuracao pro pool.
+    with get_conn() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(f"SET statement_timeout = '{TIMEOUT_PROFILE * 1000}'")
+            try:
+                cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (cnpj_completo,))
+                est_cols = [d[0] for d in cur.description]
+                est_rows = cur.fetchall()
+                if not est_rows:
+                    raise EmpresaNotFoundError(f"sem cadastro RFB: {cnpj_completo}")
+                estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
 
-        if not agg_rows:
-            return templates.TemplateResponse(
-                request,
-                "errors/404.html",
-                {"path": str(request.url.path)},
-                status_code=404,
-            )
+                matriz = None
+                if cnpj_ordem != "0001":
+                    cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
+                    mat_cols = [d[0] for d in cur.description]
+                    mat_row = cur.fetchone()
+                    if mat_row:
+                        matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
 
-        agregados = _convert_row(_row_to_dict(agg_cols, agg_rows[0]))
+                cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
+                soc_cols = [d[0] for d in cur.description]
+                socios = [
+                    _convert_row(_row_to_dict(soc_cols, r))
+                    for r in cur.fetchall()
+                ]
 
-        # 2. Cadastro RFB (estabelecimento + empresa) — chave: cnpj_completo.
-        # Detalhes (sancoes/divida/leniencia/pagamentos) sao consultados POR
-        # CNPJ_BASICO (8 digitos) pra coerencia com mv_empresa_pb que agrega
-        # por basico. URL e canonicalizada com 14 digitos da matriz mas a
-        # pagina representa a empresa raiz.
-        with get_conn() as conn:
-            conn.autocommit = True
-            with conn.cursor() as cur:
-                cur.execute(f"SET statement_timeout = '{TIMEOUT_PROFILE * 1000}'")
-                # try/finally: garante RESET statement_timeout em qualquer
-                # caminho (404 cedo, exception, ou sucesso). Sem isso, a
-                # config de sessao vaza pra proxima request que pegar a
-                # mesma conexao do pool, podendo quebrar queries pesadas
-                # de outros endpoints. (Caught by GPT-5.5 review do PR #57.)
+                cur.execute(EMPRESA_SANCOES_CEIS_BY_BASICO, (cnpj_basico,))
+                ceis_cols = [d[0] for d in cur.description]
+                sancoes: list[dict] = []
+                for r in cur.fetchall():
+                    item = _convert_row(_row_to_dict(ceis_cols, r))
+                    item["origem"] = "CEIS"
+                    sancoes.append(item)
+
+                cur.execute(EMPRESA_SANCOES_CNEP_BY_BASICO, (cnpj_basico,))
+                cnep_cols = [d[0] for d in cur.description]
+                for r in cur.fetchall():
+                    item = _convert_row(_row_to_dict(cnep_cols, r))
+                    item["origem"] = "CNEP"
+                    sancoes.append(item)
+
+                cur.execute(EMPRESA_PGFN_BY_BASICO, (cnpj_basico,))
+                pg_cols = [d[0] for d in cur.description]
+                pgfn = [
+                    _convert_row(_row_to_dict(pg_cols, r))
+                    for r in cur.fetchall()
+                ]
+
+                cur.execute(EMPRESA_LENIENCIA_BY_BASICO, (cnpj_basico,))
+                len_cols = [d[0] for d in cur.description]
+                acordos = []
+                for r in cur.fetchall():
+                    a = _convert_row(_row_to_dict(len_cols, r))
+                    cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
+                    ef_cols = [d[0] for d in cur.description]
+                    a["efeitos"] = [
+                        _row_to_dict(ef_cols, er) for er in cur.fetchall()
+                    ]
+                    acordos.append(a)
+
+                cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO, (cnpj_basico,))
+                mp_cols = [d[0] for d in cur.description]
+                municipios_pagantes = [
+                    _convert_row(_row_to_dict(mp_cols, r))
+                    for r in cur.fetchall()
+                ]
+
+                cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO, (cnpj_basico,))
+                te_cols = [d[0] for d in cur.description]
+                top_elementos = [
+                    _convert_row(_row_to_dict(te_cols, r))
+                    for r in cur.fetchall()
+                ]
+            finally:
                 try:
-                    cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (canonical,))
-                    est_cols = [d[0] for d in cur.description]
-                    est_rows = cur.fetchall()
-                    if not est_rows:
-                        return templates.TemplateResponse(
-                            request,
-                            "errors/404.html",
-                            {"path": str(request.url.path)},
-                            status_code=404,
-                        )
-                    estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
-
-                    # 3. Matriz (se a entidade nao for ela propria a matriz)
-                    matriz = None
-                    if cnpj_ordem != "0001":
-                        cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
-                        mat_cols = [d[0] for d in cur.description]
-                        mat_row = cur.fetchone()
-                        if mat_row:
-                            matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
-
-                    # 4. Socios
-                    cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
-                    soc_cols = [d[0] for d in cur.description]
-                    socios = [
-                        _convert_row(_row_to_dict(soc_cols, r))
-                        for r in cur.fetchall()
-                    ]
-
-                    # 5. Sancoes CEIS + CNEP (por basico, todos estabelecimentos)
-                    cur.execute(EMPRESA_SANCOES_CEIS_BY_BASICO, (cnpj_basico,))
-                    ceis_cols = [d[0] for d in cur.description]
-                    sancoes = []
-                    for r in cur.fetchall():
-                        item = _convert_row(_row_to_dict(ceis_cols, r))
-                        item["origem"] = "CEIS"
-                        sancoes.append(item)
-
-                    cur.execute(EMPRESA_SANCOES_CNEP_BY_BASICO, (cnpj_basico,))
-                    cnep_cols = [d[0] for d in cur.description]
-                    for r in cur.fetchall():
-                        item = _convert_row(_row_to_dict(cnep_cols, r))
-                        item["origem"] = "CNEP"
-                        sancoes.append(item)
-
-                    # 6. PGFN (por basico)
-                    cur.execute(EMPRESA_PGFN_BY_BASICO, (cnpj_basico,))
-                    pg_cols = [d[0] for d in cur.description]
-                    pgfn = [
-                        _convert_row(_row_to_dict(pg_cols, r))
-                        for r in cur.fetchall()
-                    ]
-
-                    # 7. Acordos de Leniencia + efeitos (por basico)
-                    cur.execute(EMPRESA_LENIENCIA_BY_BASICO, (cnpj_basico,))
-                    len_cols = [d[0] for d in cur.description]
-                    acordos = []
-                    for r in cur.fetchall():
-                        a = _convert_row(_row_to_dict(len_cols, r))
-                        cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
-                        ef_cols = [d[0] for d in cur.description]
-                        a["efeitos"] = [
-                            _row_to_dict(ef_cols, er) for er in cur.fetchall()
-                        ]
-                        acordos.append(a)
-
-                    # 8. Municipios pagantes (PB) + top elementos (por basico)
-                    cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO, (cnpj_basico,))
-                    mp_cols = [d[0] for d in cur.description]
-                    municipios_pagantes = [
-                        _convert_row(_row_to_dict(mp_cols, r))
-                        for r in cur.fetchall()
-                    ]
-
-                    cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO, (cnpj_basico,))
-                    te_cols = [d[0] for d in cur.description]
-                    top_elementos = [
-                        _convert_row(_row_to_dict(te_cols, r))
-                        for r in cur.fetchall()
-                    ]
-                finally:
-                    try:
-                        cur.execute("RESET statement_timeout")
-                    except Exception:
-                        # se conexao ja foi marcada como aborted, RESET
-                        # falha — tolerar porque putconn vai descartar a
-                        # conexao corrompida em vez de devolver ao pool.
-                        _log.warning(
-                            "RESET statement_timeout falhou (conexao "
-                            "provavelmente sera descartada pelo pool)"
-                        )
-    except Exception:
-        _log.exception("empresa perfil failed cnpj=%s", canonical)
-        return Response(
-            status_code=503,
-            headers={"Retry-After": "300"},
-            content="Servico temporariamente indisponivel. Tente novamente em alguns minutos.",
-            media_type="text/plain; charset=utf-8",
-        )
+                    cur.execute("RESET statement_timeout")
+                except Exception:
+                    _log.warning(
+                        "RESET statement_timeout falhou (conexao "
+                        "provavelmente sera descartada pelo pool)"
+                    )
 
     razao_social = (
         estabelecimento.get("razao_social")
@@ -236,17 +203,11 @@ async def empresa_perfil(request: Request, cnpj: str):
         or estabelecimento.get("nome_fantasia")
         or f"Empresa {cnpj_basico}"
     )
-    cnpj_fmt = _format_cnpj(canonical)
+    cnpj_fmt = _format_cnpj(cnpj_completo)
     total_pb_geral = float(agregados.get("total_pb_geral") or 0)
     qtd_municipios = len(municipios_pagantes)
     qtd_empenhos_pb = int(agregados.get("qtd_tce_empenhos") or 0) + int(
         agregados.get("qtd_pb_empenhos") or 0
-    )
-    sancoes_vigentes = sum(
-        1
-        for s in sancoes
-        if not s.get("dt_final_sancao")
-        or str(s.get("dt_final_sancao")) >= "1900-01-01"  # placeholder; UI usa data
     )
     total_divida_pgfn = float(agregados.get("total_divida_pgfn") or 0)
 
@@ -266,28 +227,82 @@ async def empresa_perfil(request: Request, cnpj: str):
         )
     meta_description = " ".join(meta_parts)[:300]
 
-    return templates.TemplateResponse(
-        request,
-        "results/empresa.html",
-        {
-            "cnpj": canonical,
-            "cnpj_basico": cnpj_basico,
-            "cnpj_ordem": cnpj_ordem,
-            "cnpj_fmt": cnpj_fmt,
-            "razao_social": razao_social,
-            "estabelecimento": estabelecimento,
-            "matriz": matriz,
-            "socios": socios,
-            "sancoes": sancoes,
-            "pgfn": pgfn,
-            "acordos_leniencia": acordos,
-            "agregados": agregados,
-            "municipios_pagantes": municipios_pagantes,
-            "top_elementos": top_elementos,
-            "kpi_total_pb": total_pb_geral,
-            "kpi_qtd_municipios": qtd_municipios,
-            "kpi_qtd_empenhos": qtd_empenhos_pb,
-            "kpi_total_divida_pgfn": total_divida_pgfn,
-            "meta_description": meta_description,
-        },
+    return {
+        "cnpj": cnpj_completo,
+        "cnpj_basico": cnpj_basico,
+        "cnpj_ordem": cnpj_ordem,
+        "cnpj_fmt": cnpj_fmt,
+        "razao_social": razao_social,
+        "estabelecimento": estabelecimento,
+        "matriz": matriz,
+        "socios": socios,
+        "sancoes": sancoes,
+        "pgfn": pgfn,
+        "acordos_leniencia": acordos,
+        "agregados": agregados,
+        "municipios_pagantes": municipios_pagantes,
+        "top_elementos": top_elementos,
+        "kpi_total_pb": total_pb_geral,
+        "kpi_qtd_municipios": qtd_municipios,
+        "kpi_qtd_empenhos": qtd_empenhos_pb,
+        "kpi_total_divida_pgfn": total_divida_pgfn,
+        "meta_description": meta_description,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Rota — cache-only.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/empresa/{cnpj}")
+async def empresa_perfil(request: Request, cnpj: str):
+    """Renderiza /empresa/<14-digits>. Le de web_cache. Cache miss = 503.
+
+    NUNCA executa as 8 queries inline. O incidente do PR #57 mostrou que
+    sob trafego de crawler agressivo (Bing + 45K URLs do IndexNow), o pool
+    de DB exauria em segundos e levava o site inteiro junto. Cache-only +
+    sitemap-after-warm garante que crawler so encontra URLs com cache
+    quente.
+    """
+    from web.main import templates
+
+    canonical = _normalize_cnpj_input(cnpj)
+    if not canonical:
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+    if cnpj != canonical:
+        return RedirectResponse(url=f"/empresa/{canonical}", status_code=301)
+
+    # Lookup no web_cache. Schema: (query_id=EMPRESA_PERFIL, municipio=cnpj),
+    # rows[0][0] = dict completo serializado como JSONB.
+    cached = read_web_cache(CACHE_QUERY_ID, canonical)
+    if cached is not None:
+        cols, rows = cached
+        if rows and rows[0]:
+            data = rows[0][0]
+            if isinstance(data, dict) and data:
+                return templates.TemplateResponse(
+                    request, "results/empresa.html", data
+                )
+
+    # Cache miss. Em fluxo normal (pos-warm), so deveria acontecer pra:
+    # (a) CNPJ que nao ta em mv_empresa_pb (deveria ser 404), ou
+    # (b) primeiras requests apos restart antes de warm completar.
+    # Retornamos 503 com Retry-After 1h pra crawler back off. A AUSENCIA
+    # do CNPJ no sitemap (gated) significa que crawlers nem deveriam
+    # estar aqui — se chegou ate aqui, eh acesso direto/legado.
+    _log.info("cache miss /empresa/%s — returning 503", canonical)
+    return Response(
+        status_code=503,
+        headers={"Retry-After": "3600"},
+        content=(
+            "Perfil em construcao — esta empresa ainda nao foi pre-processada. "
+            "Tente novamente mais tarde."
+        ),
+        media_type="text/plain; charset=utf-8",
     )

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -1,0 +1,293 @@
+"""Rota publica /empresa/{cnpj} — perfil SEO de empresa.
+
+Renderiza pagina indexavel com cadastro RFB, sancoes, dividas, agregados
+de pagamentos publicos PB e municipios pagantes. Reaproveita as queries
+de web.queries.empresa (mesma fonte que o dialog usa em cidade.py).
+
+URL: /empresa/<14-digitos>. CNPJ formatado com mascara redireciona via
+404; entrada deve ser 14 digitos numericos puros (canonical).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse, Response
+
+from web.config import TIMEOUT_PROFILE
+from web.db import execute_query, get_conn
+from web.queries.empresa import (
+    EMPRESA_AGREGADOS_PB_BY_BASICO,
+    EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
+    EMPRESA_LENIENCIA_BY_BASICO,
+    EMPRESA_LENIENCIA_EFEITOS_BY_ID,
+    EMPRESA_MATRIZ_BY_BASICO,
+    EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO,
+    EMPRESA_PGFN_BY_BASICO,
+    EMPRESA_SANCOES_CEIS_BY_BASICO,
+    EMPRESA_SANCOES_CNEP_BY_BASICO,
+    EMPRESA_SOCIOS_BY_BASICO,
+    EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO,
+)
+
+router = APIRouter()
+_log = logging.getLogger("transparencia.empresa")
+
+_CNPJ_RE = re.compile(r"^\d{14}$")
+
+
+def _row_to_dict(cols, row):
+    return dict(zip(cols, row))
+
+
+def _convert(value):
+    if hasattr(value, "as_tuple"):  # Decimal
+        return float(value)
+    if hasattr(value, "isoformat"):  # date/datetime
+        return value.isoformat()
+    return value
+
+
+def _convert_row(d: dict) -> dict:
+    return {k: _convert(v) for k, v in d.items()}
+
+
+def _format_cnpj(cnpj14: str) -> str:
+    return f"{cnpj14[:2]}.{cnpj14[2:5]}.{cnpj14[5:8]}/{cnpj14[8:12]}-{cnpj14[12:14]}"
+
+
+def _normalize_cnpj_input(raw: str) -> str | None:
+    """Retorna 14 digitos puros (sem mascara) ou None se invalido."""
+    digits = re.sub(r"\D", "", raw or "")
+    if len(digits) != 14:
+        return None
+    return digits
+
+
+@router.get("/empresa/{cnpj}")
+async def empresa_perfil(request: Request, cnpj: str):
+    """Renderiza /empresa/<14-digits>. Redireciona para forma canonica
+    (14 digitos puros) se a entrada veio com mascara/pontos.
+    """
+    from web.main import templates
+
+    canonical = _normalize_cnpj_input(cnpj)
+    if not canonical:
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+    if cnpj != canonical:
+        return RedirectResponse(url=f"/empresa/{canonical}", status_code=301)
+
+    cnpj_basico = canonical[:8]
+    cnpj_ordem = canonical[8:12]
+
+    try:
+        # 1. Agregados PB (mv_empresa_pb) — chave: cnpj_basico.
+        # Se a empresa nao esta na MV, nao tem dados PB -> 404.
+        try:
+            agg_cols, agg_rows = execute_query(
+                EMPRESA_AGREGADOS_PB_BY_BASICO,
+                (cnpj_basico,),
+                timeout_sec=TIMEOUT_PROFILE,
+            )
+        except Exception:
+            # DB indisponivel: 503 transitorio (nao 404, pra evitar deindex).
+            return Response(
+                status_code=503,
+                headers={"Retry-After": "300"},
+                content="Servico temporariamente indisponivel. Tente novamente em alguns minutos.",
+                media_type="text/plain; charset=utf-8",
+            )
+
+        if not agg_rows:
+            return templates.TemplateResponse(
+                request,
+                "errors/404.html",
+                {"path": str(request.url.path)},
+                status_code=404,
+            )
+
+        agregados = _convert_row(_row_to_dict(agg_cols, agg_rows[0]))
+
+        # 2. Cadastro RFB (estabelecimento + empresa) — chave: cnpj_completo.
+        # Detalhes (sancoes/divida/leniencia/pagamentos) sao consultados POR
+        # CNPJ_BASICO (8 digitos) pra coerencia com mv_empresa_pb que agrega
+        # por basico. URL e canonicalizada com 14 digitos da matriz mas a
+        # pagina representa a empresa raiz.
+        with get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(f"SET statement_timeout = '{TIMEOUT_PROFILE * 1000}'")
+                # try/finally: garante RESET statement_timeout em qualquer
+                # caminho (404 cedo, exception, ou sucesso). Sem isso, a
+                # config de sessao vaza pra proxima request que pegar a
+                # mesma conexao do pool, podendo quebrar queries pesadas
+                # de outros endpoints. (Caught by GPT-5.5 review do PR #57.)
+                try:
+                    cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (canonical,))
+                    est_cols = [d[0] for d in cur.description]
+                    est_rows = cur.fetchall()
+                    if not est_rows:
+                        return templates.TemplateResponse(
+                            request,
+                            "errors/404.html",
+                            {"path": str(request.url.path)},
+                            status_code=404,
+                        )
+                    estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
+
+                    # 3. Matriz (se a entidade nao for ela propria a matriz)
+                    matriz = None
+                    if cnpj_ordem != "0001":
+                        cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
+                        mat_cols = [d[0] for d in cur.description]
+                        mat_row = cur.fetchone()
+                        if mat_row:
+                            matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
+
+                    # 4. Socios
+                    cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
+                    soc_cols = [d[0] for d in cur.description]
+                    socios = [
+                        _convert_row(_row_to_dict(soc_cols, r))
+                        for r in cur.fetchall()
+                    ]
+
+                    # 5. Sancoes CEIS + CNEP (por basico, todos estabelecimentos)
+                    cur.execute(EMPRESA_SANCOES_CEIS_BY_BASICO, (cnpj_basico,))
+                    ceis_cols = [d[0] for d in cur.description]
+                    sancoes = []
+                    for r in cur.fetchall():
+                        item = _convert_row(_row_to_dict(ceis_cols, r))
+                        item["origem"] = "CEIS"
+                        sancoes.append(item)
+
+                    cur.execute(EMPRESA_SANCOES_CNEP_BY_BASICO, (cnpj_basico,))
+                    cnep_cols = [d[0] for d in cur.description]
+                    for r in cur.fetchall():
+                        item = _convert_row(_row_to_dict(cnep_cols, r))
+                        item["origem"] = "CNEP"
+                        sancoes.append(item)
+
+                    # 6. PGFN (por basico)
+                    cur.execute(EMPRESA_PGFN_BY_BASICO, (cnpj_basico,))
+                    pg_cols = [d[0] for d in cur.description]
+                    pgfn = [
+                        _convert_row(_row_to_dict(pg_cols, r))
+                        for r in cur.fetchall()
+                    ]
+
+                    # 7. Acordos de Leniencia + efeitos (por basico)
+                    cur.execute(EMPRESA_LENIENCIA_BY_BASICO, (cnpj_basico,))
+                    len_cols = [d[0] for d in cur.description]
+                    acordos = []
+                    for r in cur.fetchall():
+                        a = _convert_row(_row_to_dict(len_cols, r))
+                        cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
+                        ef_cols = [d[0] for d in cur.description]
+                        a["efeitos"] = [
+                            _row_to_dict(ef_cols, er) for er in cur.fetchall()
+                        ]
+                        acordos.append(a)
+
+                    # 8. Municipios pagantes (PB) + top elementos (por basico)
+                    cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO, (cnpj_basico,))
+                    mp_cols = [d[0] for d in cur.description]
+                    municipios_pagantes = [
+                        _convert_row(_row_to_dict(mp_cols, r))
+                        for r in cur.fetchall()
+                    ]
+
+                    cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO, (cnpj_basico,))
+                    te_cols = [d[0] for d in cur.description]
+                    top_elementos = [
+                        _convert_row(_row_to_dict(te_cols, r))
+                        for r in cur.fetchall()
+                    ]
+                finally:
+                    try:
+                        cur.execute("RESET statement_timeout")
+                    except Exception:
+                        # se conexao ja foi marcada como aborted, RESET
+                        # falha — tolerar porque putconn vai descartar a
+                        # conexao corrompida em vez de devolver ao pool.
+                        _log.warning(
+                            "RESET statement_timeout falhou (conexao "
+                            "provavelmente sera descartada pelo pool)"
+                        )
+    except Exception:
+        _log.exception("empresa perfil failed cnpj=%s", canonical)
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "300"},
+            content="Servico temporariamente indisponivel. Tente novamente em alguns minutos.",
+            media_type="text/plain; charset=utf-8",
+        )
+
+    razao_social = (
+        estabelecimento.get("razao_social")
+        or agregados.get("razao_social")
+        or estabelecimento.get("nome_fantasia")
+        or f"Empresa {cnpj_basico}"
+    )
+    cnpj_fmt = _format_cnpj(canonical)
+    total_pb_geral = float(agregados.get("total_pb_geral") or 0)
+    qtd_municipios = len(municipios_pagantes)
+    qtd_empenhos_pb = int(agregados.get("qtd_tce_empenhos") or 0) + int(
+        agregados.get("qtd_pb_empenhos") or 0
+    )
+    sancoes_vigentes = sum(
+        1
+        for s in sancoes
+        if not s.get("dt_final_sancao")
+        or str(s.get("dt_final_sancao")) >= "1900-01-01"  # placeholder; UI usa data
+    )
+    total_divida_pgfn = float(agregados.get("total_divida_pgfn") or 0)
+
+    # Meta description (150-160 chars). Mantemos curta e factual.
+    meta_parts = [
+        f"Perfil de {razao_social} (CNPJ {cnpj_fmt}) no TransparenciaPB."
+    ]
+    if total_pb_geral > 0:
+        meta_parts.append(
+            f"Recebido em PB: R$ {total_pb_geral:,.0f}".replace(",", ".")
+        )
+    if sancoes:
+        meta_parts.append(f"Sancoes: {len(sancoes)}.")
+    if total_divida_pgfn > 0:
+        meta_parts.append(
+            f"Divida PGFN: R$ {total_divida_pgfn:,.0f}".replace(",", ".")
+        )
+    meta_description = " ".join(meta_parts)[:300]
+
+    return templates.TemplateResponse(
+        request,
+        "results/empresa.html",
+        {
+            "cnpj": canonical,
+            "cnpj_basico": cnpj_basico,
+            "cnpj_ordem": cnpj_ordem,
+            "cnpj_fmt": cnpj_fmt,
+            "razao_social": razao_social,
+            "estabelecimento": estabelecimento,
+            "matriz": matriz,
+            "socios": socios,
+            "sancoes": sancoes,
+            "pgfn": pgfn,
+            "acordos_leniencia": acordos,
+            "agregados": agregados,
+            "municipios_pagantes": municipios_pagantes,
+            "top_elementos": top_elementos,
+            "kpi_total_pb": total_pb_geral,
+            "kpi_qtd_municipios": qtd_municipios,
+            "kpi_qtd_empenhos": qtd_empenhos_pb,
+            "kpi_total_divida_pgfn": total_divida_pgfn,
+            "meta_description": meta_description,
+        },
+    )

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -94,6 +94,36 @@ def _municipios_pb() -> list[tuple[str, str]]:
         return []
 
 
+def _empresas_pb() -> list[tuple[str, str]]:
+    """Lista empresas qualificadas (heuristica em web.queries.empresa).
+    Retorna [(razao_social, cnpj_completo), ...]. Cnpj eh string de 14
+    digitos numericos puros (forma canonica usada pela rota /empresa/{cnpj}).
+    """
+    from web.queries.empresa import EMPRESAS_QUALIFICADAS_PARA_SITEMAP
+
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(EMPRESAS_QUALIFICADAS_PARA_SITEMAP)
+                out: list[tuple[str, str]] = []
+                seen: set[str] = set()
+                for razao, cnpj_completo in cur.fetchall():
+                    if not cnpj_completo:
+                        continue
+                    cnpj_str = str(cnpj_completo).strip()
+                    if len(cnpj_str) != 14 or not cnpj_str.isdigit():
+                        continue
+                    if cnpj_str in seen:
+                        continue
+                    seen.add(cnpj_str)
+                    out.append((str(razao or ""), cnpj_str))
+                return out
+    except Exception:
+        _log.exception("Falha ao listar empresas PB pro sitemap")
+        return []
+
+
 def _lastmod_iso() -> str:
     """Data ISO (YYYY-MM-DD) usada como <lastmod> nas paginas de cidade.
 
@@ -145,6 +175,19 @@ def _build_sitemap_xml(origin: str) -> str:
         parts.append("    <priority>0.7</priority>")
         parts.append("  </url>")
 
+    # Pagina /empresa/<cnpj> pra cada empresa qualificada (filtro em
+    # web.queries.empresa.EMPRESAS_QUALIFICADAS_PARA_SITEMAP). URL canonica
+    # usa 14 digitos numericos puros (sem mascara).
+    empresas = _empresas_pb()
+    for _razao, cnpj_completo in empresas:
+        loc = f"{origin}/empresa/{cnpj_completo}"
+        parts.append("  <url>")
+        parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
+        parts.append("    <changefreq>weekly</changefreq>")
+        parts.append("    <priority>0.5</priority>")
+        parts.append("  </url>")
+
     parts.append("</urlset>")
     return "\n".join(parts)
 
@@ -153,11 +196,17 @@ def _build_sitemap_xml(origin: str) -> str:
 async def sitemap_xml(request: Request) -> Response:
     """Sitemap dinamico cached por 1h.
 
-    Importante: NAO cacheamos sitemap parcial (sem URLs de cidade) — caso
-    contrario, uma falha transitoria de DB no primeiro hit pos-restart
-    serviria por 1h um sitemap incompleto a Google/IndexNow. Em build
-    parcial, servimos o resultado mas mantemos cache invalido para a
-    proxima request tentar de novo.
+    Importante: NAO cacheamos sitemap parcial (sem URLs de cidade ou
+    empresa) — caso contrario, uma falha transitoria de DB no primeiro
+    hit pos-restart serviria por 1h um sitemap incompleto a Google/IndexNow.
+    Em build parcial, servimos o resultado mas mantemos cache invalido
+    para a proxima request tentar de novo.
+
+    Heuristica de completude:
+    - Sitemap completo tem static (5) + cidades (~223) + empresas (>=1).
+    - Threshold combina: precisa de >= 100 cidades E >= 1 empresa.
+    - Se DB de empresas falhar mas cidades estao OK, recusa cache (a
+      proxima request reativa _empresas_pb).
     """
     origin = _site_origin(request)
     now = time.time()
@@ -165,16 +214,23 @@ async def sitemap_xml(request: Request) -> Response:
         xml = _SITEMAP_CACHE["xml"]
     else:
         xml = _build_sitemap_xml(origin)
-        # Heuristica simples: sitemap completo tem 100+ <url>; parcial
-        # (so paginas estaticas) tem ~5. Nao cachear parcial.
-        if xml.count("<url>") >= 100:
+        cidades_n = xml.count("/cidade/")
+        empresas_n = xml.count("/empresa/")
+        # Bookmark de completude: cidades >= 100 (entre 223 PB, threshold
+        # generoso pra sobreviver a flapping) E pelo menos 1 empresa
+        # qualificada. Se filtro de qualificacao algum dia retornar 0
+        # legitimamente, este check vira "nao cacheia, mas /sitemap.xml
+        # continua servindo build novo a cada request" — penalty aceitavel.
+        is_complete = cidades_n >= 100 and empresas_n >= 1
+        if is_complete:
             _SITEMAP_CACHE["xml"] = xml
             _SITEMAP_CACHE["ts"] = now
         else:
             _log.warning(
-                "Sitemap parcial gerado (%d <url> entries) — nao cacheando, "
-                "proxima request tentara recarregar municipios",
-                xml.count("<url>"),
+                "Sitemap parcial gerado (cidades=%d, empresas=%d) — nao "
+                "cacheando, proxima request tentara recarregar do DB",
+                cidades_n,
+                empresas_n,
             )
     return Response(
         content=xml,

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -178,15 +178,26 @@ def _build_sitemap_xml(origin: str) -> str:
     # Pagina /empresa/<cnpj> pra cada empresa qualificada (filtro em
     # web.queries.empresa.EMPRESAS_QUALIFICADAS_PARA_SITEMAP). URL canonica
     # usa 14 digitos numericos puros (sem mascara).
-    empresas = _empresas_pb()
-    for _razao, cnpj_completo in empresas:
-        loc = f"{origin}/empresa/{cnpj_completo}"
-        parts.append("  <url>")
-        parts.append(f"    <loc>{xml_escape(loc)}</loc>")
-        parts.append(f"    <lastmod>{lastmod}</lastmod>")
-        parts.append("    <changefreq>weekly</changefreq>")
-        parts.append("    <priority>0.5</priority>")
-        parts.append("  </url>")
+    #
+    # GATED por env var: empresas SO entram no sitemap quando
+    # SITEMAP_INCLUDE_EMPRESAS=1. Padrao OFF porque, sem web_cache pre-
+    # populado pelas paginas /empresa/<cnpj>, expor 45K URLs ao IndexNow/
+    # Google causa thundering herd que derruba o site inteiro (incidente
+    # com PR #57). Workflow:
+    #   1. Deploy do codigo com flag OFF
+    #   2. python -m web.warm_cache --empresas (popula web_cache)
+    #   3. SITEMAP_INCLUDE_EMPRESAS=1 + reload (separar deploy)
+    #   4. IndexNow re-dispara automatico via deploy.yml
+    if os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1":
+        empresas = _empresas_pb()
+        for _razao, cnpj_completo in empresas:
+            loc = f"{origin}/empresa/{cnpj_completo}"
+            parts.append("  <url>")
+            parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+            parts.append(f"    <lastmod>{lastmod}</lastmod>")
+            parts.append("    <changefreq>weekly</changefreq>")
+            parts.append("    <priority>0.5</priority>")
+            parts.append("  </url>")
 
     parts.append("</urlset>")
     return "\n".join(parts)
@@ -203,10 +214,12 @@ async def sitemap_xml(request: Request) -> Response:
     para a proxima request tentar de novo.
 
     Heuristica de completude:
-    - Sitemap completo tem static (5) + cidades (~223) + empresas (>=1).
-    - Threshold combina: precisa de >= 100 cidades E >= 1 empresa.
-    - Se DB de empresas falhar mas cidades estao OK, recusa cache (a
-      proxima request reativa _empresas_pb).
+    - Sitemap completo tem static (5) + cidades (~223) + empresas (>=1
+      QUANDO flag SITEMAP_INCLUDE_EMPRESAS=1).
+    - Threshold combina: precisa de >= 100 cidades. Empresas opcional
+      (so quando flag ativada).
+    - Se DB de empresas falhar mas cidades estao OK e flag OFF, cacheia.
+      Se flag ON e empresas vier vazio, recusa cache.
     """
     origin = _site_origin(request)
     now = time.time()
@@ -216,21 +229,21 @@ async def sitemap_xml(request: Request) -> Response:
         xml = _build_sitemap_xml(origin)
         cidades_n = xml.count("/cidade/")
         empresas_n = xml.count("/empresa/")
-        # Bookmark de completude: cidades >= 100 (entre 223 PB, threshold
-        # generoso pra sobreviver a flapping) E pelo menos 1 empresa
-        # qualificada. Se filtro de qualificacao algum dia retornar 0
-        # legitimamente, este check vira "nao cacheia, mas /sitemap.xml
-        # continua servindo build novo a cada request" — penalty aceitavel.
-        is_complete = cidades_n >= 100 and empresas_n >= 1
+        flag_on = os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1"
+        # Se flag esta OFF, sitemap eh "completo" sem empresas (so cidades).
+        # Se flag esta ON, exige tambem empresas >= 1.
+        is_complete = cidades_n >= 100 and (not flag_on or empresas_n >= 1)
         if is_complete:
             _SITEMAP_CACHE["xml"] = xml
             _SITEMAP_CACHE["ts"] = now
         else:
             _log.warning(
-                "Sitemap parcial gerado (cidades=%d, empresas=%d) — nao "
-                "cacheando, proxima request tentara recarregar do DB",
+                "Sitemap parcial gerado (cidades=%d, empresas=%d, "
+                "flag_empresas=%s) — nao cacheando, proxima request "
+                "tentara recarregar do DB",
                 cidades_n,
                 empresas_n,
+                flag_on,
             )
     return Response(
         content=xml,

--- a/web/static/js/components/fornecedor-dialog.js
+++ b/web/static/js/components/fornecedor-dialog.js
@@ -109,6 +109,7 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
             <div class="empresa-header">
                 <strong>${_esc(est.razao_social || fornecedorNome)}</strong>
                 <code class="auditor-only">${cnpjFmt}</code>
+                <a href="/empresa/${_esc(exactDoc)}" class="ext-link-inline" title="Ver perfil completo da empresa (pagina dedicada)">Ver perfil &#8599;</a>
             </div>
             <div class="empresa-details">
                 <span>${dualLabel('Cadastro:','Situacao:')} <span class="${sitClass}">${sit}</span>${isFilial ? ` <span class="badge badge-gray">${tipoFilial}</span>` : ''}</span>
@@ -166,6 +167,7 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
                 <div class="empresa-header">
                     <strong>${_esc(fornecedorNome || nomeCredor || 'Fornecedor')}</strong>
                     <code class="auditor-only">${cnpjFmt}</code>
+                    <a href="/empresa/${_esc(exactDoc)}" class="ext-link-inline" title="Ver perfil completo da empresa (pagina dedicada)">Ver perfil &#8599;</a>
                 </div>
                 <div class="empresa-details">
                     <span>Cadastro completo da empresa indisponivel na base RFB para este CNPJ.</span>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -81,7 +81,18 @@
           "name": "TransparenciaPB",
           "url": "{{ _origin }}/",
           "logo": "{{ _origin }}/static/icon-512.png",
-          "description": "Plataforma cidadã de cruzamento de dados públicos abertos da Paraíba"
+          "description": "Plataforma cidadã de cruzamento de dados públicos abertos da Paraíba",
+          "foundingDate": "2025",
+          "sameAs": [
+            "https://github.com/lucasdiniz/govbr-cruza-dados"
+          ],
+          "publishingPrinciples": "{{ _origin }}/sobre",
+          "knowsAbout": [
+            "Transparência pública",
+            "Dados abertos",
+            "Paraíba",
+            "Fiscalização cidadã"
+          ]
         }
       ]
     }

--- a/web/templates/contato.html
+++ b/web/templates/contato.html
@@ -3,6 +3,34 @@
 {% block meta_description %}Entre em contato com a equipe da TransparenciaPB — sugestoes, correcoes ou parcerias.{% endblock %}
 {% block og_title %}Contato — TransparenciaPB{% endblock %}
 {% block og_description %}Mande uma mensagem pra equipe da TransparenciaPB.{% endblock %}
+{% block json_ld_extra %}
+{% set _origin = request_origin(request) if request else '' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "ContactPage",
+      "@id": "{{ _origin }}/contato#contactpage",
+      "url": "{{ _origin }}/contato",
+      "name": "Contato — TransparenciaPB",
+      "description": "Canal de contato com a equipe da TransparenciaPB para sugestoes, correcoes e parcerias.",
+      "isPartOf": {"@id": "{{ _origin }}/#website"},
+      "about": {"@id": "{{ _origin }}/#organization"},
+      "inLanguage": "pt-BR"
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "{{ _origin }}/contato#breadcrumb",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ _origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": "Contato", "item": "{{ _origin }}/contato"}
+      ]
+    }
+  ]
+}
+</script>
+{% endblock %}
 {% block content %}
 <section class="contato-page">
     <header class="contato-head">

--- a/web/templates/partials/empresa/_flags.html
+++ b/web/templates/partials/empresa/_flags.html
@@ -1,0 +1,33 @@
+{# Flags de risco visiveis (do mv_empresa_pb) #}
+{% set flags = [] %}
+{% if agregados.flag_capital_desproporcional %}
+    {% set flags = flags + [('Capital social desproporcional', 'Capital social muito baixo comparado ao volume recebido em pagamentos publicos. Pode indicar empresa fachada ou subdimensionada.')] %}
+{% endif %}
+{% if agregados.flag_multi_municipal %}
+    {% set flags = flags + [('Atua em 3+ municipios', 'Empresa recebeu pagamentos de tres ou mais prefeituras paraibanas. Padrao multi-municipal merece verificacao quando associado a outros indicios.')] %}
+{% endif %}
+{% if agregados.flag_predomina_sem_licitacao %}
+    {% set flags = flags + [('Predomina sem licitacao', 'Mais da metade dos empenhos foram registrados como dispensa, inexigibilidade ou sem numero de licitacao.')] %}
+{% endif %}
+{% if agregados.flag_inativa %}
+    {% set flags = flags + [('Cadastro inativo na RFB', 'Situacao cadastral na Receita Federal nao consta como Ativa.')] %}
+{% endif %}
+{% if agregados.flag_ceis_vigente %}
+    {% set flags = flags + [('Sancao vigente (CEIS)', 'Empresa esta no Cadastro de Empresas Inidoneas e Suspensas com sancao vigente.')] %}
+{% endif %}
+{% if flags %}
+<section class="empresa-section" id="sinais">
+    <h2>Sinais de atencao</h2>
+    <ul class="empresa-flags">
+        {% for label, descr in flags %}
+        <li class="empresa-flag-item">
+            <strong>{{ label }}</strong>
+            <span class="text-sm text-muted"> &mdash; {{ descr }}</span>
+        </li>
+        {% endfor %}
+    </ul>
+    <p class="text-sm text-muted">
+        Estes sinais sao automaticos e <em>nao</em> conclusoes juridicas. Sempre verifique a fonte original.
+    </p>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_hero.html
+++ b/web/templates/partials/empresa/_hero.html
@@ -1,0 +1,45 @@
+{# Hero: razao social + CNPJ + situacao cadastral + endereco sede #}
+{% set situacao = estabelecimento.situacao_cadastral %}
+{% set situacao_str = situacao|string if situacao is not none else '' %}
+{% set inativa = situacao_str != '2' %}
+<header class="empresa-hero">
+    <p class="eyebrow">Perfil de empresa</p>
+    <h1>{{ razao_social|clean_text }}</h1>
+    <p class="empresa-cnpj-line">
+        <code class="empresa-cnpj">CNPJ {{ cnpj_fmt }}</code>
+        {% if inativa %}
+            <span class="badge badge-red" title="Situacao cadastral diferente de Ativa na Receita Federal">Cadastro inativo / suspenso</span>
+        {% else %}
+            <span class="badge badge-green">Ativa na RFB</span>
+        {% endif %}
+        {% if estabelecimento.matriz_filial %}
+            <span class="text-sm text-muted">
+                {% if estabelecimento.matriz_filial|string == '1' %}Matriz{% else %}Filial{% endif %}
+            </span>
+        {% endif %}
+    </p>
+    {% if estabelecimento.nome_fantasia %}
+        <p class="text-muted">Nome fantasia: <strong>{{ estabelecimento.nome_fantasia|clean_text }}</strong></p>
+    {% endif %}
+    {% set logr = estabelecimento.logradouro or (matriz.logradouro if matriz else None) %}
+    {% set num = estabelecimento.numero or (matriz.numero if matriz else None) %}
+    {% set bai = estabelecimento.bairro or (matriz.bairro if matriz else None) %}
+    {% set mun = estabelecimento.municipio or (matriz.municipio if matriz else None) %}
+    {% set uf = estabelecimento.uf or (matriz.uf if matriz else None) %}
+    {% if logr or mun %}
+        <p class="empresa-endereco text-sm">
+            {% if estabelecimento.tipo_logradouro %}{{ estabelecimento.tipo_logradouro|clean_text }} {% endif %}
+            {% if logr %}{{ logr|clean_text }}{% endif %}{% if num %}, {{ num }}{% endif %}
+            {% if bai %} &mdash; {{ bai|clean_text }}{% endif %}
+            {% if mun %} &mdash; {{ mun|clean_text }}{% if uf %}/{{ uf }}{% endif %}{% endif %}
+        </p>
+    {% endif %}
+    {% if estabelecimento.desc_cnae_principal %}
+        <p class="text-sm text-muted">
+            Atividade principal (CNAE): {{ estabelecimento.desc_cnae_principal|clean_text }}
+        </p>
+    {% endif %}
+    {% if estabelecimento.dt_inicio_atividade %}
+        <p class="text-sm text-muted">Inicio de atividade: {{ estabelecimento.dt_inicio_atividade }}</p>
+    {% endif %}
+</header>

--- a/web/templates/partials/empresa/_leniencia.html
+++ b/web/templates/partials/empresa/_leniencia.html
@@ -1,0 +1,30 @@
+{# Acordos de leniencia (CGU) #}
+{% if acordos_leniencia %}
+<section class="empresa-section" id="leniencia">
+    <h2>Acordos de leniencia</h2>
+    <ul class="empresa-acordos">
+        {% for a in acordos_leniencia %}
+        <li class="empresa-acordo-item">
+            <p>
+                <span class="badge badge-blue">Leniencia &mdash; {{ a.situacao_acordo|clean_text or 'sem situacao' }}</span>
+                {% if a.orgao_sancionador %}<strong> {{ a.orgao_sancionador|clean_text }}</strong>{% endif %}
+            </p>
+            <p class="text-sm text-muted">
+                {% if a.dt_inicio_acordo %}Inicio: {{ a.dt_inicio_acordo }}{% endif %}
+                {% if a.dt_fim_acordo %} &mdash; fim: {{ a.dt_fim_acordo }}{% endif %}
+            </p>
+            {% if a.numero_processo %}
+            <p class="text-sm">Processo: <code>{{ a.numero_processo }}</code></p>
+            {% endif %}
+            {% if a.efeitos %}
+            <ul class="empresa-acordo-efeitos text-sm">
+                {% for ef in a.efeitos %}
+                <li><strong>{{ ef.efeito|clean_text }}</strong>{% if ef.complemento %} &mdash; {{ ef.complemento|clean_text }}{% endif %}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_municipios_pagantes.html
+++ b/web/templates/partials/empresa/_municipios_pagantes.html
@@ -1,0 +1,48 @@
+{# Lista de municipios PB que pagaram esta empresa #}
+{% if municipios_pagantes %}
+<section class="empresa-section" id="municipios-pagantes">
+    <h2>Municipios que pagaram esta empresa</h2>
+    <p class="text-sm text-muted">Pagamentos identificados no TCE-PB. Clique no municipio pra ver o panorama de transparencia.</p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile">
+            <thead>
+                <tr>
+                    <th>Municipio</th>
+                    <th class="text-right">Total pago</th>
+                    <th class="text-right">Empenhos</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for mp in municipios_pagantes %}
+                {% set _slug = mp.municipio | municipio_slug %}
+                <tr>
+                    <td data-label="Municipio">
+                        {% if _slug %}
+                            <a href="/cidade/{{ _slug }}">{{ mp.municipio|clean_text }}</a>
+                        {% else %}
+                            {{ mp.municipio|clean_text }}
+                        {% endif %}
+                    </td>
+                    <td data-label="Total pago" class="text-right num">{{ mp.total_pago|short_brl }}</td>
+                    <td data-label="Empenhos" class="text-right num">{{ mp.qtd_empenhos|short_number }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endif %}
+
+{% if top_elementos %}
+<section class="empresa-section" id="top-elementos">
+    <h2>Principais tipos de despesa</h2>
+    <ul class="empresa-elementos">
+        {% for el in top_elementos %}
+        <li>
+            <strong>{{ el.elemento_despesa|clean_text or 'Sem classificacao' }}</strong>
+            &mdash; {{ el.total_elemento|short_brl }} em {{ el.qtd|short_number }} empenhos
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_pgfn.html
+++ b/web/templates/partials/empresa/_pgfn.html
@@ -1,0 +1,39 @@
+{# Dividas ativas PGFN #}
+{% if pgfn %}
+<section class="empresa-section" id="pgfn">
+    <h2>Divida ativa da Uniao (PGFN)</h2>
+    <p class="text-sm text-muted">
+        Inscricoes da empresa em divida ativa federal. Total: <strong>{{ kpi_total_divida_pgfn|short_brl }}</strong>.
+    </p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile">
+            <thead>
+                <tr>
+                    <th>Inscricao</th>
+                    <th>Situacao</th>
+                    <th>Receita</th>
+                    <th class="text-right">Valor consolidado</th>
+                    <th>Inscricao em</th>
+                    <th>Ajuizado</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for d in pgfn %}
+                <tr>
+                    <td data-label="Inscricao"><code class="text-sm">{{ d.numero_inscricao }}</code></td>
+                    <td data-label="Situacao">{{ d.situacao_inscricao|clean_text }}</td>
+                    <td data-label="Receita">{{ d.receita_principal|clean_text }}</td>
+                    <td data-label="Valor" class="text-right num">{{ d.valor_consolidado|short_brl }}</td>
+                    <td data-label="Inscricao em">{{ d.dt_inscricao or '-' }}</td>
+                    <td data-label="Ajuizado">{{ d.indicador_ajuizado or '-' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <p class="text-sm">
+        Fonte oficial:
+        <a href="https://www.listadevedores.pgfn.gov.br/" target="_blank" rel="noopener nofollow">Lista de Devedores da PGFN</a>.
+    </p>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_resumo_pagamentos.html
+++ b/web/templates/partials/empresa/_resumo_pagamentos.html
@@ -1,0 +1,30 @@
+{# Resumo de pagamentos publicos PB (KPIs) #}
+{% if kpi_total_pb and kpi_total_pb > 0 %}
+<section class="empresa-section" id="resumo-pagamentos">
+    <h2>Pagamentos publicos na Paraiba</h2>
+    <div class="kpi-grid">
+        <div class="kpi-card">
+            <p class="kpi-label">Total recebido (PB)</p>
+            <p class="kpi-value">{{ kpi_total_pb|short_brl }}</p>
+            <p class="kpi-hint text-sm text-muted">Soma de empenhos pagos no TCE-PB + dados.pb (estado).</p>
+        </div>
+        <div class="kpi-card">
+            <p class="kpi-label">Municipios pagantes</p>
+            <p class="kpi-value">{{ kpi_qtd_municipios|short_number }}</p>
+            <p class="kpi-hint text-sm text-muted">Quantidade de prefeituras que pagaram esta empresa.</p>
+        </div>
+        <div class="kpi-card">
+            <p class="kpi-label">Empenhos</p>
+            <p class="kpi-value">{{ kpi_qtd_empenhos|short_number }}</p>
+            <p class="kpi-hint text-sm text-muted">Numero total de pagamentos publicos identificados.</p>
+        </div>
+        {% if kpi_total_divida_pgfn and kpi_total_divida_pgfn > 0 %}
+        <div class="kpi-card kpi-card-warn">
+            <p class="kpi-label">Divida ativa (PGFN)</p>
+            <p class="kpi-value">{{ kpi_total_divida_pgfn|short_brl }}</p>
+            <p class="kpi-hint text-sm text-muted">Tributos federais inscritos em divida ativa.</p>
+        </div>
+        {% endif %}
+    </div>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_sancoes.html
+++ b/web/templates/partials/empresa/_sancoes.html
@@ -1,0 +1,44 @@
+{# Sancoes CEIS + CNEP #}
+{% if sancoes %}
+<section class="empresa-section" id="sancoes">
+    <h2>Sancoes administrativas</h2>
+    <p class="text-sm text-muted">
+        Registros do CEIS e CNEP (CGU). Cada item indica orgao sancionador, periodo e fundamentacao legal.
+    </p>
+    <ul class="empresa-sancoes">
+        {% for s in sancoes %}
+        {% set vigente = (not s.dt_final_sancao) or (s.dt_final_sancao and s.dt_final_sancao >= DATA_REFRESH_DATE_ISO) %}
+        <li class="empresa-sancao-item {% if vigente %}is-vigente{% endif %}">
+            <p>
+                <span class="badge {% if vigente %}badge-red{% else %}badge-gray{% endif %}">
+                    {{ s.origem }}{% if vigente %} &mdash; vigente{% endif %}
+                </span>
+                <strong>{{ s.categoria_sancao|clean_text or 'Sancao' }}</strong>
+            </p>
+            <p class="text-sm text-muted">
+                {% if s.dt_inicio_sancao %}Inicio: {{ s.dt_inicio_sancao }}{% endif %}
+                {% if s.dt_final_sancao %} &mdash; fim: {{ s.dt_final_sancao }}{% else %} &mdash; sem data fim cadastrada{% endif %}
+            </p>
+            {% if s.orgao_sancionador %}
+            <p class="text-sm">Orgao sancionador: <strong>{{ s.orgao_sancionador|clean_text }}</strong>
+                {% if s.esfera_orgao_sancionador %} ({{ s.esfera_orgao_sancionador|clean_text }}){% endif %}
+            </p>
+            {% endif %}
+            {% if s.abrangencia_sancao %}
+            <p class="text-sm text-muted">Abrangencia: {{ s.abrangencia_sancao|clean_text }}</p>
+            {% endif %}
+            {% if s.fundamentacao_legal %}
+            <p class="text-sm text-muted">Fundamentacao: {{ s.fundamentacao_legal|clean_text }}</p>
+            {% endif %}
+            {% if s.valor_multa %}
+            <p class="text-sm">Valor da multa: {{ s.valor_multa|short_brl }}</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    <p class="text-sm">
+        Fonte oficial:
+        <a href="https://portaldatransparencia.gov.br/sancoes" target="_blank" rel="noopener nofollow">Portal da Transparencia &mdash; Sancoes</a>.
+    </p>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_socios.html
+++ b/web/templates/partials/empresa/_socios.html
@@ -1,0 +1,38 @@
+{# Quadro societario (CPFs vem mascarados pela RFB - seguro expor) #}
+{% if socios %}
+<section class="empresa-section" id="socios">
+    <h2>Quadro societario</h2>
+    <p class="text-sm text-muted">CPFs sao publicados parcialmente mascarados pela Receita Federal.</p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile">
+            <thead>
+                <tr>
+                    <th>Nome</th>
+                    <th>CPF/CNPJ</th>
+                    <th>Qualificacao</th>
+                    <th>Entrada</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for s in socios %}
+                <tr>
+                    <td data-label="Nome">{{ s.nome|clean_text }}</td>
+                    <td data-label="CPF/CNPJ"><code class="text-sm">{{ s.cpf_cnpj_socio or '-' }}</code></td>
+                    <td data-label="Qualificacao">{{ s.desc_qualificacao|clean_text or s.qualificacao or '-' }}</td>
+                    <td data-label="Entrada">{{ s.dt_entrada or '-' }}</td>
+                </tr>
+                {% if s.nome_representante %}
+                <tr class="empresa-rep-row">
+                    <td colspan="4" class="text-sm text-muted">
+                        Representante: <strong>{{ s.nome_representante|clean_text }}</strong>
+                        {% if s.cpf_representante %} &mdash; <code>{{ s.cpf_representante }}</code>{% endif %}
+                        {% if s.desc_qualif_representante %} &mdash; {{ s.desc_qualif_representante|clean_text }}{% endif %}
+                    </td>
+                </tr>
+                {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endif %}

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -48,7 +48,8 @@
                         data-fornecedor-cnpj="{{ f.cnpj_basico }}"
                         data-fornecedor-cpf-cnpj="{{ cnpj_completo_digits }}"
                         data-fornecedor-nome="{{ (f.razao_social or f.nome_credor)|clean_text }}"
-                        data-fornecedor-nome-credor="{{ f.nome_credor|clean_text }}">
+                        data-fornecedor-nome-credor="{{ f.nome_credor|clean_text }}"
+                        data-empresa-url="/empresa/{{ cnpj_completo_digits }}">
                     {% else %}
                     <tr class="row-detail-unavailable{{ row_extra }}" aria-disabled="true">
                     {% endif %}

--- a/web/templates/results/empresa.html
+++ b/web/templates/results/empresa.html
@@ -1,0 +1,114 @@
+{% extends "base.html" %}
+{% block title %}{{ razao_social|clean_text }} (CNPJ {{ cnpj_fmt }}){% endblock %}
+{% block meta_description %}{{ meta_description }}{% endblock %}
+{% block og_title %}{{ razao_social|clean_text }} - CNPJ {{ cnpj_fmt }} | TransparenciaPB{% endblock %}
+{% block og_description %}{{ meta_description }}{% endblock %}
+{% block og_type %}article{% endblock %}
+{% block json_ld_extra %}
+{% set origin = request_origin(request) if request else '' %}
+{% set page_url = origin + '/empresa/' + cnpj %}
+{% set logr = estabelecimento.logradouro or (matriz.logradouro if matriz else None) %}
+{% set num = estabelecimento.numero or (matriz.numero if matriz else None) %}
+{% set bai = estabelecimento.bairro or (matriz.bairro if matriz else None) %}
+{% set cep = estabelecimento.cep or (matriz.cep if matriz else None) %}
+{% set mun = estabelecimento.municipio or (matriz.municipio if matriz else None) %}
+{% set uf = estabelecimento.uf or (matriz.uf if matriz else None) %}
+{% set street_parts = [] %}
+{% if estabelecimento.tipo_logradouro %}{% set street_parts = street_parts + [estabelecimento.tipo_logradouro] %}{% endif %}
+{% if logr %}{% set street_parts = street_parts + [logr] %}{% endif %}
+{% set street_address = (street_parts | join(' ')) %}{% if num %}{% set street_address = street_address + ', ' + (num|string) %}{% endif %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": {{ (page_url ~ '#organization') | tojson }},
+      "name": {{ razao_social | clean_text | tojson }},
+      "url": {{ page_url | tojson }},
+      "identifier": [
+        {
+          "@type": "PropertyValue",
+          "propertyID": "CNPJ",
+          "value": {{ cnpj | tojson }}
+        }
+      ],
+      {% if estabelecimento.nome_fantasia %}"alternateName": {{ estabelecimento.nome_fantasia | clean_text | tojson }},{% endif %}
+      {% if estabelecimento.dt_inicio_atividade %}"foundingDate": {{ estabelecimento.dt_inicio_atividade | tojson }},{% endif %}
+      "address": {
+        "@type": "PostalAddress",
+        {%- set street_with_neighborhood = (street_address ~ (' - ' ~ bai if bai else '')) | trim if street_address or bai else '' %}
+        {% if street_with_neighborhood %}"streetAddress": {{ street_with_neighborhood | clean_text | tojson }},{% endif %}
+        {% if mun %}"addressLocality": {{ mun | clean_text | tojson }},{% endif %}
+        {% if uf %}"addressRegion": {{ uf | tojson }},{% endif %}
+        {% if cep %}"postalCode": {{ cep | tojson }},{% endif %}
+        "addressCountry": "BR"
+      },
+      "sameAs": [
+        {{ ("https://cnpj.biz/" ~ cnpj) | tojson }},
+        {{ ("https://www.gov.br/receitafederal/pt-br/servicos/cadastro/cnpj/consultar-situacao-cadastral") | tojson }}
+      ]
+    },
+    {
+      "@type": "Dataset",
+      "name": {{ ("Perfil publico de " ~ razao_social ~ " (CNPJ " ~ cnpj_fmt ~ ")") | clean_text | tojson }},
+      "description": {{ meta_description | tojson }},
+      "url": {{ page_url | tojson }},
+      "isAccessibleForFree": true,
+      "inLanguage": "pt-BR",
+      "creator": {
+        "@type": "Organization",
+        "@id": "{{ origin }}/#organization",
+        "name": "TransparenciaPB",
+        "url": "{{ origin }}/"
+      },
+      "license": "https://creativecommons.org/licenses/by/4.0/",
+      "keywords": [
+        "CNPJ",
+        "transparencia publica",
+        "Paraiba",
+        "fornecedor publico",
+        "CEIS", "CNEP", "PGFN"
+      ],
+      "spatialCoverage": {
+        "@type": "Place",
+        "name": "Paraiba, Brasil"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": "Empresas", "item": "{{ origin }}/sobre"},
+        {"@type": "ListItem", "position": 3, "name": {{ razao_social | clean_text | tojson }}, "item": {{ page_url | tojson }} }
+      ]
+    }
+  ]
+}
+</script>
+{% endblock %}
+{% block content %}
+<article class="empresa-page">
+    {% include "partials/empresa/_hero.html" %}
+    {% include "partials/empresa/_resumo_pagamentos.html" %}
+    {% include "partials/empresa/_flags.html" %}
+    {% include "partials/empresa/_sancoes.html" %}
+    {% include "partials/empresa/_pgfn.html" %}
+    {% include "partials/empresa/_leniencia.html" %}
+    {% include "partials/empresa/_municipios_pagantes.html" %}
+    {% include "partials/empresa/_socios.html" %}
+
+    <section class="empresa-section empresa-fontes">
+        <h2>Fontes oficiais</h2>
+        <p class="text-sm text-muted">
+            Este perfil cruza dados publicos da Receita Federal (CNPJ), CGU (CEIS, CNEP, Acordos de Leniencia),
+            PGFN (divida ativa), TCE-PB (despesas municipais) e dados.pb.gov.br (orcamento estadual).
+            Todos os dados sao oficiais e publicos. Indicamos sinais de atencao &mdash; nao conclusoes juridicas.
+        </p>
+        <p class="text-sm">
+            <a href="/sobre">Metodologia e fontes</a> &middot;
+            <a href="/contato">Reportar correcao</a>
+        </p>
+    </section>
+</article>
+{% endblock %}

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -768,20 +768,34 @@ def main():
 
     # ── Empresa warmer (modo separado, nao usa lista de municipios) ──
     if args.empresas:
-        boot = psycopg2.connect(DSN)
-        boot.autocommit = True
+        # Pool de conexoes do web/db.py precisa ser inicializado explicitamente:
+        # compute_empresa_perfil_dict() usa execute_query/get_conn que dependem
+        # do pool. Em runtime normal, web/main.py:lifespan inicializa. No
+        # warmer (CLI standalone) nao tem lifespan, fariamos
+        # RuntimeError("Connection pool not initialized") em cada empresa.
+        from web import db as web_db
+
+        web_db.init_pool()
         try:
-            cnpjs = _get_qualifying_empresas(boot)
+            boot = psycopg2.connect(DSN)
+            boot.autocommit = True
+            try:
+                cnpjs = _get_qualifying_empresas(boot)
+            finally:
+                boot.close()
+            if not cnpjs:
+                print(
+                    "Nenhuma empresa qualificada encontrada (filtro: total>=10k OR "
+                    "CEIS vigente OR PGFN>0). Talvez mv_empresa_pb nao foi refreshed.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            ok, fail = warm_cycle_empresas(cnpjs)
         finally:
-            boot.close()
-        if not cnpjs:
-            print(
-                "Nenhuma empresa qualificada encontrada (filtro: total>=10k OR "
-                "CEIS vigente OR PGFN>0). Talvez mv_empresa_pb nao foi refreshed.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        ok, fail = warm_cycle_empresas(cnpjs)
+            try:
+                web_db.close_pool()
+            except Exception:
+                pass
         total = ok + fail
         fail_pct = (fail / total * 100) if total > 0 else 0.0
         print(

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -29,6 +29,7 @@ from web.queries.cidade import (
     TOP_SERVIDORES_RISCO,
     TOP_SERVIDORES_RISCO_DATED,
 )
+from web.queries.empresa import EMPRESAS_QUALIFICADAS_PARA_SITEMAP
 from web.kpis.cidade import compute_cidade_kpis
 from web.queries.registry import CIDADE_QUERIES
 
@@ -595,6 +596,156 @@ def warm_cycle_pb(municipios: list[str], verbose: bool = True):
     return ano_ok + m12_ok + all_ok, ano_fail + m12_fail + all_fail
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# Empresa warmer — pre-computa o dict completo de cada /empresa/<cnpj>.
+# Necessario porque a rota e CACHE-ONLY (cache miss = 503) pra evitar
+# thundering herd quando crawlers acessam 45K URLs.
+#
+# Storage no web_cache:
+#   query_id = "EMPRESA_PERFIL"
+#   municipio = cnpj_completo (14 digitos numericos)
+#   columns = ["payload"]
+#   rows = [[<dict_serializado_como_json>]]
+#
+# Read pela rota:
+#   read_web_cache("EMPRESA_PERFIL", cnpj) -> rows[0][0] = dict
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _get_qualifying_empresas(conn) -> list[str]:
+    """Lista cnpj_completo (14 digits) das empresas qualificadas.
+
+    Usa EMPRESAS_QUALIFICADAS_PARA_SITEMAP de web.queries.empresa que ja
+    aplica filtro (total_pb_geral >= 10k OR ceis_vigente OR pgfn > 0) e
+    LIMIT 45000.
+    """
+    with conn.cursor() as cur:
+        cur.execute(EMPRESAS_QUALIFICADAS_PARA_SITEMAP)
+        rows = cur.fetchall()
+    out = []
+    seen = set()
+    for _razao, cnpj_completo in rows:
+        if not cnpj_completo:
+            continue
+        cnpj_str = str(cnpj_completo).strip()
+        if len(cnpj_str) != 14 or not cnpj_str.isdigit():
+            continue
+        if cnpj_str in seen:
+            continue
+        seen.add(cnpj_str)
+        out.append(cnpj_str)
+    return out
+
+
+def _warm_one_empresa(cnpj_completo: str) -> tuple[bool, str | None]:
+    """Computa o perfil de uma empresa e armazena em web_cache.
+
+    Retorna (ok, mensagem_de_erro_ou_None). Cada chamada abre conexao
+    propria (thread-safe via _thread_conn).
+    """
+    # Import diferido pra evitar ciclo na inicializacao do modulo
+    # (web.routes.empresa importa web.db que importa etl.config).
+    from web.routes.empresa import (
+        CACHE_QUERY_ID as EMPRESA_CACHE_QID,
+        EmpresaNotFoundError,
+        compute_empresa_perfil_dict,
+    )
+
+    try:
+        data = compute_empresa_perfil_dict(cnpj_completo)
+    except EmpresaNotFoundError as e:
+        # Empresa sem dados PB — nao deve estar no sitemap qualificado,
+        # mas pode acontecer se mv_empresa_pb e estabelecimento divergem.
+        # Skip silencioso (nao caching, nao erro fatal).
+        return False, f"not_found:{e}"
+    except Exception as e:
+        return False, f"compute_failed:{str(e).splitlines()[0]}"
+
+    # Serializa o dict como JSON. _upsert ja faz json.dumps em rows mas
+    # nosso "payload" eh um dict aninhado — passamos como string JSON pra
+    # evitar duplo-encode (dict -> jsonb conversion implicita).
+    payload_json = json.dumps(data, default=str, ensure_ascii=False)
+    try:
+        conn = _thread_conn()
+        with conn.cursor() as cur:
+            _upsert(
+                cur,
+                EMPRESA_CACHE_QID,
+                cnpj_completo,
+                ["payload"],
+                [[payload_json]],
+            )
+        conn.commit()
+    except Exception as e:
+        try:
+            _thread_conn().rollback()
+        except Exception:
+            pass
+        return False, f"cache_write_failed:{str(e).splitlines()[0]}"
+    return True, None
+
+
+def warm_cycle_empresas(cnpjs: list[str], verbose: bool = True) -> tuple[int, int]:
+    """Processa empresas em paralelo. Cada falha eh logada mas nao aborta.
+
+    Args:
+        cnpjs: lista de 14-digit CNPJ completo.
+        verbose: log progresso a cada 100 processadas.
+
+    Returns: (ok_count, fail_count)
+    """
+    bootstrap = psycopg2.connect(DSN)
+    bootstrap.autocommit = False
+    _ensure_cache_table(bootstrap)
+    bootstrap.close()
+
+    total = len(cnpjs)
+    if total == 0:
+        return 0, 0
+    print(
+        f"[empresas] Warming {total} empresas em {PARALLEL_WORKERS} workers...",
+        flush=True,
+    )
+
+    ok = 0
+    fail = 0
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as ex:
+        futures = {ex.submit(_warm_one_empresa, c): c for c in cnpjs}
+        done = 0
+        for fut in as_completed(futures):
+            done += 1
+            cnpj = futures[fut]
+            try:
+                success, msg = fut.result()
+            except Exception as e:
+                success = False
+                msg = f"future_exception:{e}"
+            if success:
+                ok += 1
+            else:
+                fail += 1
+                if verbose and msg and not msg.startswith("not_found:"):
+                    print(f"  [ERR] {cnpj}: {msg}", flush=True)
+            if verbose and done % 200 == 0:
+                elapsed = time.time() - t0
+                rate = done / elapsed if elapsed > 0 else 0
+                eta = (total - done) / rate if rate > 0 else 0
+                print(
+                    f"[empresas] {done}/{total} "
+                    f"({ok} ok, {fail} fail) — "
+                    f"{rate:.1f}/s, eta {eta/60:.1f}min",
+                    flush=True,
+                )
+    elapsed = time.time() - t0
+    print(
+        f"[empresas] Completo: {ok} ok, {fail} fail "
+        f"({elapsed/60:.1f}min)",
+        flush=True,
+    )
+    return ok, fail
+
+
 
 
 
@@ -604,8 +755,50 @@ def main():
     parser.add_argument("--daemon", action="store_true", help="Processa todos os municipios (use com --loop para repetir)")
     parser.add_argument("--loop", action="store_true", help="Recomeça automaticamente ao terminar a lista")
     parser.add_argument("--pb", action="store_true", help="(compat) Processar PB - default")
+    parser.add_argument(
+        "--empresas",
+        action="store_true",
+        help=(
+            "Processa SOMENTE empresas (web_cache key=EMPRESA_PERFIL:<cnpj>). "
+            "Pre-requisito pra ativar SITEMAP_INCLUDE_EMPRESAS=1 no nginx. "
+            "Demora ~30-90min pra 45K empresas em B4."
+        ),
+    )
     args = parser.parse_args()
 
+    # ── Empresa warmer (modo separado, nao usa lista de municipios) ──
+    if args.empresas:
+        boot = psycopg2.connect(DSN)
+        boot.autocommit = True
+        try:
+            cnpjs = _get_qualifying_empresas(boot)
+        finally:
+            boot.close()
+        if not cnpjs:
+            print(
+                "Nenhuma empresa qualificada encontrada (filtro: total>=10k OR "
+                "CEIS vigente OR PGFN>0). Talvez mv_empresa_pb nao foi refreshed.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        ok, fail = warm_cycle_empresas(cnpjs)
+        total = ok + fail
+        fail_pct = (fail / total * 100) if total > 0 else 0.0
+        print(
+            f"[empresas] Resultado: {ok} ok, {fail} fail ({fail_pct:.1f}%)"
+        )
+        # Threshold mais permissivo (10%) que cidades (5%) porque empresa
+        # tem maior variancia: CNPJs com cadastro RFB ausente sao "skip
+        # esperado", contam como fail mas nao sao bug.
+        if fail_pct > 10.0:
+            print(
+                f"ERRO: taxa de falha {fail_pct:.1f}% > 10% — exit 1",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return
+
+    # ── Modo cidade (default, comportamento legado) ──
     conn = psycopg2.connect(DSN)
     conn.autocommit = True
 

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -661,10 +661,16 @@ def _warm_one_empresa(cnpj_completo: str) -> tuple[bool, str | None]:
     except Exception as e:
         return False, f"compute_failed:{str(e).splitlines()[0]}"
 
-    # Serializa o dict como JSON. _upsert ja faz json.dumps em rows mas
-    # nosso "payload" eh um dict aninhado — passamos como string JSON pra
-    # evitar duplo-encode (dict -> jsonb conversion implicita).
-    payload_json = json.dumps(data, default=str, ensure_ascii=False)
+    # Passamos o dict CRU pra _upsert. Ele faz UM `json.dumps(rows, default=str)`
+    # que serializa os valores aninhados (dict, list, datetime) em JSONB
+    # corretamente. Ao ler com read_web_cache, psycopg2 desserializa o JSONB
+    # de volta pra Python — `rows[0][0]` retorna o dict.
+    #
+    # NAO fazer json.dumps aqui antes de _upsert: dupla-serializacao gera
+    # string JSON aninhada (o que JSONB armazena seria '[["{...}"]]', com
+    # o objeto como string, nao dict). Resultado: toda leitura volta str em
+    # vez de dict, isinstance(data, dict) falha, rota cai pra 503 mesmo com
+    # cache "popular". Bug pego pelo Opus 4.7 review do PR #58 (P0).
     try:
         conn = _thread_conn()
         with conn.cursor() as cur:
@@ -673,7 +679,7 @@ def _warm_one_empresa(cnpj_completo: str) -> tuple[bool, str | None]:
                 EMPRESA_CACHE_QID,
                 cnpj_completo,
                 ["payload"],
-                [[payload_json]],
+                [[data]],
             )
         conn.commit()
     except Exception as e:


### PR DESCRIPTION
# feat(seo): empresa pages cache-only + warmer + sitemap gated

Re-introduz paginas `/empresa/<cnpj>` revertidas pelo PR #57 incident, agora com arquitetura **safe-by-default** que evita o thundering herd que derrubou o site.

## Contexto: o incident

PR #57 mergeu `/empresa/<cnpj>` + auto-incluiu **45.228 empresas** no sitemap. IndexNow notificou Bing/Yandex/Yahoo simultaneamente. Bing comecou crawl agressivo:
- Cada `/empresa/<cnpj>` executa 8 queries DB
- Pool de DB exauriu em segundos
- Todas as outras requests (`/`, `/cidade/...`) foram pra fila
- Site inteiro caiu

Logs mostraram floods de `psycopg2.errors.QueryCanceled: canceling statement due to statement timeout`.

PR #57 foi revertido em `dbd7508`.

## Arquitetura nova: safe-by-default

### 1. Rota CACHE-ONLY

`web/routes/empresa.py`:
- Le `web_cache(EMPRESA_PERFIL, cnpj)`. Cache hit -> renderiza.
- Cache miss -> **503 com Retry-After 1h**. NUNCA executa queries inline.
- Funcao `compute_empresa_perfil_dict(cnpj)` extraida — chamada APENAS pelo warmer.

Sob qualquer trafego de crawler, o pool DB esta protegido. Se nao ha cache, crawler recebe 503 (cheap, no DB) e back off.

### 2. Sitemap GATED

`web/routes/seo.py`:
- Empresas so entram no sitemap quando `SITEMAP_INCLUDE_EMPRESAS=1` no env.
- Padrao OFF.
- Deploy 1 (este PR): codigo merged, sitemap nao expoe URLs. Crawlers nao chegam em `/empresa`.
- Deploy 2 (apos warm): flag ON, sitemap exposto, IndexNow re-dispara.

### 3. Warmer dedicado

`web/warm_cache.py`:
```
python -m web.warm_cache --empresas
```
- `_get_qualifying_empresas()` usa `EMPRESAS_QUALIFICADAS_PARA_SITEMAP` (mesma query do sitemap).
- ThreadPoolExecutor com `PARALLEL_WORKERS` (default 4).
- ~30-90min pra 45K empresas em B4.
- Threshold de falha 10% (vs 5% das cidades) — empresa tem mais "not_found" esperado (CNPJs sem cadastro RFB completo).

### 4. Workflow standalone

`.github/workflows/warm-empresas.yml`:
- `workflow_dispatch` separado, share `concurrency: deploy-vm-govbr`.
- Preflight: subir B4 (4 vCPU) pra paralelismo eficiente.
- Postflight: downsize automatico pra B2 ($108/mes -> $30/mes).

## Rollout (3 passos)

| Passo | Acao | Estado do site | Estado /empresa |
|---|---|---|---|
| 1 | Merge + deploy `etl_phase=web` | UP | 503 (cache vazio, sitemap nao expoe) |
| 2 | Trigger `warm-empresas.yml` (~60min) | UP (warmer e isolado) | Cache crescendo |
| 3 | Setar `SITEMAP_INCLUDE_EMPRESAS=1` no `.env` + redeploy | UP | 200 (cache hit) |

Apos passo 3, IndexNow re-dispara automatico via deploy.yml e crawler comeca trafego — mas agora em URLs com cache quente, hits sub-ms.

## Validacao

**Apos passo 1 (deploy do PR):**
```bash
curl -i https://transparenciapb.org/empresa/12345678000190
# HTTP 503, Retry-After: 3600

curl -s https://transparenciapb.org/sitemap.xml | grep -c "/empresa/"
# 0
```

**Apos passo 2 (warmer):**
```sql
SELECT COUNT(*) FROM web_cache WHERE query_id = 'EMPRESA_PERFIL';
-- ~45000
```

**Apos passo 3 (flag ON):**
```bash
curl -s https://transparenciapb.org/empresa/<cnpj-conhecido> | head -20
# HTML com Organization JSON-LD

curl -s https://transparenciapb.org/sitemap.xml | grep -c "/empresa/"
# ~45000
```

## Risco

**Deploy passo 1 (este PR)**: BAIXO. Codigo cache-only nao toca DB sob crawler. Sitemap continua sem empresas. Site deveria ficar identico ao estado atual (pos-revert).

**Passo 2 (warmer)**: BAIXO. Worker isolado, paralelismo controlado, falhas individuais nao abortam. Threshold 10% tolera CNPJs com cadastro RFB ausente.

**Passo 3 (flag ON)**: MEDIO. Bing/Yandex vao crawlar todas as URLs. Mas:
- Cada hit eh single-row jsonb lookup em web_cache (~1ms)
- IndexNow tem `time.sleep(0.5)` entre batches (do PR #56 fix)
- Se algo der errado, ROLLBACK = `SITEMAP_INCLUDE_EMPRESAS=0` + reload nginx (5 segundos)

## Reviewers

Quero 2 reviewers: 1 GPT 5.5 + 1 Opus 4.7. Foco em:
- Cache-only invariant da rota (NUNCA executa queries inline em prod)
- Warmer thread-safety (`_thread_conn` reuso correto)
- Gate do sitemap (env var lookup correto, default OFF)
- Threshold de falha 10% — razoavel pra empresa? Considerar 15%?

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
