### PR TITLE
feat(seo): sitemap-index + remove cap de 45K + remove filtros

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1102,7 +1102,7 @@ jobs:
           source .env 2>/dev/null || true
           set +a
           if [ -n "${INDEXNOW_KEY:-}" ]; then
-            echo "=== IndexNow re-submit (sitemap com $EMPRESA_URLS URLs novas) ==="
+            echo "=== IndexNow re-submit (sitemap com $INDEX_HAS_EMPRESA shards × ${SHARD1_URLS}+ URLs/shard) ==="
             SITEMAP_INCLUDE_EMPRESAS=1 python -m web.indexnow_submit 2>&1 || \
               echo "::warning::IndexNow submit falhou — Bing vai descobrir via crawl normal"
           else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -962,18 +962,19 @@ jobs:
           source .env 2>/dev/null || true
           PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
 
-          # 1. Coverage check: cache cobre >= 80% das empresas qualificadas
-          # (mesma definicao de EMPRESAS_QUALIFICADAS_PARA_SITEMAP).
-          # Sem isso, o "sanity check" de 100 rows aprovaria expor 45K
-          # URLs no sitemap com 99.8% retornando 503 — Google penaliza
+          # 1. Coverage check: cache cobre >= 80% das empresas qualificadas.
+          # SEM filtros (todos cnpj_basico em mv_empresa_pb que tem matriz
+          # cadastrada em estabelecimento). Match com EMPRESAS_QUALIFICADAS_COUNT.
+          # Sem isso, o "sanity check" de 100 rows aprovaria expor 143K
+          # URLs no sitemap com 99.9% retornando 503 — Google penaliza
           # mass-503 com deindex e cuts de crawl rate. (P1 reviewers
           # GPT-5.5 + Opus-4.7 do PR #59.)
           QUALIFYING=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
-            SELECT LEAST(45000, COUNT(*))
-            FROM mv_empresa_pb
-            WHERE total_pb_geral >= 10000
-               OR flag_ceis_vigente
-               OR total_divida_pgfn > 0
+            SELECT COUNT(*)
+            FROM mv_empresa_pb epb
+            JOIN estabelecimento est
+              ON est.cnpj_basico = epb.cnpj_basico
+             AND est.cnpj_ordem = '0001'
           ")
           CACHED=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c \
             "SELECT COUNT(*) FROM web_cache WHERE query_id = 'EMPRESA_PERFIL';")
@@ -1024,15 +1025,28 @@ jobs:
             sleep 2
           done
 
-          # 4. Verifica sitemap.xml inclui /empresa/ (rebuild via 1a request)
-          EMPRESA_URLS=$(curl -s --max-time 60 \
+          # 4. Verifica sitemap-index inclui shards de empresa (1+).
+          # Index aponta pra /sitemap-empresas-{n}.xml. Pelo menos 1 shard
+          # = pelo menos 1 empresa exposta. Sub-sitemaps cacheados
+          # individualmente; smoke test (5) vai validar URLs reais.
+          INDEX_HAS_EMPRESA=$(curl -s --max-time 60 \
             -H "Host: transparenciapb.org" \
-            http://127.0.0.1:8000/sitemap.xml | grep -c '/empresa/' || true)
-          echo "sitemap.xml expoe $EMPRESA_URLS URLs /empresa/"
-          # Threshold permissivo aqui — sitemap reflete mv_empresa_pb diretamente,
-          # nao o cache. Coverage check em (1) ja garante que estes URLs vao 200.
-          if [ "$EMPRESA_URLS" -lt 100 ]; then
-            echo "::error::Sitemap so retornou $EMPRESA_URLS empresas (esperado >100). Drop-in pode nao ter sido picked up pelo cruza-web. Rollback automatico."
+            http://127.0.0.1:8000/sitemap.xml | grep -c '/sitemap-empresas-' || true)
+          echo "sitemap.xml-index lista $INDEX_HAS_EMPRESA shards de empresa"
+          if [ "$INDEX_HAS_EMPRESA" -lt 1 ]; then
+            echo "::error::sitemap-index nao lista nenhum shard de empresa. Drop-in pode nao ter sido picked up. Rollback automatico."
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web
+            exit 1
+          fi
+          # Verifica que pelo menos shard 1 retorna URLs.
+          SHARD1_URLS=$(curl -s --max-time 60 \
+            -H "Host: transparenciapb.org" \
+            http://127.0.0.1:8000/sitemap-empresas-1.xml | grep -c '/empresa/' || true)
+          echo "sitemap-empresas-1.xml expoe $SHARD1_URLS URLs /empresa/"
+          if [ "$SHARD1_URLS" -lt 100 ]; then
+            echo "::error::Shard 1 so retornou $SHARD1_URLS empresas (esperado >100). Rollback automatico."
             sudo rm -f "$DROPIN"
             sudo systemctl daemon-reload
             sudo systemctl restart cruza-web
@@ -1044,15 +1058,13 @@ jobs:
           # cache" que o cache-only retornaria 503. Tolera 1/10 fail
           # (corresponde ao not_found rate esperado em mv_empresa_pb vs
           # estabelecimento divergente). (P1 reviewers PR #59.)
+          # Query identica a EMPRESAS_QUALIFICADAS_PARA_SITEMAP (sem filtros).
           CNPJS=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
             SELECT est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv
             FROM mv_empresa_pb epb
             JOIN estabelecimento est
               ON est.cnpj_basico = epb.cnpj_basico
              AND est.cnpj_ordem = '0001'
-            WHERE epb.total_pb_geral >= 10000
-               OR epb.flag_ceis_vigente
-               OR epb.total_divida_pgfn > 0
             ORDER BY random() LIMIT 10;
           ")
           FAIL=0

--- a/web/indexnow_submit.py
+++ b/web/indexnow_submit.py
@@ -132,15 +132,28 @@ def main() -> int:
         return 2
     host = parsed.netloc
 
-    # Gera sitemap localmente (mesma logica do endpoint /sitemap.xml).
-    # Importamos aqui pra evitar custo de DB se fizermos --dry-run sem env.
-    # _build_sitemap_xml chama _municipios_pb() que usa web.db.get_conn();
-    # como esse script e standalone (nao roda dentro do FastAPI app), o pool
-    # nao foi inicializado pelo lifespan handler — fazemos manual aqui.
+    # Gera sitemap localmente — agora usa sitemap-INDEX pattern (ver
+    # web/routes/seo.py refactor pra suportar 100K+ URLs sem hit no
+    # limite de 50K do protocolo sitemap.org). Iteramos sub-sitemaps:
+    #   1. /sitemap-cidades.xml  (static + cidades, ~228 URLs)
+    #   2. /sitemap-empresas-{n}.xml  (N shards de ate 49K cada, so se
+    #                                  SITEMAP_INCLUDE_EMPRESAS=1)
+    # Junta URLs de todos os sub-sitemaps e submete em batches de 500.
+    #
+    # NAO chamamos _build_sitemap_index — esse retorna apenas links pros
+    # sub-sitemaps, nao URLs finais. IndexNow espera URLs de paginas reais.
     from web import db as web_db
-    from web.routes.seo import _build_sitemap_xml
+    from web.routes.seo import (
+        EMPRESA_SHARD_SIZE,
+        _build_cidades_sitemap,
+        _build_empresas_shard_sitemap,
+        _empresas_qualificadas_count,
+    )
+    import math as _math
 
     pool_inited = False
+    urls: list[str] = []
+    flag_empresas = os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1"
     try:
         try:
             web_db.init_pool()
@@ -149,14 +162,47 @@ def main() -> int:
             log.exception(
                 "Falha ao inicializar pool DB; sitemap vai usar so URLs estaticas"
             )
-        xml = _build_sitemap_xml(site_url)
+
+        # Sub-sitemap das cidades (sempre presente)
+        try:
+            cidades_xml = _build_cidades_sitemap(site_url)
+            cidades_urls = _extract_urls_from_sitemap(cidades_xml)
+            urls.extend(cidades_urls)
+            log.info("sitemap-cidades: %d URLs", len(cidades_urls))
+        except Exception:
+            log.exception("Falha ao gerar sitemap-cidades")
+
+        # Sub-sitemaps de empresas (so quando flag=1 — drop-in systemd
+        # passou pelo subprocess via export SITEMAP_INCLUDE_EMPRESAS=1).
+        if flag_empresas:
+            try:
+                total = _empresas_qualificadas_count()
+                num_shards = _math.ceil(total / EMPRESA_SHARD_SIZE) if total > 0 else 0
+                log.info(
+                    "empresas qualificadas=%d, shards=%d (size=%d)",
+                    total, num_shards, EMPRESA_SHARD_SIZE,
+                )
+                for n in range(1, num_shards + 1):
+                    try:
+                        shard_xml = _build_empresas_shard_sitemap(site_url, n)
+                        shard_urls = _extract_urls_from_sitemap(shard_xml)
+                        urls.extend(shard_urls)
+                        log.info("sitemap-empresas-%d: %d URLs", n, len(shard_urls))
+                    except Exception:
+                        log.exception("Falha ao gerar sitemap-empresas shard %d", n)
+            except Exception:
+                log.exception("Falha ao contar empresas pro sitemap")
+        else:
+            log.info(
+                "SITEMAP_INCLUDE_EMPRESAS != '1' — submetendo so cidades+estaticas"
+            )
     finally:
         if pool_inited:
             try:
                 web_db.close_pool()
             except Exception:
                 log.exception("Falha ao fechar pool DB (ignorado)")
-    urls = _extract_urls_from_sitemap(xml)
+
     if args.limit:
         urls = urls[: args.limit]
 

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -212,15 +212,22 @@ EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO = """
 """
 
 # ─────────────────────────────────────────────────────────────────────────
-# Sitemap: empresas qualificadas (heuristica de filtro pra evitar ruido).
-# Inclui CNPJs com pagamentos PB relevantes (>= R$ 10k), em CEIS vigente
-# ou com divida PGFN > 0. Retorna (razao_social, cnpj_completo) onde
-# cnpj_completo = basico+ordem(0001)+dv da matriz.
+# Sitemap: TODAS as empresas em mv_empresa_pb que tem matriz cadastrada
+# em estabelecimento (cnpj_ordem='0001'). Sem filtro de threshold de
+# valor/sancao/divida — qualquer empresa que apareceu em fonte PB merece
+# pagina indexavel.
 #
-# LIMIT 45000: protocolo sitemap.org permite ate 50.000 URLs por arquivo.
-# Cidades (~223) + estaticas (5) + 45k empresas = ~45.2k, com folga ate
-# o limite. Quando passarmos disso, implementar sitemap index com chunks
-# (TODO: web/routes/seo.py — sitemap-empresas-1.xml etc).
+# JOIN com estabelecimento eh OBRIGATORIO pra gerar CNPJ completo
+# (basico+ordem+dv). Empresas em mv_empresa_pb sem matriz cadastrada na
+# RFB (~12K) nao podem ter pagina (compute_empresa_perfil_dict 404 nelas)
+# entao tambem ficam fora do sitemap. Skip esperado.
+#
+# SEM LIMIT — sitemap-index permite indexar tudo via paginacao
+# (web/routes/seo.py: /sitemap-empresas-{n}.xml com LIMIT 49000 OFFSET).
+#
+# Warmer (web/warm_cache.py:_get_qualifying_empresas) consume sem LIMIT
+# pra cachear todas, preservando ORDER BY estavel pra paginacao bater
+# entre warmer e routes.
 # ─────────────────────────────────────────────────────────────────────────
 
 EMPRESAS_QUALIFICADAS_PARA_SITEMAP = """
@@ -231,10 +238,33 @@ EMPRESAS_QUALIFICADAS_PARA_SITEMAP = """
     JOIN estabelecimento est
         ON est.cnpj_basico = epb.cnpj_basico
        AND est.cnpj_ordem = '0001'
-    WHERE epb.total_pb_geral >= 10000
-       OR epb.flag_ceis_vigente
-       OR epb.total_divida_pgfn > 0
     ORDER BY epb.total_pb_geral DESC NULLS LAST,
              epb.cnpj_basico
-    LIMIT 45000
+"""
+
+# Variante paginada usada pelos shards do sitemap. Aceita LIMIT/OFFSET via
+# params nomeados (psycopg2): %(limit)s / %(offset)s. Mesmo ORDER BY pra
+# garantir que warmer e shards do sitemap processem o mesmo conjunto
+# deterministicamente.
+EMPRESAS_QUALIFICADAS_PAGINATED = """
+    SELECT
+        COALESCE(NULLIF(epb.razao_social, ''), 'Empresa ' || epb.cnpj_basico) AS razao_social,
+        est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo
+    FROM mv_empresa_pb epb
+    JOIN estabelecimento est
+        ON est.cnpj_basico = epb.cnpj_basico
+       AND est.cnpj_ordem = '0001'
+    ORDER BY epb.total_pb_geral DESC NULLS LAST,
+             epb.cnpj_basico
+    LIMIT %(limit)s OFFSET %(offset)s
+"""
+
+# Conta total (usado por sitemap-index pra calcular num_shards e por
+# deploy.yml Enable step pra calcular coverage gate).
+EMPRESAS_QUALIFICADAS_COUNT = """
+    SELECT COUNT(*)
+    FROM mv_empresa_pb epb
+    JOIN estabelecimento est
+        ON est.cnpj_basico = epb.cnpj_basico
+       AND est.cnpj_ordem = '0001'
 """

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -417,15 +417,21 @@ async def sitemap_empresas_shard_xml(request: Request, shard_n: str) -> Response
     else:
         xml = _build_empresas_shard_sitemap(origin, n)
         urls_n = xml.count("/empresa/")
-        # Cacheia se shard tem URLs OU se eh shard que esperamos vazio
-        # (depois do ultimo). Heuristica: se shard1 retorna 0, eh erro
-        # de DB (recusa cache); shard2+ vazio eh esperado past-end.
-        if urls_n > 0 or n > 1:
+        # NUNCA cachear shard vazio. Cenario: MV cresce de 143K pra 200K
+        # entre 2 requests. Shard 4 (antes past-end, vazio) agora tem
+        # ~49K URLs reais. Se cacheamos vazio, Google lê 0 URLs por ate
+        # 1h apos crescimento — perde ~49K paginas indexaveis. Query past-
+        # end com OFFSET alto eh barata (LIMIT 49000 + index hit) entao
+        # rebuilda em ~ms. (P2 do Opus 4.7 review do PR #60.)
+        if urls_n > 0:
             _SITEMAP_CACHE["empresas"][n] = {"ts": now, "xml": xml}
-        else:
+        elif n == 1:
             _log.warning(
-                "Sitemap-empresas shard 1 vazio — nao cacheando (DB pode ter falhado)"
+                "Sitemap-empresas shard 1 vazio — nao cacheando "
+                "(DB pode ter falhado)"
             )
+        # else (n > 1, vazio): nao cacheia, mas serve urlset vazio agora.
+        # Proxima request rebuilda — se MV cresceu, vai retornar URLs.
     return Response(
         content=xml,
         media_type="application/xml",

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -1,7 +1,22 @@
-"""Rotas de SEO: /robots.txt e /sitemap.xml."""
+"""Rotas de SEO: /robots.txt, /sitemap.xml e shards.
+
+Sitemap-index pattern: /sitemap.xml e um INDEX que aponta pra
+sub-sitemaps (urlsets paginados). Suporta volume sem hit no limite
+de 50K URLs por arquivo do protocolo sitemap.org:
+
+    /sitemap.xml                    <- sitemapindex (lista de sub-sitemaps)
+      ├─ /sitemap-cidades.xml       <- urlset (static + cidades)
+      ├─ /sitemap-empresas-1.xml    <- urlset (empresas 1-49000)
+      ├─ /sitemap-empresas-2.xml    <- urlset (empresas 49001-98000)
+      └─ ...
+
+Empresas so listadas quando SITEMAP_INCLUDE_EMPRESAS=1 (drop-in systemd
+gerenciado pelo deploy.yml).
+"""
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import secrets
@@ -24,9 +39,18 @@ _log = logging.getLogger("transparencia.seo")
 _INDEXNOW_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_\-]{8,128}$")
 
 
-# Cache em memória pra sitemap (gera lista de municípios uma vez por hora).
-_SITEMAP_CACHE: dict[str, Any] = {"ts": 0.0, "xml": ""}
+# Cache em memoria pra cada urlset/index (1h TTL). Cada shard e cacheado
+# separadamente — restart do cruza-web limpa tudo, primeira request rebuilda.
 _SITEMAP_TTL = 3600  # 1h
+_SITEMAP_CACHE: dict[str, Any] = {
+    "index": {"ts": 0.0, "xml": ""},
+    "cidades": {"ts": 0.0, "xml": ""},
+    "empresas": {},  # {shard_n: {"ts": ..., "xml": ...}}
+}
+
+# Tamanho de cada shard de empresas. Limite do protocolo eh 50K URLs por
+# arquivo; 49K deixa folga pra evitar overflow se o filtro mudar.
+EMPRESA_SHARD_SIZE = 49000
 
 
 def _site_origin(request: Request) -> str:
@@ -94,10 +118,78 @@ def _municipios_pb() -> list[tuple[str, str]]:
         return []
 
 
+def _empresas_qualificadas_count() -> int:
+    """Total de empresas que vao pro sitemap (sem filtros, todas com matriz
+    cadastrada). Usado pra calcular num_shards no sitemap-index.
+
+    Cache em memoria (1h) via _SITEMAP_CACHE['empresas_count']. Restart
+    do cruza-web limpa.
+    """
+    cached = _SITEMAP_CACHE.get("empresas_count")
+    now = time.time()
+    if cached and (now - cached["ts"] < _SITEMAP_TTL):
+        return int(cached["value"])
+
+    from web.queries.empresa import EMPRESAS_QUALIFICADAS_COUNT
+
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(EMPRESAS_QUALIFICADAS_COUNT)
+                row = cur.fetchone()
+                count = int(row[0]) if row else 0
+        _SITEMAP_CACHE["empresas_count"] = {"ts": now, "value": count}
+        return count
+    except Exception:
+        _log.exception("Falha ao contar empresas pro sitemap")
+        return 0
+
+
+def _empresas_pb_paginated(shard_n: int, shard_size: int) -> list[tuple[str, str]]:
+    """Retorna empresas do shard N (1-indexed). LIMIT/OFFSET na query.
+
+    shard_size = EMPRESA_SHARD_SIZE. Pra shard 1, OFFSET=0; shard 2,
+    OFFSET=shard_size; etc. ORDER BY estavel garante que mesma posicao
+    no warmer e no sitemap referem mesma empresa.
+    """
+    from web.queries.empresa import EMPRESAS_QUALIFICADAS_PAGINATED
+
+    if shard_n < 1:
+        return []
+    offset = (shard_n - 1) * shard_size
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    EMPRESAS_QUALIFICADAS_PAGINATED,
+                    {"limit": shard_size, "offset": offset},
+                )
+                out: list[tuple[str, str]] = []
+                seen: set[str] = set()
+                for razao, cnpj_completo in cur.fetchall():
+                    if not cnpj_completo:
+                        continue
+                    cnpj_str = str(cnpj_completo).strip()
+                    if len(cnpj_str) != 14 or not cnpj_str.isdigit():
+                        continue
+                    if cnpj_str in seen:
+                        continue
+                    seen.add(cnpj_str)
+                    out.append((str(razao or ""), cnpj_str))
+                return out
+    except Exception:
+        _log.exception("Falha ao carregar shard %d de empresas", shard_n)
+        return []
+
+
 def _empresas_pb() -> list[tuple[str, str]]:
-    """Lista empresas qualificadas (heuristica em web.queries.empresa).
-    Retorna [(razao_social, cnpj_completo), ...]. Cnpj eh string de 14
-    digitos numericos puros (forma canonica usada pela rota /empresa/{cnpj}).
+    """LEGACY: lista TODAS empresas em uma chamada. Usado pelo warmer
+    (web/warm_cache.py:_get_qualifying_empresas) que ja eh single-shot.
+
+    NAO use no sitemap — use _empresas_pb_paginated com sharding.
+    Retorna [(razao_social, cnpj_completo), ...].
     """
     from web.queries.empresa import EMPRESAS_QUALIFICADAS_PARA_SITEMAP
 
@@ -138,16 +230,10 @@ def _lastmod_iso() -> str:
     return datetime.now(timezone(timedelta(hours=-3))).strftime("%Y-%m-%d")
 
 
-def _build_sitemap_xml(origin: str) -> str:
-    """Gera <urlset> com homepage + paginas estaticas + paginas /search/cidade
-    pra cada municipio PB. Usa <lastmod> = data de refresh dos dados pra
-    sinalizar a Google quando paginas precisam ser recrawladas."""
-    lastmod = _lastmod_iso()
+def _build_static_pages_xml(origin: str, lastmod: str) -> list[str]:
+    """Retorna list de <url> blocks pra paginas estaticas. Usado pelo
+    sitemap-cidades (que combina static + cidades em um arquivo)."""
     parts: list[str] = []
-    parts.append('<?xml version="1.0" encoding="UTF-8"?>')
-    parts.append('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
-
-    # Paginas estaticas com prioridades manuais
     static_pages = [
         ("/", "1.0", "daily"),
         ("/mapa", "0.9", "daily"),
@@ -162,9 +248,16 @@ def _build_sitemap_xml(origin: str) -> str:
         parts.append(f"    <changefreq>{freq}</changefreq>")
         parts.append(f"    <priority>{prio}</priority>")
         parts.append("  </url>")
+    return parts
 
-    # Pagina /cidade/<slug> pra cada municipio PB. URLs amigaveis: substituem
-    # /search/cidade?q=... no sitemap. /search permanece funcional via 301.
+
+def _build_cidades_sitemap(origin: str) -> str:
+    """urlset com paginas estaticas + /cidade/<slug>. Sub-sitemap referenciado
+    pelo /sitemap.xml index. Cacheado em _SITEMAP_CACHE['cidades']."""
+    lastmod = _lastmod_iso()
+    parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>',
+                        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+    parts.extend(_build_static_pages_xml(origin, lastmod))
     municipios = _municipios_pb()
     for _muni, slug in municipios:
         loc = f"{origin}/cidade/{slug}"
@@ -174,76 +267,164 @@ def _build_sitemap_xml(origin: str) -> str:
         parts.append("    <changefreq>weekly</changefreq>")
         parts.append("    <priority>0.7</priority>")
         parts.append("  </url>")
-
-    # Pagina /empresa/<cnpj> pra cada empresa qualificada (filtro em
-    # web.queries.empresa.EMPRESAS_QUALIFICADAS_PARA_SITEMAP). URL canonica
-    # usa 14 digitos numericos puros (sem mascara).
-    #
-    # GATED por env var: empresas SO entram no sitemap quando
-    # SITEMAP_INCLUDE_EMPRESAS=1. Padrao OFF porque, sem web_cache pre-
-    # populado pelas paginas /empresa/<cnpj>, expor 45K URLs ao IndexNow/
-    # Google causa thundering herd que derruba o site inteiro (incidente
-    # com PR #57). Workflow:
-    #   1. Deploy do codigo com flag OFF
-    #   2. python -m web.warm_cache --empresas (popula web_cache)
-    #   3. SITEMAP_INCLUDE_EMPRESAS=1 + reload (separar deploy)
-    #   4. IndexNow re-dispara automatico via deploy.yml
-    if os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1":
-        empresas = _empresas_pb()
-        for _razao, cnpj_completo in empresas:
-            loc = f"{origin}/empresa/{cnpj_completo}"
-            parts.append("  <url>")
-            parts.append(f"    <loc>{xml_escape(loc)}</loc>")
-            parts.append(f"    <lastmod>{lastmod}</lastmod>")
-            parts.append("    <changefreq>weekly</changefreq>")
-            parts.append("    <priority>0.5</priority>")
-            parts.append("  </url>")
-
     parts.append("</urlset>")
+    return "\n".join(parts)
+
+
+def _build_empresas_shard_sitemap(origin: str, shard_n: int) -> str:
+    """urlset com /empresa/<cnpj> pra empresas do shard N (1-indexed).
+    LIMIT EMPRESA_SHARD_SIZE OFFSET (n-1)*EMPRESA_SHARD_SIZE.
+    Cacheado em _SITEMAP_CACHE['empresas'][shard_n]."""
+    lastmod = _lastmod_iso()
+    parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>',
+                        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+    empresas = _empresas_pb_paginated(shard_n, EMPRESA_SHARD_SIZE)
+    for _razao, cnpj_completo in empresas:
+        loc = f"{origin}/empresa/{cnpj_completo}"
+        parts.append("  <url>")
+        parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
+        parts.append("    <changefreq>weekly</changefreq>")
+        parts.append("    <priority>0.5</priority>")
+        parts.append("  </url>")
+    parts.append("</urlset>")
+    return "\n".join(parts)
+
+
+def _build_sitemap_index(origin: str) -> str:
+    """sitemapindex que aponta pra /sitemap-cidades.xml + N
+    /sitemap-empresas-{n}.xml. Empresas so sao listadas se
+    SITEMAP_INCLUDE_EMPRESAS=1.
+
+    Numero de shards = ceil(qualifying_count / EMPRESA_SHARD_SIZE).
+    """
+    lastmod = _lastmod_iso()
+    parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>',
+                        '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+
+    # Sub-sitemap das cidades
+    parts.append("  <sitemap>")
+    parts.append(f"    <loc>{xml_escape(origin)}/sitemap-cidades.xml</loc>")
+    parts.append(f"    <lastmod>{lastmod}</lastmod>")
+    parts.append("  </sitemap>")
+
+    # Sub-sitemaps de empresas (so se flag ativada).
+    if os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1":
+        total = _empresas_qualificadas_count()
+        if total > 0:
+            num_shards = math.ceil(total / EMPRESA_SHARD_SIZE)
+            for n in range(1, num_shards + 1):
+                parts.append("  <sitemap>")
+                parts.append(f"    <loc>{xml_escape(origin)}/sitemap-empresas-{n}.xml</loc>")
+                parts.append(f"    <lastmod>{lastmod}</lastmod>")
+                parts.append("  </sitemap>")
+
+    parts.append("</sitemapindex>")
     return "\n".join(parts)
 
 
 @router.get("/sitemap.xml")
 async def sitemap_xml(request: Request) -> Response:
-    """Sitemap dinamico cached por 1h.
+    """Sitemap-INDEX raiz. Aponta pra sub-sitemaps que contem URLs.
 
-    Importante: NAO cacheamos sitemap parcial (sem URLs de cidade ou
-    empresa) — caso contrario, uma falha transitoria de DB no primeiro
-    hit pos-restart serviria por 1h um sitemap incompleto a Google/IndexNow.
-    Em build parcial, servimos o resultado mas mantemos cache invalido
-    para a proxima request tentar de novo.
+    Cache 1h em _SITEMAP_CACHE['index']. Restart limpa.
 
-    Heuristica de completude:
-    - Sitemap completo tem static (5) + cidades (~223) + empresas (>=1
-      QUANDO flag SITEMAP_INCLUDE_EMPRESAS=1).
-    - Threshold combina: precisa de >= 100 cidades. Empresas opcional
-      (so quando flag ativada).
-    - Se DB de empresas falhar mas cidades estao OK e flag OFF, cacheia.
-      Se flag ON e empresas vier vazio, recusa cache.
+    Heuristica de completude (anti-cache parcial):
+    - Cidades sub-sitemap sempre presente.
+    - Empresas shards (>= 1) so quando flag SITEMAP_INCLUDE_EMPRESAS=1
+      E mv_empresa_pb tem rows.
+    - Se flag ON mas empresas count = 0 (DB falhou ou MV vazia),
+      recusamos cache pra proxima request reativar.
     """
     origin = _site_origin(request)
     now = time.time()
-    if _SITEMAP_CACHE["xml"] and (now - _SITEMAP_CACHE["ts"] < _SITEMAP_TTL):
-        xml = _SITEMAP_CACHE["xml"]
+    cached = _SITEMAP_CACHE["index"]
+    if cached["xml"] and (now - cached["ts"] < _SITEMAP_TTL):
+        return Response(
+            content=cached["xml"],
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+
+    xml = _build_sitemap_index(origin)
+    flag_on = os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1"
+    has_empresa_shards = "/sitemap-empresas-" in xml
+    is_complete = (not flag_on) or has_empresa_shards
+    if is_complete:
+        _SITEMAP_CACHE["index"] = {"ts": now, "xml": xml}
     else:
-        xml = _build_sitemap_xml(origin)
+        _log.warning(
+            "Sitemap-index parcial (flag_empresas=%s mas sem shards) — "
+            "nao cacheando",
+            flag_on,
+        )
+    return Response(
+        content=xml,
+        media_type="application/xml",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@router.get("/sitemap-cidades.xml")
+async def sitemap_cidades_xml(request: Request) -> Response:
+    """Sub-sitemap: paginas estaticas + /cidade/<slug>. Cacheado 1h."""
+    origin = _site_origin(request)
+    now = time.time()
+    cached = _SITEMAP_CACHE["cidades"]
+    if cached["xml"] and (now - cached["ts"] < _SITEMAP_TTL):
+        xml = cached["xml"]
+    else:
+        xml = _build_cidades_sitemap(origin)
         cidades_n = xml.count("/cidade/")
-        empresas_n = xml.count("/empresa/")
-        flag_on = os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1"
-        # Se flag esta OFF, sitemap eh "completo" sem empresas (so cidades).
-        # Se flag esta ON, exige tambem empresas >= 1.
-        is_complete = cidades_n >= 100 and (not flag_on or empresas_n >= 1)
-        if is_complete:
-            _SITEMAP_CACHE["xml"] = xml
-            _SITEMAP_CACHE["ts"] = now
+        if cidades_n >= 100:
+            _SITEMAP_CACHE["cidades"] = {"ts": now, "xml": xml}
         else:
             _log.warning(
-                "Sitemap parcial gerado (cidades=%d, empresas=%d, "
-                "flag_empresas=%s) — nao cacheando, proxima request "
-                "tentara recarregar do DB",
+                "Sitemap-cidades parcial (cidades=%d) — nao cacheando",
                 cidades_n,
-                empresas_n,
-                flag_on,
+            )
+    return Response(
+        content=xml,
+        media_type="application/xml",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+# Pattern: /sitemap-empresas-{n}.xml onde n = inteiro 1..num_shards
+_EMPRESAS_SHARD_RE = re.compile(r"^[1-9]\d{0,3}$")
+
+
+@router.get("/sitemap-empresas-{shard_n}.xml")
+async def sitemap_empresas_shard_xml(request: Request, shard_n: str) -> Response:
+    """Sub-sitemap shard de empresas. shard_n eh 1-indexed.
+
+    Validacao defensiva: regex 1-9999. Shards inexistentes (alem do
+    numero de shards atual) retornam urlset vazio (200 valido) — Google
+    tolera, e evita 404 transitorio se sitemap-index aponta pra shard
+    que ainda nao foi cacheado.
+
+    Cache 1h por shard em _SITEMAP_CACHE['empresas'][n].
+    """
+    if not _EMPRESAS_SHARD_RE.match(shard_n):
+        raise HTTPException(status_code=404)
+    n = int(shard_n)
+
+    origin = _site_origin(request)
+    now = time.time()
+    shard_cache = _SITEMAP_CACHE["empresas"].get(n)
+    if shard_cache and shard_cache.get("xml") and (now - shard_cache["ts"] < _SITEMAP_TTL):
+        xml = shard_cache["xml"]
+    else:
+        xml = _build_empresas_shard_sitemap(origin, n)
+        urls_n = xml.count("/empresa/")
+        # Cacheia se shard tem URLs OU se eh shard que esperamos vazio
+        # (depois do ultimo). Heuristica: se shard1 retorna 0, eh erro
+        # de DB (recusa cache); shard2+ vazio eh esperado past-end.
+        if urls_n > 0 or n > 1:
+            _SITEMAP_CACHE["empresas"][n] = {"ts": now, "xml": xml}
+        else:
+            _log.warning(
+                "Sitemap-empresas shard 1 vazio — nao cacheando (DB pode ter falhado)"
             )
     return Response(
         content=xml,

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -615,9 +615,10 @@ def warm_cycle_pb(municipios: list[str], verbose: bool = True):
 def _get_qualifying_empresas(conn) -> list[str]:
     """Lista cnpj_completo (14 digits) das empresas qualificadas.
 
-    Usa EMPRESAS_QUALIFICADAS_PARA_SITEMAP de web.queries.empresa que ja
-    aplica filtro (total_pb_geral >= 10k OR ceis_vigente OR pgfn > 0) e
-    LIMIT 45000.
+    Usa EMPRESAS_QUALIFICADAS_PARA_SITEMAP de web.queries.empresa que retorna
+    TODAS as empresas em mv_empresa_pb com matriz cadastrada em
+    estabelecimento (cnpj_ordem='0001'). Sem LIMIT — warmer cacheia tudo
+    pra cobertura total do sitemap-index.
     """
     with conn.cursor() as cur:
         cur.execute(EMPRESAS_QUALIFICADAS_PARA_SITEMAP)


### PR DESCRIPTION
# feat(seo): sitemap-index + remove cap de 45K + remove filtros

User feedback: cap de 45K perdia ~55K páginas. Remover filtros e indexar TUDO.

## Números (mv_empresa_pb local — prod pode variar)

| Universo | Count |
|---|---|
| `mv_empresa_pb` total | 156.346 |
| Com matriz em `estabelecimento` (target sitemap) | **143.682** |
| Filtro antigo (≥R$10k OU sanção OU PGFN) | 99.988 (perdia 44K) |
| Cap antigo (LIMIT 45000) | 45.000 (perdia 99K!) |

## Mudanças

### 1. `web/queries/empresa.py`

**Antes:**
```sql
WHERE epb.total_pb_geral >= 10000 OR epb.flag_ceis_vigente OR epb.total_divida_pgfn > 0
LIMIT 45000
```

**Agora:**
```sql
-- Sem WHERE, sem LIMIT
FROM mv_empresa_pb epb JOIN estabelecimento est ON ... AND est.cnpj_ordem = '0001'
```

Adicionadas:
- `EMPRESAS_QUALIFICADAS_PAGINATED` — `LIMIT %(limit)s OFFSET %(offset)s` para shards
- `EMPRESAS_QUALIFICADAS_COUNT` — pra calcular `num_shards`

### 2. `web/routes/seo.py` — sitemap-index pattern

```
/sitemap.xml                       <- sitemapindex (lista de sub-sitemaps)
  ├─ /sitemap-cidades.xml          <- urlset (5 estáticas + 223 cidades)
  ├─ /sitemap-empresas-1.xml       <- urlset (49K empresas)
  ├─ /sitemap-empresas-2.xml       <- urlset (49K empresas)
  └─ /sitemap-empresas-3.xml       <- urlset (~45K empresas)
```

- `EMPRESA_SHARD_SIZE = 49000` (margem ate o limite de 50K do protocolo)
- Cada sub-sitemap cacheado independente (1h TTL)
- `num_shards = ceil(total / 49000)` — ~3 hoje, escala automatic

### 3. `web/indexnow_submit.py`

Itera sub-sitemaps em vez de gerar urlset monolítico:
- Build `_build_cidades_sitemap` + para cada N: `_build_empresas_shard_sitemap`
- Extrai URLs de cada
- Submete em batches de 500 com `time.sleep(0.5)` entre batches

### 4. `.github/workflows/deploy.yml`

- Coverage gate query atualizada (sem WHERE, sem LIMIT 45000)
- Sitemap verify: checa /sitemap.xml-index tem ≥1 shard, e /sitemap-empresas-1.xml tem ≥100 URLs
- Smoke test query atualizada

### 5. `web/warm_cache.py`

Sem mudança de comportamento — `_get_qualifying_empresas` já chamava `EMPRESAS_QUALIFICADAS_PARA_SITEMAP`, agora vem com universo expandido. Resume mode (WARM_SKIP_RECENT_HOURS) preserva trabalho do deploy anterior.

## Capacidade

| Métrica | Antes | Agora |
|---|---|---|
| URLs indexáveis | 45.000 | **2.5 bilhões** (50K shards × 50K URLs) |
| Hoje (143K empresas) | 1 sitemap parcial | 3 shards |
| Escala futura | Refactor | Automático (num_shards calculado) |

## Compatibilidade com deploy atual

Deploy em curso (`run 25619735608`) está com warmer rodando empresas (LIMIT 45K). Quando esse PR mergear:
- Cancelar deploy atual
- Re-disparar com mesmos params (`warm_cache=true`, `expose_empresa_sitemap=enable`)
- Resume mode (`WARM_SKIP_RECENT_HOURS=24`) preserva os ~45K já cacheados
- Novo warm continua processando os ~99K restantes

## Reviewers

Quero 2 reviewers (GPT 5.5 + Opus 4.7). Foco em:
- Sub-sitemap routes com cache parcial OK?
- `_empresas_pb_paginated` ordenação estável (mesmo `ORDER BY` do warmer)?
- `_build_empresas_shard_sitemap` idempotente entre shards?
- `indexnow_submit.py` itera shards corretamente quando flag ON?
- Coverage gate em deploy.yml usa nova query?
- Smoke test cobre URLs reais (sample do qualifying set, não do cache)?

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
