### PR TITLE
fix(seo): warmer timeout 120s pra mega-empresas (BB/Caixa/INSS)

### DIFF
--- a/web/config.py
+++ b/web/config.py
@@ -12,6 +12,14 @@ TIMEOUT_QUERY_LIGHT = 15
 TIMEOUT_QUERY_MEDIUM = 45
 TIMEOUT_QUERY_HEAVY = 90
 
+# Timeout do warmer compute_empresa_perfil_dict (web/warm_cache.py).
+# Maior que TIMEOUT_PROFILE porque mega-empresas (BB cnpj_basico=00000000,
+# Caixa 00360305, INSS 29979036) tem milhoes de empenhos em tce_pb_despesa
+# — GROUP BY municipio e GROUP BY elemento_despesa estouram 3s. Warmer
+# roda offline, vale esperar mais. Route nao chama compute (cache-only),
+# entao TIMEOUT_PROFILE=3s do route nao eh afetado.
+TIMEOUT_PROFILE_WARM = 120
+
 # Limites de resultado
 LIMIT_AUTOCOMPLETE = 20
 LIMIT_QUERY = 500

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -113,8 +113,19 @@ class EmpresaNotFoundError(Exception):
     """Empresa nao tem dados PB (nao em mv_empresa_pb) ou CNPJ invalido."""
 
 
-def compute_empresa_perfil_dict(cnpj_completo: str) -> dict[str, Any]:
+def compute_empresa_perfil_dict(
+    cnpj_completo: str,
+    timeout_sec: int = TIMEOUT_PROFILE,
+) -> dict[str, Any]:
     """Executa as 8 queries e monta o dict completo do perfil.
+
+    Args:
+        cnpj_completo: 14 digitos numericos puros.
+        timeout_sec: statement_timeout em segundos. Default TIMEOUT_PROFILE
+            (3s) — adequado pra empresas tipicas. Warmer passa
+            TIMEOUT_PROFILE_WARM (120s) pra cobrir mega-empresas
+            governamentais (BB, Caixa, INSS) que tem milhoes de empenhos
+            e estouram timeouts curtos em GROUP BY.
 
     Returns: dict pronto pra TemplateResponse.
     Raises: EmpresaNotFoundError se empresa nao em mv_empresa_pb ou
@@ -130,7 +141,7 @@ def compute_empresa_perfil_dict(cnpj_completo: str) -> dict[str, Any]:
     agg_cols, agg_rows = execute_query(
         EMPRESA_AGREGADOS_PB_BY_BASICO,
         (cnpj_basico,),
-        timeout_sec=TIMEOUT_PROFILE,
+        timeout_sec=timeout_sec,
     )
     if not agg_rows:
         raise EmpresaNotFoundError(f"sem dados PB: {cnpj_completo}")
@@ -142,7 +153,7 @@ def compute_empresa_perfil_dict(cnpj_completo: str) -> dict[str, Any]:
     with get_conn() as conn:
         conn.autocommit = True
         with conn.cursor() as cur:
-            cur.execute(f"SET statement_timeout = '{TIMEOUT_PROFILE * 1000}'")
+            cur.execute(f"SET statement_timeout = '{timeout_sec * 1000}'")
             try:
                 cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (cnpj_completo,))
                 est_cols = [d[0] for d in cur.description]

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -646,6 +646,7 @@ def _warm_one_empresa(cnpj_completo: str) -> tuple[bool, str | None]:
     """
     # Import diferido pra evitar ciclo na inicializacao do modulo
     # (web.routes.empresa importa web.db que importa etl.config).
+    from web.config import TIMEOUT_PROFILE_WARM
     from web.routes.empresa import (
         CACHE_QUERY_ID as EMPRESA_CACHE_QID,
         EmpresaNotFoundError,
@@ -653,7 +654,12 @@ def _warm_one_empresa(cnpj_completo: str) -> tuple[bool, str | None]:
     )
 
     try:
-        data = compute_empresa_perfil_dict(cnpj_completo)
+        # timeout_sec=120 cobre mega-empresas governamentais (BB,
+        # Caixa, INSS) com milhoes de empenhos. TIMEOUT_PROFILE=3s do
+        # frontend nao se aplica aqui (warmer roda offline).
+        data = compute_empresa_perfil_dict(
+            cnpj_completo, timeout_sec=TIMEOUT_PROFILE_WARM
+        )
     except EmpresaNotFoundError as e:
         # Empresa sem dados PB — nao deve estar no sitemap qualificado,
         # mas pode acontecer se mv_empresa_pb e estabelecimento divergem.


### PR DESCRIPTION
Hotfix isolado: TIMEOUT_PROFILE=3s era insuficiente pro warmer processar mega-empresas governamentais com milhoes de empenhos.`Observado em deploy 25630419934:``- 00000000000191 (BB): timeout`- 00360305000104 (Caixa): timeout  `- 29979036000140 (INSS): timeout`- 00394460000141, 09095183000140, 09188376000146, 09123654000187: timeout`Total: 7/99K = 0.007% (passa threshold 5%, mas pages ficam 503 forever).`` Mudancas: `1. web/config.py: TIMEOUT_PROFILE_WARM = 120s`2. compute_empresa_perfil_dict aceita timeout_sec (default TIMEOUT_PROFILE retro-compat)`3. _warm_one_empresa passa 120s `Route NAO afetada (cache-only nao chama compute). `Apos merge: re-deploy com warm_cache=true. Resume mode skipa ~143K cached, re-processa apenas as 7 failed (sem cache row). ~1min total.