### PR TITLE
feat(seo): rich empresa page + URL com municipio + layout fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -989,6 +989,35 @@ jobs:
             exit 1
           fi
 
+          # Coverage check para EMPRESA_PERFIL_MUN (variantes /empresa/<cnpj>/<slug>).
+          # Mesma logica: rejeita se < 80%, evitando expor mass-503.
+          QUALIFYING_MUN=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT COUNT(*) FROM (
+              SELECT 1
+              FROM tce_pb_despesa d
+              JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
+              JOIN estabelecimento est
+                ON est.cnpj_basico = epb.cnpj_basico
+               AND est.cnpj_ordem = '0001'
+              WHERE d.cnpj_basico IS NOT NULL
+                AND d.municipio IS NOT NULL
+                AND d.valor_pago > 0
+              GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
+            ) sub
+          ")
+          CACHED_MUN=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c \
+            "SELECT COUNT(*) FROM web_cache WHERE query_id = 'EMPRESA_PERFIL_MUN';")
+          if [ "$QUALIFYING_MUN" -gt 0 ]; then
+            COVERAGE_MUN_PCT=$((CACHED_MUN * 100 / QUALIFYING_MUN))
+            echo "Coverage MUN: $CACHED_MUN/$QUALIFYING_MUN = ${COVERAGE_MUN_PCT}%"
+            if [ "$COVERAGE_MUN_PCT" -lt 80 ]; then
+              echo "::error::Cobertura EMPRESA_PERFIL_MUN ${COVERAGE_MUN_PCT}% < 80%. Rode warm_cache=true para popular as URLs /empresa/<cnpj>/<slug>."
+              exit 1
+            fi
+          else
+            echo "::warning::Sem pares (empresa, municipio) qualificados — cache MUN nao sera expandido."
+          fi
+
           # 2. Escreve drop-in (idempotente — overwrite OK).
           DROPIN_DIR=/etc/systemd/system/cruza-web.service.d
           DROPIN="$DROPIN_DIR/sitemap-empresas.conf"
@@ -1053,6 +1082,23 @@ jobs:
             exit 1
           fi
 
+          # Verifica shards de empresas-municipios listados no index.
+          INDEX_HAS_MUN=$(curl -s --max-time 60 \
+            -H "Host: transparenciapb.org" \
+            http://127.0.0.1:8000/sitemap.xml | grep -c '/sitemap-empresas-municipios-' || true)
+          echo "sitemap.xml-index lista $INDEX_HAS_MUN shards de empresas-municipios"
+          if [ "$INDEX_HAS_MUN" -lt 1 ]; then
+            echo "::warning::sitemap-index nao lista shards de empresas-municipios. Cache MUN pode estar vazio (warming nao rodou)."
+          else
+            SHARD1_MUN_URLS=$(curl -s --max-time 60 \
+              -H "Host: transparenciapb.org" \
+              http://127.0.0.1:8000/sitemap-empresas-municipios-1.xml | grep -c '/empresa/' || true)
+            echo "sitemap-empresas-municipios-1.xml expoe $SHARD1_MUN_URLS URLs /empresa/<cnpj>/<slug>"
+            if [ "$SHARD1_MUN_URLS" -lt 100 ]; then
+              echo "::warning::Shard 1 (municipios) so retornou $SHARD1_MUN_URLS pares (esperado >100)."
+            fi
+          fi
+
           # 5. E2E smoke test: amostra CNPJs DO SITEMAP QUALIFYING SET (NAO
           # do web_cache). Pega justamente o caso "URL exposta mas sem
           # cache" que o cache-only retornaria 503. Tolera 1/10 fail
@@ -1090,6 +1136,53 @@ jobs:
             sudo systemctl daemon-reload
             sudo systemctl restart cruza-web
             exit 1
+          fi
+
+          # 5b. E2E smoke pra /empresa/<cnpj>/<slug> (variantes scoped por
+          # municipio). Mesma logica: amostra do qualifying set, tolera 2/10.
+          if [ "${QUALIFYING_MUN:-0}" -gt 0 ]; then
+            PARES=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -F'|' -c "
+              SELECT
+                est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv,
+                d.municipio
+              FROM tce_pb_despesa d
+              JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
+              JOIN estabelecimento est
+                ON est.cnpj_basico = epb.cnpj_basico
+               AND est.cnpj_ordem = '0001'
+              WHERE d.cnpj_basico IS NOT NULL
+                AND d.municipio IS NOT NULL
+                AND d.valor_pago > 0
+              GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
+              ORDER BY random() LIMIT 10;
+            ")
+            FAIL_MUN=0
+            OK_MUN=0
+            while IFS='|' read -r cnpj municipio; do
+              [ -z "$cnpj" ] && continue
+              # Slug via Python helper, mesmo do warmer/sitemap.
+              slug=$(python -c "from web.utils.slug import municipio_slug; print(municipio_slug('''$municipio'''))")
+              [ -z "$slug" ] && continue
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                --max-time 10 \
+                -H "Host: transparenciapb.org" \
+                "http://127.0.0.1:8000/empresa/$cnpj/$slug")
+              if [ "$STATUS" = "200" ]; then
+                echo "  /empresa/$cnpj/$slug -> 200 OK"
+                OK_MUN=$((OK_MUN + 1))
+              else
+                echo "  /empresa/$cnpj/$slug -> $STATUS (FAIL)"
+                FAIL_MUN=$((FAIL_MUN + 1))
+              fi
+            done <<< "$PARES"
+            echo "E2E smoke MUN: $OK_MUN/10 OK, $FAIL_MUN/10 FAIL"
+            if [ "$OK_MUN" -lt 8 ]; then
+              echo "::error::E2E smoke MUN FAIL — so $OK_MUN/10 pares respondem 200. Cache MUN parcial. Rollback automatico."
+              sudo rm -f "$DROPIN"
+              sudo systemctl daemon-reload
+              sudo systemctl restart cruza-web
+              exit 1
+            fi
           fi
 
           # 6. IndexNow: notifica Bing/Yandex das URLs novas. CRITICO setar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1158,11 +1158,16 @@ jobs:
             ")
             FAIL_MUN=0
             OK_MUN=0
+            TESTED_MUN=0
             while IFS='|' read -r cnpj municipio; do
               [ -z "$cnpj" ] && continue
               # Slug via Python helper, mesmo do warmer/sitemap.
-              slug=$(python -c "from web.utils.slug import municipio_slug; print(municipio_slug('''$municipio'''))")
+              # Passa municipio como argv pra evitar shell injection
+              # (nomes de municipio podem conter aspas/$ — quebrariam o
+              # python -c '''$mun''' interpolado). (P2 Opus 4.7 PR #62.)
+              slug=$(python -c "import sys; from web.utils.slug import municipio_slug; print(municipio_slug(sys.argv[1]))" "$municipio")
               [ -z "$slug" ] && continue
+              TESTED_MUN=$((TESTED_MUN + 1))
               STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
                 --max-time 10 \
                 -H "Host: transparenciapb.org" \
@@ -1175,7 +1180,17 @@ jobs:
                 FAIL_MUN=$((FAIL_MUN + 1))
               fi
             done <<< "$PARES"
-            echo "E2E smoke MUN: $OK_MUN/10 OK, $FAIL_MUN/10 FAIL"
+            echo "E2E smoke MUN: $OK_MUN/$TESTED_MUN OK, $FAIL_MUN/$TESTED_MUN FAIL (de 10 pares amostrados)"
+            # Falha tambem se < 10 efetivamente testados — slug helper
+            # silenciosamente retornando vazio inflaria OK_MUN/TESTED_MUN
+            # ratio sem realmente testar. (P2 Opus 4.7 PR #62.)
+            if [ "$TESTED_MUN" -lt 10 ]; then
+              echo "::error::E2E smoke MUN: so $TESTED_MUN/10 pares foram efetivamente testados (slug helper falhou pra $((10 - TESTED_MUN))). Rollback automatico."
+              sudo rm -f "$DROPIN"
+              sudo systemctl daemon-reload
+              sudo systemctl restart cruza-web
+              exit 1
+            fi
             if [ "$OK_MUN" -lt 8 ]; then
               echo "::error::E2E smoke MUN FAIL — so $OK_MUN/10 pares respondem 200. Cache MUN parcial. Rollback automatico."
               sudo rm -f "$DROPIN"

--- a/web/config.py
+++ b/web/config.py
@@ -14,11 +14,14 @@ TIMEOUT_QUERY_HEAVY = 90
 
 # Timeout do warmer compute_empresa_perfil_dict (web/warm_cache.py).
 # Maior que TIMEOUT_PROFILE porque mega-empresas (BB cnpj_basico=00000000,
-# Caixa 00360305, INSS 29979036) tem milhoes de empenhos em tce_pb_despesa
-# — GROUP BY municipio e GROUP BY elemento_despesa estouram 3s. Warmer
-# roda offline, vale esperar mais. Route nao chama compute (cache-only),
-# entao TIMEOUT_PROFILE=3s do route nao eh afetado.
-TIMEOUT_PROFILE_WARM = 120
+# Caixa 00360305, INSS 29979036) tem MILHOES de empenhos em tce_pb_despesa
+# — GROUP BY municipio e GROUP BY elemento_despesa em prod podem demorar
+# minutos. 600s = 10min eh teto generoso (warmer roda offline, paralelo,
+# vale esperar). Empresa que demorar mais que isso fica de fora — provavelmente
+# bug no plano de query ou estatisticas stale.
+# Route nao chama compute (cache-only), entao TIMEOUT_PROFILE=3s do route
+# nao eh afetado.
+TIMEOUT_PROFILE_WARM = 600
 
 # Limites de resultado
 LIMIT_AUTOCOMPLETE = 20

--- a/web/indexnow_submit.py
+++ b/web/indexnow_submit.py
@@ -146,7 +146,9 @@ def main() -> int:
     from web.routes.seo import (
         EMPRESA_SHARD_SIZE,
         _build_cidades_sitemap,
+        _build_empresas_municipios_shard_sitemap,
         _build_empresas_shard_sitemap,
+        _empresas_municipios_qualificadas_count,
         _empresas_qualificadas_count,
     )
     import math as _math
@@ -192,6 +194,36 @@ def main() -> int:
                         log.exception("Falha ao gerar sitemap-empresas shard %d", n)
             except Exception:
                 log.exception("Falha ao contar empresas pro sitemap")
+
+            # Pares (empresa, municipio) — variantes /empresa/<cnpj>/<slug>.
+            try:
+                total_em = _empresas_municipios_qualificadas_count()
+                num_shards_em = (
+                    _math.ceil(total_em / EMPRESA_SHARD_SIZE) if total_em > 0 else 0
+                )
+                log.info(
+                    "empresas-municipios qualificados=%d, shards=%d (size=%d)",
+                    total_em, num_shards_em, EMPRESA_SHARD_SIZE,
+                )
+                for n in range(1, num_shards_em + 1):
+                    try:
+                        shard_xml = _build_empresas_municipios_shard_sitemap(
+                            site_url, n
+                        )
+                        shard_urls = _extract_urls_from_sitemap(shard_xml)
+                        urls.extend(shard_urls)
+                        log.info(
+                            "sitemap-empresas-municipios-%d: %d URLs",
+                            n, len(shard_urls),
+                        )
+                    except Exception:
+                        log.exception(
+                            "Falha ao gerar sitemap-empresas-municipios shard %d", n
+                        )
+            except Exception:
+                log.exception(
+                    "Falha ao contar empresas-municipios pro sitemap"
+                )
         else:
             log.info(
                 "SITEMAP_INCLUDE_EMPRESAS != '1' — submetendo so cidades+estaticas"

--- a/web/main.py
+++ b/web/main.py
@@ -62,6 +62,40 @@ def _host_from_url(value: str) -> str:
 
 
 @app.middleware("http")
+async def head_as_get(request: Request, call_next):
+    """Crawlers (Googlebot, Bing, GSC) usam HEAD pra validar sitemap e
+    URLs rapido sem baixar body. FastAPI/Starlette por padrao soh aceita
+    GET em @router.get() — HEAD retorna 405. Esse middleware muta o
+    method pra GET internamente, deixa a rota processar normal, e descarta
+    o body antes de retornar — RFC 7231 §4.3.2: HEAD deve retornar mesmos
+    headers que GET sem body.
+
+    Sem isso, GSC reportava 'Couldn't fetch' em /sitemap-cidades.xml e
+    /sitemap-empresas-N.xml.
+    """
+    if request.method == "HEAD":
+        request.scope["method"] = "GET"
+        response = await call_next(request)
+        # Consome o body iterator pra evitar leak/hang, descarta bytes.
+        body_iter = getattr(response, "body_iterator", None)
+        if body_iter is not None:
+            try:
+                async for _ in body_iter:
+                    pass
+            except Exception:
+                pass
+        from starlette.responses import Response as _Response
+        # Preserva content-type, content-length, cache-control etc.
+        return _Response(
+            content=b"",
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            media_type=response.media_type,
+        )
+    return await call_next(request)
+
+
+@app.middleware("http")
 async def api_origin_guard(request: Request, call_next):
     """Rejeita POST /api/* se Origin nao bate com hosts permitidos.
 
@@ -531,10 +565,23 @@ async def _handle_http_exception(request: Request, exc):
             {"path": str(request.url.path)},
             status_code=404,
         )
-    # outros HTTPException mantem resposta padrao (usado por APIs)
-    if isinstance(exc, _HTTPException):
-        raise exc
-    raise exc
+    # Outros HTTPException (405, 503, etc): devolve resposta padrao do
+    # Starlette (status code + message text). NAO re-raise — isso cairia
+    # no _handle_unexpected e viraria 500 estilizado, escondendo o status
+    # real. Crawlers (Googlebot, Bing) usam HEAD pra validar sitemap;
+    # FastAPI ate aceita HEAD em rotas GET, mas se a rota nao define HEAD
+    # explicitamente algumas versoes retornam 405. Devolvendo o 405 puro,
+    # o crawler interpreta como "rota existe, vou usar GET" em vez de
+    # "servidor quebrado, ignora". (Bug: GSC reportava 'Couldn't fetch'
+    # nos sitemaps porque 500 era retornado em vez de 405/200.)
+    from starlette.responses import PlainTextResponse
+    headers = getattr(exc, "headers", None) or {}
+    detail = getattr(exc, "detail", "") or ""
+    return PlainTextResponse(
+        str(detail) if detail else "",
+        status_code=status_code,
+        headers=headers,
+    )
 
 
 @app.exception_handler(Exception)

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -212,6 +212,113 @@ EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO = """
 """
 
 # ─────────────────────────────────────────────────────────────────────────
+# Detalhe (cnpj × municipio) — alimenta /empresa/<cnpj>/<municipio_slug>
+# e tambem a secao "Pagamentos detalhados" da pagina global. Replicam
+# a logica que o dialog de fornecedor faz inline em cidade.py
+# (/api/fornecedor/detalhes), mas filtram por cnpj_basico (em vez de
+# cpf_cnpj exato) para coerencia com mv_empresa_pb e
+# EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO. Diferenca esperada: filiais
+# do mesmo grupo (ordens != 0001) que recebam no mesmo municipio
+# entram juntas, alinhado com a visao "perfil da empresa raiz".
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_EMPENHOS_RECENTES_BY_MUN = """
+    SELECT id, numero_empenho, data_empenho, elemento_despesa,
+           valor_empenhado, valor_pago,
+           modalidade_licitacao, numero_licitacao
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+    ORDER BY data_empenho DESC
+    LIMIT 50
+"""
+
+EMPRESA_STATS_BY_MUN = """
+    SELECT COUNT(*) AS qtd_empenhos,
+           COALESCE(SUM(valor_empenhado), 0) AS total_empenhado,
+           COALESCE(SUM(valor_pago), 0) AS total_pago,
+           MIN(data_empenho) AS primeiro_empenho,
+           MAX(data_empenho) AS ultimo_empenho,
+           COUNT(*) FILTER (
+               WHERE numero_licitacao IS NULL
+                  OR numero_licitacao = '000000000'
+                  OR modalidade_licitacao ILIKE '%%sem licit%%'
+           ) AS qtd_sem_licitacao
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+"""
+
+EMPRESA_PAGAMENTOS_MENSAIS_BY_MUN = """
+    SELECT TO_CHAR(data_empenho, 'YYYY-MM') AS mes,
+           SUM(valor_pago) AS total_mes
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+      AND data_empenho >= (CURRENT_DATE - INTERVAL '12 months')
+    GROUP BY TO_CHAR(data_empenho, 'YYYY-MM')
+    ORDER BY mes
+"""
+
+EMPRESA_TOP_ELEMENTOS_BY_MUN = """
+    SELECT elemento_despesa,
+           SUM(valor_pago) AS total_elemento,
+           COUNT(*) AS qtd
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+    GROUP BY elemento_despesa
+    ORDER BY SUM(valor_pago) DESC
+    LIMIT 5
+"""
+
+# Pagamentos durante sancao em OUTROS municipios (excluindo o atual).
+# Usado quando a empresa tem sancoes registradas para destacar
+# pagamentos em municipios alheios durante o periodo da sancao.
+# Reproduz a logica que vivia inline em cidade.py:1788-1809 mas
+# filtra por cnpj_basico (alinhado com perfil agregado).
+EMPRESA_PAGAMENTOS_SANCAO_OUTROS = """
+    SELECT d.municipio, COUNT(*) AS qtd_empenhos,
+           SUM(d.valor_pago) AS total_pago
+    FROM tce_pb_despesa d
+    JOIN (
+        SELECT cpf_cnpj_norm, dt_inicio_sancao, dt_final_sancao
+        FROM ceis_sancao
+        WHERE LEFT(cpf_cnpj_norm, 8) = %(cnpj_basico)s
+          AND tipo_pessoa = 'J'
+        UNION ALL
+        SELECT cpf_cnpj_norm, dt_inicio_sancao, dt_final_sancao
+        FROM cnep_sancao
+        WHERE LEFT(cpf_cnpj_norm, 8) = %(cnpj_basico)s
+          AND tipo_pessoa = 'J'
+    ) san ON LEFT(san.cpf_cnpj_norm, 8) = d.cnpj_basico
+    WHERE d.cnpj_basico = %(cnpj_basico)s
+      AND d.municipio != %(municipio_atual)s
+      AND d.valor_pago > 0
+      AND d.data_empenho >= san.dt_inicio_sancao
+      AND (san.dt_final_sancao IS NULL OR d.data_empenho <= san.dt_final_sancao)
+    GROUP BY d.municipio
+    ORDER BY total_pago DESC
+"""
+
+# Visao global (sem filtro de municipio) das pagamentos mensais,
+# usado pelo chart "monthly" da pagina /empresa/<cnpj>.
+EMPRESA_PAGAMENTOS_MENSAIS_GLOBAL_BY_BASICO = """
+    SELECT TO_CHAR(data_empenho, 'YYYY-MM') AS mes,
+           SUM(valor_pago) AS total_mes
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %s
+      AND valor_pago > 0
+      AND data_empenho >= (CURRENT_DATE - INTERVAL '12 months')
+    GROUP BY TO_CHAR(data_empenho, 'YYYY-MM')
+    ORDER BY mes
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
 # Sitemap: TODAS as empresas em mv_empresa_pb que tem matriz cadastrada
 # em estabelecimento (cnpj_ordem='0001'). Sem filtro de threshold de
 # valor/sancao/divida — qualquer empresa que apareceu em fonte PB merece
@@ -267,4 +374,68 @@ EMPRESAS_QUALIFICADAS_COUNT = """
     JOIN estabelecimento est
         ON est.cnpj_basico = epb.cnpj_basico
        AND est.cnpj_ordem = '0001'
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sitemap empresa × municipio: pares (cnpj_completo, municipio_nome).
+# Cada par vira uma URL /empresa/<cnpj>/<municipio_slug>. Como o
+# warmer cobre todos os municipios pagantes de cada empresa, o sitemap
+# aqui REUSA exatamente a mesma fonte (mv_empresa_pb + estabelecimento
+# + tce_pb_despesa GROUP BY) para ficar 1:1 com o cache populado.
+#
+# ORDER BY total desc estabiliza paginacao (mesma posicao no warmer
+# e nos shards do sitemap).
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESAS_MUNICIPIOS_QUALIFICADAS_PAGINATED = """
+    SELECT
+        est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo,
+        d.municipio,
+        SUM(d.valor_pago) AS total
+    FROM tce_pb_despesa d
+    JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
+    JOIN estabelecimento est
+        ON est.cnpj_basico = epb.cnpj_basico
+       AND est.cnpj_ordem = '0001'
+    WHERE d.cnpj_basico IS NOT NULL
+      AND d.municipio IS NOT NULL
+      AND d.valor_pago > 0
+    GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
+    ORDER BY SUM(d.valor_pago) DESC NULLS LAST,
+             est.cnpj_basico, d.municipio
+    LIMIT %(limit)s OFFSET %(offset)s
+"""
+
+EMPRESAS_MUNICIPIOS_QUALIFICADAS_COUNT = """
+    SELECT COUNT(*) FROM (
+        SELECT 1
+        FROM tce_pb_despesa d
+        JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
+        JOIN estabelecimento est
+            ON est.cnpj_basico = epb.cnpj_basico
+           AND est.cnpj_ordem = '0001'
+        WHERE d.cnpj_basico IS NOT NULL
+          AND d.municipio IS NOT NULL
+          AND d.valor_pago > 0
+        GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
+    ) sub
+"""
+
+# Versao sem LIMIT, usada pelo warmer (single shot, processa todos
+# os pares de uma vez). Mantem mesmo ORDER BY do paginated.
+EMPRESAS_MUNICIPIOS_QUALIFICADAS_TODOS = """
+    SELECT
+        est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo,
+        d.municipio
+    FROM tce_pb_despesa d
+    JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
+    JOIN estabelecimento est
+        ON est.cnpj_basico = epb.cnpj_basico
+       AND est.cnpj_ordem = '0001'
+    WHERE d.cnpj_basico IS NOT NULL
+      AND d.municipio IS NOT NULL
+      AND d.valor_pago > 0
+    GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
+    ORDER BY SUM(d.valor_pago) DESC NULLS LAST,
+             est.cnpj_basico, d.municipio
 """

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -279,28 +279,36 @@ EMPRESA_TOP_ELEMENTOS_BY_MUN = """
 # Pagamentos durante sancao em OUTROS municipios (excluindo o atual).
 # Usado quando a empresa tem sancoes registradas para destacar
 # pagamentos em municipios alheios durante o periodo da sancao.
-# Reproduz a logica que vivia inline em cidade.py:1788-1809 mas
-# filtra por cnpj_basico (alinhado com perfil agregado).
+#
+# IMPORTANTE: usa EXISTS em vez de JOIN+UNION pra evitar inflar COUNT/SUM.
+# Bug original (P0 do Opus 4.7 review do PR #62): JOIN com UNION ALL de
+# CEIS+CNEP fazia produto cartesiano — empresa com 2 sancoes ativas via
+# COUNT/SUM dobrados. Com EXISTS, cada despesa entra UMA vez se houver
+# qualquer sancao cobrindo a data.
 EMPRESA_PAGAMENTOS_SANCAO_OUTROS = """
     SELECT d.municipio, COUNT(*) AS qtd_empenhos,
            SUM(d.valor_pago) AS total_pago
     FROM tce_pb_despesa d
-    JOIN (
-        SELECT cpf_cnpj_norm, dt_inicio_sancao, dt_final_sancao
-        FROM ceis_sancao
-        WHERE LEFT(cpf_cnpj_norm, 8) = %(cnpj_basico)s
-          AND tipo_pessoa = 'J'
-        UNION ALL
-        SELECT cpf_cnpj_norm, dt_inicio_sancao, dt_final_sancao
-        FROM cnep_sancao
-        WHERE LEFT(cpf_cnpj_norm, 8) = %(cnpj_basico)s
-          AND tipo_pessoa = 'J'
-    ) san ON LEFT(san.cpf_cnpj_norm, 8) = d.cnpj_basico
     WHERE d.cnpj_basico = %(cnpj_basico)s
       AND d.municipio != %(municipio_atual)s
       AND d.valor_pago > 0
-      AND d.data_empenho >= san.dt_inicio_sancao
-      AND (san.dt_final_sancao IS NULL OR d.data_empenho <= san.dt_final_sancao)
+      AND EXISTS (
+          SELECT 1
+          FROM ceis_sancao s
+          WHERE LEFT(s.cpf_cnpj_norm, 8) = %(cnpj_basico)s
+            AND s.tipo_pessoa = 'J'
+            AND d.data_empenho >= s.dt_inicio_sancao
+            AND (s.dt_final_sancao IS NULL
+                 OR d.data_empenho <= s.dt_final_sancao)
+          UNION ALL
+          SELECT 1
+          FROM cnep_sancao s
+          WHERE LEFT(s.cpf_cnpj_norm, 8) = %(cnpj_basico)s
+            AND s.tipo_pessoa = 'J'
+            AND d.data_empenho >= s.dt_inicio_sancao
+            AND (s.dt_final_sancao IS NULL
+                 OR d.data_empenho <= s.dt_final_sancao)
+      )
     GROUP BY d.municipio
     ORDER BY total_pago DESC
 """

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -337,14 +337,15 @@ def compute_empresa_perfil_dict(
         - cadastrais (estabelecimento, matriz, socios, sancoes, pgfn,
           leniencia)
         - agregados/KPIs
-        - municipios_pagantes (com slug pre-computado)
+        - municipios_pagantes (com slug pre-computado — lista clicavel
+          pra /empresa/<cnpj>/<slug>)
         - top_elementos GLOBAL
         - monthly_global (chart 12 meses GLOBAL)
-        - municipios_data: dict {municipio_slug: {stats, monthly,
-          top_elementos, empenhos, [pagamentos_sancao_outros]}}
-          — usado pelo perfil global para mostrar prévia de cada
-          municipio. Se sancoes vazias, pagamentos_sancao_outros eh
-          omitido por municipio (poupa I/O).
+        Detalhes POR municipio (50 empenhos, monthly local, top elementos,
+        stats, sancao_outros) NAO sao cacheados aqui — vivem em
+        EMPRESA_PERFIL_MUN:<cnpj>:<slug> populado por
+        _warm_one_empresa_municipio. Pagina global so mostra preview;
+        detalhes carregam via /empresa/<cnpj>/<slug>.
     Raises: EmpresaNotFoundError se empresa nao em mv_empresa_pb ou
             cadastro RFB ausente.
     """
@@ -376,34 +377,15 @@ def compute_empresa_perfil_dict(
                     cur, cnpj_completo, cnpj_basico, cnpj_ordem
                 )
 
-                # Para cada municipio pagante, traz stats+monthly+top+empenhos.
-                # Se a empresa tem sancoes, inclui tambem
-                # pagamentos_sancao_outros pra cada municipio (so faz
-                # sentido nesse caso).
-                #
-                # LIMIT 10: empresas governamentais (BB, Caixa, INSS) pagam
-                # 200+ municipios. Embed de 200 sub-perfis no JSONB do
-                # web_cache global produzia payload de MB e duplicava
-                # trabalho do cache EMPRESA_PERFIL_MUN. Top-10 cobre os
-                # casos visiveis na pagina global; municipios alem disso
-                # so renderizam via /empresa/<cnpj>/<slug> dedicada.
-                # (P1 Opus 4.7 review PR #62.)
-                with_sancao_outros = bool(cadastral["sancoes"])
-                municipios_data: dict[str, dict[str, Any]] = {}
-                MAX_MUNICIPIOS_INLINE = 10
-                # municipios_pagantes ja vem ordenado por total_pago DESC
-                # (EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO).
-                for mp in cadastral["municipios_pagantes"][:MAX_MUNICIPIOS_INLINE]:
-                    slug = mp.get("slug")
-                    nome = mp.get("municipio")
-                    if not slug or not nome:
-                        continue
-                    if slug in municipios_data:
-                        continue
-                    municipios_data[slug] = _fetch_pagamentos_municipio(
-                        cur, cnpj_basico, nome,
-                        with_sancao_outros=with_sancao_outros,
-                    )
+                # NOTA: dados detalhados POR MUNICIPIO (50 empenhos, monthly,
+                # top elementos, stats, sancao_outros) NAO sao cacheados aqui.
+                # Eles vivem em cache separado (EMPRESA_PERFIL_MUN:<cnpj>:<slug>)
+                # populado por _warm_one_empresa_municipio. Pagina global so
+                # mostra preview + lista clicavel; detalhes carregam via
+                # /empresa/<cnpj>/<slug>. Versao anterior do PR #62 cacheava
+                # tudo aqui inline (dict municipios_data) — dead code que
+                # inflava blobs ate 15MB pra mega-empresas governamentais
+                # (BB, Caixa, INSS) sem nenhum template lendo.
             finally:
                 try:
                     cur.execute("RESET statement_timeout")
@@ -447,7 +429,6 @@ def compute_empresa_perfil_dict(
         "municipios_pagantes": cadastral["municipios_pagantes"],
         "top_elementos": cadastral["top_elementos"],
         "monthly_global": cadastral["monthly_global"],
-        "municipios_data": municipios_data,
         "kpi_total_pb": total_pb_geral,
         "kpi_qtd_municipios": qtd_municipios,
         "kpi_qtd_empenhos": qtd_empenhos_pb,

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -380,9 +380,20 @@ def compute_empresa_perfil_dict(
                 # Se a empresa tem sancoes, inclui tambem
                 # pagamentos_sancao_outros pra cada municipio (so faz
                 # sentido nesse caso).
+                #
+                # LIMIT 10: empresas governamentais (BB, Caixa, INSS) pagam
+                # 200+ municipios. Embed de 200 sub-perfis no JSONB do
+                # web_cache global produzia payload de MB e duplicava
+                # trabalho do cache EMPRESA_PERFIL_MUN. Top-10 cobre os
+                # casos visiveis na pagina global; municipios alem disso
+                # so renderizam via /empresa/<cnpj>/<slug> dedicada.
+                # (P1 Opus 4.7 review PR #62.)
                 with_sancao_outros = bool(cadastral["sancoes"])
                 municipios_data: dict[str, dict[str, Any]] = {}
-                for mp in cadastral["municipios_pagantes"]:
+                MAX_MUNICIPIOS_INLINE = 10
+                # municipios_pagantes ja vem ordenado por total_pago DESC
+                # (EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO).
+                for mp in cadastral["municipios_pagantes"][:MAX_MUNICIPIOS_INLINE]:
                     slug = mp.get("slug")
                     nome = mp.get("municipio")
                     if not slug or not nome:
@@ -640,9 +651,9 @@ async def empresa_perfil(request: Request, cnpj: str):
     )
 
 
-# Slug pattern: alfanumerico + hifen, 1-100 chars (defesa contra path
-# travado e injecao). municipio_slug() emite exatamente esse formato.
-_MUN_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+# slug_to_municipio() ja normaliza acentos/case e tolera hifens duplos.
+# Nao precisamos validar regex aqui: lookup falha (None) eh suficiente
+# pra rejeitar slug invalido com 404. (Ver fix P2 GPT-5.5 PR #62.)
 
 
 @router.get("/empresa/{cnpj}/{municipio_slug_in}")
@@ -693,16 +704,19 @@ async def empresa_perfil_municipio(
                 status_code=404,
             )
 
-    # Validacao defensiva do slug (formato, antes de hit no DB)
-    if not municipio_slug_in or not _MUN_SLUG_RE.fullmatch(municipio_slug_in):
+    # Resolve slug -> nome canonico do municipio.
+    # IMPORTANTE: slug_to_municipio() ja normaliza (case, acentos), entao
+    # variantes como Joao-Pessoa, JOAO-PESSOA, joao--pessoa resolvem.
+    # Tentamos resolver ANTES de validar regex estrito — se nao bater
+    # case canonico, devolvemos 301. Sem isso, slugs validos mas
+    # nao-canonicos virariam 404 silenciosos. (P2 GPT-5.5 PR #62.)
+    if not municipio_slug_in:
         return templates.TemplateResponse(
             request,
             "errors/404.html",
             {"path": str(request.url.path)},
             status_code=404,
         )
-
-    # Resolve slug -> nome canonico do municipio
     try:
         municipio_nome = slug_to_municipio(municipio_slug_in)
     except SlugLookupError:
@@ -715,6 +729,8 @@ async def empresa_perfil_municipio(
             media_type="text/plain; charset=utf-8",
         )
     if not municipio_nome:
+        # Slug nao bate com nenhum municipio conhecido — agora sim 404
+        # (depois de tentar resolver via lookup que tolera variantes).
         return templates.TemplateResponse(
             request,
             "errors/404.html",

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -27,17 +27,24 @@ from web.config import TIMEOUT_PROFILE
 from web.db import execute_query, get_conn, read_web_cache
 from web.queries.empresa import (
     EMPRESA_AGREGADOS_PB_BY_BASICO,
+    EMPRESA_EMPENHOS_RECENTES_BY_MUN,
     EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
     EMPRESA_LENIENCIA_BY_BASICO,
     EMPRESA_LENIENCIA_EFEITOS_BY_ID,
     EMPRESA_MATRIZ_BY_BASICO,
     EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO,
+    EMPRESA_PAGAMENTOS_MENSAIS_BY_MUN,
+    EMPRESA_PAGAMENTOS_MENSAIS_GLOBAL_BY_BASICO,
+    EMPRESA_PAGAMENTOS_SANCAO_OUTROS,
     EMPRESA_PGFN_BY_BASICO,
     EMPRESA_SANCOES_CEIS_BY_BASICO,
     EMPRESA_SANCOES_CNEP_BY_BASICO,
     EMPRESA_SOCIOS_BY_BASICO,
+    EMPRESA_STATS_BY_MUN,
+    EMPRESA_TOP_ELEMENTOS_BY_MUN,
     EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO,
 )
+from web.utils.slug import SlugLookupError, municipio_slug, slug_to_municipio
 
 router = APIRouter()
 _log = logging.getLogger("transparencia.empresa")
@@ -47,6 +54,29 @@ _CNPJ_RE = re.compile(r"^\d{14}$")
 # Chave canonica usada em web_cache. Warmer e rota DEVEM usar exatamente
 # esta string. Mudancas exigem invalidar o cache existente.
 CACHE_QUERY_ID = "EMPRESA_PERFIL"
+
+# Cache para a variante /empresa/<cnpj>/<municipio_slug>. Storage:
+#   query_id = "EMPRESA_PERFIL_MUN"
+#   municipio = f"{cnpj_completo}:{municipio_slug}"
+CACHE_QUERY_ID_MUN = "EMPRESA_PERFIL_MUN"
+
+
+# Mapeamento RFB do campo `porte` (codigo numerico de 2 digitos) para
+# o label oficial. "00" significa nao informado e nao deve ser exibido.
+_PORTE_LABELS = {
+    "00": None,
+    "01": "ME (Microempresa)",
+    "03": "EPP (Empresa de Pequeno Porte)",
+    "05": "Demais",
+}
+
+
+def compute_empresa_porte_label(porte_raw: Any) -> str | None:
+    """Converte codigo de porte RFB para label legivel ou None."""
+    if porte_raw is None:
+        return None
+    s = str(porte_raw).strip().zfill(2)
+    return _PORTE_LABELS.get(s)
 
 
 def _row_to_dict(cols, row):
@@ -113,11 +143,187 @@ class EmpresaNotFoundError(Exception):
     """Empresa nao tem dados PB (nao em mv_empresa_pb) ou CNPJ invalido."""
 
 
+def _fetch_pagamentos_municipio(cur, cnpj_basico: str, municipio: str,
+                                with_sancao_outros: bool = False) -> dict[str, Any]:
+    """Roda as queries _BY_MUN para um (cnpj_basico, municipio) e retorna
+    dict com chaves: stats, monthly, top_elementos, empenhos e
+    opcionalmente pagamentos_sancao_outros.
+
+    Reusada por:
+      - compute_empresa_perfil_dict (uma vez por municipio pagante)
+      - compute_empresa_municipio_perfil_dict (uma unica vez)
+    """
+    params = {"cnpj_basico": cnpj_basico, "municipio": municipio}
+
+    cur.execute(EMPRESA_STATS_BY_MUN, params)
+    st_cols = [d[0] for d in cur.description]
+    st_row = cur.fetchone()
+    stats = _convert_row(_row_to_dict(st_cols, st_row)) if st_row else {}
+
+    cur.execute(EMPRESA_PAGAMENTOS_MENSAIS_BY_MUN, params)
+    m_cols = [d[0] for d in cur.description]
+    monthly = [_convert_row(_row_to_dict(m_cols, r)) for r in cur.fetchall()]
+
+    cur.execute(EMPRESA_TOP_ELEMENTOS_BY_MUN, params)
+    te_cols = [d[0] for d in cur.description]
+    top_elementos = [_convert_row(_row_to_dict(te_cols, r)) for r in cur.fetchall()]
+
+    cur.execute(EMPRESA_EMPENHOS_RECENTES_BY_MUN, params)
+    e_cols = [d[0] for d in cur.description]
+    empenhos = [_convert_row(_row_to_dict(e_cols, r)) for r in cur.fetchall()]
+
+    out = {
+        "municipio": municipio,
+        "municipio_slug": municipio_slug(municipio),
+        "stats": stats,
+        "monthly": monthly,
+        "top_elementos": top_elementos,
+        "empenhos": empenhos,
+    }
+    if with_sancao_outros:
+        cur.execute(
+            EMPRESA_PAGAMENTOS_SANCAO_OUTROS,
+            {"cnpj_basico": cnpj_basico, "municipio_atual": municipio},
+        )
+        so_cols = [d[0] for d in cur.description]
+        out["pagamentos_sancao_outros"] = [
+            _convert_row(_row_to_dict(so_cols, r)) for r in cur.fetchall()
+        ]
+    return out
+
+
+def _fetch_cadastral_block(cur, cnpj_completo: str, cnpj_basico: str,
+                           cnpj_ordem: str) -> dict[str, Any]:
+    """Roda as queries cadastrais (estabelecimento, matriz, socios,
+    sancoes, pgfn, leniencia, municipios_pagantes, top_elementos
+    global, monthly_global) e retorna dict.
+
+    Compartilhado entre as duas funcoes compute_*. Levanta
+    EmpresaNotFoundError se nao houver cadastro RFB.
+    """
+    cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (cnpj_completo,))
+    est_cols = [d[0] for d in cur.description]
+    est_rows = cur.fetchall()
+    if not est_rows:
+        raise EmpresaNotFoundError(f"sem cadastro RFB: {cnpj_completo}")
+    estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
+
+    matriz = None
+    if cnpj_ordem != "0001":
+        cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
+        mat_cols = [d[0] for d in cur.description]
+        mat_row = cur.fetchone()
+        if mat_row:
+            matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
+
+    cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
+    soc_cols = [d[0] for d in cur.description]
+    socios = [_convert_row(_row_to_dict(soc_cols, r)) for r in cur.fetchall()]
+
+    cur.execute(EMPRESA_SANCOES_CEIS_BY_BASICO, (cnpj_basico,))
+    ceis_cols = [d[0] for d in cur.description]
+    sancoes: list[dict] = []
+    for r in cur.fetchall():
+        item = _convert_row(_row_to_dict(ceis_cols, r))
+        item["origem"] = "CEIS"
+        sancoes.append(item)
+
+    cur.execute(EMPRESA_SANCOES_CNEP_BY_BASICO, (cnpj_basico,))
+    cnep_cols = [d[0] for d in cur.description]
+    for r in cur.fetchall():
+        item = _convert_row(_row_to_dict(cnep_cols, r))
+        item["origem"] = "CNEP"
+        sancoes.append(item)
+
+    cur.execute(EMPRESA_PGFN_BY_BASICO, (cnpj_basico,))
+    pg_cols = [d[0] for d in cur.description]
+    pgfn = [_convert_row(_row_to_dict(pg_cols, r)) for r in cur.fetchall()]
+
+    cur.execute(EMPRESA_LENIENCIA_BY_BASICO, (cnpj_basico,))
+    len_cols = [d[0] for d in cur.description]
+    acordos = []
+    for r in cur.fetchall():
+        a = _convert_row(_row_to_dict(len_cols, r))
+        cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
+        ef_cols = [d[0] for d in cur.description]
+        a["efeitos"] = [
+            _row_to_dict(ef_cols, er) for er in cur.fetchall()
+        ]
+        acordos.append(a)
+
+    cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO, (cnpj_basico,))
+    mp_cols = [d[0] for d in cur.description]
+    municipios_pagantes = [
+        _convert_row(_row_to_dict(mp_cols, r)) for r in cur.fetchall()
+    ]
+    # anota slug em cada item para os templates linkarem direto
+    for mp in municipios_pagantes:
+        mp["slug"] = municipio_slug(mp.get("municipio") or "")
+
+    cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO, (cnpj_basico,))
+    te_cols = [d[0] for d in cur.description]
+    top_elementos = [
+        _convert_row(_row_to_dict(te_cols, r)) for r in cur.fetchall()
+    ]
+
+    cur.execute(EMPRESA_PAGAMENTOS_MENSAIS_GLOBAL_BY_BASICO, (cnpj_basico,))
+    m_cols = [d[0] for d in cur.description]
+    monthly_global = [
+        _convert_row(_row_to_dict(m_cols, r)) for r in cur.fetchall()
+    ]
+
+    return {
+        "estabelecimento": estabelecimento,
+        "matriz": matriz,
+        "socios": socios,
+        "sancoes": sancoes,
+        "pgfn": pgfn,
+        "acordos_leniencia": acordos,
+        "municipios_pagantes": municipios_pagantes,
+        "top_elementos": top_elementos,
+        "monthly_global": monthly_global,
+    }
+
+
+def _build_meta_description(razao_social: str, cnpj_fmt: str,
+                            total_pb: float, sancoes: list,
+                            total_divida_pgfn: float,
+                            municipio_scope: str | None = None) -> str:
+    """Gera meta description curta e factual. Se municipio_scope dado,
+    foca no escopo daquele municipio."""
+    if municipio_scope:
+        parts = [
+            f"Pagamentos publicos de {razao_social} (CNPJ {cnpj_fmt}) "
+            f"em {municipio_scope}/PB."
+        ]
+    else:
+        parts = [f"Perfil de {razao_social} (CNPJ {cnpj_fmt}) no TransparenciaPB."]
+    if total_pb > 0:
+        parts.append(f"Recebido em PB: R$ {total_pb:,.0f}".replace(",", "."))
+    if sancoes:
+        parts.append(f"Sancoes: {len(sancoes)}.")
+    if total_divida_pgfn > 0:
+        parts.append(
+            f"Divida PGFN: R$ {total_divida_pgfn:,.0f}".replace(",", ".")
+        )
+    return " ".join(parts)[:300]
+
+
+def _resolve_razao_social(estabelecimento: dict, agregados: dict,
+                          cnpj_basico: str) -> str:
+    return (
+        estabelecimento.get("razao_social")
+        or agregados.get("razao_social")
+        or estabelecimento.get("nome_fantasia")
+        or f"Empresa {cnpj_basico}"
+    )
+
+
 def compute_empresa_perfil_dict(
     cnpj_completo: str,
     timeout_sec: int = TIMEOUT_PROFILE,
 ) -> dict[str, Any]:
-    """Executa as 8 queries e monta o dict completo do perfil.
+    """Executa todas as queries e monta o dict completo do perfil global.
 
     Args:
         cnpj_completo: 14 digitos numericos puros.
@@ -127,9 +333,20 @@ def compute_empresa_perfil_dict(
             governamentais (BB, Caixa, INSS) que tem milhoes de empenhos
             e estouram timeouts curtos em GROUP BY.
 
-    Returns: dict pronto pra TemplateResponse.
+    Returns: dict pronto pra TemplateResponse. Inclui:
+        - cadastrais (estabelecimento, matriz, socios, sancoes, pgfn,
+          leniencia)
+        - agregados/KPIs
+        - municipios_pagantes (com slug pre-computado)
+        - top_elementos GLOBAL
+        - monthly_global (chart 12 meses GLOBAL)
+        - municipios_data: dict {municipio_slug: {stats, monthly,
+          top_elementos, empenhos, [pagamentos_sancao_outros]}}
+          — usado pelo perfil global para mostrar prévia de cada
+          municipio. Se sancoes vazias, pagamentos_sancao_outros eh
+          omitido por municipio (poupa I/O).
     Raises: EmpresaNotFoundError se empresa nao em mv_empresa_pb ou
-            cadastro RFB ausente. Outras exceptions sao do DB e propagam.
+            cadastro RFB ausente.
     """
     if not _CNPJ_RE.fullmatch(cnpj_completo):
         raise EmpresaNotFoundError(f"CNPJ invalido: {cnpj_completo}")
@@ -147,7 +364,7 @@ def compute_empresa_perfil_dict(
         raise EmpresaNotFoundError(f"sem dados PB: {cnpj_completo}")
     agregados = _convert_row(_row_to_dict(agg_cols, agg_rows[0]))
 
-    # 2. Cadastro RFB + 3-8 demais detalhes — uma transaction com todos
+    # 2. Cadastro RFB + demais detalhes — uma transaction com todos
     # os SELECTs. statement_timeout setado e resetado em try/finally pra
     # nao vazar configuracao pro pool.
     with get_conn() as conn:
@@ -155,75 +372,27 @@ def compute_empresa_perfil_dict(
         with conn.cursor() as cur:
             cur.execute(f"SET statement_timeout = '{timeout_sec * 1000}'")
             try:
-                cur.execute(EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO, (cnpj_completo,))
-                est_cols = [d[0] for d in cur.description]
-                est_rows = cur.fetchall()
-                if not est_rows:
-                    raise EmpresaNotFoundError(f"sem cadastro RFB: {cnpj_completo}")
-                estabelecimento = _convert_row(_row_to_dict(est_cols, est_rows[0]))
+                cadastral = _fetch_cadastral_block(
+                    cur, cnpj_completo, cnpj_basico, cnpj_ordem
+                )
 
-                matriz = None
-                if cnpj_ordem != "0001":
-                    cur.execute(EMPRESA_MATRIZ_BY_BASICO, (cnpj_basico,))
-                    mat_cols = [d[0] for d in cur.description]
-                    mat_row = cur.fetchone()
-                    if mat_row:
-                        matriz = _convert_row(_row_to_dict(mat_cols, mat_row))
-
-                cur.execute(EMPRESA_SOCIOS_BY_BASICO, (cnpj_basico,))
-                soc_cols = [d[0] for d in cur.description]
-                socios = [
-                    _convert_row(_row_to_dict(soc_cols, r))
-                    for r in cur.fetchall()
-                ]
-
-                cur.execute(EMPRESA_SANCOES_CEIS_BY_BASICO, (cnpj_basico,))
-                ceis_cols = [d[0] for d in cur.description]
-                sancoes: list[dict] = []
-                for r in cur.fetchall():
-                    item = _convert_row(_row_to_dict(ceis_cols, r))
-                    item["origem"] = "CEIS"
-                    sancoes.append(item)
-
-                cur.execute(EMPRESA_SANCOES_CNEP_BY_BASICO, (cnpj_basico,))
-                cnep_cols = [d[0] for d in cur.description]
-                for r in cur.fetchall():
-                    item = _convert_row(_row_to_dict(cnep_cols, r))
-                    item["origem"] = "CNEP"
-                    sancoes.append(item)
-
-                cur.execute(EMPRESA_PGFN_BY_BASICO, (cnpj_basico,))
-                pg_cols = [d[0] for d in cur.description]
-                pgfn = [
-                    _convert_row(_row_to_dict(pg_cols, r))
-                    for r in cur.fetchall()
-                ]
-
-                cur.execute(EMPRESA_LENIENCIA_BY_BASICO, (cnpj_basico,))
-                len_cols = [d[0] for d in cur.description]
-                acordos = []
-                for r in cur.fetchall():
-                    a = _convert_row(_row_to_dict(len_cols, r))
-                    cur.execute(EMPRESA_LENIENCIA_EFEITOS_BY_ID, (a["id_acordo"],))
-                    ef_cols = [d[0] for d in cur.description]
-                    a["efeitos"] = [
-                        _row_to_dict(ef_cols, er) for er in cur.fetchall()
-                    ]
-                    acordos.append(a)
-
-                cur.execute(EMPRESA_MUNICIPIOS_PAGANTES_BY_BASICO, (cnpj_basico,))
-                mp_cols = [d[0] for d in cur.description]
-                municipios_pagantes = [
-                    _convert_row(_row_to_dict(mp_cols, r))
-                    for r in cur.fetchall()
-                ]
-
-                cur.execute(EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO, (cnpj_basico,))
-                te_cols = [d[0] for d in cur.description]
-                top_elementos = [
-                    _convert_row(_row_to_dict(te_cols, r))
-                    for r in cur.fetchall()
-                ]
+                # Para cada municipio pagante, traz stats+monthly+top+empenhos.
+                # Se a empresa tem sancoes, inclui tambem
+                # pagamentos_sancao_outros pra cada municipio (so faz
+                # sentido nesse caso).
+                with_sancao_outros = bool(cadastral["sancoes"])
+                municipios_data: dict[str, dict[str, Any]] = {}
+                for mp in cadastral["municipios_pagantes"]:
+                    slug = mp.get("slug")
+                    nome = mp.get("municipio")
+                    if not slug or not nome:
+                        continue
+                    if slug in municipios_data:
+                        continue
+                    municipios_data[slug] = _fetch_pagamentos_municipio(
+                        cur, cnpj_basico, nome,
+                        with_sancao_outros=with_sancao_outros,
+                    )
             finally:
                 try:
                     cur.execute("RESET statement_timeout")
@@ -233,35 +402,22 @@ def compute_empresa_perfil_dict(
                         "provavelmente sera descartada pelo pool)"
                     )
 
-    razao_social = (
-        estabelecimento.get("razao_social")
-        or agregados.get("razao_social")
-        or estabelecimento.get("nome_fantasia")
-        or f"Empresa {cnpj_basico}"
-    )
+    estabelecimento = cadastral["estabelecimento"]
+    razao_social = _resolve_razao_social(estabelecimento, agregados, cnpj_basico)
     cnpj_fmt = _format_cnpj(cnpj_completo)
     total_pb_geral = float(agregados.get("total_pb_geral") or 0)
-    qtd_municipios = len(municipios_pagantes)
+    qtd_municipios = len(cadastral["municipios_pagantes"])
     qtd_empenhos_pb = int(agregados.get("qtd_tce_empenhos") or 0) + int(
         agregados.get("qtd_pb_empenhos") or 0
     )
     total_divida_pgfn = float(agregados.get("total_divida_pgfn") or 0)
 
-    # Meta description (150-160 chars). Mantemos curta e factual.
-    meta_parts = [
-        f"Perfil de {razao_social} (CNPJ {cnpj_fmt}) no TransparenciaPB."
-    ]
-    if total_pb_geral > 0:
-        meta_parts.append(
-            f"Recebido em PB: R$ {total_pb_geral:,.0f}".replace(",", ".")
-        )
-    if sancoes:
-        meta_parts.append(f"Sancoes: {len(sancoes)}.")
-    if total_divida_pgfn > 0:
-        meta_parts.append(
-            f"Divida PGFN: R$ {total_divida_pgfn:,.0f}".replace(",", ".")
-        )
-    meta_description = " ".join(meta_parts)[:300]
+    porte_label = compute_empresa_porte_label(estabelecimento.get("porte"))
+
+    meta_description = _build_meta_description(
+        razao_social, cnpj_fmt, total_pb_geral,
+        cadastral["sancoes"], total_divida_pgfn,
+    )
 
     return {
         "cnpj": cnpj_completo,
@@ -269,20 +425,140 @@ def compute_empresa_perfil_dict(
         "cnpj_ordem": cnpj_ordem,
         "cnpj_fmt": cnpj_fmt,
         "razao_social": razao_social,
+        "porte_label": porte_label,
         "estabelecimento": estabelecimento,
-        "matriz": matriz,
-        "socios": socios,
-        "sancoes": sancoes,
-        "pgfn": pgfn,
-        "acordos_leniencia": acordos,
+        "matriz": cadastral["matriz"],
+        "socios": cadastral["socios"],
+        "sancoes": cadastral["sancoes"],
+        "pgfn": cadastral["pgfn"],
+        "acordos_leniencia": cadastral["acordos_leniencia"],
         "agregados": agregados,
-        "municipios_pagantes": municipios_pagantes,
-        "top_elementos": top_elementos,
+        "municipios_pagantes": cadastral["municipios_pagantes"],
+        "top_elementos": cadastral["top_elementos"],
+        "monthly_global": cadastral["monthly_global"],
+        "municipios_data": municipios_data,
         "kpi_total_pb": total_pb_geral,
         "kpi_qtd_municipios": qtd_municipios,
         "kpi_qtd_empenhos": qtd_empenhos_pb,
         "kpi_total_divida_pgfn": total_divida_pgfn,
         "meta_description": meta_description,
+        "scope": "global",
+    }
+
+
+def compute_empresa_municipio_perfil_dict(
+    cnpj_completo: str,
+    municipio: str,
+    timeout_sec: int = TIMEOUT_PROFILE,
+) -> dict[str, Any]:
+    """Computa o perfil de uma empresa SCOPED a um municipio especifico.
+
+    Reaproveita o cadastral block (estabelecimento, matriz, socios,
+    sancoes, pgfn, leniencia) e substitui as listagens globais de
+    pagamentos por dados focados no municipio recebido.
+
+    Args:
+        cnpj_completo: 14 digitos numericos puros.
+        municipio: nome canonico do municipio (NAO slug). Caller deve
+            ter resolvido via slug_to_municipio.
+        timeout_sec: idem compute_empresa_perfil_dict.
+
+    Raises: EmpresaNotFoundError se empresa nao em mv_empresa_pb,
+            sem cadastro RFB, ou sem pagamentos no municipio dado.
+    """
+    if not _CNPJ_RE.fullmatch(cnpj_completo):
+        raise EmpresaNotFoundError(f"CNPJ invalido: {cnpj_completo}")
+    if not municipio:
+        raise EmpresaNotFoundError("municipio vazio")
+
+    cnpj_basico = cnpj_completo[:8]
+    cnpj_ordem = cnpj_completo[8:12]
+
+    agg_cols, agg_rows = execute_query(
+        EMPRESA_AGREGADOS_PB_BY_BASICO,
+        (cnpj_basico,),
+        timeout_sec=timeout_sec,
+    )
+    if not agg_rows:
+        raise EmpresaNotFoundError(f"sem dados PB: {cnpj_completo}")
+    agregados = _convert_row(_row_to_dict(agg_cols, agg_rows[0]))
+
+    with get_conn() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(f"SET statement_timeout = '{timeout_sec * 1000}'")
+            try:
+                cadastral = _fetch_cadastral_block(
+                    cur, cnpj_completo, cnpj_basico, cnpj_ordem
+                )
+                pag = _fetch_pagamentos_municipio(
+                    cur, cnpj_basico, municipio,
+                    with_sancao_outros=bool(cadastral["sancoes"]),
+                )
+            finally:
+                try:
+                    cur.execute("RESET statement_timeout")
+                except Exception:
+                    _log.warning("RESET statement_timeout falhou")
+
+    stats = pag.get("stats") or {}
+    qtd_no_mun = int(stats.get("qtd_empenhos") or 0)
+    if qtd_no_mun == 0:
+        raise EmpresaNotFoundError(
+            f"sem pagamentos: {cnpj_completo} em {municipio}"
+        )
+
+    estabelecimento = cadastral["estabelecimento"]
+    razao_social = _resolve_razao_social(estabelecimento, agregados, cnpj_basico)
+    cnpj_fmt = _format_cnpj(cnpj_completo)
+    total_pago_mun = float(stats.get("total_pago") or 0)
+    total_emp_mun = float(stats.get("total_empenhado") or 0)
+    qtd_sem_lic = int(stats.get("qtd_sem_licitacao") or 0)
+    pct_sem_lic = (qtd_sem_lic * 100.0 / qtd_no_mun) if qtd_no_mun > 0 else 0.0
+
+    porte_label = compute_empresa_porte_label(estabelecimento.get("porte"))
+    total_divida_pgfn = float(agregados.get("total_divida_pgfn") or 0)
+
+    meta_description = _build_meta_description(
+        razao_social, cnpj_fmt, total_pago_mun,
+        cadastral["sancoes"], total_divida_pgfn,
+        municipio_scope=municipio,
+    )
+
+    slug = municipio_slug(municipio)
+
+    return {
+        "cnpj": cnpj_completo,
+        "cnpj_basico": cnpj_basico,
+        "cnpj_ordem": cnpj_ordem,
+        "cnpj_fmt": cnpj_fmt,
+        "razao_social": razao_social,
+        "porte_label": porte_label,
+        "estabelecimento": estabelecimento,
+        "matriz": cadastral["matriz"],
+        "socios": cadastral["socios"],
+        "sancoes": cadastral["sancoes"],
+        "pgfn": cadastral["pgfn"],
+        "acordos_leniencia": cadastral["acordos_leniencia"],
+        "agregados": agregados,
+        "municipios_pagantes": cadastral["municipios_pagantes"],
+        # Pagamentos restritos ao municipio:
+        "municipio": municipio,
+        "municipio_slug": slug,
+        "stats_municipio": stats,
+        "monthly": pag["monthly"],
+        "top_elementos": pag["top_elementos"],
+        "empenhos": pag["empenhos"],
+        "pagamentos_sancao_outros": pag.get("pagamentos_sancao_outros") or [],
+        # KPIs focados no municipio:
+        "kpi_total_pago_mun": total_pago_mun,
+        "kpi_total_empenhado_mun": total_emp_mun,
+        "kpi_qtd_empenhos_mun": qtd_no_mun,
+        "kpi_qtd_sem_licitacao_mun": qtd_sem_lic,
+        "kpi_pct_sem_licitacao_mun": pct_sem_lic,
+        "kpi_total_divida_pgfn": total_divida_pgfn,
+        "meta_description": meta_description,
+        "scope": "municipio",
     }
 
 
@@ -359,6 +635,122 @@ async def empresa_perfil(request: Request, cnpj: str):
         content=(
             "Perfil em construcao — esta empresa ainda nao foi pre-processada. "
             "Tente novamente mais tarde."
+        ),
+        media_type="text/plain; charset=utf-8",
+    )
+
+
+# Slug pattern: alfanumerico + hifen, 1-100 chars (defesa contra path
+# travado e injecao). municipio_slug() emite exatamente esse formato.
+_MUN_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+@router.get("/empresa/{cnpj}/{municipio_slug_in}")
+async def empresa_perfil_municipio(
+    request: Request, cnpj: str, municipio_slug_in: str
+):
+    """Renderiza /empresa/<14-digits>/<municipio-slug>. Cache-only (mesmo
+    invariant da rota global): cache miss = 503 com Retry-After 1h.
+
+    Validacoes em ordem:
+    1. CNPJ canonico (14 digitos numericos puros, sem mascara).
+    2. Filial (ordem != 0001) -> redireciona pra matriz preservando o slug.
+    3. Slug municipio resolve via slug_to_municipio. None = 404.
+    4. Slug nao canonico -> 301 pro slug canonico.
+    5. Lookup web_cache(EMPRESA_PERFIL_MUN, "<cnpj>:<slug>"). Hit -> render.
+       Miss -> 503.
+    """
+    from web.main import templates
+
+    canonical_cnpj = _normalize_cnpj_input(cnpj)
+    if not canonical_cnpj:
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+    if cnpj != canonical_cnpj:
+        return RedirectResponse(
+            url=f"/empresa/{canonical_cnpj}/{municipio_slug_in}",
+            status_code=301,
+        )
+
+    cnpj_ordem = canonical_cnpj[8:12]
+    if cnpj_ordem != "0001":
+        try:
+            matriz_dv = _calculate_cnpj_dv(canonical_cnpj[:8], "0001")
+            matriz = canonical_cnpj[:8] + "0001" + matriz_dv
+            return RedirectResponse(
+                url=f"/empresa/{matriz}/{municipio_slug_in}",
+                status_code=301,
+            )
+        except ValueError:
+            return templates.TemplateResponse(
+                request,
+                "errors/404.html",
+                {"path": str(request.url.path)},
+                status_code=404,
+            )
+
+    # Validacao defensiva do slug (formato, antes de hit no DB)
+    if not municipio_slug_in or not _MUN_SLUG_RE.fullmatch(municipio_slug_in):
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+
+    # Resolve slug -> nome canonico do municipio
+    try:
+        municipio_nome = slug_to_municipio(municipio_slug_in)
+    except SlugLookupError:
+        # Cold start sem cache + DB indisponivel -> 503 (caller deve
+        # retentar). Evita 404 falso enquanto o cache nao carregou.
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "60"},
+            content="Cache de slugs indisponivel. Tente novamente.",
+            media_type="text/plain; charset=utf-8",
+        )
+    if not municipio_nome:
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+
+    # Slug nao canonico (ex: case diferente, hifens duplos) -> 301 pro canonico
+    canonical_slug = municipio_slug(municipio_nome)
+    if canonical_slug and canonical_slug != municipio_slug_in:
+        return RedirectResponse(
+            url=f"/empresa/{canonical_cnpj}/{canonical_slug}",
+            status_code=301,
+        )
+
+    cache_key = f"{canonical_cnpj}:{canonical_slug}"
+    cached = read_web_cache(CACHE_QUERY_ID_MUN, cache_key)
+    if cached is not None:
+        _cols, rows = cached
+        if rows and rows[0]:
+            data = rows[0][0]
+            if isinstance(data, dict) and data:
+                return templates.TemplateResponse(
+                    request, "results/empresa_municipio.html", data
+                )
+
+    _log.info(
+        "cache miss /empresa/%s/%s — returning 503",
+        canonical_cnpj, canonical_slug,
+    )
+    return Response(
+        status_code=503,
+        headers={"Retry-After": "3600"},
+        content=(
+            "Perfil em construcao — este recorte (empresa × municipio) "
+            "ainda nao foi pre-processado. Tente novamente mais tarde."
         ),
         media_type="text/plain; charset=utf-8",
     )

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -494,20 +494,27 @@ async def sitemap_cidades_xml(request: Request) -> Response:
 _EMPRESAS_SHARD_RE = re.compile(r"^[1-9]\d{0,3}$")
 
 
-@router.get("/sitemap-empresas-{shard_n}.xml")
-async def sitemap_empresas_shard_xml(request: Request, shard_n: str) -> Response:
+@router.get("/sitemap-empresas-{shard_n:int}.xml")
+async def sitemap_empresas_shard_xml(request: Request, shard_n: int) -> Response:
     """Sub-sitemap shard de empresas. shard_n eh 1-indexed.
 
-    Validacao defensiva: regex 1-9999. Shards inexistentes (alem do
+    Path converter `int` (FastAPI/Starlette) garante que so digitos puros
+    casam — `municipios-1` cai pro handler especifico abaixo, nao aqui.
+    Sem isso, /sitemap-empresas-municipios-1.xml seria capturado por essa
+    rota com shard_n="municipios-1" e retornaria 404 silenciosamente,
+    quebrando todas as URLs municipios-scoped no sitemap. (P1 do GPT-5.5
+    review do PR #62.)
+
+    Validacao adicional: 1-9999 via regex. Shards inexistentes (alem do
     numero de shards atual) retornam urlset vazio (200 valido) — Google
     tolera, e evita 404 transitorio se sitemap-index aponta pra shard
     que ainda nao foi cacheado.
 
     Cache 1h por shard em _SITEMAP_CACHE['empresas'][n].
     """
-    if not _EMPRESAS_SHARD_RE.match(shard_n):
+    if shard_n < 1 or shard_n > 9999:
         raise HTTPException(status_code=404)
-    n = int(shard_n)
+    n = shard_n
 
     origin = _site_origin(request)
     now = time.time()
@@ -543,14 +550,17 @@ async def sitemap_empresas_shard_xml(request: Request, shard_n: str) -> Response
 _EMPRESAS_MUN_SHARD_RE = re.compile(r"^[1-9]\d{0,3}$")
 
 
-@router.get("/sitemap-empresas-municipios-{shard_n}.xml")
-async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: str) -> Response:
+@router.get("/sitemap-empresas-municipios-{shard_n:int}.xml")
+async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: int) -> Response:
     """Sub-sitemap shard das URLs /empresa/<cnpj>/<slug>. Mesma logica do
     shard /sitemap-empresas-{n}.xml: regex 1-9999, past-end retorna urlset
-    vazio sem cache. Cache 1h por shard."""
-    if not _EMPRESAS_MUN_SHARD_RE.match(shard_n):
+    vazio sem cache. Cache 1h por shard.
+
+    Path converter `int` evita conflito com a rota irma (sem isso ambas
+    competem pelo mesmo path). Vide P1 do GPT-5.5 review."""
+    if shard_n < 1 or shard_n > 9999:
         raise HTTPException(status_code=404)
-    n = int(shard_n)
+    n = shard_n
 
     origin = _site_origin(request)
     now = time.time()

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -46,6 +46,7 @@ _SITEMAP_CACHE: dict[str, Any] = {
     "index": {"ts": 0.0, "xml": ""},
     "cidades": {"ts": 0.0, "xml": ""},
     "empresas": {},  # {shard_n: {"ts": ..., "xml": ...}}
+    "empresas_municipios": {},  # {shard_n: {"ts": ..., "xml": ...}}
 }
 
 # Tamanho de cada shard de empresas. Limite do protocolo eh 50K URLs por
@@ -291,6 +292,95 @@ def _build_empresas_shard_sitemap(origin: str, shard_n: int) -> str:
     return "\n".join(parts)
 
 
+def _empresas_municipios_qualificadas_count() -> int:
+    """Total de pares (empresa, municipio) que vao pro sitemap. Usado pra
+    calcular num_shards do /sitemap-empresas-municipios-{n}.xml.
+
+    Cache em memoria (1h) via _SITEMAP_CACHE['empresas_municipios_count'].
+    """
+    cached = _SITEMAP_CACHE.get("empresas_municipios_count")
+    now = time.time()
+    if cached and (now - cached["ts"] < _SITEMAP_TTL):
+        return int(cached["value"])
+
+    from web.queries.empresa import EMPRESAS_MUNICIPIOS_QUALIFICADAS_COUNT
+
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(EMPRESAS_MUNICIPIOS_QUALIFICADAS_COUNT)
+                row = cur.fetchone()
+                count = int(row[0]) if row else 0
+        _SITEMAP_CACHE["empresas_municipios_count"] = {"ts": now, "value": count}
+        return count
+    except Exception:
+        _log.exception("Falha ao contar pares (empresa, municipio) pro sitemap")
+        return 0
+
+
+def _empresas_municipios_paginated(shard_n: int, shard_size: int) -> list[tuple[str, str, str]]:
+    """Retorna pares (cnpj_completo, municipio_nome, slug) do shard N
+    (1-indexed). Aplica municipio_slug() aqui pra evitar SQL fancy.
+    """
+    from web.queries.empresa import EMPRESAS_MUNICIPIOS_QUALIFICADAS_PAGINATED
+    from web.utils.slug import municipio_slug as _slug_of
+
+    if shard_n < 1:
+        return []
+    offset = (shard_n - 1) * shard_size
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    EMPRESAS_MUNICIPIOS_QUALIFICADAS_PAGINATED,
+                    {"limit": shard_size, "offset": offset},
+                )
+                out: list[tuple[str, str, str]] = []
+                seen: set[tuple[str, str]] = set()
+                for cnpj_completo, municipio, _total in cur.fetchall():
+                    if not cnpj_completo or not municipio:
+                        continue
+                    cnpj_str = str(cnpj_completo).strip()
+                    if len(cnpj_str) != 14 or not cnpj_str.isdigit():
+                        continue
+                    mun = str(municipio).strip()
+                    if not mun:
+                        continue
+                    slug = _slug_of(mun)
+                    if not slug:
+                        continue
+                    key = (cnpj_str, slug)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    out.append((cnpj_str, mun, slug))
+                return out
+    except Exception:
+        _log.exception("Falha ao carregar shard %d de empresas-municipios", shard_n)
+        return []
+
+
+def _build_empresas_municipios_shard_sitemap(origin: str, shard_n: int) -> str:
+    """urlset com /empresa/<cnpj>/<slug> pra pares do shard N (1-indexed).
+    Cacheado em _SITEMAP_CACHE['empresas_municipios'][shard_n]."""
+    lastmod = _lastmod_iso()
+    parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>',
+                        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+    pares = _empresas_municipios_paginated(shard_n, EMPRESA_SHARD_SIZE)
+    for cnpj_completo, _mun_nome, slug in pares:
+        loc = f"{origin}/empresa/{cnpj_completo}/{slug}"
+        parts.append("  <url>")
+        parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
+        parts.append("    <changefreq>weekly</changefreq>")
+        parts.append("    <priority>0.5</priority>")
+        parts.append("  </url>")
+    parts.append("</urlset>")
+    return "\n".join(parts)
+
+
 def _build_sitemap_index(origin: str) -> str:
     """sitemapindex que aponta pra /sitemap-cidades.xml + N
     /sitemap-empresas-{n}.xml. Empresas so sao listadas se
@@ -316,6 +406,16 @@ def _build_sitemap_index(origin: str) -> str:
             for n in range(1, num_shards + 1):
                 parts.append("  <sitemap>")
                 parts.append(f"    <loc>{xml_escape(origin)}/sitemap-empresas-{n}.xml</loc>")
+                parts.append(f"    <lastmod>{lastmod}</lastmod>")
+                parts.append("  </sitemap>")
+
+        # Pares (empresa, municipio) — variantes /empresa/<cnpj>/<slug>.
+        total_mun = _empresas_municipios_qualificadas_count()
+        if total_mun > 0:
+            num_shards_mun = math.ceil(total_mun / EMPRESA_SHARD_SIZE)
+            for n in range(1, num_shards_mun + 1):
+                parts.append("  <sitemap>")
+                parts.append(f"    <loc>{xml_escape(origin)}/sitemap-empresas-municipios-{n}.xml</loc>")
                 parts.append(f"    <lastmod>{lastmod}</lastmod>")
                 parts.append("  </sitemap>")
 
@@ -432,6 +532,41 @@ async def sitemap_empresas_shard_xml(request: Request, shard_n: str) -> Response
             )
         # else (n > 1, vazio): nao cacheia, mas serve urlset vazio agora.
         # Proxima request rebuilda — se MV cresceu, vai retornar URLs.
+    return Response(
+        content=xml,
+        media_type="application/xml",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+# Pattern: /sitemap-empresas-municipios-{n}.xml onde n = inteiro 1..num_shards
+_EMPRESAS_MUN_SHARD_RE = re.compile(r"^[1-9]\d{0,3}$")
+
+
+@router.get("/sitemap-empresas-municipios-{shard_n}.xml")
+async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: str) -> Response:
+    """Sub-sitemap shard das URLs /empresa/<cnpj>/<slug>. Mesma logica do
+    shard /sitemap-empresas-{n}.xml: regex 1-9999, past-end retorna urlset
+    vazio sem cache. Cache 1h por shard."""
+    if not _EMPRESAS_MUN_SHARD_RE.match(shard_n):
+        raise HTTPException(status_code=404)
+    n = int(shard_n)
+
+    origin = _site_origin(request)
+    now = time.time()
+    shard_cache = _SITEMAP_CACHE["empresas_municipios"].get(n)
+    if shard_cache and shard_cache.get("xml") and (now - shard_cache["ts"] < _SITEMAP_TTL):
+        xml = shard_cache["xml"]
+    else:
+        xml = _build_empresas_municipios_shard_sitemap(origin, n)
+        urls_n = xml.count("/empresa/")
+        if urls_n > 0:
+            _SITEMAP_CACHE["empresas_municipios"][n] = {"ts": now, "xml": xml}
+        elif n == 1:
+            _log.warning(
+                "Sitemap-empresas-municipios shard 1 vazio — nao cacheando "
+                "(DB pode ter falhado)"
+            )
     return Response(
         content=xml,
         media_type="application/xml",

--- a/web/static/css/components/empresa-page.css
+++ b/web/static/css/components/empresa-page.css
@@ -1,0 +1,131 @@
+/* === components/empresa-page.css === */
+@layer components {
+/* Layout pra as paginas /empresa/<cnpj> e /empresa/<cnpj>/<slug>.
+   Foco: hero compacto, sections menos espacadas, e KPI/charts grids
+   responsivos (>=2 cards por linha em mobile pra eliminar a "torre"
+   de cards empilhados). Casa com kpi-card.css e mini-chart.css. */
+
+.empresa-page {
+    /* Limita largura pra leitura confortavel mas sem sufocar tabelas. */
+    max-width: 1100px;
+    margin-inline: auto;
+}
+
+/* Hero compacto: menos respiro vertical, paragrafos justos. */
+.empresa-hero {
+    margin-block: 1.25rem 1.5rem;
+}
+.empresa-hero h1 {
+    margin-block: 0.5rem 0.25rem;
+    line-height: 1.2;
+}
+.empresa-hero p {
+    margin-block: 0.25rem;
+}
+.empresa-cnpj-line {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    align-items: center;
+}
+.empresa-hero-meta {
+    list-style: none;
+    padding: 0;
+    margin: .75rem 0 0;
+    display: grid;
+    gap: .25rem .75rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.empresa-hero-meta li {
+    margin: 0;
+}
+.empresa-hero-meta .meta-label {
+    color: var(--md-sys-color-on-surface-variant);
+    font-weight: 600;
+    margin-right: .25rem;
+}
+.empresa-hero-email {
+    word-break: break-all;
+}
+
+/* Sections menos espacadas que o default do site. */
+.empresa-section {
+    margin-block: 1.5rem;
+}
+.empresa-section h2 {
+    margin-block: 0 0.75rem;
+    font-size: 1.15rem;
+}
+.empresa-section-scope {
+    margin-block: 1rem 1.25rem;
+}
+.empresa-municipio-title {
+    margin-block: .25rem .35rem !important;
+    font-size: 1.35rem !important;
+}
+
+/* KPI grid responsivo: 2 cards por linha em mobile (vs 1 antes),
+   espaco reduzido em telas estreitas. */
+.empresa-page .kpi-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+@media (max-width: 600px) {
+    .empresa-page .kpi-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.5rem;
+    }
+    .empresa-page .kpi-card {
+        padding: 0.75rem;
+    }
+    .empresa-page .kpi-value {
+        font-size: 1.1rem;
+    }
+}
+
+/* Para fileiras "lado-a-lado" de cards de info (ex: sanção + pgfn
+   exibidos em telas largas). */
+.empresa-card-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+@media (max-width: 600px) {
+    .empresa-card-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Charts side-by-side em desktop, stacked em mobile. mini-chart.css ja
+   define .charts-grid; aqui apenas reforcamos o breakpoint dentro do
+   contexto da pagina pra evitar cisao acidental quando o componente
+   for usado isolado em outra pagina. */
+.empresa-page .charts-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr 1fr;
+}
+@media (max-width: 700px) {
+    .empresa-page .charts-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Tabela de empenhos: numerica, monospace nos numeros, scroll-x se
+   sobrar coluna em telas estreitas. */
+.empresa-empenhos-table td.num,
+.empresa-empenhos-table th.num {
+    font-variant-numeric: tabular-nums;
+}
+
+/* Acordos de leniencia: efeitos como bullets compactos. */
+.empresa-acordo-efeitos {
+    margin: .35rem 0 0 1rem;
+    padding-left: .25rem;
+    list-style: disc;
+}
+.empresa-acordo-efeitos li {
+    margin-block: .15rem;
+}
+}

--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -40,6 +40,7 @@
 @import url("./components/date-filter.css");
 @import url("./components/denuncia.css");
 @import url("./components/empresa-dialog.css");
+@import url("./components/empresa-page.css");
 @import url("./components/fab.css");
 @import url("./components/finding-card.css");
 @import url("./components/font-toggle.css");

--- a/web/templates/partials/empresa/_charts.html
+++ b/web/templates/partials/empresa/_charts.html
@@ -1,0 +1,61 @@
+{# Charts: mini bar mensal + top elementos.
+   Reusa as classes mini-chart / top-elementos do dialog
+   (web/static/css/components/mini-chart.css). Sem JS — bars puro CSS.
+
+   Vars esperadas:
+     monthly_data: list[{mes: 'YYYY-MM', total_mes: float}] (12 meses).
+     top_elementos: list[{elemento_despesa, total_elemento, qtd}] (top 5).
+     charts_titulo (opcional): string que titula a secao. Se vazio,
+                               renderiza so os charts sem header.
+#}
+{% set monthly_data = monthly_data|default([]) %}
+{% set top_elementos_local = top_elementos|default([]) %}
+{% if monthly_data|length > 1 or top_elementos_local %}
+<section class="empresa-section empresa-charts">
+    {% if charts_titulo %}<h2>{{ charts_titulo }}</h2>{% endif %}
+    <div class="charts-grid">
+        {% if monthly_data|length > 1 %}
+        {% set max_mes = monthly_data|map(attribute='total_mes')|map('float')|max %}
+        <div>
+            <p class="text-sm text-muted" style="margin-bottom:.2rem">Pagamentos mensais (ultimos 12 meses)</p>
+            <div class="mini-chart" role="img" aria-label="Grafico de pagamentos mensais">
+                {% for m in monthly_data %}
+                {% set total_mes = m.total_mes|float %}
+                {% set pct = (total_mes / max_mes * 100) if max_mes and max_mes > 0 else 0 %}
+                {% set yy_mm = (m.mes or '')|string %}
+                {% set yy = yy_mm[:4] %}
+                {% set mm = yy_mm[5:7] %}
+                <div class="mini-bar-col">
+                    <span class="mini-bar-tip">{{ total_mes|short_brl }}</span>
+                    <div class="mini-bar" style="height:{{ [pct, 3]|max }}%"></div>
+                    <span class="mini-bar-label">{{ mm }}/{{ yy[2:] }}</span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+        {% if top_elementos_local %}
+        {% set top_max = top_elementos_local[0].total_elemento|float %}
+        {% set total_geral = top_elementos_local|sum(attribute='total_elemento') %}
+        <div>
+            <p class="text-sm text-muted" style="margin-bottom:.2rem">Principais elementos de despesa</p>
+            <div class="top-elementos">
+                {% for el in top_elementos_local %}
+                {% set v = el.total_elemento|float %}
+                {% set pct = (v / top_max * 100) if top_max and top_max > 0 else 0 %}
+                {% set pct_total = ((v / total_geral * 100)|round|int) if total_geral and total_geral > 0 else 0 %}
+                <div class="top-el-row">
+                    <span class="top-el-name" title="{{ el.elemento_despesa|clean_text or 'Sem classificacao' }}">{{ el.elemento_despesa|clean_text or 'Sem classificacao' }}</span>
+                    <div class="top-el-track">
+                        <div class="top-el-fill" style="width:{{ pct }}%"></div>
+                        <span class="top-el-pct">{{ pct_total }}%</span>
+                    </div>
+                    <span class="top-el-value">{{ v|short_brl }}</span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_empenhos.html
+++ b/web/templates/partials/empresa/_empenhos.html
@@ -1,0 +1,46 @@
+{# Tabela de empenhos recentes (ate 50). Esperada a var `empenhos`. #}
+{% if empenhos %}
+<section class="empresa-section" id="empenhos-recentes">
+    <h2>Empenhos recentes</h2>
+    <p class="text-sm text-muted">
+        Ultimos {{ empenhos|length }} empenhos pagos identificados no TCE-PB
+        (ordenados pela data do empenho, mais recentes primeiro).
+    </p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile data-table empresa-empenhos-table">
+            <thead>
+                <tr>
+                    <th>Data</th>
+                    <th>Numero</th>
+                    <th>Elemento de despesa</th>
+                    <th>Modalidade / Licitacao</th>
+                    <th class="text-right">Empenhado</th>
+                    <th class="text-right">Pago</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for e in empenhos %}
+                {% set sem_lic = (not e.numero_licitacao) or (e.numero_licitacao == '000000000') or ((e.modalidade_licitacao or '')|lower).startswith('sem licit') %}
+                <tr>
+                    <td data-label="Data">{{ e.data_empenho or '—' }}</td>
+                    <td data-label="Numero"><code>{{ e.numero_empenho|clean_text or '—' }}</code></td>
+                    <td data-label="Elemento">{{ e.elemento_despesa|clean_text or '—' }}</td>
+                    <td data-label="Modalidade">
+                        {% if sem_lic %}
+                            <span class="badge badge-yellow" title="Empenho sem licitacao identificada">Sem licitacao</span>
+                        {% else %}
+                            {{ e.modalidade_licitacao|clean_text or '—' }}
+                            {% if e.numero_licitacao and e.numero_licitacao != '000000000' %}
+                                <br><span class="text-sm text-muted"><code>{{ e.numero_licitacao }}</code></span>
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    <td data-label="Empenhado" class="text-right num">{{ e.valor_empenhado|short_brl }}</td>
+                    <td data-label="Pago" class="text-right num"><strong>{{ e.valor_pago|short_brl }}</strong></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_hero.html
+++ b/web/templates/partials/empresa/_hero.html
@@ -42,4 +42,33 @@
     {% if estabelecimento.dt_inicio_atividade %}
         <p class="text-sm text-muted">Inicio de atividade: {{ estabelecimento.dt_inicio_atividade }}</p>
     {% endif %}
+    {# Cadastro RFB extendido: porte / capital social / natureza juridica
+       (descricao) / contato. Preferimos os campos do estabelecimento
+       solicitado; se forem nulos numa filial, recaimos sobre os da
+       matriz para nao deixar a hero pelada. #}
+    {% set ddd = estabelecimento.ddd1 or (matriz.ddd1 if matriz else None) %}
+    {% set tel = estabelecimento.telefone1 or (matriz.telefone1 if matriz else None) %}
+    {% set mail = estabelecimento.email or (matriz.email if matriz else None) %}
+    <ul class="empresa-hero-meta text-sm">
+        {% if porte_label %}
+            <li><span class="meta-label">Porte:</span> {{ porte_label|clean_text }}</li>
+        {% endif %}
+        {% if estabelecimento.capital_social and estabelecimento.capital_social|float > 0 %}
+            <li><span class="meta-label">Capital social:</span> {{ estabelecimento.capital_social|short_brl }}</li>
+        {% endif %}
+        {% if estabelecimento.desc_natureza_juridica %}
+            <li><span class="meta-label">Natureza juridica:</span> {{ estabelecimento.desc_natureza_juridica|clean_text }}{% if estabelecimento.natureza_juridica %} <code class="text-muted">({{ estabelecimento.natureza_juridica }})</code>{% endif %}</li>
+        {% elif estabelecimento.natureza_juridica %}
+            <li><span class="meta-label">Natureza juridica:</span> <code>{{ estabelecimento.natureza_juridica }}</code></li>
+        {% endif %}
+        {% if tel %}
+            <li><span class="meta-label">Telefone:</span> {% if ddd %}({{ ddd }}) {% endif %}{{ tel|clean_text }}</li>
+        {% endif %}
+        {% if mail %}
+            <li><span class="meta-label">Email:</span> <span class="empresa-hero-email">{{ mail|clean_text }}</span></li>
+        {% endif %}
+        {% if estabelecimento.ente_federativo %}
+            <li><span class="meta-label">Ente federativo:</span> {{ estabelecimento.ente_federativo|clean_text }}</li>
+        {% endif %}
+    </ul>
 </header>

--- a/web/templates/partials/empresa/_municipios_pagantes.html
+++ b/web/templates/partials/empresa/_municipios_pagantes.html
@@ -1,8 +1,7 @@
-{# Lista de municipios PB que pagaram esta empresa #}
 {% if municipios_pagantes %}
 <section class="empresa-section" id="municipios-pagantes">
     <h2>Municipios que pagaram esta empresa</h2>
-    <p class="text-sm text-muted">Pagamentos identificados no TCE-PB. Clique no municipio pra ver o panorama de transparencia.</p>
+    <p class="text-sm text-muted">Pagamentos identificados no TCE-PB. Clique no municipio para o panorama da prefeitura, ou em "Detalhes" para o recorte desta empresa naquele municipio.</p>
     <div class="tbl-wrap">
         <table class="stack-mobile">
             <thead>
@@ -10,11 +9,12 @@
                     <th>Municipio</th>
                     <th class="text-right">Total pago</th>
                     <th class="text-right">Empenhos</th>
+                    <th>Recorte</th>
                 </tr>
             </thead>
             <tbody>
                 {% for mp in municipios_pagantes %}
-                {% set _slug = mp.municipio | municipio_slug %}
+                {% set _slug = mp.slug or (mp.municipio | municipio_slug) %}
                 <tr>
                     <td data-label="Municipio">
                         {% if _slug %}
@@ -25,24 +25,17 @@
                     </td>
                     <td data-label="Total pago" class="text-right num">{{ mp.total_pago|short_brl }}</td>
                     <td data-label="Empenhos" class="text-right num">{{ mp.qtd_empenhos|short_number }}</td>
+                    <td data-label="Recorte">
+                        {% if _slug and cnpj %}
+                            <a class="text-sm" href="/empresa/{{ cnpj }}/{{ _slug }}" title="Detalhes desta empresa em {{ mp.municipio|clean_text }}">Ver detalhes &rarr;</a>
+                        {% else %}
+                            &mdash;
+                        {% endif %}
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
     </div>
-</section>
-{% endif %}
-
-{% if top_elementos %}
-<section class="empresa-section" id="top-elementos">
-    <h2>Principais tipos de despesa</h2>
-    <ul class="empresa-elementos">
-        {% for el in top_elementos %}
-        <li>
-            <strong>{{ el.elemento_despesa|clean_text or 'Sem classificacao' }}</strong>
-            &mdash; {{ el.total_elemento|short_brl }} em {{ el.qtd|short_number }} empenhos
-        </li>
-        {% endfor %}
-    </ul>
 </section>
 {% endif %}

--- a/web/templates/partials/empresa/_sancao_outros.html
+++ b/web/templates/partials/empresa/_sancao_outros.html
@@ -1,0 +1,41 @@
+{# Pagamentos sob sancao em outros municipios.
+   Renderiza apenas se a empresa tem sancoes registradas (a propria
+   query nao retornaria linhas de outra forma) e ha registros em
+   outros municipios durante a vigencia da sancao.
+   Var esperada: pagamentos_sancao_outros (lista). #}
+{% if pagamentos_sancao_outros %}
+<section class="empresa-section" id="sancao-outros">
+    <h2>Pagamentos durante sancao em outros municipios</h2>
+    <p class="text-sm text-muted">
+        Periodos em que esta empresa estava com sancao ativa (CEIS/CNEP)
+        e ainda recebeu pagamentos publicos em outros municipios da Paraiba.
+    </p>
+    <div class="tbl-wrap">
+        <table class="stack-mobile data-table">
+            <thead>
+                <tr>
+                    <th>Municipio</th>
+                    <th class="text-right">Total pago</th>
+                    <th class="text-right">Empenhos</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for o in pagamentos_sancao_outros %}
+                {% set _slug = o.municipio | municipio_slug %}
+                <tr>
+                    <td data-label="Municipio">
+                        {% if _slug %}
+                            <a href="/empresa/{{ cnpj }}/{{ _slug }}">{{ o.municipio|clean_text }}</a>
+                        {% else %}
+                            {{ o.municipio|clean_text }}
+                        {% endif %}
+                    </td>
+                    <td data-label="Total pago" class="text-right num">{{ o.total_pago|short_brl }}</td>
+                    <td data-label="Empenhos" class="text-right num">{{ o.qtd_empenhos|short_number }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endif %}

--- a/web/templates/partials/empresa/_stats_municipio.html
+++ b/web/templates/partials/empresa/_stats_municipio.html
@@ -1,0 +1,44 @@
+{# KPI grid para um (empresa, municipio).
+   Vars esperadas:
+     municipio: nome canonico
+     stats_municipio: dict {total_pago, total_empenhado, qtd_empenhos,
+                            qtd_sem_licitacao, primeiro_empenho,
+                            ultimo_empenho}
+     kpi_total_pago_mun, kpi_total_empenhado_mun, kpi_qtd_empenhos_mun,
+     kpi_qtd_sem_licitacao_mun, kpi_pct_sem_licitacao_mun (calculados em
+     compute_empresa_municipio_perfil_dict). #}
+{% if kpi_qtd_empenhos_mun and kpi_qtd_empenhos_mun > 0 %}
+<section class="empresa-section" id="resumo-municipio">
+    <h2>Pagamentos em {{ municipio|clean_text }}, PB</h2>
+    <div class="kpi-grid">
+        <div class="kpi-card">
+            <p class="kpi-label">Total pago</p>
+            <p class="kpi-value">{{ kpi_total_pago_mun|short_brl }}</p>
+            <p class="kpi-hint text-sm text-muted">Soma de empenhos pagos identificados no TCE-PB.</p>
+        </div>
+        <div class="kpi-card">
+            <p class="kpi-label">Total empenhado</p>
+            <p class="kpi-value">{{ kpi_total_empenhado_mun|short_brl }}</p>
+            <p class="kpi-hint text-sm text-muted">Inclui empenhos nao integralmente pagos.</p>
+        </div>
+        <div class="kpi-card">
+            <p class="kpi-label">Empenhos</p>
+            <p class="kpi-value">{{ kpi_qtd_empenhos_mun|short_number }}</p>
+            <p class="kpi-hint text-sm text-muted">Quantidade de empenhos com pagamento &gt; 0.</p>
+        </div>
+        <div class="kpi-card {% if kpi_pct_sem_licitacao_mun and kpi_pct_sem_licitacao_mun >= 50 %}kpi-card-warn{% endif %}">
+            <p class="kpi-label">Sem licitacao</p>
+            <p class="kpi-value">{{ '%.0f' % (kpi_pct_sem_licitacao_mun or 0) }}%</p>
+            <p class="kpi-hint text-sm text-muted">{{ kpi_qtd_sem_licitacao_mun|short_number }} de {{ kpi_qtd_empenhos_mun|short_number }} empenhos.</p>
+        </div>
+    </div>
+    {% if stats_municipio.primeiro_empenho or stats_municipio.ultimo_empenho %}
+    <p class="text-sm text-muted" style="margin-top:.5rem">
+        Periodo:
+        {% if stats_municipio.primeiro_empenho %}{{ stats_municipio.primeiro_empenho }}{% endif %}
+        {% if stats_municipio.primeiro_empenho and stats_municipio.ultimo_empenho %} &mdash; {% endif %}
+        {% if stats_municipio.ultimo_empenho %}{{ stats_municipio.ultimo_empenho }}{% endif %}
+    </p>
+    {% endif %}
+</section>
+{% endif %}

--- a/web/templates/results/empresa_municipio.html
+++ b/web/templates/results/empresa_municipio.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}{{ razao_social|clean_text }} (CNPJ {{ cnpj_fmt }}){% endblock %}
+{% block title %}{{ razao_social|clean_text }} em {{ municipio|clean_text }}, PB (CNPJ {{ cnpj_fmt }}){% endblock %}
 {% block meta_description %}{{ meta_description }}{% endblock %}
-{% block og_title %}{{ razao_social|clean_text }} - CNPJ {{ cnpj_fmt }} | TransparenciaPB{% endblock %}
+{% block og_title %}{{ razao_social|clean_text }} em {{ municipio|clean_text }} - CNPJ {{ cnpj_fmt }} | TransparenciaPB{% endblock %}
 {% block og_description %}{{ meta_description }}{% endblock %}
 {% block og_type %}article{% endblock %}
 {% block json_ld_extra %}
 {% set origin = request_origin(request) if request else '' %}
-{% set page_url = origin + '/empresa/' + cnpj %}
+{% set page_url = origin + '/empresa/' + cnpj + '/' + municipio_slug %}
 {% set logr = estabelecimento.logradouro or (matriz.logradouro if matriz else None) %}
 {% set num = estabelecimento.numero or (matriz.numero if matriz else None) %}
 {% set bai = estabelecimento.bairro or (matriz.bairro if matriz else None) %}
@@ -23,9 +23,9 @@
   "@graph": [
     {
       "@type": "Organization",
-      "@id": {{ (page_url ~ '#organization') | tojson }},
+      "@id": {{ (origin ~ '/empresa/' ~ cnpj ~ '#organization') | tojson }},
       "name": {{ razao_social | clean_text | tojson }},
-      "url": {{ page_url | tojson }},
+      "url": {{ (origin ~ '/empresa/' ~ cnpj) | tojson }},
       "identifier": [
         {
           "@type": "PropertyValue",
@@ -43,15 +43,11 @@
         {% if uf %}"addressRegion": {{ uf | tojson }},{% endif %}
         {% if cep %}"postalCode": {{ cep | tojson }},{% endif %}
         "addressCountry": "BR"
-      },
-      "sameAs": [
-        {{ ("https://cnpj.biz/" ~ cnpj) | tojson }},
-        {{ ("https://www.gov.br/receitafederal/pt-br/servicos/cadastro/cnpj/consultar-situacao-cadastral") | tojson }}
-      ]
+      }
     },
     {
       "@type": "Dataset",
-      "name": {{ ("Perfil publico de " ~ razao_social ~ " (CNPJ " ~ cnpj_fmt ~ ")") | clean_text | tojson }},
+      "name": {{ ("Pagamentos publicos de " ~ razao_social ~ " em " ~ municipio ~ ", PB (CNPJ " ~ cnpj_fmt ~ ")") | clean_text | tojson }},
       "description": {{ meta_description | tojson }},
       "url": {{ page_url | tojson }},
       "isAccessibleForFree": true,
@@ -67,12 +63,18 @@
         "CNPJ",
         "transparencia publica",
         "Paraiba",
-        "fornecedor publico",
-        "CEIS", "CNEP", "PGFN"
+        {{ municipio | clean_text | tojson }},
+        "fornecedor publico"
       ],
       "spatialCoverage": {
         "@type": "Place",
-        "name": "Paraiba, Brasil"
+        "name": {{ (municipio ~ ', Paraiba, Brasil') | clean_text | tojson }},
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": {{ municipio | clean_text | tojson }},
+          "addressRegion": "PB",
+          "addressCountry": "BR"
+        }
       }
     },
     {
@@ -80,7 +82,8 @@
       "itemListElement": [
         {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ origin }}/"},
         {"@type": "ListItem", "position": 2, "name": "Empresas", "item": "{{ origin }}/sobre"},
-        {"@type": "ListItem", "position": 3, "name": {{ razao_social | clean_text | tojson }}, "item": {{ page_url | tojson }} }
+        {"@type": "ListItem", "position": 3, "name": {{ razao_social | clean_text | tojson }}, "item": {{ (origin ~ '/empresa/' ~ cnpj) | tojson }} },
+        {"@type": "ListItem", "position": 4, "name": {{ municipio | clean_text | tojson }}, "item": {{ page_url | tojson }} }
       ]
     }
   ]
@@ -88,25 +91,40 @@
 </script>
 {% endblock %}
 {% block content %}
-<article class="empresa-page">
+<article class="empresa-page empresa-page-municipio">
     {% include "partials/empresa/_hero.html" %}
-    {% include "partials/empresa/_resumo_pagamentos.html" %}
-    {# Charts globais (12 meses + top 5 elementos PB inteiro) #}
-    {% with monthly_data = monthly_global, charts_titulo = 'Resumo grafico (todo PB)' %}
+
+    <section class="empresa-section empresa-section-scope">
+        <p class="eyebrow">Recorte por municipio</p>
+        <h2 class="empresa-municipio-title">Pagamentos em {{ municipio|clean_text }}, PB</h2>
+        <p class="text-sm">
+            <a href="/empresa/{{ cnpj }}">&larr; Ver perfil global da empresa</a>
+            &middot;
+            <a href="/cidade/{{ municipio_slug }}">Panorama de {{ municipio|clean_text }}</a>
+        </p>
+    </section>
+
+    {% include "partials/empresa/_stats_municipio.html" %}
+
+    {% with monthly_data = monthly, charts_titulo = 'Resumo grafico em ' ~ municipio %}
         {% include "partials/empresa/_charts.html" %}
     {% endwith %}
-    {% include "partials/empresa/_flags.html" %}
+
+    {% include "partials/empresa/_empenhos.html" %}
+
+    {% include "partials/empresa/_sancao_outros.html" %}
+
     {% include "partials/empresa/_sancoes.html" %}
     {% include "partials/empresa/_pgfn.html" %}
     {% include "partials/empresa/_leniencia.html" %}
-    {% include "partials/empresa/_municipios_pagantes.html" %}
+
     {% include "partials/empresa/_socios.html" %}
 
     <section class="empresa-section empresa-fontes">
         <h2>Fontes oficiais</h2>
         <p class="text-sm text-muted">
-            Este perfil cruza dados publicos da Receita Federal (CNPJ), CGU (CEIS, CNEP, Acordos de Leniencia),
-            PGFN (divida ativa), TCE-PB (despesas municipais) e dados.pb.gov.br (orcamento estadual).
+            Este recorte cruza dados publicos da Receita Federal (CNPJ), CGU (CEIS, CNEP, Acordos de Leniencia),
+            PGFN (divida ativa) e TCE-PB (despesas municipais).
             Todos os dados sao oficiais e publicos. Indicamos sinais de atencao &mdash; nao conclusoes juridicas.
         </p>
         <p class="text-sm">

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -29,7 +29,10 @@ from web.queries.cidade import (
     TOP_SERVIDORES_RISCO,
     TOP_SERVIDORES_RISCO_DATED,
 )
-from web.queries.empresa import EMPRESAS_QUALIFICADAS_PARA_SITEMAP
+from web.queries.empresa import (
+    EMPRESAS_MUNICIPIOS_QUALIFICADAS_TODOS,
+    EMPRESAS_QUALIFICADAS_PARA_SITEMAP,
+)
 from web.kpis.cidade import compute_cidade_kpis
 from web.queries.registry import CIDADE_QUERIES
 
@@ -813,9 +816,11 @@ def main():
         print(f"--- PB: {len(municipios_pb)} municipios ---")
         ok_p, fail_p = warm_cycle_pb(municipios_pb)
         ok_e = fail_e = skip_e = 0
+        ok_em = fail_em = skip_em = 0
         if not skip_empresas_flag:
             ok_e, fail_e, skip_e = _warm_empresas_phase()
-        return ok_p + ok_e, fail_p + fail_e, skip_e
+            ok_em, fail_em, skip_em = _warm_empresas_municipios_phase()
+        return ok_p + ok_e + ok_em, fail_p + fail_e + fail_em, skip_e + skip_em
 
     if args.daemon:
         print(f"Daemon mode: {len(municipios_pb)} PB municipios.")
@@ -916,6 +921,215 @@ def _warm_empresas_phase() -> tuple[int, int, int]:
 
     # skip_resume eh tambem skipped (nao foi processado nesse ciclo).
     # Soma com skip_nf pra reportagem completa.
+    return ok, fail, skipped_resume + skip_nf
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Empresa x Municipio warmer — pre-computa /empresa/<cnpj>/<slug>.
+# Mesma estrategia de cache-only do /empresa/<cnpj>: cache miss = 503.
+#
+# Storage no web_cache:
+#   query_id = "EMPRESA_PERFIL_MUN"
+#   municipio = f"{cnpj_completo}:{slug}" (key composta)
+#   columns = ["payload"]
+#   rows = [[<dict_serializado_como_json>]]
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _get_qualifying_empresas_municipios(conn) -> list[tuple[str, str]]:
+    """Lista pares (cnpj_completo, municipio_nome) das empresas qualificadas
+    em cada municipio onde tem pagamentos. Usa a mesma query do sitemap."""
+    with conn.cursor() as cur:
+        cur.execute(EMPRESAS_MUNICIPIOS_QUALIFICADAS_TODOS)
+        rows = cur.fetchall()
+    out: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for cnpj_completo, municipio in rows:
+        if not cnpj_completo or not municipio:
+            continue
+        cnpj_str = str(cnpj_completo).strip()
+        if len(cnpj_str) != 14 or not cnpj_str.isdigit():
+            continue
+        mun = str(municipio).strip()
+        if not mun:
+            continue
+        key = (cnpj_str, mun)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
+def _warm_one_empresa_municipio(par: tuple[str, str]) -> tuple[bool, str | None]:
+    """Computa o perfil de uma empresa em um municipio especifico e armazena
+    em web_cache. par = (cnpj_completo, municipio_nome).
+    """
+    from web.config import TIMEOUT_PROFILE_WARM
+    from web.routes.empresa import (
+        CACHE_QUERY_ID_MUN as EMPRESA_MUN_CACHE_QID,
+        EmpresaNotFoundError,
+        compute_empresa_municipio_perfil_dict,
+    )
+    from web.utils.slug import municipio_slug as _slug_of
+
+    cnpj_completo, municipio_nome = par
+    slug = _slug_of(municipio_nome)
+    if not slug:
+        return False, "no_slug"
+
+    try:
+        data = compute_empresa_municipio_perfil_dict(
+            cnpj_completo, municipio_nome, timeout_sec=TIMEOUT_PROFILE_WARM
+        )
+    except EmpresaNotFoundError as e:
+        return False, f"not_found:{e}"
+    except Exception as e:
+        return False, f"compute_failed:{str(e).splitlines()[0]}"
+
+    key = f"{cnpj_completo}:{slug}"
+    try:
+        conn = _thread_conn()
+        with conn.cursor() as cur:
+            _upsert(
+                cur,
+                EMPRESA_MUN_CACHE_QID,
+                key,
+                ["payload"],
+                [[data]],
+            )
+        conn.commit()
+    except Exception as e:
+        try:
+            _thread_conn().rollback()
+        except Exception:
+            pass
+        return False, f"cache_write_failed:{str(e).splitlines()[0]}"
+    return True, None
+
+
+def warm_cycle_empresas_municipios(
+    pares: list[tuple[str, str]], verbose: bool = True
+) -> tuple[int, int, int]:
+    """Processa pares (empresa, municipio) em paralelo. Mesma semantica de
+    warm_cycle_empresas. Returns: (ok, fail, skipped_not_found)."""
+    bootstrap = psycopg2.connect(DSN)
+    bootstrap.autocommit = False
+    _ensure_cache_table(bootstrap)
+    bootstrap.close()
+
+    total = len(pares)
+    if total == 0:
+        return 0, 0, 0
+    print(
+        f"[empresas-mun] Warming {total} pares em {PARALLEL_WORKERS} workers...",
+        flush=True,
+    )
+
+    ok = 0
+    fail = 0
+    skipped = 0
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as ex:
+        futures = {ex.submit(_warm_one_empresa_municipio, p): p for p in pares}
+        done = 0
+        for fut in as_completed(futures):
+            done += 1
+            par = futures[fut]
+            try:
+                success, msg = fut.result()
+            except Exception as e:
+                success = False
+                msg = f"future_exception:{e}"
+            if success:
+                ok += 1
+            elif msg and msg.startswith("not_found:"):
+                skipped += 1
+            else:
+                fail += 1
+                if verbose and msg:
+                    print(f"  [ERR] {par[0]}@{par[1]}: {msg}", flush=True)
+            if verbose and done % 500 == 0:
+                elapsed = time.time() - t0
+                rate = done / elapsed if elapsed > 0 else 0
+                eta = (total - done) / rate if rate > 0 else 0
+                print(
+                    f"[empresas-mun] {done}/{total} "
+                    f"({ok} ok, {fail} fail, {skipped} skipped) — "
+                    f"{rate:.1f}/s, eta {eta/60:.1f}min",
+                    flush=True,
+                )
+    elapsed = time.time() - t0
+    print(
+        f"[empresas-mun] Completo: {ok} ok, {fail} fail, {skipped} skipped "
+        f"({elapsed/60:.1f}min)",
+        flush=True,
+    )
+    return ok, fail, skipped
+
+
+def _warm_empresas_municipios_phase() -> tuple[int, int, int]:
+    """Fase de warming de pares (empresa, municipio). Mesma logica do
+    _warm_empresas_phase mas sobre EMPRESA_PERFIL_MUN. Resume mode aplicado
+    via _filter_cached_munis com keys f'{cnpj}:{slug}'.
+    """
+    from web.utils.slug import municipio_slug as _slug_of
+
+    print("--- Empresas-Municipios: enumerando qualificadas ---")
+    boot = psycopg2.connect(DSN)
+    boot.autocommit = True
+    try:
+        all_pares = _get_qualifying_empresas_municipios(boot)
+    finally:
+        boot.close()
+
+    if not all_pares:
+        print(
+            "[empresas-mun] Nenhum par (empresa, municipio) qualificado. "
+            "Skipping."
+        )
+        return 0, 0, 0
+
+    # Construir keys e mapping pra filtrar resume mode.
+    par_by_key: dict[str, tuple[str, str]] = {}
+    keys: list[str] = []
+    for cnpj_completo, municipio_nome in all_pares:
+        slug = _slug_of(municipio_nome)
+        if not slug:
+            continue
+        key = f"{cnpj_completo}:{slug}"
+        par_by_key[key] = (cnpj_completo, municipio_nome)
+        keys.append(key)
+
+    if not keys:
+        return 0, 0, 0
+
+    remaining_keys, skipped_resume = _filter_cached_munis(
+        "EMPRESA_PERFIL_MUN", keys
+    )
+    if skipped_resume > 0:
+        print(
+            f"[empresas-mun] Resume mode: {skipped_resume} ja cacheados nas "
+            f"ultimas {SKIP_RECENT_HOURS}h, processando {len(remaining_keys)} "
+            f"restantes."
+        )
+
+    if not remaining_keys:
+        return 0, 0, skipped_resume
+
+    pares_proc = [par_by_key[k] for k in remaining_keys if k in par_by_key]
+
+    from web import db as web_db
+
+    web_db.init_pool()
+    try:
+        ok, fail, skip_nf = warm_cycle_empresas_municipios(pares_proc)
+    finally:
+        try:
+            web_db.close_pool()
+        except Exception:
+            pass
+
     return ok, fail, skipped_resume + skip_nf
 
 


### PR DESCRIPTION
## Sumario

Expande as paginas `/empresa/<cnpj>` com cadastral completo + charts + empenhos detalhados, e adiciona uma **nova variante por municipio** `/empresa/<cnpj>/<municipio_slug>`. Mantem o invariant cache-only (cache miss = 503) que ja protege o pool DB de thundering herd de crawlers (incidente PR #57).

Resolve o gap visivel no screenshot do dialog de fornecedor: hero rico, charts (mensal + top elementos), 50 empenhos detalhados, stats por municipio, pagamentos sob sancao em outros municipios e leniencia com efeitos.

## O que muda

### Hero & cadastral (`_hero.html`)
- **Porte** (com label expandido — ME/EPP/Demais via `compute_empresa_porte_label`)
- **Capital social**, **natureza juridica + descricao**, **telefone (DDD)**, **email**, **ente federativo**

### Per-municipio scoped page (NEW)
- Rota `GET /empresa/{cnpj}/{municipio_slug}` com cadeia de validacao identica a global:
  - CNPJ canonical (14 digitos) -> 301 se nao normalizado
  - Filial -> matriz redirect (preservando slug, sem DB hit)
  - `slug_to_municipio()` resolve o municipio canonico
  - Slug nao-canonico -> 301 pra canonical
  - Cache-only (`web_cache.query_id="EMPRESA_PERFIL_MUN"`, key `<cnpj>:<slug>`); miss = 503 com Retry-After 1h
- `compute_empresa_municipio_perfil_dict` reusa `_fetch_cadastral_block` e adiciona `_fetch_pagamentos_municipio`:
  - 50 empenhos recentes (data, numero, elemento, modalidade, empenhado, pago)
  - Monthly chart (12 meses)
  - Top 5 elementos do municipio
  - Stats agregadas (total_pago, total_empenhado, qtd, qtd_sem_licitacao, periodo)
  - Pagamentos sob sancao em outros municipios PB (so se sancao vigente)

### Templates
- Novos partials: `_charts.html` (mini-bar mensal + top elementos, no JS — pure CSS bars, reusa classes mini-chart), `_empenhos.html`, `_stats_municipio.html`, `_sancao_outros.html`.
- Nova `results/empresa_municipio.html` com JSON-LD `Organization` + `BreadcrumbList` (4 niveis: Inicio > Empresas > {Razao} > {Municipio}) + `Dataset` (com `spatialCoverage`={municipio, PB}).
- `results/empresa.html` (global) inclui `_charts.html` com `monthly_global` apos resumo.
- `_municipios_pagantes.html`: nova coluna **"Recorte"** linkando `/empresa/<cnpj>/<slug>`. Remove a duplicata textual de top elementos (ja exibidos visualmente em `_charts`).

### Layout (`empresa-page.css` + import em `index.css`)
- Hero compacto (margin-block reduzido)
- Sections menos espacadas (1.5rem)
- **kpi-grid 2-col em mobile** (era 1-col empilhada — fix do feedback de "torre vertical")
- charts-grid responsivo (2-col desktop, 1-col mobile)
- empresa-card-grid pra cards lado-a-lado quando aplicavel

### Sitemap (seo.py + queries/empresa.py)
- 3 queries novas: `EMPRESAS_MUNICIPIOS_QUALIFICADAS_PAGINATED/COUNT/TODOS`.
- Nova rota `/sitemap-empresas-municipios-{n}.xml` (mesma estrategia: shard 49K URLs, cache 1h, past-end retorna urlset vazio sem cache).
- `_build_sitemap_index` lista os shards de empresas-municipios apos os de empresas (gated em `SITEMAP_INCLUDE_EMPRESAS=1`).

### Warmer (`warm_cache.py`)
- `_warm_one_empresa_municipio` + `warm_cycle_empresas_municipios` + `_warm_empresas_municipios_phase` rodam apos `_warm_empresas_phase` no `run_one_cycle`.
- Mesmo `skip_empresas_flag` e mesmo threshold combinado de 5%.
- Resume mode: `_filter_cached_munis(query_id="EMPRESA_PERFIL_MUN", keys=["<cnpj>:<slug>", ...])`.

### IndexNow (`indexnow_submit.py`)
- Itera shards adicionais `/sitemap-empresas-municipios-{n}.xml` dentro do `flag_empresas` block.

### Deploy (`.github/workflows/deploy.yml`)
- Step `Enable empresa sitemap` ganha:
  - **Coverage check** para `EMPRESA_PERFIL_MUN >= 80%` (mesmo gate da global).
  - **Sitemap-index verify** cobre os dois prefixos de shard (warning, nao error, se MUN ainda vazio).
  - **E2E smoke MUN**: 10 URLs `/empresa/<cnpj>/<slug>` amostradas do qualifying set; tolera 2/10 fail; rollback automatico do drop-in se < 8 OK.

## Validacao local

```
python -m compileall web -q                                            # OK
python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml').read())"  # OK
git --no-pager diff --stat origin/main                                  # 16 files, +1644/-121
```

- Rota nova `/empresa/<cnpj>/<slug>` retorna 503 em cache miss (correto — antes do warmer rodar).
- Sem regressao em `/api/fornecedor/detalhes` (cidade.py): nenhum import alterado.
- BANCO LOCAL TEM `mv_empresa_pb` STALE — testar funcionalmente em prod apos warmer rodar.

## Arquivos

```
.github/workflows/deploy.yml                            +93
web/queries/empresa.py                                  +171
web/routes/empresa.py                                   +596 / -121
web/routes/seo.py                                       +135
web/warm_cache.py                                       +218
web/indexnow_submit.py                                  +32
web/static/css/index.css                                +1
web/static/css/components/empresa-page.css              NEW
web/templates/partials/empresa/_hero.html               +29
web/templates/partials/empresa/_municipios_pagantes.html  +27 / -22
web/templates/partials/empresa/_charts.html             NEW
web/templates/partials/empresa/_empenhos.html           NEW
web/templates/partials/empresa/_stats_municipio.html    NEW
web/templates/partials/empresa/_sancao_outros.html      NEW
web/templates/results/empresa.html                      +4
web/templates/results/empresa_municipio.html            NEW
```

## Notas / dividas

- Ordem de operacoes pra exposicao: rodar `warm_cache=true` (vai popular ambos `EMPRESA_PERFIL` e `EMPRESA_PERFIL_MUN`) **antes** de `expose_empresa_sitemap=enable`. O coverage gate de 80% nos dois bloqueia exposicao parcial.
- Volume estimado de pares (empresa, municipio): cada empresa qualificada x media de municipios pagantes (~3-5). Assumindo ~150K empresas qualificadas, ~500K-750K pares. Com `EMPRESA_SHARD_SIZE=49000`, ~10-15 shards de `sitemap-empresas-municipios-*`. Warmer com 16 workers a ~2-3 perfis/s leva varias horas — daemon `--loop` recomendado pra primeira passagem.
- Nao fiz merge nem trigger de workflows (conforme solicitado).
