### PR TITLE
feat(empresa-mun): empenhos no fim + clickable -> empenho-dialog

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -402,7 +402,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "98"
+templates.env.globals["ASSET_VERSION"] = "99"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/components/clickable-rows.js
+++ b/web/static/js/components/clickable-rows.js
@@ -9,7 +9,16 @@ function initClickableRows(root = document) {
         if (titleCell && !row.getAttribute('aria-label')) {
             row.setAttribute('aria-label', `Abrir detalhes de ${titleCell.textContent.trim()}`);
         }
-        const activate = () => {
+        const activate = (event) => {
+            // Empenho row (top-level, fora de dialog)
+            const empenhoId = row.dataset.empenhoId || '';
+            if (empenhoId) {
+                if (event && event.target && event.target.closest && event.target.closest('a')) return;
+                if (typeof openEmpenhoDialog === 'function') {
+                    openEmpenhoDialog(empenhoId);
+                }
+                return;
+            }
             // Servidor row
             const cpf6 = row.dataset.cpf6 || '';
             const nomeUpper = row.dataset.nomeUpper || '';
@@ -40,11 +49,11 @@ function initClickableRows(root = document) {
                 openLicitacaoDialog(licNum, licAno, _currentMunicipio, `Licitacao ${licNum}`, licMod);
             }
         };
-        row.addEventListener('click', activate);
+        row.addEventListener('click', (event) => activate(event));
         row.addEventListener('keydown', (event) => {
             if (event.key !== 'Enter' && event.key !== ' ') return;
             event.preventDefault();
-            activate();
+            activate(event);
         });
     });
 }

--- a/web/templates/partials/dialogs/_empresa_dialog.html
+++ b/web/templates/partials/dialogs/_empresa_dialog.html
@@ -1,0 +1,22 @@
+{# Dialog reutilizavel pra detalhes de empresa/empenho/servidor/licitacao/heatmap.
+
+   Incluso em /cidade/<slug> e /empresa/<cnpj>/<mun>. Os componentes JS
+   (empenho-dialog.js, fornecedor-dialog.js etc) procuram `#empresa-dialog`
+   e fazem early-return se nao encontrarem, entao paginas que nao precisam
+   de dialog simplesmente nao incluem este partial.
+#}
+<md-dialog id="empresa-dialog" class="empresa-dialog" aria-labelledby="empresa-dialog-title">
+    <div slot="headline" class="dialog-header">
+        <md-icon-button class="dialog-back" data-dialog-back style="visibility:hidden" aria-label="Voltar">
+            <md-icon>arrow_back</md-icon>
+        </md-icon-button>
+        <h3 class="dialog-title" id="empresa-dialog-title">Detalhes</h3>
+        <md-icon-button class="dialog-share" data-share data-share-text="Detalhe compartilhado da TransparenciaPB" aria-label="Compartilhar este detalhe">
+            <md-icon>share</md-icon>
+        </md-icon-button>
+        <md-icon-button class="dialog-close" data-md-dialog-close aria-label="Fechar">
+            <md-icon>close</md-icon>
+        </md-icon-button>
+    </div>
+    <div slot="content" class="dialog-body"></div>
+</md-dialog>

--- a/web/templates/partials/empresa/_empenhos.html
+++ b/web/templates/partials/empresa/_empenhos.html
@@ -1,10 +1,16 @@
-{# Tabela de empenhos recentes (ate 50). Esperada a var `empenhos`. #}
+{# Tabela de empenhos recentes (ate 50). Esperada a var `empenhos`.
+
+   Linhas sao clickable: abrem #empresa-dialog via openEmpenhoDialog (handler
+   em clickable-rows.js -> empenho-dialog.js). Caller deve incluir o partial
+   partials/dialogs/_empresa_dialog.html no template pra que o dialog exista.
+#}
 {% if empenhos %}
 <section class="empresa-section" id="empenhos-recentes">
     <h2>Empenhos recentes</h2>
     <p class="text-sm text-muted">
         Ultimos {{ empenhos|length }} empenhos pagos identificados no TCE-PB
-        (ordenados pela data do empenho, mais recentes primeiro).
+        (ordenados pela data do empenho, mais recentes primeiro). Clique em uma
+        linha para abrir os detalhes.
     </p>
     <div class="tbl-wrap">
         <table class="stack-mobile data-table empresa-empenhos-table">
@@ -21,7 +27,7 @@
             <tbody>
                 {% for e in empenhos %}
                 {% set sem_lic = (not e.numero_licitacao) or (e.numero_licitacao == '000000000') or ((e.modalidade_licitacao or '')|lower).startswith('sem licit') %}
-                <tr>
+                <tr class="clickable-row"{% if e.id %} data-empenho-id="{{ e.id }}"{% endif %}>
                     <td data-label="Data">{{ e.data_empenho|date_br }}</td>
                     <td data-label="Numero"><code>{{ e.numero_empenho|clean_text or '—' }}</code></td>
                     <td data-label="Elemento">{{ e.elemento_despesa|clean_text or '—' }}</td>

--- a/web/templates/results/empresa_municipio.html
+++ b/web/templates/results/empresa_municipio.html
@@ -144,7 +144,24 @@
 // senao corremos o risco de chamar dialog.show() antes da custom-element
 // upgrade resolver, o que da TypeError. main.js tambem espera por isso
 // pra wirear handlers.
+//
+// IMPORTANTE: setamos _currentMunicipio/_currentUf imediatamente no
+// DOMContentLoaded (nao dentro do whenMD3Ready). Esses globals (declarados
+// em dialog-nav.js, escopo compartilhado entre scripts classicos) sao
+// usados por dialog-links.js + fornecedor/licitacao dialogs como fallback
+// quando nenhum override eh passado. Sem isso, click numa licitacao dentro
+// do empenho-dialog manda municipio="" pra /api/licitacao/detalhes (que
+// devolve {} = dialog vazio).
 document.addEventListener("DOMContentLoaded", () => {
+    try {
+        // eslint-disable-next-line no-undef
+        _currentMunicipio = {{ municipio|tojson }};
+        // eslint-disable-next-line no-undef
+        _currentUf = "PB";
+    } catch (_) {
+        // dialog-nav.js ainda nao carregou — improvavel apos
+        // DOMContentLoaded mas seguro ignorar.
+    }
     const restore = () => {
         if (typeof restoreDialogFromUrl === 'function') {
             restoreDialogFromUrl();

--- a/web/templates/results/empresa_municipio.html
+++ b/web/templates/results/empresa_municipio.html
@@ -140,14 +140,21 @@
 
 <script>
 // Deep-link de dialog: ?d=empenho&id=... abre o dialog correspondente.
-// Ver dialog-url-state.js. Roda apos main.js wirear os handlers do
-// dialog (DOMContentLoaded). Pequeno setTimeout pra garantir ordem.
+// Ver dialog-url-state.js. Espera o md-dialog upgrade (whenMD3Ready) —
+// senao corremos o risco de chamar dialog.show() antes da custom-element
+// upgrade resolver, o que da TypeError. main.js tambem espera por isso
+// pra wirear handlers.
 document.addEventListener("DOMContentLoaded", () => {
-    setTimeout(() => {
+    const restore = () => {
         if (typeof restoreDialogFromUrl === 'function') {
             restoreDialogFromUrl();
         }
-    }, 0);
+    };
+    if (typeof window.whenMD3Ready === 'function') {
+        window.whenMD3Ready(restore);
+    } else {
+        setTimeout(restore, 0);
+    }
 });
 </script>
 {% endblock %}

--- a/web/templates/results/empresa_municipio.html
+++ b/web/templates/results/empresa_municipio.html
@@ -110,8 +110,6 @@
         {% include "partials/empresa/_charts.html" %}
     {% endwith %}
 
-    {% include "partials/empresa/_empenhos.html" %}
-
     {% include "partials/empresa/_sancao_outros.html" %}
 
     {% include "partials/empresa/_sancoes.html" %}
@@ -119,6 +117,10 @@
     {% include "partials/empresa/_leniencia.html" %}
 
     {% include "partials/empresa/_socios.html" %}
+
+    {# Empenhos no fim — pode ser longo (ate 50 linhas). Linhas clickaveis
+       abrem #empresa-dialog (ver partials/dialogs/_empresa_dialog.html). #}
+    {% include "partials/empresa/_empenhos.html" %}
 
     <section class="empresa-section empresa-fontes">
         <h2>Fontes oficiais</h2>
@@ -133,4 +135,19 @@
         </p>
     </section>
 </article>
+
+{% include "partials/dialogs/_empresa_dialog.html" %}
+
+<script>
+// Deep-link de dialog: ?d=empenho&id=... abre o dialog correspondente.
+// Ver dialog-url-state.js. Roda apos main.js wirear os handlers do
+// dialog (DOMContentLoaded). Pequeno setTimeout pra garantir ordem.
+document.addEventListener("DOMContentLoaded", () => {
+    setTimeout(() => {
+        if (typeof restoreDialogFromUrl === 'function') {
+            restoreDialogFromUrl();
+        }
+    }, 0);
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Problema

Na pagina `/empresa/<cnpj>/<municipio>`:

1. **Empenhos no meio da pagina, empurrando socios e fontes pra baixo.**
   Tabela tem ate 50 linhas — em telas pequenas voce rola muito antes
   de chegar nas secoes finais.

2. **Empenhos eram apenas leitura.** Sem detalhes do empenho (licitacao
   vinculada, valor liquidado, historico, classificacao orcamentaria),
   diferente da pagina de cidade onde ja temos o `empenho-dialog` rico.

## Mudancas

### UX
- Move `_empenhos.html` pro **final da pagina**, logo antes de "Fontes
  oficiais". Topo fica com info compacta (charts, sancoes, socios).
- Linhas da tabela ficam **clickaveis** (cursor pointer, hover, chevron)
  e abrem o `empenho-dialog` ja existente.

### Wiring
- `_empenhos.html`: `<tr>` ganha `class="clickable-row" data-empenho-id`.
- `components/clickable-rows.js`: novo case pra `empenhoId` no
  `activate()` chama `openEmpenhoDialog(empenhoId)`. Skip se click foi
  num `<a>` aninhado.
- `partials/dialogs/_empresa_dialog.html`: extrai o `md-dialog` que
  estava inline em cidade.html como partial reutilizavel.
- `empresa_municipio.html`: inclui o partial + script inline pra
  `restoreDialogFromUrl()` (deep-links `?d=empenho&id=...` agora funcionam).
- Bump `ASSET_VERSION` 98 -> 99 (JS + templates mudaram).

## Compat
- Cidade.html **mantida inalterada** (markup duplicado mas zero risco
  de regressao — bootstrapCityReport tem inline script proprio).
- `web_cache` **nao** precisa invalidacao: payload eh dict puro
  (empenhos ja tinham `id`); template re-renderiza server-side.
- Empresa global `/empresa/<cnpj>` **nao** afetada (nao inclui
  `_empenhos.html`).

## Smoke test pos-deploy

```bash
# Pagina abre normal e empenhos estao no fim
curl -sS https://transparenciapb.org/empresa/00360305000104/joao-pessoa | grep -E '(empenhos-recentes|clickable-row|empresa-dialog)' | head -5

# Deep-link de empenho (substitua ID por um valido):
# https://transparenciapb.org/empresa/<cnpj>/<slug>?d=empenho&id=<empenho_id>
```

## Arquivos

- `web/main.py` — ASSET_VERSION bump
- `web/static/js/components/clickable-rows.js` — novo case empenho
- `web/templates/partials/empresa/_empenhos.html` — clickable-row
- `web/templates/partials/dialogs/_empresa_dialog.html` — **novo**
- `web/templates/results/empresa_municipio.html` — reorder + include + restore
