### PR TITLE
feat(empenhos): paginacao + filtros (data + busca) em 3 superficies

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -399,10 +399,11 @@ JS_FILES: list[str] = [
     "lib/run-limited.js",
     "components/data-table.js",
     "components/clickable-rows.js",
+    "components/empenhos-controller.js",
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "99"
+templates.env.globals["ASSET_VERSION"] = "100"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -230,7 +230,7 @@ EMPRESA_EMPENHOS_RECENTES_BY_MUN = """
     WHERE cnpj_basico = %(cnpj_basico)s
       AND municipio = %(municipio)s
       AND valor_pago > 0
-    ORDER BY data_empenho DESC
+    ORDER BY data_empenho DESC NULLS LAST, id DESC
     LIMIT 50
 """
 

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -234,6 +234,152 @@ EMPRESA_EMPENHOS_RECENTES_BY_MUN = """
     LIMIT 50
 """
 
+# ─────────────────────────────────────────────────────────────────────────
+# Empenhos paginados + filtraveis (data + busca textual). Alimentam o
+# endpoint /api/empresa/empenhos para paginacao live (page 2+ ou qualquer
+# filtro). Page 1 sem filtros eh servido do warmer cache (campo `empenhos`
+# em EMPRESA_PERFIL_MUN/EMPRESA_PERFIL).
+#
+# Filtros opcionais via padrao "param IS NULL OR coluna OP param" — isso
+# permite uma unica query servir todos os casos (com/sem data, com/sem
+# busca) sem string concat. PG otimiza bem esse padrao quando os params
+# sao todos NULL (planner pode pular).
+#
+# Busca textual: ILIKE em 4 colunas (numero, elemento, historico,
+# modalidade). Sem FTS por ora — ILIKE funciona bem com WHERE ja restrito
+# por cnpj_basico/municipio (poucos milhares de rows). Frontend exige
+# min 2 chars.
+#
+# ORDER BY data_empenho DESC NULLS LAST, id DESC: estavel para
+# paginacao (id desempata datas iguais).
+# ─────────────────────────────────────────────────────────────────────────
+
+EMPRESA_EMPENHOS_PAGINATED_BY_MUN = """
+    SELECT id, numero_empenho, data_empenho, elemento_despesa,
+           valor_empenhado, valor_pago,
+           modalidade_licitacao, numero_licitacao
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+      AND (%(data_inicio)s IS NULL OR data_empenho >= %(data_inicio)s::date)
+      AND (%(data_fim)s IS NULL OR data_empenho <= %(data_fim)s::date)
+      AND (
+          %(q)s IS NULL OR (
+              numero_empenho ILIKE %(q_pat)s
+              OR elemento_despesa ILIKE %(q_pat)s
+              OR COALESCE(historico, '') ILIKE %(q_pat)s
+              OR COALESCE(modalidade_licitacao, '') ILIKE %(q_pat)s
+          )
+      )
+    ORDER BY data_empenho DESC NULLS LAST, id DESC
+    LIMIT %(limit)s OFFSET %(offset)s
+"""
+
+EMPRESA_EMPENHOS_COUNT_BY_MUN = """
+    SELECT COUNT(*)
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+      AND (%(data_inicio)s IS NULL OR data_empenho >= %(data_inicio)s::date)
+      AND (%(data_fim)s IS NULL OR data_empenho <= %(data_fim)s::date)
+      AND (
+          %(q)s IS NULL OR (
+              numero_empenho ILIKE %(q_pat)s
+              OR elemento_despesa ILIKE %(q_pat)s
+              OR COALESCE(historico, '') ILIKE %(q_pat)s
+              OR COALESCE(modalidade_licitacao, '') ILIKE %(q_pat)s
+          )
+      )
+"""
+
+# Variantes globais (sem filtro de municipio) — usadas pela pagina
+# /empresa/<cnpj> (perfil global). Warmer popula primeira pagina;
+# pages 2+ ou filtros sao live.
+EMPRESA_EMPENHOS_PAGINATED_GLOBAL = """
+    SELECT id, numero_empenho, data_empenho, municipio, elemento_despesa,
+           valor_empenhado, valor_pago,
+           modalidade_licitacao, numero_licitacao
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND valor_pago > 0
+      AND (%(data_inicio)s IS NULL OR data_empenho >= %(data_inicio)s::date)
+      AND (%(data_fim)s IS NULL OR data_empenho <= %(data_fim)s::date)
+      AND (
+          %(q)s IS NULL OR (
+              numero_empenho ILIKE %(q_pat)s
+              OR elemento_despesa ILIKE %(q_pat)s
+              OR COALESCE(historico, '') ILIKE %(q_pat)s
+              OR COALESCE(modalidade_licitacao, '') ILIKE %(q_pat)s
+              OR municipio ILIKE %(q_pat)s
+          )
+      )
+    ORDER BY data_empenho DESC NULLS LAST, id DESC
+    LIMIT %(limit)s OFFSET %(offset)s
+"""
+
+EMPRESA_EMPENHOS_COUNT_GLOBAL = """
+    SELECT COUNT(*)
+    FROM tce_pb_despesa
+    WHERE cnpj_basico = %(cnpj_basico)s
+      AND valor_pago > 0
+      AND (%(data_inicio)s IS NULL OR data_empenho >= %(data_inicio)s::date)
+      AND (%(data_fim)s IS NULL OR data_empenho <= %(data_fim)s::date)
+      AND (
+          %(q)s IS NULL OR (
+              numero_empenho ILIKE %(q_pat)s
+              OR elemento_despesa ILIKE %(q_pat)s
+              OR COALESCE(historico, '') ILIKE %(q_pat)s
+              OR COALESCE(modalidade_licitacao, '') ILIKE %(q_pat)s
+              OR municipio ILIKE %(q_pat)s
+          )
+      )
+"""
+
+# Variantes para fornecedor (cpf_cnpj exato em vez de cnpj_basico) — o
+# dialog de fornecedor em /cidade/ usa identidade exata pra evitar
+# colisao CPF/CNPJ por prefixo de 8 digitos (ver cidade.py:1655).
+EMPRESA_EMPENHOS_PAGINATED_BY_DOC_MUN = """
+    SELECT id, numero_empenho, data_empenho, elemento_despesa,
+           valor_empenhado, valor_pago,
+           modalidade_licitacao, numero_licitacao
+    FROM tce_pb_despesa
+    WHERE cpf_cnpj = %(cpf_cnpj)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+      AND (%(data_inicio)s IS NULL OR data_empenho >= %(data_inicio)s::date)
+      AND (%(data_fim)s IS NULL OR data_empenho <= %(data_fim)s::date)
+      AND (
+          %(q)s IS NULL OR (
+              numero_empenho ILIKE %(q_pat)s
+              OR elemento_despesa ILIKE %(q_pat)s
+              OR COALESCE(historico, '') ILIKE %(q_pat)s
+              OR COALESCE(modalidade_licitacao, '') ILIKE %(q_pat)s
+          )
+      )
+    ORDER BY data_empenho DESC NULLS LAST, id DESC
+    LIMIT %(limit)s OFFSET %(offset)s
+"""
+
+EMPRESA_EMPENHOS_COUNT_BY_DOC_MUN = """
+    SELECT COUNT(*)
+    FROM tce_pb_despesa
+    WHERE cpf_cnpj = %(cpf_cnpj)s
+      AND municipio = %(municipio)s
+      AND valor_pago > 0
+      AND (%(data_inicio)s IS NULL OR data_empenho >= %(data_inicio)s::date)
+      AND (%(data_fim)s IS NULL OR data_empenho <= %(data_fim)s::date)
+      AND (
+          %(q)s IS NULL OR (
+              numero_empenho ILIKE %(q_pat)s
+              OR elemento_despesa ILIKE %(q_pat)s
+              OR COALESCE(historico, '') ILIKE %(q_pat)s
+              OR COALESCE(modalidade_licitacao, '') ILIKE %(q_pat)s
+          )
+      )
+"""
+
 EMPRESA_STATS_BY_MUN = """
     SELECT COUNT(*) AS qtd_empenhos,
            COALESCE(SUM(valor_empenhado), 0) AS total_empenhado,

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -42,6 +42,8 @@ from web.queries.cidade import (
     TOP_SERVIDORES_RISCO_DATED,
 )
 from web.queries.empresa import (
+    EMPRESA_EMPENHOS_COUNT_BY_DOC_MUN,
+    EMPRESA_EMPENHOS_PAGINATED_BY_DOC_MUN,
     EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
     EMPRESA_LENIENCIA_BY_CNPJ,
     EMPRESA_LENIENCIA_EFEITOS_BY_ID,
@@ -1965,6 +1967,158 @@ async def get_empenho_detalhes(payload: dict = Body(...)):
     except Exception:
         import logging; logging.exception("empenho detalhes failed")
         return JSONResponse({})
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# /api/fornecedor/empenhos — paginate + filtra empenhos do dialog de
+# fornecedor em /cidade/<slug>. Usa cpf_cnpj exato (em vez de
+# cnpj_basico) pra evitar colisao CPF/CNPJ — mesmo padrao do
+# /api/fornecedor/detalhes acima.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_EMP_FORN_PAGE_SIZE = 50
+_EMP_FORN_TIMEOUT_SEC = 5
+_EMP_FORN_Q_MIN = 2
+_EMP_FORN_Q_MAX = 100
+
+
+def _empforn_parse_iso_date(s):
+    """YYYY-MM-DD ou None."""
+    if s is None:
+        return None
+    s = str(s).strip()
+    if not s:
+        return None
+    import re as _re
+    if not _re.fullmatch(r"\d{4}-\d{2}-\d{2}", s):
+        return None
+    return s
+
+
+def _empforn_parse_q(q):
+    """Retorna (q_clean, q_pat) ou (None, None) se invalido. Escapa
+    wildcards SQL pra impedir patterns lentos do usuario."""
+    if q is None:
+        return (None, None)
+    s = str(q).strip()
+    if len(s) < _EMP_FORN_Q_MIN:
+        return (None, None)
+    if len(s) > _EMP_FORN_Q_MAX:
+        s = s[:_EMP_FORN_Q_MAX]
+    escaped = s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return (s, f"%{escaped}%")
+
+
+@router.post("/api/fornecedor/empenhos")
+async def get_fornecedor_empenhos(payload: dict = Body(...)):
+    """Lista paginada de empenhos de um fornecedor num municipio.
+
+    Body:
+        cpf_cnpj: 14 digitos (canonico). Obrigatorio.
+        municipio: nome canonico. Obrigatorio (dialog sempre tem mun
+            scope — escopo cross-mun ja eh tratado por
+            empenhos_sancao_outros separado).
+        q, data_inicio, data_fim, page: idem /api/empresa/empenhos.
+
+    Returns: {empenhos, total, page, total_pages, page_size}
+    """
+    cpf_cnpj = "".join(ch for ch in str(payload.get("cpf_cnpj", "")) if ch.isdigit())
+    if len(cpf_cnpj) != 14:
+        return JSONResponse(
+            {"error": "cpf_cnpj invalido (esperado 14 digitos)"},
+            status_code=400,
+        )
+    municipio = (payload.get("municipio") or "").strip()
+    if not municipio:
+        return JSONResponse(
+            {"error": "municipio obrigatorio"}, status_code=400
+        )
+
+    data_inicio = _empforn_parse_iso_date(payload.get("data_inicio"))
+    data_fim = _empforn_parse_iso_date(payload.get("data_fim"))
+    q_clean, q_pat = _empforn_parse_q(payload.get("q"))
+
+    try:
+        page = int(payload.get("page") or 1)
+    except (TypeError, ValueError):
+        page = 1
+    if page < 1:
+        page = 1
+    offset = (page - 1) * _EMP_FORN_PAGE_SIZE
+
+    params = {
+        "cpf_cnpj": cpf_cnpj,
+        "municipio": municipio,
+        "data_inicio": data_inicio,
+        "data_fim": data_fim,
+        "q": q_clean,
+        "q_pat": q_pat,
+        "limit": _EMP_FORN_PAGE_SIZE,
+        "offset": offset,
+    }
+
+    try:
+        from psycopg2.errors import QueryCanceled
+        from web.db import get_conn
+        with get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SET statement_timeout = '{_EMP_FORN_TIMEOUT_SEC * 1000}'"
+                )
+                try:
+                    cur.execute(EMPRESA_EMPENHOS_PAGINATED_BY_DOC_MUN, params)
+                    cols = [d[0] for d in cur.description]
+                    empenhos = []
+                    for row in cur.fetchall():
+                        d = _row_to_dict(cols, row)
+                        for k, v in d.items():
+                            if hasattr(v, "as_tuple"):
+                                d[k] = float(v)
+                            elif hasattr(v, "isoformat"):
+                                d[k] = v.isoformat()
+                        empenhos.append(d)
+
+                    count_params = {k: v for k, v in params.items()
+                                    if k not in ("limit", "offset")}
+                    cur.execute(EMPRESA_EMPENHOS_COUNT_BY_DOC_MUN, count_params)
+                    cnt = cur.fetchone()
+                    total = int(cnt[0]) if cnt else 0
+                finally:
+                    try:
+                        cur.execute("RESET statement_timeout")
+                    except Exception:
+                        pass
+    except QueryCanceled:
+        return JSONResponse(
+            {
+                "error": "timeout",
+                "message": (
+                    "A busca demorou muito. Use filtros (data ou texto) "
+                    "para refinar."
+                ),
+            },
+            status_code=504,
+        )
+    except Exception:
+        import logging; logging.exception("fornecedor empenhos failed")
+        return JSONResponse(
+            {"error": "internal", "message": "Erro ao buscar empenhos."},
+            status_code=500,
+        )
+
+    total_pages = (
+        (total + _EMP_FORN_PAGE_SIZE - 1) // _EMP_FORN_PAGE_SIZE
+        if total > 0 else 0
+    )
+    return {
+        "empenhos": empenhos,
+        "total": total,
+        "page": page,
+        "total_pages": total_pages,
+        "page_size": _EMP_FORN_PAGE_SIZE,
+    }
 
 
 @router.post("/api/licitacao/detalhes")

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1658,7 +1658,10 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                 id_clause = "cpf_cnpj = %s AND municipio = %s"
                 id_params = [cpf_cnpj, municipio]
 
-                # Empenhos recentes no municipio
+                # Empenhos recentes no municipio. ORDER BY estavel
+                # (data DESC NULLS LAST, id DESC) bate com o que o endpoint
+                # paginado /api/fornecedor/empenhos usa em pg 2+ — evita
+                # duplicar/pular rows quando ha empenhos com a mesma data.
                 cur.execute(f"""
                     SELECT id, numero_empenho, data_empenho, elemento_despesa,
                            valor_empenhado, valor_pago,
@@ -1666,7 +1669,7 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     FROM tce_pb_despesa
                     WHERE {id_clause}
                       AND valor_pago > 0
-                    ORDER BY data_empenho DESC
+                    ORDER BY data_empenho DESC NULLS LAST, id DESC
                     LIMIT 50
                 """, id_params)
                 emp_cols = [d[0] for d in cur.description]
@@ -1984,7 +1987,9 @@ _EMP_FORN_Q_MAX = 100
 
 
 def _empforn_parse_iso_date(s):
-    """YYYY-MM-DD ou None."""
+    """YYYY-MM-DD valido (calendar-wise) ou None. Valida via fromisoformat
+    pra rejeitar 2026-02-31 etc que passariam pelo regex e quebrariam
+    o cast ::date em PG."""
     if s is None:
         return None
     s = str(s).strip()
@@ -1992,6 +1997,11 @@ def _empforn_parse_iso_date(s):
         return None
     import re as _re
     if not _re.fullmatch(r"\d{4}-\d{2}-\d{2}", s):
+        return None
+    try:
+        from datetime import date as _date
+        _date.fromisoformat(s)
+    except ValueError:
         return None
     return s
 

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -27,6 +27,10 @@ from web.config import TIMEOUT_PROFILE
 from web.db import execute_query, get_conn, read_web_cache
 from web.queries.empresa import (
     EMPRESA_AGREGADOS_PB_BY_BASICO,
+    EMPRESA_EMPENHOS_COUNT_BY_MUN,
+    EMPRESA_EMPENHOS_COUNT_GLOBAL,
+    EMPRESA_EMPENHOS_PAGINATED_BY_MUN,
+    EMPRESA_EMPENHOS_PAGINATED_GLOBAL,
     EMPRESA_EMPENHOS_RECENTES_BY_MUN,
     EMPRESA_ESTABELECIMENTO_BY_CNPJ_COMPLETO,
     EMPRESA_LENIENCIA_BY_BASICO,
@@ -172,6 +176,11 @@ def _fetch_pagamentos_municipio(cur, cnpj_basico: str, municipio: str,
     e_cols = [d[0] for d in cur.description]
     empenhos = [_convert_row(_row_to_dict(e_cols, r)) for r in cur.fetchall()]
 
+    # `qtd_empenhos` em stats ja eh o count total (foi computado pela
+    # mesma query EMPRESA_STATS_BY_MUN acima). Usado pelo footer de
+    # paginacao no frontend ("X paginas de Y empenhos") sem 1 query extra.
+    empenhos_total = int(stats.get("qtd_empenhos") or 0) if stats else 0
+
     out = {
         "municipio": municipio,
         "municipio_slug": municipio_slug(municipio),
@@ -179,6 +188,7 @@ def _fetch_pagamentos_municipio(cur, cnpj_basico: str, municipio: str,
         "monthly": monthly,
         "top_elementos": top_elementos,
         "empenhos": empenhos,
+        "empenhos_total": empenhos_total,
     }
     if with_sancao_outros:
         cur.execute(
@@ -272,6 +282,35 @@ def _fetch_cadastral_block(cur, cnpj_completo: str, cnpj_basico: str,
         _convert_row(_row_to_dict(m_cols, r)) for r in cur.fetchall()
     ]
 
+    # Top 50 empenhos GLOBAIS (sem filtro de municipio) + count total.
+    # Alimenta a primeira pagina da tabela paginada em /empresa/<cnpj>.
+    # Pages 2+ ou filtros sao live via /api/empresa/empenhos. Cache key
+    # global eh EMPRESA_PERFIL:<cnpj> — entries pre-deploy nao tem esses
+    # campos, frontend lida com fallback (lazy fetch live ao mount).
+    cur.execute(
+        EMPRESA_EMPENHOS_PAGINATED_GLOBAL,
+        {
+            "cnpj_basico": cnpj_basico,
+            "data_inicio": None, "data_fim": None,
+            "q": None, "q_pat": None,
+            "limit": 50, "offset": 0,
+        },
+    )
+    eg_cols = [d[0] for d in cur.description]
+    empenhos_global = [
+        _convert_row(_row_to_dict(eg_cols, r)) for r in cur.fetchall()
+    ]
+    cur.execute(
+        EMPRESA_EMPENHOS_COUNT_GLOBAL,
+        {
+            "cnpj_basico": cnpj_basico,
+            "data_inicio": None, "data_fim": None,
+            "q": None, "q_pat": None,
+        },
+    )
+    cnt_row = cur.fetchone()
+    empenhos_total_global = int(cnt_row[0]) if cnt_row else 0
+
     return {
         "estabelecimento": estabelecimento,
         "matriz": matriz,
@@ -282,6 +321,8 @@ def _fetch_cadastral_block(cur, cnpj_completo: str, cnpj_basico: str,
         "municipios_pagantes": municipios_pagantes,
         "top_elementos": top_elementos,
         "monthly_global": monthly_global,
+        "empenhos_global": empenhos_global,
+        "empenhos_total_global": empenhos_total_global,
     }
 
 
@@ -429,6 +470,11 @@ def compute_empresa_perfil_dict(
         "municipios_pagantes": cadastral["municipios_pagantes"],
         "top_elementos": cadastral["top_elementos"],
         "monthly_global": cadastral["monthly_global"],
+        # Empenhos globais (top 50 + count) — pagina 1 da tabela
+        # paginada em /empresa/<cnpj>. Adicionado no PR de paginacao;
+        # entries pre-PR nao tem esses campos, frontend faz fallback live.
+        "empenhos_global": cadastral.get("empenhos_global", []),
+        "empenhos_total_global": cadastral.get("empenhos_total_global", 0),
         "kpi_total_pb": total_pb_geral,
         "kpi_qtd_municipios": qtd_municipios,
         "kpi_qtd_empenhos": qtd_empenhos_pb,
@@ -556,6 +602,11 @@ def compute_empresa_municipio_perfil_dict(
         "monthly": pag["monthly"],
         "top_elementos": pag["top_elementos"],
         "empenhos": pag["empenhos"],
+        # Total empenhos no municipio (count) — usado pra paginacao.
+        # Adicionado no PR de paginacao; entries pre-PR cacheadas usam
+        # fallback len(empenhos) no frontend (ate primeiro fetch live
+        # popular total real).
+        "empenhos_total": pag.get("empenhos_total") or qtd_no_mun,
         "pagamentos_sancao_outros": pag.get("pagamentos_sancao_outros") or [],
         # KPIs focados no municipio:
         "kpi_total_pago_mun": total_pago_mun,
@@ -766,3 +817,176 @@ async def empresa_perfil_municipio(
         ),
         media_type="text/plain; charset=utf-8",
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# /api/empresa/empenhos — paginate + filtra empenhos. Live (5s timeout).
+# Page 1 sem filtros eh servido pelo warmer cache (campo `empenhos` em
+# EMPRESA_PERFIL/EMPRESA_PERFIL_MUN); frontend so chama este endpoint pra
+# pages 2+ ou qualquer filtro. Sem cache server-side proprio: usuario que
+# pagina/filtra geralmente vai ver dados unicos, baixa hit rate.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+from fastapi import Body
+from fastapi.responses import JSONResponse
+from psycopg2.errors import QueryCanceled
+
+# Limites do endpoint. Ver plan.md "Performance: limites e safeguards".
+_PAGE_SIZE = 50
+_API_TIMEOUT_SEC = 5
+_Q_MIN_CHARS = 2
+_Q_MAX_CHARS = 100
+
+
+def _parse_iso_date_or_none(s: Any) -> str | None:
+    """Aceita 'YYYY-MM-DD' ou retorna None. Rejeita qualquer outro
+    formato pra evitar SQL injection via cast (tho psycopg2 ja escapa).
+    Defensivo + claro.
+    """
+    if s is None:
+        return None
+    s = str(s).strip()
+    if not s:
+        return None
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", s):
+        return None
+    return s
+
+
+def _parse_search_query_or_none(q: Any) -> tuple[str | None, str | None]:
+    """Normaliza query de busca textual. Retorna (q_clean, q_pat) onde
+    q_pat eh o pattern para ILIKE (com wildcards %). Min 2 chars, max
+    100. Strings menores/vazias retornam (None, None) — query SQL
+    simplifica via `%(q)s IS NULL OR ...`.
+    """
+    if q is None:
+        return (None, None)
+    s = str(q).strip()
+    if len(s) < _Q_MIN_CHARS:
+        return (None, None)
+    if len(s) > _Q_MAX_CHARS:
+        s = s[:_Q_MAX_CHARS]
+    # Escape % e _ pra que o usuario nao injete wildcards (pode tornar
+    # busca extremamente lenta sem retornar erros).
+    escaped = s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pat = f"%{escaped}%"
+    return (s, pat)
+
+
+def _empenho_row_to_dict(row, cols):
+    """Converte row do PG (Decimal/date) pra dict JSON-serializavel."""
+    d = _row_to_dict(cols, row)
+    return _convert_row(d)
+
+
+@router.post("/api/empresa/empenhos")
+async def get_empresa_empenhos(payload: dict = Body(...)):
+    """Lista paginada de empenhos de uma empresa.
+
+    Body:
+        cnpj: 14 digitos (canonico). Obrigatorio.
+        municipio: nome canonico do municipio (NAO slug). Opcional —
+            None/vazio = visao global (todos os municipios).
+        q: busca textual (min 2 chars). Opcional.
+        data_inicio, data_fim: 'YYYY-MM-DD'. Opcional.
+        page: 1-indexed. Default 1.
+
+    Returns:
+        {empenhos: [...], total: int, page: int, total_pages: int,
+         page_size: int, scope: 'global'|'municipio'}
+
+    Errors:
+        400 cnpj invalido
+        504 query timeout (mega-empresa + filtros pesados)
+    """
+    # Validacao
+    cnpj_raw = "".join(ch for ch in str(payload.get("cnpj", "")) if ch.isdigit())
+    if not _CNPJ_RE.fullmatch(cnpj_raw):
+        return JSONResponse(
+            {"error": "cnpj invalido (esperado 14 digitos)"}, status_code=400
+        )
+    cnpj_basico = cnpj_raw[:8]
+
+    municipio = (payload.get("municipio") or "").strip() or None
+    data_inicio = _parse_iso_date_or_none(payload.get("data_inicio"))
+    data_fim = _parse_iso_date_or_none(payload.get("data_fim"))
+    q_clean, q_pat = _parse_search_query_or_none(payload.get("q"))
+
+    try:
+        page = int(payload.get("page") or 1)
+    except (TypeError, ValueError):
+        page = 1
+    if page < 1:
+        page = 1
+    offset = (page - 1) * _PAGE_SIZE
+
+    params = {
+        "cnpj_basico": cnpj_basico,
+        "data_inicio": data_inicio,
+        "data_fim": data_fim,
+        "q": q_clean,
+        "q_pat": q_pat,
+        "limit": _PAGE_SIZE,
+        "offset": offset,
+    }
+    if municipio:
+        params["municipio"] = municipio
+        list_sql = EMPRESA_EMPENHOS_PAGINATED_BY_MUN
+        count_sql = EMPRESA_EMPENHOS_COUNT_BY_MUN
+        scope = "municipio"
+    else:
+        list_sql = EMPRESA_EMPENHOS_PAGINATED_GLOBAL
+        count_sql = EMPRESA_EMPENHOS_COUNT_GLOBAL
+        scope = "global"
+
+    try:
+        with get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(f"SET statement_timeout = '{_API_TIMEOUT_SEC * 1000}'")
+                try:
+                    cur.execute(list_sql, params)
+                    cols = [d[0] for d in cur.description]
+                    empenhos = [_empenho_row_to_dict(r, cols) for r in cur.fetchall()]
+
+                    # Count com mesmos params (sem limit/offset)
+                    count_params = {k: v for k, v in params.items()
+                                    if k not in ("limit", "offset")}
+                    cur.execute(count_sql, count_params)
+                    cnt_row = cur.fetchone()
+                    total = int(cnt_row[0]) if cnt_row else 0
+                finally:
+                    try:
+                        cur.execute("RESET statement_timeout")
+                    except Exception:
+                        _log.warning("RESET statement_timeout falhou")
+    except QueryCanceled:
+        # Timeout — geralmente mega-empresa (BB/Caixa/INSS) com OFFSET
+        # alto sem filtros. Frontend mostra mensagem amigavel.
+        return JSONResponse(
+            {
+                "error": "timeout",
+                "message": (
+                    "A busca demorou muito. Use filtros (data ou texto) "
+                    "para refinar."
+                ),
+            },
+            status_code=504,
+        )
+    except Exception as exc:
+        _log.exception("get_empresa_empenhos: %s", exc)
+        return JSONResponse(
+            {"error": "internal", "message": "Erro ao buscar empenhos."},
+            status_code=500,
+        )
+
+    total_pages = (total + _PAGE_SIZE - 1) // _PAGE_SIZE if total > 0 else 0
+    return {
+        "empenhos": empenhos,
+        "total": total,
+        "page": page,
+        "total_pages": total_pages,
+        "page_size": _PAGE_SIZE,
+        "scope": scope,
+    }

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -840,9 +840,13 @@ _Q_MAX_CHARS = 100
 
 
 def _parse_iso_date_or_none(s: Any) -> str | None:
-    """Aceita 'YYYY-MM-DD' ou retorna None. Rejeita qualquer outro
-    formato pra evitar SQL injection via cast (tho psycopg2 ja escapa).
-    Defensivo + claro.
+    """Aceita 'YYYY-MM-DD' valido OU retorna None.
+
+    Validacao em 2 passos:
+    1. Regex de shape (defensivo contra strings absurdas).
+    2. `date.fromisoformat` pra rejeitar datas calendarial-mente
+       impossiveis (ex: '2026-02-31') que passariam pelo regex mas
+       quebrariam o cast `::date` em PG (-> 500).
     """
     if s is None:
         return None
@@ -850,6 +854,11 @@ def _parse_iso_date_or_none(s: Any) -> str | None:
     if not s:
         return None
     if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", s):
+        return None
+    try:
+        from datetime import date as _date
+        _date.fromisoformat(s)
+    except ValueError:
         return None
     return s
 

--- a/web/static/css/components/empresa-page.css
+++ b/web/static/css/components/empresa-page.css
@@ -190,3 +190,66 @@
     }
 }
 }
+
+/* ────────────────────────────────────────────────────────────────────
+   Tabela paginada de empenhos: filter bar local + footer de paginacao.
+
+   Filter bar reusa estilos de .date-filter-bar (cidade) com pequenas
+   diferencas de scope/dimensao. Pagination eh um chip-like centralizado
+   com dois botoes md-text-button (prev/next).
+   ──────────────────────────────────────────────────────────────────── */
+.empenhos-section .empenhos-filter-bar {
+    margin: .75rem 0 1rem 0;
+}
+.empenhos-section .empenhos-filter-bar .date-filter-panel {
+    padding: .75rem 0 .25rem 0;
+}
+.empenhos-search-row {
+    margin-bottom: .75rem;
+}
+.empenhos-search-field {
+    flex: 1 1 100%;
+}
+.empenhos-search-field input[type="search"] {
+    width: 100%;
+}
+.empenhos-section [data-empenhos-table].loading {
+    opacity: .55;
+    pointer-events: none;
+    transition: opacity .15s linear;
+}
+.empenhos-empty {
+    padding: 1.5rem 0;
+    text-align: center;
+}
+.empenhos-loading-placeholder {
+    padding: 1.5rem 0;
+    text-align: center;
+}
+.empenhos-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: .75rem;
+    margin-top: 1rem;
+    flex-wrap: wrap;
+}
+.empenhos-pagination[hidden] {
+    display: none;
+}
+.empenhos-pagination .empenhos-page-info {
+    font-size: .9rem;
+    color: var(--md-sys-color-on-surface-variant);
+    min-width: 12rem;
+    text-align: center;
+}
+@media (max-width: 600px) {
+    .empenhos-pagination {
+        gap: .35rem;
+    }
+    .empenhos-pagination .empenhos-page-info {
+        order: -1;
+        flex-basis: 100%;
+        margin-bottom: .25rem;
+    }
+}

--- a/web/static/js/components/dialog-links.js
+++ b/web/static/js/components/dialog-links.js
@@ -3,13 +3,22 @@ function _reattachDialogLinks(body) {
     body.querySelectorAll('.dialog-link[data-lic-num]').forEach(link => {
         link.addEventListener('click', (e) => {
             e.preventDefault();
-            openLicitacaoDialog(link.dataset.licNum, link.dataset.licAno || '0', _currentMunicipio, link.textContent);
+            // data-lic-mun override permite empenho-dialog em pagina
+            // /empresa/<cnpj> (global) — onde _currentMunicipio eh '' —
+            // resolver a licitacao com o municipio do proprio empenho.
+            const linkMun = link.dataset.licMun || '';
+            const mun = linkMun || _currentMunicipio;
+            openLicitacaoDialog(link.dataset.licNum, link.dataset.licAno || '0', mun, link.textContent);
         });
     });
     body.querySelectorAll('.dialog-link[data-forn-cnpj]').forEach(link => {
         link.addEventListener('click', (e) => {
             e.preventDefault();
-            openFornecedorDialog(link.dataset.fornCnpj, link.dataset.fornNome || 'Fornecedor', null, false, link.dataset.fornNomeCredor || '', link.dataset.fornCpfCnpj || '');
+            // data-forn-mun override: empenho-dialog em /empresa/<cnpj>
+            // (global) precisa repassar o municipio do empenho — sem ele,
+            // fornecedor-dialog cai em _currentMunicipio='' e abre vazio.
+            const linkMun = link.dataset.fornMun || null;
+            openFornecedorDialog(link.dataset.fornCnpj, link.dataset.fornNome || 'Fornecedor', linkMun, false, link.dataset.fornNomeCredor || '', link.dataset.fornCpfCnpj || '');
         });
     });
     body.querySelectorAll('tr.clickable-row[data-empenho-id]').forEach(row => {

--- a/web/static/js/components/empenho-dialog.js
+++ b/web/static/js/components/empenho-dialog.js
@@ -57,8 +57,13 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     const cnpjB = cnpjRaw.slice(0, 8);
     const isClickable = cnpjB.length === 8 && /^\d{8}$/.test(cnpjB) && cnpjRaw.length >= 14;
     const credorNome = _esc(data.nome_credor || '-');
+    // data-forn-mun: igual ao licitacao link logo abaixo, repassa o
+    // municipio do empenho pra que o fornecedor-dialog tenha context
+    // correto na pagina /empresa/<cnpj> global onde _currentMunicipio
+    // eh vazio.
+    const credorMun = _esc(data.municipio || '');
     const credorLink = isClickable
-        ? `<a href="#" class="dialog-link" data-forn-cnpj="${cnpjB}" data-forn-cpf-cnpj="${cnpjRaw}" data-forn-nome="${credorNome}" data-forn-nome-credor="${credorNome}">${credorNome}</a>`
+        ? `<a href="#" class="dialog-link" data-forn-cnpj="${cnpjB}" data-forn-cpf-cnpj="${cnpjRaw}" data-forn-nome="${credorNome}" data-forn-nome-credor="${credorNome}" data-forn-mun="${credorMun}">${credorNome}</a>`
         : credorNome;
     html += `<div class="empresa-card"><div class="empresa-header">
         <strong>${credorLink}</strong>
@@ -90,12 +95,18 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     if (data.municipio) html += `<span><strong>Municipio:</strong> ${_esc(data.municipio)}</span>`;
     html += '</div></div>';
 
-    // Licitacao vinculada
+    // Licitacao vinculada. Inclui data-mun do proprio empenho — sem ele,
+    // dialog-links.js cai em _currentMunicipio global. Em /empresa/<cnpj>
+    // (global) esse global eh '' e a API devolve vazio. Repassar o
+    // municipio do empenho corrige cross-dialog navigation no perfil
+    // global; nas demais paginas (cidade, empresa-municipio) eh
+    // equivalente ao comportamento atual.
     const mod = data.modalidade_licitacao || '';
     const numLic = data.numero_licitacao || '';
     const semLic = !numLic || numLic === '000000000' || mod.toLowerCase().includes('sem licit');
+    const empMun = data.municipio || '';
     if (!semLic) {
-        html += `<p class="text-sm mt-2"><strong>Licitacao:</strong> <a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="0">${_esc(mod)} (${_esc(numLic)})</a></p>`;
+        html += `<p class="text-sm mt-2"><strong>Licitacao:</strong> <a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="0" data-lic-mun="${_esc(empMun)}">${_esc(mod)} (${_esc(numLic)})</a></p>`;
     } else {
         html += '<p class="text-sm mt-2"><strong>Licitacao:</strong> <span class="badge badge-yellow">Sem licitacao</span></p>';
     }

--- a/web/static/js/components/empenhos-controller.js
+++ b/web/static/js/components/empenhos-controller.js
@@ -1,0 +1,468 @@
+// === components/empenhos-controller.js ===
+//
+// Controller generico pra tabela paginada+filtravel de empenhos. Funciona em
+// 3 superficies:
+//   1. Pagina /empresa/<cnpj>/<municipio> — initial empenhos vem do warmer
+//      cache (server-side rendered pg1). Endpoint: /api/empresa/empenhos.
+//   2. Pagina /empresa/<cnpj> (global) — idem, scope=global. Page 1
+//      vem do cache `empenhos_global` ou (se cache velho pre-PR) lazy fetch
+//      automatico ao mount.
+//   3. Dialog de fornecedor em /cidade/<slug> — initial empenhos vem do
+//      payload do /api/fornecedor/detalhes. Endpoint:
+//      /api/fornecedor/empenhos. Identidade: cpf_cnpj exato.
+//
+// Mount:
+//   Procura `[data-empenhos-mount]` na arvore. Para cada container, le os
+//   data-* attrs (endpoint, scope, cnpj, municipio, cpf_cnpj, total) e
+//   wirea filter bar + paginacao + lazy fetch.
+//
+// Fallback compat: se data-empenhos-initial="0" (sem empenhos server-side
+// renderizados), faz fetch live de page 1 ao mount. Isso cobre entries
+// cacheadas pre-PR de paginacao que nao tem `empenhos_global` no payload.
+
+function initEmpenhosControllers(root) {
+    const scope = root || document;
+    scope.querySelectorAll('[data-empenhos-mount]').forEach((mount) => {
+        if (mount.dataset.empenhosWired === '1') return;
+        mount.dataset.empenhosWired = '1';
+        try {
+            new EmpenhosController(mount).init();
+        } catch (err) {
+            console.warn('empenhos-controller init failed', err);
+        }
+    });
+}
+
+class EmpenhosController {
+    constructor(mount) {
+        this.mount = mount;
+        this.endpoint = mount.dataset.empenhosEndpoint || '/api/empresa/empenhos';
+        this.scope = mount.dataset.empenhosScope || 'municipio';
+        this.cnpj = mount.dataset.empenhosCnpj || '';
+        this.cpfCnpj = mount.dataset.empenhosCpfCnpj || '';
+        this.municipio = mount.dataset.empenhosMunicipio || '';
+        this.total = parseInt(mount.dataset.empenhosTotal || '0', 10) || 0;
+        this.hasInitial = mount.dataset.empenhosInitial === '1';
+        this.page = 1;
+        this.pageSize = 50;
+        this.filters = { q: '', dateInicio: '', dateFim: '' };
+        this.busy = false;
+        this.searchDebounceMs = 300;
+        this._searchTimer = null;
+        this._reqSeq = 0;
+
+        // Refs
+        this.tableContainer = mount.querySelector('[data-empenhos-table]');
+        this.summary = mount.querySelector('[data-empenhos-summary]');
+        this.filterSummary = mount.querySelector('[data-empenhos-filter-summary]');
+        this.qInput = mount.querySelector('[data-empenhos-q]');
+        this.dateInicioInput = mount.querySelector('[data-empenhos-date-inicio]');
+        this.dateFimInput = mount.querySelector('[data-empenhos-date-fim]');
+        this.applyBtn = mount.querySelector('[data-empenhos-apply]');
+        this.statusEl = mount.querySelector('[data-empenhos-status]');
+        this.clearBtn = mount.querySelector('[data-empenhos-clear]');
+        this.pagination = mount.querySelector('[data-empenhos-pagination]');
+        this.prevBtn = mount.querySelector('[data-empenhos-prev]');
+        this.nextBtn = mount.querySelector('[data-empenhos-next]');
+        this.pageInfo = mount.querySelector('[data-empenhos-page-info]');
+    }
+
+    init() {
+        this._wireEvents();
+        this._updatePagination();
+        this._updateFilterSummary();
+        if (!this.hasInitial) {
+            this._fetchAndRender();
+        } else {
+            // Empenhos ja renderizados server-side. So inicializa
+            // clickable rows pra wirear empenho-dialog.
+            if (typeof initClickableRows === 'function') {
+                initClickableRows(this.tableContainer);
+            }
+        }
+    }
+
+    _wireEvents() {
+        if (this.qInput) {
+            this.qInput.addEventListener('input', () => {
+                clearTimeout(this._searchTimer);
+                this._searchTimer = setTimeout(() => {
+                    this.filters.q = (this.qInput.value || '').trim();
+                    this.page = 1;
+                    this._fetchAndRender();
+                }, this.searchDebounceMs);
+            });
+            this.qInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    clearTimeout(this._searchTimer);
+                    this.filters.q = (this.qInput.value || '').trim();
+                    this.page = 1;
+                    this._fetchAndRender();
+                }
+            });
+        }
+        // Date input mask (DD/MM/AAAA) — reusa _maskBrDate se disponivel
+        [this.dateInicioInput, this.dateFimInput].forEach((el) => {
+            if (!el) return;
+            if (typeof _maskBrDate === 'function') _maskBrDate(el);
+            el.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    this._applyDateInputs();
+                }
+            });
+        });
+        if (this.applyBtn) {
+            this.applyBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this._applyDateInputs();
+            });
+        }
+        if (this.clearBtn) {
+            this.clearBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this._clearFilters();
+            });
+        }
+        // Presets
+        this.mount.querySelectorAll('[data-empenhos-preset]').forEach((chip) => {
+            chip.addEventListener('click', () => {
+                const preset = chip.dataset.empenhosPreset;
+                this._applyPreset(preset);
+            });
+        });
+        if (this.prevBtn) {
+            this.prevBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                if (this.page > 1) {
+                    this.page -= 1;
+                    this._fetchAndRender({ scrollTop: true });
+                }
+            });
+        }
+        if (this.nextBtn) {
+            this.nextBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                const totalPages = this._totalPages();
+                if (totalPages === 0 || this.page < totalPages) {
+                    this.page += 1;
+                    this._fetchAndRender({ scrollTop: true });
+                }
+            });
+        }
+    }
+
+    _applyDateInputs() {
+        const inicioBr = (this.dateInicioInput && this.dateInicioInput.value) || '';
+        const fimBr = (this.dateFimInput && this.dateFimInput.value) || '';
+        const inicioIso = _empBrToIso(inicioBr);
+        const fimIso = _empBrToIso(fimBr);
+        if (inicioBr && !inicioIso) {
+            this._setStatus('Data inicial invalida (use DD/MM/AAAA).', true);
+            return;
+        }
+        if (fimBr && !fimIso) {
+            this._setStatus('Data final invalida (use DD/MM/AAAA).', true);
+            return;
+        }
+        if (inicioIso && fimIso && inicioIso > fimIso) {
+            this._setStatus('Data inicial maior que data final.', true);
+            return;
+        }
+        this.filters.dateInicio = inicioIso || '';
+        this.filters.dateFim = fimIso || '';
+        this.page = 1;
+        this._fetchAndRender();
+    }
+
+    _applyPreset(preset) {
+        const today = new Date();
+        const yyyy = today.getFullYear();
+        const mm = String(today.getMonth() + 1).padStart(2, '0');
+        const dd = String(today.getDate()).padStart(2, '0');
+        const todayIso = `${yyyy}-${mm}-${dd}`;
+        if (preset === 'all') {
+            this.filters.dateInicio = '';
+            this.filters.dateFim = '';
+        } else if (preset === 'current-year') {
+            this.filters.dateInicio = `${yyyy}-01-01`;
+            this.filters.dateFim = todayIso;
+        } else if (preset === 'last-12m') {
+            const start = new Date(today);
+            start.setFullYear(start.getFullYear() - 1);
+            const sy = start.getFullYear();
+            const sm = String(start.getMonth() + 1).padStart(2, '0');
+            const sd = String(start.getDate()).padStart(2, '0');
+            this.filters.dateInicio = `${sy}-${sm}-${sd}`;
+            this.filters.dateFim = todayIso;
+        }
+        // Sync UI
+        if (this.dateInicioInput) {
+            this.dateInicioInput.value = this.filters.dateInicio
+                ? _empIsoToBr(this.filters.dateInicio) : '';
+        }
+        if (this.dateFimInput) {
+            this.dateFimInput.value = this.filters.dateFim
+                ? _empIsoToBr(this.filters.dateFim) : '';
+        }
+        // Marca chip ativo
+        this.mount.querySelectorAll('[data-empenhos-preset]').forEach((c) => {
+            const isActive = c.dataset.empenhosPreset === preset;
+            if (c.tagName === 'MD-FILTER-CHIP') {
+                if (isActive) c.setAttribute('selected', '');
+                else c.removeAttribute('selected');
+            }
+        });
+        this.page = 1;
+        this._fetchAndRender();
+    }
+
+    _clearFilters() {
+        this.filters = { q: '', dateInicio: '', dateFim: '' };
+        if (this.qInput) this.qInput.value = '';
+        if (this.dateInicioInput) this.dateInicioInput.value = '';
+        if (this.dateFimInput) this.dateFimInput.value = '';
+        // Volta preset pra "all"
+        this.mount.querySelectorAll('[data-empenhos-preset]').forEach((c) => {
+            const isAll = c.dataset.empenhosPreset === 'all';
+            if (c.tagName === 'MD-FILTER-CHIP') {
+                if (isAll) c.setAttribute('selected', '');
+                else c.removeAttribute('selected');
+            }
+        });
+        this.page = 1;
+        this._fetchAndRender();
+    }
+
+    _hasActiveFilters() {
+        return !!(this.filters.q || this.filters.dateInicio || this.filters.dateFim);
+    }
+
+    _setStatus(msg, isError) {
+        if (!this.statusEl) return;
+        this.statusEl.textContent = msg || '';
+        this.statusEl.classList.toggle('color-red', !!isError);
+    }
+
+    _updateFilterSummary() {
+        if (!this.filterSummary) return;
+        const parts = [];
+        if (this.filters.dateInicio || this.filters.dateFim) {
+            const di = this.filters.dateInicio
+                ? _empIsoToBr(this.filters.dateInicio) : '...';
+            const df = this.filters.dateFim
+                ? _empIsoToBr(this.filters.dateFim) : '...';
+            parts.push(`${di} a ${df}`);
+        } else {
+            parts.push('todo o historico');
+        }
+        if (this.filters.q) parts.push(`busca: "${this.filters.q}"`);
+        this.filterSummary.textContent = `Periodo: ${parts.join(' · ')}`;
+        if (this.clearBtn) {
+            this.clearBtn.style.display = this._hasActiveFilters() ? '' : 'none';
+        }
+    }
+
+    _totalPages() {
+        if (this.total <= 0) return 0;
+        return Math.ceil(this.total / this.pageSize);
+    }
+
+    _updatePagination() {
+        if (!this.pagination) return;
+        const totalPages = this._totalPages();
+        if (totalPages <= 1) {
+            this.pagination.hidden = true;
+            return;
+        }
+        this.pagination.hidden = false;
+        if (this.prevBtn) this.prevBtn.disabled = this.page <= 1;
+        if (this.nextBtn) this.nextBtn.disabled = this.page >= totalPages;
+        if (this.pageInfo) {
+            const totalLabel = this.total.toLocaleString('pt-BR');
+            this.pageInfo.textContent =
+                `Pagina ${this.page} de ${totalPages} · ${totalLabel} empenhos`;
+        }
+    }
+
+    _updateSummary() {
+        if (!this.summary) return;
+        const totalLabel = this.total.toLocaleString('pt-BR');
+        if (this.total > 0) {
+            const filterMsg = this._hasActiveFilters() ? ' (com filtros)' : '';
+            this.summary.textContent =
+                `${totalLabel} empenhos encontrados${filterMsg}. ` +
+                'Clique em uma linha para ver os detalhes.';
+        } else if (this._hasActiveFilters()) {
+            this.summary.textContent =
+                'Nenhum empenho encontrado com os filtros atuais.';
+        } else {
+            this.summary.textContent = 'Nenhum empenho disponivel.';
+        }
+    }
+
+    _buildBody() {
+        const body = { page: this.page };
+        if (this.cnpj) body.cnpj = this.cnpj;
+        if (this.cpfCnpj) body.cpf_cnpj = this.cpfCnpj;
+        if (this.municipio) body.municipio = this.municipio;
+        if (this.filters.q) body.q = this.filters.q;
+        if (this.filters.dateInicio) body.data_inicio = this.filters.dateInicio;
+        if (this.filters.dateFim) body.data_fim = this.filters.dateFim;
+        return body;
+    }
+
+    async _fetchAndRender(opts) {
+        const options = opts || {};
+        if (this.busy) return;
+        this.busy = true;
+        const seq = ++this._reqSeq;
+        this._setStatus('Carregando...');
+        if (this.tableContainer) {
+            this.tableContainer.classList.add('loading');
+        }
+        let data;
+        try {
+            const resp = await fetch(this.endpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(this._buildBody()),
+            });
+            if (resp.status === 504) {
+                if (seq !== this._reqSeq) return;
+                this._setStatus(
+                    'A busca demorou muito. Use filtros (data ou texto) para refinar.',
+                    true
+                );
+                return;
+            }
+            if (!resp.ok) {
+                if (seq !== this._reqSeq) return;
+                this._setStatus(`Erro ao carregar (${resp.status}).`, true);
+                return;
+            }
+            data = await resp.json();
+        } catch (err) {
+            if (seq !== this._reqSeq) return;
+            this._setStatus('Falha de rede ao carregar empenhos.', true);
+            return;
+        } finally {
+            this.busy = false;
+            if (this.tableContainer) {
+                this.tableContainer.classList.remove('loading');
+            }
+        }
+        if (seq !== this._reqSeq) return; // request stale
+        this._setStatus('');
+        this.total = parseInt(data.total || 0, 10) || 0;
+        this.page = parseInt(data.page || 1, 10) || 1;
+        this.pageSize = parseInt(data.page_size || 50, 10) || 50;
+        this._renderTable(data.empenhos || []);
+        this._updateSummary();
+        this._updatePagination();
+        this._updateFilterSummary();
+        if (options.scrollTop && this.mount.scrollIntoView) {
+            this.mount.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    _renderTable(empenhos) {
+        if (!this.tableContainer) return;
+        if (!empenhos.length) {
+            this.tableContainer.innerHTML =
+                '<p class="text-sm text-muted empenhos-empty">' +
+                'Nenhum empenho encontrado.</p>';
+            return;
+        }
+        const showMun = this.scope === 'global';
+        const rows = empenhos.map((e) => _empRenderRow(e, showMun)).join('');
+        const munTh = showMun ? '<th>Municipio</th>' : '';
+        this.tableContainer.innerHTML =
+            '<div class="tbl-wrap">' +
+            '<table class="stack-mobile data-table empresa-empenhos-table">' +
+            '<thead><tr>' +
+            '<th>Data</th>' +
+            '<th>Numero</th>' +
+            munTh +
+            '<th>Elemento de despesa</th>' +
+            '<th>Modalidade / Licitacao</th>' +
+            '<th class="text-right">Empenhado</th>' +
+            '<th class="text-right">Pago</th>' +
+            '</tr></thead>' +
+            `<tbody>${rows}</tbody>` +
+            '</table></div>';
+        if (typeof initClickableRows === 'function') {
+            initClickableRows(this.tableContainer);
+        }
+    }
+}
+
+// Helpers
+function _empRenderRow(e, showMun) {
+    const semLic = !e.numero_licitacao
+        || e.numero_licitacao === '000000000'
+        || ((e.modalidade_licitacao || '').toLowerCase().indexOf('sem licit') === 0);
+    const modCell = semLic
+        ? '<span class="badge badge-yellow" title="Empenho sem licitacao identificada">Sem licitacao</span>'
+        : `${_empEsc(e.modalidade_licitacao || '')}${
+            e.numero_licitacao && e.numero_licitacao !== '000000000'
+                ? `<br><span class="text-sm text-muted"><code>${_empEsc(e.numero_licitacao)}</code></span>`
+                : ''
+        }`;
+    const munCell = showMun
+        ? `<td data-label="Municipio">${_empEsc(e.municipio || '—')}</td>`
+        : '';
+    const empenhoIdAttr = e.id ? ` data-empenho-id="${_empEsc(String(e.id))}"` : '';
+    return `<tr class="clickable-row"${empenhoIdAttr}>
+        <td data-label="Data">${_empFmtDate(e.data_empenho)}</td>
+        <td data-label="Numero"><code>${_empEsc(e.numero_empenho || '—')}</code></td>
+        ${munCell}
+        <td data-label="Elemento">${_empEsc(e.elemento_despesa || '—')}</td>
+        <td data-label="Modalidade">${modCell}</td>
+        <td data-label="Empenhado" class="text-right num">${_empBrl(e.valor_empenhado)}</td>
+        <td data-label="Pago" class="text-right num"><strong>${_empBrl(e.valor_pago)}</strong></td>
+    </tr>`;
+}
+
+function _empEsc(s) {
+    if (s === null || s === undefined) return '';
+    return String(s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function _empFmtDate(iso) {
+    if (!iso) return '—';
+    const m = String(iso).match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (!m) return _empEsc(iso);
+    return `${m[3]}/${m[2]}/${m[1]}`;
+}
+
+function _empBrToIso(br) {
+    if (!br) return '';
+    const m = String(br).match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (!m) return '';
+    const [, dd, mm, yyyy] = m;
+    const d = parseInt(dd, 10), mo = parseInt(mm, 10), y = parseInt(yyyy, 10);
+    if (mo < 1 || mo > 12 || d < 1 || d > 31) return '';
+    if (y < 1900 || y > 2100) return '';
+    return `${yyyy}-${mm}-${dd}`;
+}
+
+function _empIsoToBr(iso) {
+    if (!iso) return '';
+    const m = String(iso).match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (!m) return iso;
+    return `${m[3]}/${m[2]}/${m[1]}`;
+}
+
+function _empBrl(v) {
+    if (v === null || v === undefined || v === '') return '—';
+    const n = typeof v === 'number' ? v : parseFloat(v);
+    if (!isFinite(n)) return '—';
+    if (typeof _shortBrl === 'function') return _shortBrl(n);
+    return 'R$ ' + n.toLocaleString('pt-BR', {
+        minimumFractionDigits: 2, maximumFractionDigits: 2,
+    });
+}

--- a/web/static/js/components/empenhos-controller.js
+++ b/web/static/js/components/empenhos-controller.js
@@ -43,10 +43,17 @@ class EmpenhosController {
         this.municipio = mount.dataset.empenhosMunicipio || '';
         this.total = parseInt(mount.dataset.empenhosTotal || '0', 10) || 0;
         this.hasInitial = mount.dataset.empenhosInitial === '1';
+        // Flag: total acima eh autoritativo (warmer novo) ou eh um proxy
+        // (entry cacheada pre-PR de paginacao que so tinha 50 empenhos
+        // sem count). Se desconhecido, mesmo com rows iniciais fazemos
+        // fetch live ao mount pra descobrir o total real e desbloquear
+        // paginacao. Sem isso, paginas /empresa/<cnpj>/<mun> ja cacheadas
+        // mostrariam exatamente 50 e esconderiam paginacao mesmo quando
+        // existem milhares de empenhos.
+        this.totalKnown = mount.dataset.empenhosTotalKnown === '1';
         this.page = 1;
         this.pageSize = 50;
         this.filters = { q: '', dateInicio: '', dateFim: '' };
-        this.busy = false;
         this.searchDebounceMs = 300;
         this._searchTimer = null;
         this._reqSeq = 0;
@@ -72,10 +79,21 @@ class EmpenhosController {
         this._updatePagination();
         this._updateFilterSummary();
         if (!this.hasInitial) {
+            // Sem rows server-side: fetch page 1 live (placeholder esta
+            // visivel ate fetch retornar).
+            this._fetchAndRender();
+        } else if (!this.totalKnown) {
+            // Tem rows mas total nao eh autoritativo (entry cacheada
+            // pre-PR de paginacao). Inicializa clickable rows pra UX
+            // imediata, mas dispara fetch live em paralelo pra obter
+            // total real e desbloquear paginacao. Re-render eh inofensivo:
+            // mesma pagina, mesmo ORDER BY estavel.
+            if (typeof initClickableRows === 'function') {
+                initClickableRows(this.tableContainer);
+            }
             this._fetchAndRender();
         } else {
-            // Empenhos ja renderizados server-side. So inicializa
-            // clickable rows pra wirear empenho-dialog.
+            // Tem rows + total conhecido: sem fetch ao mount.
             if (typeof initClickableRows === 'function') {
                 initClickableRows(this.tableContainer);
             }
@@ -315,8 +333,12 @@ class EmpenhosController {
 
     async _fetchAndRender(opts) {
         const options = opts || {};
-        if (this.busy) return;
-        this.busy = true;
+        // NAO guard com `this.busy`: usuario digitando rapido durante um
+        // fetch lento (mega-empresa pode estourar 5s timeout) teria o
+        // input silenciosamente descartado. Em vez disso, incrementamos
+        // _reqSeq antes de cada fetch e checamos apos o await — qualquer
+        // request stale e descartado sem render. Concorrencia eh ok
+        // (server-side cada call eh independente; pool aguenta).
         const seq = ++this._reqSeq;
         this._setStatus('Carregando...');
         if (this.tableContainer) {
@@ -329,8 +351,8 @@ class EmpenhosController {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(this._buildBody()),
             });
+            if (seq !== this._reqSeq) return; // request stale
             if (resp.status === 504) {
-                if (seq !== this._reqSeq) return;
                 this._setStatus(
                     'A busca demorou muito. Use filtros (data ou texto) para refinar.',
                     true
@@ -338,22 +360,23 @@ class EmpenhosController {
                 return;
             }
             if (!resp.ok) {
-                if (seq !== this._reqSeq) return;
                 this._setStatus(`Erro ao carregar (${resp.status}).`, true);
                 return;
             }
             data = await resp.json();
+            if (seq !== this._reqSeq) return; // request stale
         } catch (err) {
             if (seq !== this._reqSeq) return;
             this._setStatus('Falha de rede ao carregar empenhos.', true);
             return;
         } finally {
-            this.busy = false;
-            if (this.tableContainer) {
+            // So tira loading se for o request mais recente. Senao deixa
+            // o spinner ate o que esta mais novo terminar.
+            if (seq === this._reqSeq && this.tableContainer) {
                 this.tableContainer.classList.remove('loading');
             }
         }
-        if (seq !== this._reqSeq) return; // request stale
+        if (seq !== this._reqSeq) return;
         this._setStatus('');
         this.total = parseInt(data.total || 0, 10) || 0;
         this.page = parseInt(data.page || 1, 10) || 1;
@@ -447,6 +470,13 @@ function _empBrToIso(br) {
     const d = parseInt(dd, 10), mo = parseInt(mm, 10), y = parseInt(yyyy, 10);
     if (mo < 1 || mo > 12 || d < 1 || d > 31) return '';
     if (y < 1900 || y > 2100) return '';
+    // Valida calendario (rejeita 31/02, 30/02, 31/04 etc) construindo
+    // um Date e re-extraindo as partes — JS normaliza datas invalidas
+    // pra dias seguintes, entao se nao bater eh invalida.
+    const dt = new Date(y, mo - 1, d);
+    if (dt.getFullYear() !== y || dt.getMonth() !== mo - 1 || dt.getDate() !== d) {
+        return '';
+    }
     return `${yyyy}-${mm}-${dd}`;
 }
 

--- a/web/static/js/components/fornecedor-dialog.js
+++ b/web/static/js/components/fornecedor-dialog.js
@@ -361,8 +361,12 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
         html += '</div>';
     }
 
-    // Empenhos recentes
-    if (data.empenhos && data.empenhos.length) {
+    // Empenhos recentes (paginado + filtravel via empenhos-controller).
+    // Sempre renderiza a secao mesmo se data.empenhos vazio: o controller
+    // pode buscar empenhos paginados a partir do API se houver total > 0.
+    const stStats = data.stats || {};
+    const empTotal = parseInt(stStats.qtd_empenhos || 0, 10) || 0;
+    if ((data.empenhos && data.empenhos.length) || empTotal > 0) {
         // Municipality selector
         const munOptions = (data.municipios_ativos || []);
         let munSelect = '';
@@ -374,11 +378,71 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
             munSelect = `<select class="mun-selector" data-forn-cnpj="${_esc(cnpjBasico)}" data-forn-nome="${_esc(fornecedorNome)}" data-forn-nome-credor="${_esc(nomeCredor || '')}" data-forn-cpf-cnpj="${_esc(cpfCnpj || '')}">${opts}</select>`;
         }
 
-        html += `<div class="dialog-section" id="forn-empenhos"><h4>${dualLabel('Pagamentos recentes','Empenhos recentes')} ${munSelect ? 'em' : 'neste municipio'} ${munSelect}</h4>`;
-        html += _buildEmpenhoTable(data.empenhos, sancaoRanges);
-        if (data.empenhos.length >= 50) {
-            html += '<p class="text-sm text-muted">Mostrando os 50 empenhos mais recentes.</p>';
+        html += `<div class="dialog-section" id="forn-empenhos"><h4>${dualLabel('Pagamentos','Empenhos')} ${munSelect ? 'em' : 'neste municipio'} ${munSelect}</h4>`;
+        // Container montado pelo empenhos-controller. Initial empenhos vem
+        // do payload do /detalhes (50 mais recentes); paginas 2+ ou
+        // filtros chamam /api/fornecedor/empenhos.
+        html += `<section
+            class="empenhos-section empenhos-section-dialog"
+            data-empenhos-mount
+            data-empenhos-endpoint="/api/fornecedor/empenhos"
+            data-empenhos-scope="municipio"
+            data-empenhos-cpf-cnpj="${_esc(cpfCnpj || '')}"
+            data-empenhos-municipio="${_esc(viewMunicipio || '')}"
+            data-empenhos-total="${empTotal}"
+            data-empenhos-initial="1">
+            <p class="text-sm text-muted" data-empenhos-summary>
+                ${empTotal.toLocaleString('pt-BR')} empenhos encontrados.
+            </p>`;
+        // Filter bar (sub-template inline pra evitar dependencia de Jinja
+        // no dialog que eh montado client-side).
+        html += `<details class="date-filter-bar empenhos-filter-bar">
+            <summary class="date-filter-summary">
+                <span class="date-filter-current" data-empenhos-filter-summary>Periodo: todo o historico</span>
+                <span class="date-filter-action">Filtrar empenhos</span>
+            </summary>
+            <div class="date-filter-panel" role="group" aria-label="Filtros de empenhos">
+                <div class="empenhos-search-row">
+                    <label class="date-field empenhos-search-field"><span>Buscar</span>
+                        <input type="search" data-empenhos-q placeholder="Numero, elemento, historico..." inputmode="search" maxlength="100" autocomplete="off">
+                    </label>
+                </div>
+                <div class="date-filter-inputs">
+                    <label class="date-field"><span>De</span>
+                        <input type="text" data-empenhos-date-inicio inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off">
+                    </label>
+                    <label class="date-field"><span>Ate</span>
+                        <input type="text" data-empenhos-date-fim inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off">
+                    </label>
+                    <md-filled-button data-empenhos-apply class="date-filter-submit">Aplicar</md-filled-button>
+                    <p class="date-filter-status text-sm text-muted" data-empenhos-status aria-live="polite"></p>
+                </div>
+                <div class="date-filter-presets" role="group" aria-label="Atalhos de periodo">
+                    <md-filter-chip label="Tudo" data-empenhos-preset="all" selected></md-filter-chip>
+                    <md-filter-chip label="Ano atual" data-empenhos-preset="current-year"></md-filter-chip>
+                    <md-filter-chip label="12 meses" data-empenhos-preset="last-12m"></md-filter-chip>
+                    <md-text-button data-empenhos-clear style="display:none">Limpar filtros</md-text-button>
+                </div>
+            </div>
+        </details>`;
+        // Tabela inicial: 50 do payload (se houver). Senao placeholder
+        // pro controller fetch live.
+        if (data.empenhos && data.empenhos.length) {
+            html += `<div data-empenhos-table>${_buildEmpenhoTable(data.empenhos, sancaoRanges)}</div>`;
+        } else {
+            html += '<div data-empenhos-table><p class="text-sm text-muted empenhos-loading-placeholder">Carregando empenhos...</p></div>';
         }
+        // Pagination footer
+        html += `<nav class="empenhos-pagination" data-empenhos-pagination aria-label="Paginacao de empenhos" hidden>
+            <md-text-button data-empenhos-prev disabled aria-label="Pagina anterior">
+                <md-icon slot="icon">chevron_left</md-icon>Anterior
+            </md-text-button>
+            <span class="empenhos-page-info" data-empenhos-page-info aria-live="polite">Pagina 1</span>
+            <md-text-button data-empenhos-next aria-label="Proxima pagina">
+                Proxima<md-icon slot="icon">chevron_right</md-icon>
+            </md-text-button>
+        </nav>`;
+        html += '</section>';
         html += '</div>';
     }
 
@@ -404,6 +468,9 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
     body.innerHTML = html;
     _reattachDialogLinks(body);
     _decorateDialogBody(body);
+    if (typeof initEmpenhosControllers === 'function') {
+        initEmpenhosControllers(body);
+    }
     if (switchMun) {
         _activateDialogSection(body, 'forn-empenhos', { focus: false, scroll: false, smooth: false });
         const empSection = body.querySelector('#forn-empenhos');

--- a/web/static/js/pages/main.js
+++ b/web/static/js/pages/main.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initCidadeAutocomplete();
     initInteractiveToggles(document);
     initClickableRows(document);
+    initEmpenhosControllers(document);
     initBackToTop();
     initShareButtons();
     initModeToggle();

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -9,7 +9,7 @@
 // Fallback estatico (FALLBACK_CACHE_VERSION) é usado quando manifest indisponível
 // (dev mode sem build, ou race no deploy).
 
-const FALLBACK_CACHE_VERSION = 'tpb-v44-fallback';
+const FALLBACK_CACHE_VERSION = 'tpb-v45-fallback';
 
 // Lista mínima usada APENAS quando manifest.json não pode ser fetched.
 // Mantém PWA instalável mesmo em deploy race / 404 transitorio.

--- a/web/templates/partials/empresa/_empenhos.html
+++ b/web/templates/partials/empresa/_empenhos.html
@@ -20,10 +20,15 @@
    Linhas sao clickaveis: abrem #empresa-dialog via openEmpenhoDialog
    (precisa do partial dialogs/_empresa_dialog.html no template).
 #}
-{% set _empenhos_total = empenhos_total or (empenhos|length if empenhos else 0) %}
 {% set _empenhos_endpoint = empenhos_endpoint or '/api/empresa/empenhos' %}
 {% set _empenhos_scope = empenhos_scope or 'municipio' %}
 {% set _show_municipio_col = (_empenhos_scope == 'global') %}
+{# `empenhos_total` autoritativo do payload (warmer novo). Se ausente
+   (entry cacheada pre-PR), nao sabemos o total real — frontend faz
+   fetch live ao mount ate descobrir. `_empenhos_total_known` controla
+   esse comportamento via data-empenhos-total-known. #}
+{% set _empenhos_total_known = (empenhos_total is defined) and (empenhos_total is not none) %}
+{% set _empenhos_total = empenhos_total if _empenhos_total_known else (empenhos|length if empenhos else 0) %}
 <section class="empresa-section empenhos-section"
          id="empenhos-recentes"
          data-empenhos-mount
@@ -33,9 +38,10 @@
          {% if empenhos_municipio %}data-empenhos-municipio="{{ empenhos_municipio }}"{% endif %}
          {% if empenhos_cpf_cnpj %}data-empenhos-cpf-cnpj="{{ empenhos_cpf_cnpj }}"{% endif %}
          data-empenhos-total="{{ _empenhos_total }}"
+         data-empenhos-total-known="{{ '1' if _empenhos_total_known else '0' }}"
          data-empenhos-initial="{{ '1' if empenhos else '0' }}">
     <h2>Empenhos</h2>
-    {% if _empenhos_total %}
+    {% if _empenhos_total_known and _empenhos_total %}
     <p class="text-sm text-muted" data-empenhos-summary>
         {{ "{:,}".format(_empenhos_total).replace(',', '.') }} empenhos encontrados.
         Clique em uma linha para ver os detalhes.

--- a/web/templates/partials/empresa/_empenhos.html
+++ b/web/templates/partials/empresa/_empenhos.html
@@ -1,52 +1,117 @@
-{# Tabela de empenhos recentes (ate 50). Esperada a var `empenhos`.
+{# Tabela de empenhos com paginacao + filtros.
 
-   Linhas sao clickable: abrem #empresa-dialog via openEmpenhoDialog (handler
-   em clickable-rows.js -> empenho-dialog.js). Caller deve incluir o partial
-   partials/dialogs/_empresa_dialog.html no template pra que o dialog exista.
+   CALLER deve passar variaveis no template:
+       empenhos: lista do warmer (page 1, ate 50). Pode estar vazia.
+       empenhos_total: int. Count total. None/0 = pagina renderiza
+           sem footer ate primeiro fetch live (fallback p/ payloads
+           cacheados pre-PR de paginacao).
+       empenhos_endpoint: '/api/empresa/empenhos' (default) ou
+           '/api/fornecedor/empenhos'.
+       empenhos_scope: 'global' ou 'municipio' (afeta colunas
+           exibidas — global mostra coluna Municipio).
+       empenhos_cnpj: 14 digitos canonicos (passado pro endpoint
+           via JS no body).
+       empenhos_municipio: nome canonico OU None (None = global).
+
+   JS empenhos-controller.js procura `[data-empenhos-mount]` e wirea
+   filter bar + paginacao. Tabela inicial eh server-side renderizada
+   abaixo (SEO friendly + first-paint sem JS).
+
+   Linhas sao clickaveis: abrem #empresa-dialog via openEmpenhoDialog
+   (precisa do partial dialogs/_empresa_dialog.html no template).
 #}
-{% if empenhos %}
-<section class="empresa-section" id="empenhos-recentes">
-    <h2>Empenhos recentes</h2>
-    <p class="text-sm text-muted">
-        Ultimos {{ empenhos|length }} empenhos pagos identificados no TCE-PB
-        (ordenados pela data do empenho, mais recentes primeiro). Clique em uma
-        linha para abrir os detalhes.
+{% set _empenhos_total = empenhos_total or (empenhos|length if empenhos else 0) %}
+{% set _empenhos_endpoint = empenhos_endpoint or '/api/empresa/empenhos' %}
+{% set _empenhos_scope = empenhos_scope or 'municipio' %}
+{% set _show_municipio_col = (_empenhos_scope == 'global') %}
+<section class="empresa-section empenhos-section"
+         id="empenhos-recentes"
+         data-empenhos-mount
+         data-empenhos-endpoint="{{ _empenhos_endpoint }}"
+         data-empenhos-scope="{{ _empenhos_scope }}"
+         data-empenhos-cnpj="{{ empenhos_cnpj or cnpj or '' }}"
+         {% if empenhos_municipio %}data-empenhos-municipio="{{ empenhos_municipio }}"{% endif %}
+         {% if empenhos_cpf_cnpj %}data-empenhos-cpf-cnpj="{{ empenhos_cpf_cnpj }}"{% endif %}
+         data-empenhos-total="{{ _empenhos_total }}"
+         data-empenhos-initial="{{ '1' if empenhos else '0' }}">
+    <h2>Empenhos</h2>
+    {% if _empenhos_total %}
+    <p class="text-sm text-muted" data-empenhos-summary>
+        {{ "{:,}".format(_empenhos_total).replace(',', '.') }} empenhos encontrados.
+        Clique em uma linha para ver os detalhes.
     </p>
-    <div class="tbl-wrap">
-        <table class="stack-mobile data-table empresa-empenhos-table">
-            <thead>
-                <tr>
-                    <th>Data</th>
-                    <th>Numero</th>
-                    <th>Elemento de despesa</th>
-                    <th>Modalidade / Licitacao</th>
-                    <th class="text-right">Empenhado</th>
-                    <th class="text-right">Pago</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for e in empenhos %}
-                {% set sem_lic = (not e.numero_licitacao) or (e.numero_licitacao == '000000000') or ((e.modalidade_licitacao or '')|lower).startswith('sem licit') %}
-                <tr class="clickable-row"{% if e.id %} data-empenho-id="{{ e.id }}"{% endif %}>
-                    <td data-label="Data">{{ e.data_empenho|date_br }}</td>
-                    <td data-label="Numero"><code>{{ e.numero_empenho|clean_text or '—' }}</code></td>
-                    <td data-label="Elemento">{{ e.elemento_despesa|clean_text or '—' }}</td>
-                    <td data-label="Modalidade">
-                        {% if sem_lic %}
-                            <span class="badge badge-yellow" title="Empenho sem licitacao identificada">Sem licitacao</span>
-                        {% else %}
-                            {{ e.modalidade_licitacao|clean_text or '—' }}
-                            {% if e.numero_licitacao and e.numero_licitacao != '000000000' %}
-                                <br><span class="text-sm text-muted"><code>{{ e.numero_licitacao }}</code></span>
-                            {% endif %}
+    {% else %}
+    <p class="text-sm text-muted" data-empenhos-summary>
+        Clique em uma linha para ver os detalhes.
+    </p>
+    {% endif %}
+
+    {% include "partials/empresa/_empenhos_filter.html" %}
+
+    <div data-empenhos-table>
+        {% if empenhos %}
+        <div class="tbl-wrap">
+            <table class="stack-mobile data-table empresa-empenhos-table">
+                <thead>
+                    <tr>
+                        <th>Data</th>
+                        <th>Numero</th>
+                        {% if _show_municipio_col %}<th>Municipio</th>{% endif %}
+                        <th>Elemento de despesa</th>
+                        <th>Modalidade / Licitacao</th>
+                        <th class="text-right">Empenhado</th>
+                        <th class="text-right">Pago</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for e in empenhos %}
+                    {% set sem_lic = (not e.numero_licitacao) or (e.numero_licitacao == '000000000') or ((e.modalidade_licitacao or '')|lower).startswith('sem licit') %}
+                    <tr class="clickable-row"{% if e.id %} data-empenho-id="{{ e.id }}"{% endif %}>
+                        <td data-label="Data">{{ e.data_empenho|date_br }}</td>
+                        <td data-label="Numero"><code>{{ e.numero_empenho|clean_text or '—' }}</code></td>
+                        {% if _show_municipio_col %}
+                        <td data-label="Municipio">{{ e.municipio|clean_text or '—' }}</td>
                         {% endif %}
-                    </td>
-                    <td data-label="Empenhado" class="text-right num">{{ e.valor_empenhado|short_brl }}</td>
-                    <td data-label="Pago" class="text-right num"><strong>{{ e.valor_pago|short_brl }}</strong></td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                        <td data-label="Elemento">{{ e.elemento_despesa|clean_text or '—' }}</td>
+                        <td data-label="Modalidade">
+                            {% if sem_lic %}
+                                <span class="badge badge-yellow" title="Empenho sem licitacao identificada">Sem licitacao</span>
+                            {% else %}
+                                {{ e.modalidade_licitacao|clean_text or '—' }}
+                                {% if e.numero_licitacao and e.numero_licitacao != '000000000' %}
+                                    <br><span class="text-sm text-muted"><code>{{ e.numero_licitacao }}</code></span>
+                                {% endif %}
+                            {% endif %}
+                        </td>
+                        <td data-label="Empenhado" class="text-right num">{{ e.valor_empenhado|short_brl }}</td>
+                        <td data-label="Pago" class="text-right num"><strong>{{ e.valor_pago|short_brl }}</strong></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        {# Sem empenhos no warmer cache OU payload velho (pre-PR pagination).
+           Frontend faz lazy fetch live ao mount; placeholder enquanto. #}
+        <div class="empenhos-loading-placeholder text-sm text-muted" role="status">
+            Carregando empenhos...
+        </div>
+        {% endif %}
     </div>
+
+    <nav class="empenhos-pagination" data-empenhos-pagination
+         aria-label="Paginacao de empenhos"
+         hidden>
+        <md-text-button data-empenhos-prev disabled aria-label="Pagina anterior">
+            <md-icon slot="icon">chevron_left</md-icon>
+            Anterior
+        </md-text-button>
+        <span class="empenhos-page-info" data-empenhos-page-info aria-live="polite">
+            Pagina 1
+        </span>
+        <md-text-button data-empenhos-next aria-label="Proxima pagina">
+            Proxima
+            <md-icon slot="icon">chevron_right</md-icon>
+        </md-text-button>
+    </nav>
 </section>
-{% endif %}

--- a/web/templates/partials/empresa/_empenhos_filter.html
+++ b/web/templates/partials/empresa/_empenhos_filter.html
@@ -1,0 +1,63 @@
+{# Mini barra de filtros pra tabela paginada de empenhos.
+
+   ESCOPO LOCAL: nao afeta o filtro global da pagina /cidade/ (que tem
+   IDs dateInicio/dateFim/btnFiltrarData). IDs aqui prefixados com
+   `empenhos*` pra evitar colisao quando o partial eh incluso em
+   /cidade/<slug> (dialog de fornecedor) ao mesmo tempo que existe a
+   filter bar global.
+
+   Caller: define o data attribute `data-empenhos-mount` no container
+   <section> que envolve esta filter bar e a tabela. JS empenhos-controller.js
+   busca esses elementos por proximidade dentro do mount.
+#}
+<details class="date-filter-bar empenhos-filter-bar">
+    <summary class="date-filter-summary">
+        <span class="date-filter-current" data-empenhos-filter-summary>Periodo: todo o historico</span>
+        <span class="date-filter-action">Filtrar empenhos</span>
+    </summary>
+    <div class="date-filter-panel" role="group" aria-label="Filtros de empenhos">
+        <div class="empenhos-search-row">
+            <label class="date-field empenhos-search-field">
+                <span>Buscar</span>
+                <input
+                    type="search"
+                    data-empenhos-q
+                    placeholder="Numero, elemento, historico, modalidade..."
+                    inputmode="search"
+                    maxlength="100"
+                    autocomplete="off"
+                >
+            </label>
+        </div>
+        <div class="date-filter-inputs">
+            <label class="date-field"><span>De</span>
+                <input
+                    type="text"
+                    data-empenhos-date-inicio
+                    inputmode="numeric"
+                    placeholder="DD/MM/AAAA"
+                    maxlength="10"
+                    autocomplete="off"
+                >
+            </label>
+            <label class="date-field"><span>Ate</span>
+                <input
+                    type="text"
+                    data-empenhos-date-fim
+                    inputmode="numeric"
+                    placeholder="DD/MM/AAAA"
+                    maxlength="10"
+                    autocomplete="off"
+                >
+            </label>
+            <md-filled-button data-empenhos-apply class="date-filter-submit">Aplicar</md-filled-button>
+            <p class="date-filter-status text-sm text-muted" data-empenhos-status aria-live="polite"></p>
+        </div>
+        <div class="date-filter-presets" role="group" aria-label="Atalhos de periodo">
+            <md-filter-chip label="Tudo" data-empenhos-preset="all" selected></md-filter-chip>
+            <md-filter-chip label="Ano atual" data-empenhos-preset="current-year"></md-filter-chip>
+            <md-filter-chip label="12 meses" data-empenhos-preset="last-12m"></md-filter-chip>
+            <md-text-button data-empenhos-clear style="display:none">Limpar filtros</md-text-button>
+        </div>
+    </div>
+</details>

--- a/web/templates/results/empresa.html
+++ b/web/templates/results/empresa.html
@@ -102,6 +102,24 @@
     {% include "partials/empresa/_municipios_pagantes.html" %}
     {% include "partials/empresa/_socios.html" %}
 
+    {# Empenhos GLOBAIS (todos os municipios) — paginado + filtravel.
+       Page 1 vem do warmer (campo `empenhos_global`). Entries cacheadas
+       pre-PR de paginacao nao tem esses campos — frontend faz lazy
+       fetch live ao mount.
+
+       NOTA: empresa.html tambem precisa do partial dialogs/_empresa_dialog.html
+       pra empenho-dialog poder abrir. Adicionado no fim do template. #}
+    {% with
+       empenhos = empenhos_global or [],
+       empenhos_total = empenhos_total_global or 0,
+       empenhos_endpoint = '/api/empresa/empenhos',
+       empenhos_scope = 'global',
+       empenhos_cnpj = cnpj,
+       empenhos_municipio = None
+    %}
+        {% include "partials/empresa/_empenhos.html" %}
+    {% endwith %}
+
     <section class="empresa-section empresa-fontes">
         <h2>Fontes oficiais</h2>
         <p class="text-sm text-muted">
@@ -115,4 +133,21 @@
         </p>
     </section>
 </article>
+
+{% include "partials/dialogs/_empresa_dialog.html" %}
+
+<script>
+// _currentMunicipio nao se aplica aqui (perfil global), mas dialog-nav
+// declara o global — mantemos vazio. Deep-link de empenho via
+// ?d=empenho&id=... eh restaurado quando dialog estiver pronto.
+document.addEventListener("DOMContentLoaded", () => {
+    if (typeof window.whenMD3Ready === 'function') {
+        window.whenMD3Ready(() => {
+            if (typeof restoreDialogFromUrl === 'function') {
+                restoreDialogFromUrl();
+            }
+        });
+    }
+});
+</script>
 {% endblock %}

--- a/web/templates/results/empresa_municipio.html
+++ b/web/templates/results/empresa_municipio.html
@@ -118,9 +118,19 @@
 
     {% include "partials/empresa/_socios.html" %}
 
-    {# Empenhos no fim — pode ser longo (ate 50 linhas). Linhas clickaveis
-       abrem #empresa-dialog (ver partials/dialogs/_empresa_dialog.html). #}
-    {% include "partials/empresa/_empenhos.html" %}
+    {# Empenhos no fim — pode ser longo (paginado, busca, filtros).
+       Linhas clickaveis abrem #empresa-dialog (ver partials/dialogs/_empresa_dialog.html).
+       Variaveis empenhos_endpoint/scope/cnpj/municipio orientam o
+       empenhos-controller (JS) a fazer fetches paginados ao
+       /api/empresa/empenhos com escopo de municipio. #}
+    {% with
+       empenhos_endpoint = '/api/empresa/empenhos',
+       empenhos_scope = 'municipio',
+       empenhos_cnpj = cnpj,
+       empenhos_municipio = municipio
+    %}
+        {% include "partials/empresa/_empenhos.html" %}
+    {% endwith %}
 
     <section class="empresa-section empresa-fontes">
         <h2>Fontes oficiais</h2>


### PR DESCRIPTION
## Problema

Empenhos truncados a **LIMIT 50** sem paginacao em 3 superficies:

1. **Dialog de fornecedor** (em `/cidade/<slug>`) — fixo 50, sem filtros
2. **Pagina `/empresa/<cnpj>/<municipio>`** — fixo 50, sem filtros
3. **Pagina `/empresa/<cnpj>` global** — nao tinha empenhos

Mega-fornecedores (BB/Caixa/INSS) e municipios pequenos com muitos
contratos tinham milhares de empenhos invisiveis.

## Solucao

Paginacao + filtros (data + busca textual) em todas as 3 superficies.
Pagina 1 sem filtros vem do warmer cache (intacto). Paginas 2+ ou
qualquer filtro = endpoint live com `statement_timeout=5s`.

## Backend

| Item | Onde |
|---|---|
| 3 pares queries paginadas (`*_PAGINATED_*` + `*_COUNT_*`) | `web/queries/empresa.py` |
| `POST /api/empresa/empenhos` | `web/routes/empresa.py` |
| `POST /api/fornecedor/empenhos` | `web/routes/cidade.py` |
| Warmer payload: `empenhos_total` (mun) | `compute_empresa_municipio_perfil_dict` |
| Warmer payload: `empenhos_global` + `empenhos_total_global` | `_fetch_cadastral_block` |

Filtros via padrao `%(param)s IS NULL OR coluna OP param`. Busca
textual ILIKE em 4-5 colunas (numero, elemento, historico, modalidade,
+municipio na variante global). Wildcards SQL escapados.

## Frontend

| Item | Onde |
|---|---|
| Controller generico (filter bar + paginacao + fetch) | `components/empenhos-controller.js` (NOVO) |
| Partial filter bar local (IDs prefixados) | `partials/empresa/_empenhos_filter.html` (NOVO) |
| Refactor mount-driven (SSR pg1 + JS toma controle) | `partials/empresa/_empenhos.html` |
| Integracao dialog | `fornecedor-dialog.js` (mount inline) |
| Empenhos em `/empresa/<cnpj>` global | `results/empresa.html` |
| CSS empenhos-section + pagination + states | `empresa-page.css` |

## Cache invalidation strategy 🎯

**Backward-compatible. ZERO invalidacao.**

Campos novos no payload (`empenhos_total`, `empenhos_global`,
`empenhos_total_global`) sao **opcionais**. Frontend trata cada um
como opt-in:

- Sem `empenhos_total` → footer mostra "50 mais recentes" ate primeiro fetch
- Sem `empenhos_global` em `/empresa/<cnpj>` → placeholder + lazy fetch live ao mount (`data-empenhos-initial="0"`)

**Resultado**: cache existente (143K + 775K entries em prod) continua
servindo. Proximo warm cycle natural re-popula campos novos sem mudanca
visivel pro user.

## Deploy plan

1. **Deploy A** (este PR): `etl_phase=web` apenas, **NAO** `warm_cache=true`. Push + restart. Cache velho serve com fallback.
2. **Deploy B** (proximas 24h): warm cycle oportunistico re-popula campos novos.

## Bumps

- `ASSET_VERSION` 99 → **100** (novo JS file + templates)
- `sw.js FALLBACK_CACHE_VERSION` v44 → **v45**

## Safeguards

- `statement_timeout=5s` → 504 → JS mostra "Use filtros pra refinar"
- ILIKE com WHERE pre-restrito → poucos milhares de rows tipicamente
- Wildcards do usuario escapados (`\%`, `\_`)
- Min 2 chars busca + debounce 300ms
- Sem max de paginas
- Page size fixo 50

## Out of scope

- FTS (fulltext) — ILIKE basico por enquanto
- Export CSV do filtrado
- Filtro dedicado por elemento/modalidade
- Cache server-side de paginas 2+ ou filtros
- Cache do `/api/fornecedor/detalhes` (mantido live por escolha do user)

## Smoke test pos-deploy

```bash
# Endpoint empresa global
curl -sS -X POST https://transparenciapb.org/api/empresa/empenhos \
  -H "Content-Type: application/json" \
  -d '{"cnpj":"00360305000104","page":1}' | jq '.total, (.empenhos | length)'

# Endpoint empresa-municipio + busca
curl -sS -X POST https://transparenciapb.org/api/empresa/empenhos \
  -H "Content-Type: application/json" \
  -d '{"cnpj":"00360305000104","municipio":"Joao Pessoa","q":"licenciamento","page":2}' | jq '.total, .total_pages'

# Pagina renderiza com empenhos_global do warmer (apos warm cycle)
curl -sS https://transparenciapb.org/empresa/00360305000104 | grep -E '(empenhos-recentes|data-empenhos-mount|empenhos-pagination)' | head -5

# Empresa-municipio com paginacao
curl -sS https://transparenciapb.org/empresa/00360305000104/joao-pessoa | grep -E 'data-empenhos-(endpoint|total)' | head -3
```
