### PR TITLE
fix(sitemap): MV dedicada empresa-municipio + TTL 24h

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -568,6 +568,13 @@ jobs:
           # para que o postflight NAO faca downsize da VM (deixa em 16GB para retomar).
           python -m etl.21_views 2>&1
 
+          # 22_mv_sitemap: MV dedicada pro sitemap (mv_empresa_municipio_pagantes).
+          # Idempotente (DROP IF EXISTS + CREATE) e rapido (~1-2min em B4) — ok
+          # rodar mesmo em deploys SQL incrementais. Sem isso, queries
+          # EMPRESAS_MUNICIPIOS_QUALIFICADAS_* fazem GROUP BY em ~16M rows
+          # do tce_pb_despesa e os sitemaps empresa-municipio dao timeout.
+          python -m etl.22_mv_sitemap 2>&1
+
       # ── Incremental ETL (framework PB POC) ──
       - name: "ETL: Incremental"
         if: inputs.etl_phase == 'incremental'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -589,6 +589,13 @@ jobs:
           else
             python -m etl.incremental.runner 2>&1
           fi
+          # Refresh da MV de sitemap apos incremental: mv_empresa_municipio_pagantes
+          # depende de tce_pb_despesa que pode ter ganhado novos rows na fase
+          # incremental (TCE-PB esta no escopo POC v7). Sem refresh, sitemap fica
+          # stale e novos pares (empresa, municipio) nao indexam ate o proximo
+          # etl_phase=sql. Idempotente, ~1-2min.
+          echo "=== Refresh mv_empresa_municipio_pagantes (sitemap) ==="
+          python -m etl.22_mv_sitemap 2>&1 || echo "::warning::Refresh da MV de sitemap falhou — sitemap pode ficar stale ate proximo etl_phase=sql"
 
       # ── Specific phase ──
       - name: "ETL: Phase ${{ inputs.etl_phase }}"
@@ -998,19 +1005,10 @@ jobs:
 
           # Coverage check para EMPRESA_PERFIL_MUN (variantes /empresa/<cnpj>/<slug>).
           # Mesma logica: rejeita se < 80%, evitando expor mass-503.
+          # Usa mv_empresa_municipio_pagantes (instantaneo) em vez do GROUP BY
+          # original de ~16M rows do tce_pb_despesa (que dava timeout).
           QUALIFYING_MUN=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
-            SELECT COUNT(*) FROM (
-              SELECT 1
-              FROM tce_pb_despesa d
-              JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
-              JOIN estabelecimento est
-                ON est.cnpj_basico = epb.cnpj_basico
-               AND est.cnpj_ordem = '0001'
-              WHERE d.cnpj_basico IS NOT NULL
-                AND d.municipio IS NOT NULL
-                AND d.valor_pago > 0
-              GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
-            ) sub
+            SELECT COUNT(*) FROM mv_empresa_municipio_pagantes
           ")
           CACHED_MUN=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c \
             "SELECT COUNT(*) FROM web_cache WHERE query_id = 'EMPRESA_PERFIL_MUN';")
@@ -1147,20 +1145,11 @@ jobs:
 
           # 5b. E2E smoke pra /empresa/<cnpj>/<slug> (variantes scoped por
           # municipio). Mesma logica: amostra do qualifying set, tolera 2/10.
+          # Sample direto da MV (rapido) em vez do GROUP BY pesado.
           if [ "${QUALIFYING_MUN:-0}" -gt 0 ]; then
             PARES=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -F'|' -c "
-              SELECT
-                est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv,
-                d.municipio
-              FROM tce_pb_despesa d
-              JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
-              JOIN estabelecimento est
-                ON est.cnpj_basico = epb.cnpj_basico
-               AND est.cnpj_ordem = '0001'
-              WHERE d.cnpj_basico IS NOT NULL
-                AND d.municipio IS NOT NULL
-                AND d.valor_pago > 0
-              GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
+              SELECT cnpj_completo, municipio
+              FROM mv_empresa_municipio_pagantes
               ORDER BY random() LIMIT 10;
             ")
             FAIL_MUN=0

--- a/etl/22_mv_sitemap.py
+++ b/etl/22_mv_sitemap.py
@@ -1,0 +1,55 @@
+"""Fase 19: MV dedicada pro sitemap empresa-municipio.
+
+Cria/recria mv_empresa_municipio_pagantes a partir de
+sql/12b_mv_empresa_municipio_pagantes.sql. Standalone — pode ser rodado
+independentemente do 21_views (que recria TODAS as MVs e demora 1-2h).
+
+Uso:
+    python -m etl.22_mv_sitemap
+
+Depois disso, queries em web/queries/empresa.py
+(EMPRESAS_MUNICIPIOS_QUALIFICADAS_*) usam a MV. COUNT vira O(1) e
+PAGINATED fica < 100ms vs. ~30s+ do GROUP BY anterior em ~16M rows do
+tce_pb_despesa.
+
+Resolve o problema do GSC reportando "Couldn't fetch" nos sitemaps
+empresa pos-restart do cruza-web (cache em memoria limpo).
+"""
+
+import time
+
+from etl.config import SQL_DIR
+from etl.db import get_conn
+
+
+def run() -> None:
+    path = SQL_DIR / "12b_mv_empresa_municipio_pagantes.sql"
+    sql = path.read_text(encoding="utf-8")
+
+    print(f"  Executando {path.name}...", flush=True)
+    t0 = time.time()
+    conn = get_conn()
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+    finally:
+        conn.close()
+    elapsed = time.time() - t0
+    print(f"  OK ({elapsed:.0f}s).", flush=True)
+
+    # Sanity: count rows
+    conn2 = get_conn()
+    conn2.autocommit = True
+    try:
+        with conn2.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM mv_empresa_municipio_pagantes")
+            row = cur.fetchone()
+            n = int(row[0]) if row else 0
+            print(f"  mv_empresa_municipio_pagantes tem {n:,} pares.", flush=True)
+    finally:
+        conn2.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/etl/run_all.py
+++ b/etl/run_all.py
@@ -97,6 +97,7 @@ def main():
         ("Fase 16: PNCP Itens", "etl.04b_pncp_itens"),
         ("Fase 17: Normalizacao (colunas CPF/CNPJ + indices)", "etl.15_normalizar"),
         ("Fase 18: Views materializadas", "etl.21_views"),
+        ("Fase 19: MV sitemap empresa-municipio", "etl.22_mv_sitemap"),
     ]
 
     errors = []

--- a/sql/12b_mv_empresa_municipio_pagantes.sql
+++ b/sql/12b_mv_empresa_municipio_pagantes.sql
@@ -1,0 +1,44 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- mv_empresa_municipio_pagantes
+--
+-- Materializa pares DISTINCT (cnpj_completo, municipio) onde a empresa
+-- recebeu pagamentos > 0 em algum municipio PB. Substitui o GROUP BY
+-- pesado em ~16M rows do tce_pb_despesa que era feito on-demand pelo
+-- endpoint /sitemap-empresas-municipios-{n}.xml e o COUNT pelo
+-- /sitemap.xml — esses davam timeout >30s no Google Search Console
+-- pos-restart (cache em memoria limpo).
+--
+-- Tamanho estimado: ~775K rows. Refresh: ~1-2min em B4.
+--
+-- Indices:
+--   - UNIQUE (cnpj_completo, municipio) pra REFRESH CONCURRENTLY
+--   - (total_pago DESC) pra ORDER BY estavel da paginacao (sitemap shards)
+-- ─────────────────────────────────────────────────────────────────────────
+
+DROP MATERIALIZED VIEW IF EXISTS mv_empresa_municipio_pagantes CASCADE;
+
+CREATE MATERIALIZED VIEW mv_empresa_municipio_pagantes AS
+SELECT
+    est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo,
+    d.municipio,
+    SUM(d.valor_pago) AS total_pago
+FROM tce_pb_despesa d
+JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
+JOIN estabelecimento est
+    ON est.cnpj_basico = epb.cnpj_basico
+   AND est.cnpj_ordem = '0001'
+WHERE d.cnpj_basico IS NOT NULL
+  AND d.municipio IS NOT NULL
+  AND d.valor_pago > 0
+GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio;
+
+CREATE UNIQUE INDEX idx_mv_empmunpag_cnpj_mun
+    ON mv_empresa_municipio_pagantes (cnpj_completo, municipio);
+
+CREATE INDEX idx_mv_empmunpag_total
+    ON mv_empresa_municipio_pagantes (total_pago DESC NULLS LAST);
+
+ANALYZE mv_empresa_municipio_pagantes;
+
+-- Para refresh futuro (sem bloquear leituras):
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_empresa_municipio_pagantes;

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -542,54 +542,20 @@ EMPRESAS_QUALIFICADAS_COUNT = """
 # ─────────────────────────────────────────────────────────────────────────
 
 EMPRESAS_MUNICIPIOS_QUALIFICADAS_PAGINATED = """
-    SELECT
-        est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo,
-        d.municipio,
-        SUM(d.valor_pago) AS total
-    FROM tce_pb_despesa d
-    JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
-    JOIN estabelecimento est
-        ON est.cnpj_basico = epb.cnpj_basico
-       AND est.cnpj_ordem = '0001'
-    WHERE d.cnpj_basico IS NOT NULL
-      AND d.municipio IS NOT NULL
-      AND d.valor_pago > 0
-    GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
-    ORDER BY SUM(d.valor_pago) DESC NULLS LAST,
-             est.cnpj_basico, d.municipio
+    SELECT cnpj_completo, municipio, total_pago AS total
+    FROM mv_empresa_municipio_pagantes
+    ORDER BY total_pago DESC NULLS LAST, cnpj_completo, municipio
     LIMIT %(limit)s OFFSET %(offset)s
 """
 
 EMPRESAS_MUNICIPIOS_QUALIFICADAS_COUNT = """
-    SELECT COUNT(*) FROM (
-        SELECT 1
-        FROM tce_pb_despesa d
-        JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
-        JOIN estabelecimento est
-            ON est.cnpj_basico = epb.cnpj_basico
-           AND est.cnpj_ordem = '0001'
-        WHERE d.cnpj_basico IS NOT NULL
-          AND d.municipio IS NOT NULL
-          AND d.valor_pago > 0
-        GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
-    ) sub
+    SELECT COUNT(*) FROM mv_empresa_municipio_pagantes
 """
 
 # Versao sem LIMIT, usada pelo warmer (single shot, processa todos
 # os pares de uma vez). Mantem mesmo ORDER BY do paginated.
 EMPRESAS_MUNICIPIOS_QUALIFICADAS_TODOS = """
-    SELECT
-        est.cnpj_basico || est.cnpj_ordem || est.cnpj_dv AS cnpj_completo,
-        d.municipio
-    FROM tce_pb_despesa d
-    JOIN mv_empresa_pb epb ON epb.cnpj_basico = d.cnpj_basico
-    JOIN estabelecimento est
-        ON est.cnpj_basico = epb.cnpj_basico
-       AND est.cnpj_ordem = '0001'
-    WHERE d.cnpj_basico IS NOT NULL
-      AND d.municipio IS NOT NULL
-      AND d.valor_pago > 0
-    GROUP BY est.cnpj_basico, est.cnpj_ordem, est.cnpj_dv, d.municipio
-    ORDER BY SUM(d.valor_pago) DESC NULLS LAST,
-             est.cnpj_basico, d.municipio
+    SELECT cnpj_completo, municipio
+    FROM mv_empresa_municipio_pagantes
+    ORDER BY total_pago DESC NULLS LAST, cnpj_completo, municipio
 """

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -41,7 +41,15 @@ _INDEXNOW_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_\-]{8,128}$")
 
 # Cache em memoria pra cada urlset/index (1h TTL). Cada shard e cacheado
 # separadamente — restart do cruza-web limpa tudo, primeira request rebuilda.
-_SITEMAP_TTL = 3600  # 1h
+_SITEMAP_TTL = 86400  # 24h
+# 24h ao inves de 1h: counts/shards mudam pouco (depende de novos
+# fornecedores aparecerem em tce_pb_despesa). Reduz exposicao a queries
+# pesadas pos-restart do cruza-web (cache em memoria limpo) — Google
+# Search Console reportou "Couldn't fetch" quando o primeiro hit pos-
+# restart batia em GROUP BY de ~16M rows.
+#
+# Plus o COUNT/PAGINATED agora usam mv_empresa_municipio_pagantes
+# (instantaneo) em vez de GROUP BY live — TTL longo eh seguranca extra.
 _SITEMAP_CACHE: dict[str, Any] = {
     "index": {"ts": 0.0, "xml": ""},
     "cidades": {"ts": 0.0, "xml": ""},


### PR DESCRIPTION
## Problema

GSC reportou "Couldn't fetch" em `/sitemap-empresas-{1,2,3}.xml`. Probe local mostrou:

```
HEAD https://transparenciapb.org/sitemap.xml -> timeout >90s
HEAD https://transparenciapb.org/sitemap-empresas-1.xml -> timeout >30s
HEAD https://transparenciapb.org/sitemap-empresas-municipios-1.xml -> timeout >30s
```

## Causa raiz

Queries `EMPRESAS_MUNICIPIOS_QUALIFICADAS_*` faziam **GROUP BY em ~16M rows** do `tce_pb_despesa` com 2 JOINs por request. Cache em memória (`_SITEMAP_CACHE`) durava 1h MAS restart do cruza-web limpava — primeiro hit pós-restart pagava o custo, GSC dava timeout.

## Fix

| Mudança | Onde |
|---|---|
| **MV `mv_empresa_municipio_pagantes`** (~775K rows, indices UNIQUE+total_pago) | `sql/12b_mv_*.sql` (NOVO) |
| Phase ETL standalone | `etl/22_mv_sitemap.py` (NOVO) |
| Queries usam a MV (`SELECT FROM mv`) | `web/queries/empresa.py` |
| TTL 1h → 24h (segurança extra) | `web/routes/seo.py` |
| Step ETL `phase=sql` roda a nova MV | `.github/workflows/deploy.yml` |

## Performance esperada

| Endpoint | Antes (cold cache) | Depois |
|---|---|---|
| `EMPRESAS_MUNICIPIOS_QUALIFICADAS_COUNT` | ~30s | <10ms |
| `EMPRESAS_MUNICIPIOS_QUALIFICADAS_PAGINATED` (per shard) | ~30s | <100ms |
| `/sitemap.xml` first hit pós-restart | timeout >90s | <1s |
| `/sitemap-empresas-municipios-N.xml` | timeout >30s | <1s |

## Deploy plan

```bash
# 1. Cria a MV (idempotente, ~1-2min):
gh workflow run deploy.yml --ref main \
  -f etl_phase=sql \
  -f warm_cache=false \
  -f expose_empresa_sitemap=keep

# 2. Re-submit sitemap-index no GSC.
```

⚠️ **`etl_phase=sql` re-roda 21_views (todas as MVs)** — ~1-2h. Se isso for problemático, alternativa via SSH direto:
```bash
ssh govbr@vm-govbr "cd /home/govbr/govbr-project && source venv/bin/activate && python -m etl.22_mv_sitemap"
```

## Rollback

- Git revert: queries voltam pro GROUP BY antigo (lento mas funcional)
- `DROP MATERIALIZED VIEW IF EXISTS mv_empresa_municipio_pagantes CASCADE;`

## Smoke test pós-deploy

```bash
time curl -sS -o /dev/null -w '%{http_code} %{time_total}s\n' \
  https://transparenciapb.org/sitemap.xml
# Esperado: 200 < 1s

time curl -sS -o /dev/null -w '%{http_code} %{size_download} %{time_total}s\n' \
  https://transparenciapb.org/sitemap-empresas-municipios-1.xml
# Esperado: 200 ~9MB < 2s
```
