### PR TITLE
feat(seo): FAQ schema + visible UI em 4 superficies (PR A search intent)

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -403,7 +403,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "100"
+templates.env.globals["ASSET_VERSION"] = "101"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/css/components/faq.css
+++ b/web/static/css/components/faq.css
@@ -92,6 +92,39 @@
     margin-bottom: 0;
 }
 
+/* Linha de links contextuais apos a resposta (internal linking + UX) */
+.faq-links {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: .35rem .25rem;
+    margin-top: .65rem !important;
+    padding-top: .5rem;
+    border-top: 1px solid var(--md-sys-color-outline-variant, rgba(255,255,255,.08));
+    font-size: .85rem;
+    color: var(--md-sys-color-on-surface-variant);
+}
+
+.faq-links-label {
+    font-weight: 600;
+    margin-right: .25rem;
+}
+
+.faq-links a {
+    color: var(--md-sys-color-primary, #3b82f6);
+    text-decoration: none;
+}
+
+.faq-links a:hover,
+.faq-links a:focus-visible {
+    text-decoration: underline;
+}
+
+.faq-links-sep {
+    color: var(--md-sys-color-outline, rgba(255,255,255,.3));
+    user-select: none;
+}
+
 @media (max-width: 600px) {
     .faq-section {
         margin: 1.5rem 0;

--- a/web/static/css/components/faq.css
+++ b/web/static/css/components/faq.css
@@ -1,0 +1,111 @@
+/* ─────────────────────────────────────────────────────────────────────
+   FAQ section — usado em /sobre, /cidade/<slug>, /empresa/<cnpj>,
+   /empresa/<cnpj>/<municipio>. Renderiza HTML + JSON-LD FAQPage.
+
+   IMPORTANTE: o conteudo PRECISA estar visivel na pagina (Google penaliza
+   FAQ schema com conteudo so em JSON-LD desde out/2023). Por isso usamos
+   <details> nativo — colapsavel sem JS, acessivel por keyboard,
+   indexavel pelo crawler.
+   ─────────────────────────────────────────────────────────────────── */
+
+.faq-section {
+    margin: 2rem 0;
+    padding: 1.25rem;
+    border: 1px solid var(--md-sys-color-outline-variant, rgba(255,255,255,.1));
+    border-radius: 8px;
+    background: var(--md-sys-color-surface-container-low, rgba(255,255,255,.02));
+}
+
+.faq-section-title {
+    margin: 0 0 1rem 0;
+    font-size: 1.25rem;
+    line-height: 1.3;
+}
+
+.faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.faq-item {
+    border-radius: 6px;
+    overflow: hidden;
+    transition: background-color .15s ease;
+}
+
+.faq-item[open] {
+    background: var(--md-sys-color-surface-container, rgba(255,255,255,.04));
+}
+
+.faq-question {
+    cursor: pointer;
+    padding: .85rem 1rem;
+    font-weight: 600;
+    font-size: .95rem;
+    line-height: 1.4;
+    list-style: none;
+    position: relative;
+    padding-right: 2.5rem;
+    user-select: none;
+}
+
+.faq-question::-webkit-details-marker {
+    display: none;
+}
+
+/* Chevron pseudo-element pra indicar estado */
+.faq-question::after {
+    content: '+';
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 1.4rem;
+    font-weight: 400;
+    color: var(--md-sys-color-on-surface-variant);
+    transition: transform .2s ease;
+    line-height: 1;
+}
+
+.faq-item[open] .faq-question::after {
+    content: '−';
+}
+
+.faq-question:hover,
+.faq-question:focus-visible {
+    background: var(--md-sys-color-surface-container-high, rgba(255,255,255,.06));
+    outline: none;
+}
+
+.faq-answer {
+    padding: 0 1rem 1rem 1rem;
+    color: var(--md-sys-color-on-surface-variant);
+    line-height: 1.55;
+}
+
+.faq-answer p {
+    margin: 0 0 .5rem 0;
+}
+
+.faq-answer p:last-child {
+    margin-bottom: 0;
+}
+
+@media (max-width: 600px) {
+    .faq-section {
+        margin: 1.5rem 0;
+        padding: 1rem;
+    }
+    .faq-section-title {
+        font-size: 1.1rem;
+    }
+    .faq-question {
+        font-size: .9rem;
+        padding: .75rem 2.25rem .75rem .85rem;
+    }
+    .faq-answer {
+        font-size: .9rem;
+        padding: 0 .85rem .85rem .85rem;
+    }
+}

--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -42,6 +42,7 @@
 @import url("./components/empresa-dialog.css");
 @import url("./components/empresa-page.css");
 @import url("./components/fab.css");
+@import url("./components/faq.css");
 @import url("./components/finding-card.css");
 @import url("./components/font-toggle.css");
 @import url("./components/footer.css");

--- a/web/templates/partials/seo/_faq.html
+++ b/web/templates/partials/seo/_faq.html
@@ -1,21 +1,45 @@
 {# Macro reutilizavel pra renderizar FAQs com SEO + UX:
 
-   1. JSON-LD FAQPage (rich results no Google)
+   1. JSON-LD FAQPage (structured data — schema valido pra todos os
+      search engines: Bing, Yandex, voice assistants, Brave Search etc)
    2. Markup visivel acessivel (<details> nativo, colapsavel sem JS)
 
+   NOTA SOBRE GOOGLE FAQ RICH RESULTS:
+   Google restringe FAQPage rich results (accordion no SERP) para sites
+   "well-known and authoritative" de saude ou governo. transparenciapb
+   nao se qualifica como rich result eligible por enquanto. Ainda assim,
+   FAQ schema:
+   - Eh structured data valida (todos os crawlers entendem o contexto)
+   - Bing/Yandex/Brave: rich results possiveis (regras diferentes)
+   - Voice assistants (Google Assistant, Siri, Alexa): usam structured data
+   - Long-tail keywords: cada Q vira keyword indexavel no body
+
    IMPORTANTE: Google penaliza FAQ schema quando o conteudo nao esta
-   visivel na pagina (politica oct/2023). Por isso renderizamos AMBOS:
+   visivel na pagina (politica oct/2023). Renderizamos AMBOS:
    schema E HTML <details>. Conteudo identico nos dois.
 
-   Uso:
-       {% set faqs = [
-           {'q': 'Pergunta?', 'a': 'Resposta.'},
-           {'q': '...', 'a': '...'},
-       ] %}
-       {{ faq_section(faqs, title='Perguntas frequentes', anchor='faq-empresa') }}
+   Cada FAQ eh um dict:
+       {
+           'q': 'Pergunta?',           # plain text (auto-escapado)
+           'a': 'Resposta plain.',     # plain text (auto-escapado em <p>)
+           'links': [                  # opcional — links contextuais.
+               {'label': 'Texto', 'href': '/url'},  # auto-escapado
+               ...
+           ],
+       }
 
-   - title: string opcional (header h2)
-   - anchor: string opcional pra id do <section> (deep-link friendly)
+   `a` eh sempre o texto plain (sem HTML) — eh o que vai no JSON-LD
+   `acceptedAnswer.text`. Google ignora HTML em FAQPage answers de
+   qualquer modo.
+
+   `links` eh opcional. Quando presente, eh renderizado APOS o paragrafo
+   da resposta como linha de "Veja tambem: [link1] [link2]". Links sao
+   APENAS visiveis (nao vao pro JSON-LD — manda Google ler so texto).
+   Cada link tem label (texto auto-escapado) e href (auto-escapado em
+   atributo).
+
+   Internal linking via `links` ajuda crawl, deep-link UX, e mantem
+   sanitization simples (sem string concat de HTML).
 #}
 
 {% macro faq_jsonld(faqs) -%}
@@ -52,10 +76,14 @@
         <details class="faq-item">
             <summary class="faq-question">{{ f.q }}</summary>
             <div class="faq-answer">
-                {%- if f.a_html %}
-                {{ f.a_html | safe }}
-                {%- else %}
                 <p>{{ f.a }}</p>
+                {%- if f.links %}
+                <p class="faq-links">
+                    <span class="faq-links-label">Veja tambem:</span>
+                    {%- for lk in f.links %}
+                    <a href="{{ lk.href }}"{% if lk.external %} target="_blank" rel="noopener"{% endif %}>{{ lk.label }}</a>{% if not loop.last %} <span class="faq-links-sep">&middot;</span>{% endif %}
+                    {%- endfor %}
+                </p>
                 {%- endif %}
             </div>
         </details>

--- a/web/templates/partials/seo/_faq.html
+++ b/web/templates/partials/seo/_faq.html
@@ -1,0 +1,71 @@
+{# Macro reutilizavel pra renderizar FAQs com SEO + UX:
+
+   1. JSON-LD FAQPage (rich results no Google)
+   2. Markup visivel acessivel (<details> nativo, colapsavel sem JS)
+
+   IMPORTANTE: Google penaliza FAQ schema quando o conteudo nao esta
+   visivel na pagina (politica oct/2023). Por isso renderizamos AMBOS:
+   schema E HTML <details>. Conteudo identico nos dois.
+
+   Uso:
+       {% set faqs = [
+           {'q': 'Pergunta?', 'a': 'Resposta.'},
+           {'q': '...', 'a': '...'},
+       ] %}
+       {{ faq_section(faqs, title='Perguntas frequentes', anchor='faq-empresa') }}
+
+   - title: string opcional (header h2)
+   - anchor: string opcional pra id do <section> (deep-link friendly)
+#}
+
+{% macro faq_jsonld(faqs) -%}
+{%- if faqs %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {%- for f in faqs %}
+    {
+      "@type": "Question",
+      "name": {{ f.q | tojson }},
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": {{ f.a | tojson }}
+      }
+    }{%- if not loop.last %},{% endif %}
+    {%- endfor %}
+  ]
+}
+</script>
+{%- endif %}
+{%- endmacro %}
+
+{% macro faq_visible(faqs, title=None, anchor=None) -%}
+{%- if faqs %}
+<section class="faq-section"{% if anchor %} id="{{ anchor }}"{% endif %} aria-labelledby="{{ (anchor or 'faq') }}-title">
+    {%- if title %}
+    <h2 id="{{ (anchor or 'faq') }}-title" class="faq-section-title">{{ title }}</h2>
+    {%- endif %}
+    <div class="faq-list">
+        {%- for f in faqs %}
+        <details class="faq-item">
+            <summary class="faq-question">{{ f.q }}</summary>
+            <div class="faq-answer">
+                {%- if f.a_html %}
+                {{ f.a_html | safe }}
+                {%- else %}
+                <p>{{ f.a }}</p>
+                {%- endif %}
+            </div>
+        </details>
+        {%- endfor %}
+    </div>
+</section>
+{%- endif %}
+{%- endmacro %}
+
+{% macro faq_section(faqs, title=None, anchor=None) -%}
+{{- faq_jsonld(faqs) -}}
+{{- faq_visible(faqs, title=title, anchor=anchor) -}}
+{%- endmacro %}

--- a/web/templates/partials/seo/_faq_cidade.html
+++ b/web/templates/partials/seo/_faq_cidade.html
@@ -1,43 +1,66 @@
 {# FAQs dinamicas pra /cidade/<slug>. Personalizadas com o nome do
-   municipio pra capturar long-tail "gastos prefeitura X", "fornecedores X",
-   etc. Mantemos perguntas factuais — sem promessas sobre que vai estar
-   listado na pagina (cache pode ter scope diferente).
-
-   Caller deve passar:
-       perfil.municipio: string canonica
-
-   FAQs ficam ABAIXO da secao "fontes oficiais" do bloco content.
-#}
+   municipio. Links contextuais via campo 'links'. #}
 {% from "partials/seo/_faq.html" import faq_section %}
 {% set _mun_nome = perfil.municipio %}
 {% set _cidade_faqs = [
     {
         'q': 'Quanto a prefeitura de ' ~ _mun_nome ~ ' gastou em despesas?',
         'a': 'A pagina mostra o total de empenhos pagos pela prefeitura de ' ~ _mun_nome ~ ', com base nos dados oficiais do TCE-PB desde 2022. Voce pode filtrar por periodo (ano atual, ultimos 12 meses, ou intervalo customizado) usando o filtro de data no topo da pagina.',
+        'links': [
+            {'label': 'Filtro de periodo', 'href': '#dateFilterBar'},
+        ],
     },
     {
         'q': 'Quem sao os maiores fornecedores da prefeitura de ' ~ _mun_nome ~ '?',
-        'a': 'A secao "Maiores fornecedores" lista empresas e prestadores ordenados pelo total recebido. Clique em uma linha para abrir o detalhe (CNPJ, sancoes, divida PGFN, historico de pagamentos no municipio). Os dados vem do TCE-PB cruzados com cadastro RFB.',
+        'a': 'A secao "Maiores fornecedores" lista empresas e prestadores ordenados pelo total recebido. Clique em uma linha para abrir o detalhe (CNPJ, sancoes, divida PGFN, historico de pagamentos no municipio).',
+        'links': [
+            {'label': 'Maiores fornecedores', 'href': '#fornecedores'},
+            {'label': 'Concentracao de fornecedores', 'href': '#concentracao-fornecedores'},
+        ],
     },
     {
         'q': 'A prefeitura de ' ~ _mun_nome ~ ' contrata empresas sancionadas (CEIS/CNEP)?',
-        'a': 'A pagina destaca contratos com empresas que estavam sancionadas no momento do empenho. Sancoes vem dos cadastros oficiais da CGU (CEIS - empresas inidoneas/suspensas; CNEP - empresas sancionadas pela Lei Anticorrupcao). Verde = sem sancao registrada; vermelho = sancao ativa cobrindo o periodo do empenho.',
+        'a': 'A pagina destaca contratos com empresas sancionadas na CGU (CEIS - empresas inidoneas/suspensas; CNEP - empresas sancionadas pela Lei Anticorrupcao). Verde = sem sancao registrada; vermelho = sancao ativa cobrindo o periodo do empenho.',
+        'links': [
+            {'label': 'Relatorio completo', 'href': '#relatorio'},
+            {'label': 'Glossario', 'href': '/glossario'},
+        ],
     },
     {
         'q': 'Quantos servidores trabalham na prefeitura de ' ~ _mun_nome ~ '?',
         'a': 'A secao "Servidores" lista os trabalhadores publicos registrados no TCE-PB (ultimos 2 anos), com cargo e maior salario observado. Voce pode clicar pra ver historico do servidor e eventuais vinculos com empresas que recebem da propria prefeitura — sinal de atencao para conflitos de interesse.',
+        'links': [
+            {'label': 'Servidores', 'href': '#servidores'},
+            {'label': 'Relatorio completo', 'href': '#relatorio'},
+        ],
     },
     {
         'q': 'Como saber se uma empresa que recebe da prefeitura de ' ~ _mun_nome ~ ' tem divida ativa?',
         'a': 'Clique no fornecedor pra abrir o detalhe. Mostramos divida PGFN (federal) e flags de cadastro RFB (situacao cadastral irregular, baixada, suspensa). Para divida estadual/municipal, consulte os portais especificos.',
+        'links': [
+            {'label': 'Maiores fornecedores', 'href': '#fornecedores'},
+            {'label': 'Glossario', 'href': '/glossario'},
+        ],
     },
     {
         'q': 'Os dados de ' ~ _mun_nome ~ ' sao oficiais?',
-        'a': 'Sim. Todos os dados de despesa, licitacao, servidores e receitas vem do TCE-PB (Tribunal de Contas do Estado da Paraiba) — fonte oficial. Cadastro CNPJ vem da Receita Federal. Sancoes vem da CGU. Atualizamos periodicamente; sempre indicamos a data do ultimo snapshot.',
+        'a': 'Sim. Despesas, licitacoes, servidores e receitas vem do TCE-PB. Cadastro CNPJ vem da Receita Federal. Sancoes vem da CGU. Atualizamos periodicamente; sempre indicamos a data do ultimo snapshot.',
+        'links': [
+            {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
+            {'label': 'Receita Federal', 'href': 'https://www.gov.br/receitafederal', 'external': True},
+            {'label': 'CGU', 'href': 'https://www.gov.br/cgu', 'external': True},
+            {'label': 'Mais sobre as fontes', 'href': '/sobre#fontes'},
+        ],
     },
     {
         'q': 'Como reportar uma irregularidade em ' ~ _mun_nome ~ '?',
-        'a': 'Os dados aqui sao um ponto de partida. Para denuncia formal: Ministerio Publico da Paraiba (mppb.mp.br), TCE-PB (tce.pb.gov.br), Camara Municipal de ' ~ _mun_nome ~ ', ou Controladoria-Geral da Uniao (gov.br/cgu).',
+        'a': 'Os dados aqui sao um ponto de partida. Para denuncia formal: Ministerio Publico da Paraiba, TCE-PB, Camara Municipal de ' ~ _mun_nome ~ ', ou Controladoria-Geral da Uniao. Encontrou dado incorreto na plataforma? Use a pagina de contato.',
+        'links': [
+            {'label': 'MP-PB', 'href': 'https://www.mppb.mp.br/', 'external': True},
+            {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
+            {'label': 'CGU', 'href': 'https://www.gov.br/cgu', 'external': True},
+            {'label': 'Contato (correcao de dado)', 'href': '/contato'},
+        ],
     }
 ] %}
 

--- a/web/templates/partials/seo/_faq_cidade.html
+++ b/web/templates/partials/seo/_faq_cidade.html
@@ -1,0 +1,44 @@
+{# FAQs dinamicas pra /cidade/<slug>. Personalizadas com o nome do
+   municipio pra capturar long-tail "gastos prefeitura X", "fornecedores X",
+   etc. Mantemos perguntas factuais — sem promessas sobre que vai estar
+   listado na pagina (cache pode ter scope diferente).
+
+   Caller deve passar:
+       perfil.municipio: string canonica
+
+   FAQs ficam ABAIXO da secao "fontes oficiais" do bloco content.
+#}
+{% from "partials/seo/_faq.html" import faq_section %}
+{% set _mun_nome = perfil.municipio %}
+{% set _cidade_faqs = [
+    {
+        'q': 'Quanto a prefeitura de ' ~ _mun_nome ~ ' gastou em despesas?',
+        'a': 'A pagina mostra o total de empenhos pagos pela prefeitura de ' ~ _mun_nome ~ ', com base nos dados oficiais do TCE-PB desde 2022. Voce pode filtrar por periodo (ano atual, ultimos 12 meses, ou intervalo customizado) usando o filtro de data no topo da pagina.',
+    },
+    {
+        'q': 'Quem sao os maiores fornecedores da prefeitura de ' ~ _mun_nome ~ '?',
+        'a': 'A secao "Maiores fornecedores" lista empresas e prestadores ordenados pelo total recebido. Clique em uma linha para abrir o detalhe (CNPJ, sancoes, divida PGFN, historico de pagamentos no municipio). Os dados vem do TCE-PB cruzados com cadastro RFB.',
+    },
+    {
+        'q': 'A prefeitura de ' ~ _mun_nome ~ ' contrata empresas sancionadas (CEIS/CNEP)?',
+        'a': 'A pagina destaca contratos com empresas que estavam sancionadas no momento do empenho. Sancoes vem dos cadastros oficiais da CGU (CEIS - empresas inidoneas/suspensas; CNEP - empresas sancionadas pela Lei Anticorrupcao). Verde = sem sancao registrada; vermelho = sancao ativa cobrindo o periodo do empenho.',
+    },
+    {
+        'q': 'Quantos servidores trabalham na prefeitura de ' ~ _mun_nome ~ '?',
+        'a': 'A secao "Servidores" lista os trabalhadores publicos registrados no TCE-PB (ultimos 2 anos), com cargo e maior salario observado. Voce pode clicar pra ver historico do servidor e eventuais vinculos com empresas que recebem da propria prefeitura — sinal de atencao para conflitos de interesse.',
+    },
+    {
+        'q': 'Como saber se uma empresa que recebe da prefeitura de ' ~ _mun_nome ~ ' tem divida ativa?',
+        'a': 'Clique no fornecedor pra abrir o detalhe. Mostramos divida PGFN (federal) e flags de cadastro RFB (situacao cadastral irregular, baixada, suspensa). Para divida estadual/municipal, consulte os portais especificos.',
+    },
+    {
+        'q': 'Os dados de ' ~ _mun_nome ~ ' sao oficiais?',
+        'a': 'Sim. Todos os dados de despesa, licitacao, servidores e receitas vem do TCE-PB (Tribunal de Contas do Estado da Paraiba) — fonte oficial. Cadastro CNPJ vem da Receita Federal. Sancoes vem da CGU. Atualizamos periodicamente; sempre indicamos a data do ultimo snapshot.',
+    },
+    {
+        'q': 'Como reportar uma irregularidade em ' ~ _mun_nome ~ '?',
+        'a': 'Os dados aqui sao um ponto de partida. Para denuncia formal: Ministerio Publico da Paraiba (mppb.mp.br), TCE-PB (tce.pb.gov.br), Camara Municipal de ' ~ _mun_nome ~ ', ou Controladoria-Geral da Uniao (gov.br/cgu).',
+    }
+] %}
+
+{{ faq_section(_cidade_faqs, title='Perguntas frequentes sobre ' ~ _mun_nome, anchor='faq-cidade') }}

--- a/web/templates/partials/seo/_faq_empresa.html
+++ b/web/templates/partials/seo/_faq_empresa.html
@@ -1,0 +1,51 @@
+{# FAQs dinamicas pra /empresa/<cnpj> (perfil global). Personalizadas com
+   nome da empresa + CNPJ. Capturam long-tail "[empresa] recebimentos
+   governo", "[empresa] divida PGFN", "[CNPJ] paraiba".
+
+   Caller passa:
+       razao_social, cnpj_fmt, cnpj, agregados, sancoes, pgfn,
+       kpi_total_pb, kpi_qtd_municipios, kpi_total_divida_pgfn,
+       municipios_pagantes
+#}
+{% from "partials/seo/_faq.html" import faq_section %}
+{% set _emp_nome = razao_social %}
+{% set _total_pb = kpi_total_pb or 0 %}
+{% set _qtd_mun = kpi_qtd_municipios or 0 %}
+{% set _divida = kpi_total_divida_pgfn or 0 %}
+{% set _qtd_sanc = sancoes|length if sancoes else 0 %}
+
+{# Formata BRL "R$ 1.234.567,00" — usa locale aproximado #}
+{% macro _fmt_brl(v) %}R$ {{ "%.2f"|format(v)|replace(".", ",")|replace(",", ".", 1) }}{% endmacro %}
+
+{% set _empresa_faqs = [
+    {
+        'q': 'Quanto a empresa ' ~ _emp_nome ~ ' recebeu de prefeituras na Paraiba?',
+        'a': ('Segundo dados do TCE-PB, ' ~ _emp_nome ~ ' (CNPJ ' ~ cnpj_fmt ~ ') recebeu o equivalente a R$ ' ~ ("{:,.2f}".format(_total_pb)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ' em pagamentos municipais somando todos os municipios da PB. A pagina detalha a distribuicao por municipio, periodo e categoria de gasto.') if _total_pb > 0 else ('Os dados oficiais do TCE-PB indicam que ' ~ _emp_nome ~ ' (CNPJ ' ~ cnpj_fmt ~ ') aparece no nosso recorte de empresas com pagamentos municipais na Paraiba. Veja na pagina os municipios pagantes e historico detalhado.'),
+    },
+    {
+        'q': 'Em quais municipios da Paraiba ' ~ _emp_nome ~ ' e fornecedora?',
+        'a': ('A empresa ' ~ _emp_nome ~ ' aparece em ' ~ _qtd_mun ~ ' municipio(s) paraibano(s). A secao "Municipios pagantes" lista cada um com o total recebido — clique para abrir o detalhe scoped (empenhos recentes, monthly chart, top elementos de despesa).') if _qtd_mun > 0 else ('A pagina lista todos os municipios da PB onde ' ~ _emp_nome ~ ' recebeu pagamentos. Em alguns casos a lista pode estar vazia se nao houver dados nos snapshots atuais.'),
+    },
+    {
+        'q': _emp_nome ~ ' tem divida ativa na PGFN?',
+        'a': ('Sim. ' ~ _emp_nome ~ ' tem divida ativa registrada na Procuradoria-Geral da Fazenda Nacional. O total inscrito e R$ ' ~ ("{:,.2f}".format(_divida)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ '. A secao "Divida ativa" mostra detalhes (data de inscricao, tipo, status).') if _divida > 0 else (_emp_nome ~ ' nao possui divida ativa registrada na PGFN segundo o snapshot atual da Procuradoria-Geral da Fazenda Nacional. Note que dividas estaduais/municipais nao sao cobertas por esse cadastro.'),
+    },
+    {
+        'q': _emp_nome ~ ' esta sancionada (CEIS, CNEP ou inidonea)?',
+        'a': ('Sim. ' ~ _emp_nome ~ ' possui ' ~ _qtd_sanc ~ ' sancao(es) registrada(s) na CGU. A secao "Sancoes" detalha cada uma (orgao sancionador, periodo de vigencia, fundamentacao legal). Sancao ativa significa restricao de contratacao com o setor publico — verifique a abrangencia.') if _qtd_sanc > 0 else (_emp_nome ~ ' nao possui sancoes ativas registradas no CEIS (Cadastro de Empresas Inidoneas) nem no CNEP (Cadastro Nacional de Empresas Punidas) segundo a CGU. Isso nao exclui sancoes municipais ou estaduais nao reportadas.'),
+    },
+    {
+        'q': 'Quem sao os socios da ' ~ _emp_nome ~ '?',
+        'a': 'A secao "Socios" lista os representantes da pessoa juridica conforme cadastro RFB (Receita Federal). Para cada um mostramos nome, qualificacao (administrador, diretor, etc) e data de entrada. CPFs sao parcialmente mascarados conforme exigencia da LGPD.',
+    },
+    {
+        'q': 'Os dados sobre ' ~ _emp_nome ~ ' sao oficiais?',
+        'a': 'Sim. Cadastro CNPJ (razao social, socios, endereco, situacao) vem da Receita Federal. Pagamentos vem do TCE-PB. Sancoes da CGU (CEIS/CNEP/CEAF). Divida da PGFN. dados.pb.gov.br para orcamento estadual. Indicamos a data do snapshot. Para verificacao adicional, consulte os portais oficiais.',
+    },
+    {
+        'q': 'Como verificar se ' ~ _emp_nome ~ ' pode contratar com o setor publico?',
+        'a': 'Verifique: (1) sancoes ativas no CEIS/CNEP — restringem contratacao; (2) regularidade fiscal (PGFN, Receita Federal); (3) cadastro RFB ativo (situacao cadastral != "baixada/suspensa"); (4) certidoes especificas (FGTS, trabalhista). A pagina sinaliza os pontos publicos — certidoes formais devem ser obtidas dos orgaos.',
+    }
+] %}
+
+{{ faq_section(_empresa_faqs, title='Perguntas frequentes sobre ' ~ _emp_nome, anchor='faq-empresa') }}

--- a/web/templates/partials/seo/_faq_empresa.html
+++ b/web/templates/partials/seo/_faq_empresa.html
@@ -1,6 +1,5 @@
-{# FAQs dinamicas pra /empresa/<cnpj> (perfil global). Personalizadas com
-   nome da empresa + CNPJ. Capturam long-tail "[empresa] recebimentos
-   governo", "[empresa] divida PGFN", "[CNPJ] paraiba".
+{# FAQs dinamicas pra /empresa/<cnpj> (perfil global). Links contextuais
+   via campo 'links'.
 
    Caller passa:
        razao_social, cnpj_fmt, cnpj, agregados, sancoes, pgfn,
@@ -14,37 +13,72 @@
 {% set _divida = kpi_total_divida_pgfn or 0 %}
 {% set _qtd_sanc = sancoes|length if sancoes else 0 %}
 
-{# Formata BRL "R$ 1.234.567,00" — usa locale aproximado #}
-{% macro _fmt_brl(v) %}R$ {{ "%.2f"|format(v)|replace(".", ",")|replace(",", ".", 1) }}{% endmacro %}
+{# Top 1 municipio pagante (pra link contextual). Pode ser None. #}
+{% set _top_mun = (municipios_pagantes[0] if municipios_pagantes else None) %}
 
 {% set _empresa_faqs = [
     {
         'q': 'Quanto a empresa ' ~ _emp_nome ~ ' recebeu de prefeituras na Paraiba?',
         'a': ('Segundo dados do TCE-PB, ' ~ _emp_nome ~ ' (CNPJ ' ~ cnpj_fmt ~ ') recebeu o equivalente a R$ ' ~ ("{:,.2f}".format(_total_pb)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ' em pagamentos municipais somando todos os municipios da PB. A pagina detalha a distribuicao por municipio, periodo e categoria de gasto.') if _total_pb > 0 else ('Os dados oficiais do TCE-PB indicam que ' ~ _emp_nome ~ ' (CNPJ ' ~ cnpj_fmt ~ ') aparece no nosso recorte de empresas com pagamentos municipais na Paraiba. Veja na pagina os municipios pagantes e historico detalhado.'),
+        'links': [
+            {'label': 'Resumo de pagamentos', 'href': '#resumo-pagamentos'},
+            {'label': 'Municipios pagantes', 'href': '#municipios-pagantes'},
+            {'label': 'Empenhos detalhados', 'href': '#empenhos-recentes'},
+        ],
     },
     {
         'q': 'Em quais municipios da Paraiba ' ~ _emp_nome ~ ' e fornecedora?',
         'a': ('A empresa ' ~ _emp_nome ~ ' aparece em ' ~ _qtd_mun ~ ' municipio(s) paraibano(s). A secao "Municipios pagantes" lista cada um com o total recebido — clique para abrir o detalhe scoped (empenhos recentes, monthly chart, top elementos de despesa).') if _qtd_mun > 0 else ('A pagina lista todos os municipios da PB onde ' ~ _emp_nome ~ ' recebeu pagamentos. Em alguns casos a lista pode estar vazia se nao houver dados nos snapshots atuais.'),
+        'links': ([
+            {'label': 'Lista completa de municipios', 'href': '#municipios-pagantes'},
+            {'label': 'Acesse direto: ' ~ _top_mun.municipio, 'href': '/empresa/' ~ cnpj ~ '/' ~ _top_mun.slug}
+        ] if (_top_mun and _top_mun.slug) else [
+            {'label': 'Municipios pagantes', 'href': '#municipios-pagantes'},
+        ]),
     },
     {
         'q': _emp_nome ~ ' tem divida ativa na PGFN?',
         'a': ('Sim. ' ~ _emp_nome ~ ' tem divida ativa registrada na Procuradoria-Geral da Fazenda Nacional. O total inscrito e R$ ' ~ ("{:,.2f}".format(_divida)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ '. A secao "Divida ativa" mostra detalhes (data de inscricao, tipo, status).') if _divida > 0 else (_emp_nome ~ ' nao possui divida ativa registrada na PGFN segundo o snapshot atual da Procuradoria-Geral da Fazenda Nacional. Note que dividas estaduais/municipais nao sao cobertas por esse cadastro.'),
+        'links': [
+            {'label': 'Divida PGFN (na pagina)', 'href': '#pgfn'},
+            {'label': 'Sinais de atencao', 'href': '#sinais'},
+            {'label': 'Glossario', 'href': '/glossario'},
+        ],
     },
     {
         'q': _emp_nome ~ ' esta sancionada (CEIS, CNEP ou inidonea)?',
         'a': ('Sim. ' ~ _emp_nome ~ ' possui ' ~ _qtd_sanc ~ ' sancao(es) registrada(s) na CGU. A secao "Sancoes" detalha cada uma (orgao sancionador, periodo de vigencia, fundamentacao legal). Sancao ativa significa restricao de contratacao com o setor publico — verifique a abrangencia.') if _qtd_sanc > 0 else (_emp_nome ~ ' nao possui sancoes ativas registradas no CEIS (Cadastro de Empresas Inidoneas) nem no CNEP (Cadastro Nacional de Empresas Punidas) segundo a CGU. Isso nao exclui sancoes municipais ou estaduais nao reportadas.'),
+        'links': [
+            {'label': 'Sancoes na pagina', 'href': '#sancoes'},
+            {'label': 'Acordos de leniencia', 'href': '#leniencia'},
+            {'label': 'Portal da CGU', 'href': 'https://www.gov.br/cgu', 'external': True},
+        ],
     },
     {
         'q': 'Quem sao os socios da ' ~ _emp_nome ~ '?',
         'a': 'A secao "Socios" lista os representantes da pessoa juridica conforme cadastro RFB (Receita Federal). Para cada um mostramos nome, qualificacao (administrador, diretor, etc) e data de entrada. CPFs sao parcialmente mascarados conforme exigencia da LGPD.',
+        'links': [
+            {'label': 'Quadro societario', 'href': '#socios'},
+        ],
     },
     {
         'q': 'Os dados sobre ' ~ _emp_nome ~ ' sao oficiais?',
         'a': 'Sim. Cadastro CNPJ (razao social, socios, endereco, situacao) vem da Receita Federal. Pagamentos vem do TCE-PB. Sancoes da CGU (CEIS/CNEP/CEAF). Divida da PGFN. dados.pb.gov.br para orcamento estadual. Indicamos a data do snapshot. Para verificacao adicional, consulte os portais oficiais.',
+        'links': [
+            {'label': 'Receita Federal', 'href': 'https://www.gov.br/receitafederal', 'external': True},
+            {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
+            {'label': 'CGU', 'href': 'https://www.gov.br/cgu', 'external': True},
+            {'label': 'Metodologia', 'href': '/sobre#fontes'},
+        ],
     },
     {
         'q': 'Como verificar se ' ~ _emp_nome ~ ' pode contratar com o setor publico?',
-        'a': 'Verifique: (1) sancoes ativas no CEIS/CNEP — restringem contratacao; (2) regularidade fiscal (PGFN, Receita Federal); (3) cadastro RFB ativo (situacao cadastral != "baixada/suspensa"); (4) certidoes especificas (FGTS, trabalhista). A pagina sinaliza os pontos publicos — certidoes formais devem ser obtidas dos orgaos.',
+        'a': 'Verifique sancoes ativas no CEIS/CNEP (restringem contratacao), regularidade fiscal (PGFN, Receita Federal), cadastro RFB ativo (situacao cadastral != "baixada/suspensa") e certidoes especificas (FGTS, trabalhista). A pagina sinaliza os pontos publicos — certidoes formais devem ser obtidas dos orgaos.',
+        'links': [
+            {'label': 'Sancoes', 'href': '#sancoes'},
+            {'label': 'Divida PGFN', 'href': '#pgfn'},
+            {'label': 'Sinais', 'href': '#sinais'},
+        ],
     }
 ] %}
 

--- a/web/templates/partials/seo/_faq_empresa_municipio.html
+++ b/web/templates/partials/seo/_faq_empresa_municipio.html
@@ -1,9 +1,8 @@
 {# FAQs pra /empresa/<cnpj>/<municipio>. Escopa cada pergunta no
-   municipio especifico — long-tail "[empresa] em [cidade]", "[empresa]
-   prefeitura [cidade]", etc.
+   municipio especifico. Links contextuais via campo 'links'.
 
    Caller passa:
-       razao_social, cnpj_fmt, municipio,
+       razao_social, cnpj, cnpj_fmt, municipio, municipio_slug,
        kpi_total_pago_mun, kpi_qtd_empenhos_mun, kpi_pct_sem_licitacao_mun,
        sancoes
 #}
@@ -19,26 +18,42 @@
     {
         'q': 'Quanto a empresa ' ~ _emp_nome ~ ' recebeu da prefeitura de ' ~ _mun_nome ~ '?',
         'a': ('Segundo dados oficiais do TCE-PB, ' ~ _emp_nome ~ ' recebeu R$ ' ~ ("{:,.2f}".format(_total_mun)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ' da prefeitura de ' ~ _mun_nome ~ '. A pagina detalha cada empenho (data, valor empenhado, valor pago, elemento de despesa, licitacao vinculada).') if _total_mun > 0 else (_emp_nome ~ ' aparece como fornecedora da prefeitura de ' ~ _mun_nome ~ '. Veja na pagina o detalhamento dos empenhos.'),
+        'links': [
+            {'label': 'Resumo no municipio', 'href': '#resumo-municipio'},
+            {'label': 'Tabela de empenhos', 'href': '#empenhos-recentes'},
+        ],
     },
     {
         'q': 'Quantos empenhos a empresa ' ~ _emp_nome ~ ' tem em ' ~ _mun_nome ~ '?',
         'a': ('A empresa tem ' ~ _qtd_emp ~ ' empenho(s) registrados no TCE-PB para a prefeitura de ' ~ _mun_nome ~ ' (desde 2022, com valor pago > 0). Voce pode paginar a tabela completa, buscar por numero/elemento/historico, ou filtrar por periodo.') if _qtd_emp > 0 else 'A tabela de empenhos na pagina mostra os pagamentos registrados. Use os filtros (data, busca textual) pra refinar.',
+        'links': [
+            {'label': 'Tabela completa com paginacao', 'href': '#empenhos-recentes'},
+        ],
     },
     {
         'q': 'Os contratos sao com licitacao ou sem licitacao?',
         'a': ('Aproximadamente ' ~ ('%.1f' % _pct_sl) ~ '% dos empenhos para ' ~ _emp_nome ~ ' em ' ~ _mun_nome ~ ' foram registrados sem licitacao formal (dispensa, inexigibilidade ou sem identificacao no TCE-PB). A pagina destaca cada caso com badge "Sem licitacao".') if _qtd_emp > 0 else 'A coluna "Modalidade / Licitacao" na tabela indica para cada empenho se houve licitacao formal ou se foi sem concorrencia (dispensa, inexigibilidade, etc).',
+        'links': [
+            {'label': 'Tabela de empenhos (com badge "sem licitacao")', 'href': '#empenhos-recentes'},
+        ],
     },
     {
-        'q': _emp_nome ~ ' estava sancionada quando recebeu pagamentos de ' ~ _mun_nome ~ '?',
-        'a': ('Sim. A empresa tem ' ~ _qtd_sanc ~ ' sancao(es) registrada(s) na CGU (CEIS/CNEP). A pagina destaca empenhos que ocorreram durante periodo(s) de sancao ativa — sinal de atencao pra fiscalizacao.') if _qtd_sanc > 0 else (_emp_nome ~ ' nao tem sancoes ativas registradas no CEIS/CNEP da CGU. Verifique sempre na fonte oficial (gov.br/cgu) para confirmacao.'),
-    },
-    {
-        'q': 'Como acessar o detalhamento de um empenho especifico?',
-        'a': 'Clique em qualquer linha da tabela de empenhos para abrir o detalhe completo: numero, data, valor empenhado/liquidado/pago, classificacao orcamentaria (funcao, programa, elemento), origem do recurso (unidade gestora, fonte), historico descritivo e licitacao vinculada (quando houver).',
+        'q': _emp_nome ~ ' tem sancoes registradas na CGU?',
+        'a': ('Sim. ' ~ _emp_nome ~ ' tem ' ~ _qtd_sanc ~ ' sancao(es) registrada(s) no CEIS/CNEP da CGU. A tabela de empenhos na pagina sinaliza visualmente cada empenho que ocorreu durante periodo de sancao com abrangencia que afeta a contratacao com este municipio — verifique caso a caso.') if _qtd_sanc > 0 else (_emp_nome ~ ' nao tem sancoes registradas no CEIS/CNEP da CGU. Verifique sempre na fonte oficial (gov.br/cgu) para confirmacao.'),
+        'links': ([
+            {'label': 'Tabela de empenhos', 'href': '#empenhos-recentes'},
+            {'label': 'Sancoes no perfil global', 'href': '/empresa/' ~ cnpj ~ '#sancoes'},
+        ] if _qtd_sanc > 0 else [
+            {'label': 'Portal da CGU', 'href': 'https://www.gov.br/cgu', 'external': True},
+        ]),
     },
     {
         'q': 'Como ver o perfil global de ' ~ _emp_nome ~ ' em toda a Paraiba?',
-        'a': 'Clique no link "Ver perfil global da empresa" no topo da pagina ou acesse /empresa/' ~ cnpj ~ '. Mostra agregados de todos os municipios pagantes da PB, sancoes globais, divida PGFN e cadastro RFB completo.',
+        'a': 'Acesse o perfil global da empresa pra ver agregados de todos os municipios pagantes da PB, sancoes globais, divida PGFN e cadastro RFB completo. Veja tambem o panorama completo de ' ~ _mun_nome ~ ' com todos os fornecedores e servidores da prefeitura.',
+        'links': [
+            {'label': 'Perfil global de ' ~ _emp_nome, 'href': '/empresa/' ~ cnpj},
+            {'label': 'Panorama de ' ~ _mun_nome, 'href': '/cidade/' ~ municipio_slug},
+        ],
     }
 ] %}
 

--- a/web/templates/partials/seo/_faq_empresa_municipio.html
+++ b/web/templates/partials/seo/_faq_empresa_municipio.html
@@ -1,0 +1,45 @@
+{# FAQs pra /empresa/<cnpj>/<municipio>. Escopa cada pergunta no
+   municipio especifico — long-tail "[empresa] em [cidade]", "[empresa]
+   prefeitura [cidade]", etc.
+
+   Caller passa:
+       razao_social, cnpj_fmt, municipio,
+       kpi_total_pago_mun, kpi_qtd_empenhos_mun, kpi_pct_sem_licitacao_mun,
+       sancoes
+#}
+{% from "partials/seo/_faq.html" import faq_section %}
+{% set _emp_nome = razao_social %}
+{% set _mun_nome = municipio %}
+{% set _total_mun = kpi_total_pago_mun or 0 %}
+{% set _qtd_emp = kpi_qtd_empenhos_mun or 0 %}
+{% set _pct_sl = kpi_pct_sem_licitacao_mun or 0 %}
+{% set _qtd_sanc = sancoes|length if sancoes else 0 %}
+
+{% set _empmun_faqs = [
+    {
+        'q': 'Quanto a empresa ' ~ _emp_nome ~ ' recebeu da prefeitura de ' ~ _mun_nome ~ '?',
+        'a': ('Segundo dados oficiais do TCE-PB, ' ~ _emp_nome ~ ' recebeu R$ ' ~ ("{:,.2f}".format(_total_mun)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ' da prefeitura de ' ~ _mun_nome ~ '. A pagina detalha cada empenho (data, valor empenhado, valor pago, elemento de despesa, licitacao vinculada).') if _total_mun > 0 else (_emp_nome ~ ' aparece como fornecedora da prefeitura de ' ~ _mun_nome ~ '. Veja na pagina o detalhamento dos empenhos.'),
+    },
+    {
+        'q': 'Quantos empenhos a empresa ' ~ _emp_nome ~ ' tem em ' ~ _mun_nome ~ '?',
+        'a': ('A empresa tem ' ~ _qtd_emp ~ ' empenho(s) registrados no TCE-PB para a prefeitura de ' ~ _mun_nome ~ ' (desde 2022, com valor pago > 0). Voce pode paginar a tabela completa, buscar por numero/elemento/historico, ou filtrar por periodo.') if _qtd_emp > 0 else 'A tabela de empenhos na pagina mostra os pagamentos registrados. Use os filtros (data, busca textual) pra refinar.',
+    },
+    {
+        'q': 'Os contratos sao com licitacao ou sem licitacao?',
+        'a': ('Aproximadamente ' ~ ('%.1f' % _pct_sl) ~ '% dos empenhos para ' ~ _emp_nome ~ ' em ' ~ _mun_nome ~ ' foram registrados sem licitacao formal (dispensa, inexigibilidade ou sem identificacao no TCE-PB). A pagina destaca cada caso com badge "Sem licitacao".') if _qtd_emp > 0 else 'A coluna "Modalidade / Licitacao" na tabela indica para cada empenho se houve licitacao formal ou se foi sem concorrencia (dispensa, inexigibilidade, etc).',
+    },
+    {
+        'q': _emp_nome ~ ' estava sancionada quando recebeu pagamentos de ' ~ _mun_nome ~ '?',
+        'a': ('Sim. A empresa tem ' ~ _qtd_sanc ~ ' sancao(es) registrada(s) na CGU (CEIS/CNEP). A pagina destaca empenhos que ocorreram durante periodo(s) de sancao ativa — sinal de atencao pra fiscalizacao.') if _qtd_sanc > 0 else (_emp_nome ~ ' nao tem sancoes ativas registradas no CEIS/CNEP da CGU. Verifique sempre na fonte oficial (gov.br/cgu) para confirmacao.'),
+    },
+    {
+        'q': 'Como acessar o detalhamento de um empenho especifico?',
+        'a': 'Clique em qualquer linha da tabela de empenhos para abrir o detalhe completo: numero, data, valor empenhado/liquidado/pago, classificacao orcamentaria (funcao, programa, elemento), origem do recurso (unidade gestora, fonte), historico descritivo e licitacao vinculada (quando houver).',
+    },
+    {
+        'q': 'Como ver o perfil global de ' ~ _emp_nome ~ ' em toda a Paraiba?',
+        'a': 'Clique no link "Ver perfil global da empresa" no topo da pagina ou acesse /empresa/' ~ cnpj ~ '. Mostra agregados de todos os municipios pagantes da PB, sancoes globais, divida PGFN e cadastro RFB completo.',
+    }
+] %}
+
+{{ faq_section(_empmun_faqs, title='Perguntas frequentes sobre ' ~ _emp_nome ~ ' em ' ~ _mun_nome, anchor='faq-empresa-mun') }}

--- a/web/templates/partials/seo/_faq_sobre.html
+++ b/web/templates/partials/seo/_faq_sobre.html
@@ -1,0 +1,34 @@
+{# FAQs dinamicas pra /sobre. Estaticas — nao precisam de variaveis. #}
+{% from "partials/seo/_faq.html" import faq_section %}
+{% set _sobre_faqs = [
+    {
+        'q': 'O que e o TransparenciaPB?',
+        'a': 'TransparenciaPB e uma ferramenta independente que cruza dados publicos oficiais do TCE-PB, Receita Federal, CGU, PNCP, dados.pb.gov.br e Portal da Transparencia para tornar visivel como cada uma das 223 prefeituras da Paraiba gasta o dinheiro publico. Apresentamos dados oficiais com sinais de atencao — nao substituem investigacao formal nem conclusoes juridicas.',
+    },
+    {
+        'q': 'De onde vem os dados?',
+        'a': 'Todos os dados sao publicos e oficiais. Coletamos diretamente das fontes: TCE-PB (despesas municipais, licitacoes, servidores, receitas), Receita Federal (cadastro CNPJ — empresa, estabelecimento, socios), CGU (sancoes CEIS/CNEP/CEAF, acordos de leniencia), PGFN (divida ativa da Uniao), PNCP (contratacoes publicas), dados.pb.gov.br (orcamento estadual) e Portal da Transparencia (SIAPE, CPGF, Bolsa Familia).',
+    },
+    {
+        'q': 'Os dados sao confiaveis?',
+        'a': 'Sim, os dados sao oficiais. A confiabilidade depende da fonte original: TCE-PB tem prazos de envio e correcao pelas prefeituras; cadastro RFB tem latencia ate ~30 dias; sancoes CEIS sao atualizadas semanalmente pela CGU. Sempre indicamos a data do snapshot. Os cruzamentos que fazemos sao deterministicos (mesmo CNPJ/CPF) — nao usamos heuristicas que poderiam gerar falsos positivos.',
+    },
+    {
+        'q': 'Posso usar para fazer denuncia?',
+        'a': 'Os dados aqui sao um ponto de partida, nao conclusao. Para denuncias formais, recomendamos: (1) confirmar nas fontes oficiais (link de cada item leva a fonte); (2) reunir contexto adicional; (3) acionar Ministerio Publico, TCU, TCE ou Controladoria. As sinais de atencao que destacamos (sancoes ativas, divida PGFN, sem licitacao) nao implicam ilicito — sao informacoes objetivas pra triagem.',
+    },
+    {
+        'q': 'Como reportar uma irregularidade ou dado errado?',
+        'a': 'Para reportar dado incorreto na nossa plataforma, use a pagina de contato. Para reportar irregularidade administrativa, acione: Ministerio Publico da Paraiba (mppb.mp.br), TCE-PB (tce.pb.gov.br), CGU (gov.br/cgu) ou Camara Municipal/Vereador.',
+    },
+    {
+        'q': 'O codigo eh aberto?',
+        'a': 'Sim. O codigo-fonte do TransparenciaPB e publico no GitHub. Documentamos metodologia, queries e estrutura de dados.',
+    },
+    {
+        'q': 'Por que so prefeituras paraibanas?',
+        'a': 'O TCE-PB publica dados unitarios de despesa por empenho desde 2003 — uma cobertura unica no Brasil. Aplicar essa metodologia em outros estados depende de cada TCE liberar a mesma granularidade de dados. Hoje, e a Paraiba.',
+    }
+] %}
+
+{{ faq_section(_sobre_faqs, title='Perguntas frequentes', anchor='faq-sobre') }}

--- a/web/templates/partials/seo/_faq_sobre.html
+++ b/web/templates/partials/seo/_faq_sobre.html
@@ -1,33 +1,71 @@
-{# FAQs dinamicas pra /sobre. Estaticas — nao precisam de variaveis. #}
+{# FAQs dinamicas pra /sobre. Estaticas — nao precisam de variaveis.
+
+   Links internos (campo 'links' do FAQ dict):
+   - /contato pra reportar
+   - /glossario pra termos
+   - anchors de outras secoes do /sobre
+   - links externos (MPPB, TCE, CGU, Receita Federal) marcados com external=true
+#}
 {% from "partials/seo/_faq.html" import faq_section %}
 {% set _sobre_faqs = [
     {
         'q': 'O que e o TransparenciaPB?',
         'a': 'TransparenciaPB e uma ferramenta independente que cruza dados publicos oficiais do TCE-PB, Receita Federal, CGU, PNCP, dados.pb.gov.br e Portal da Transparencia para tornar visivel como cada uma das 223 prefeituras da Paraiba gasta o dinheiro publico. Apresentamos dados oficiais com sinais de atencao — nao substituem investigacao formal nem conclusoes juridicas.',
+        'links': [
+            {'label': 'Metodologia completa', 'href': '/sobre#o-que-fazemos'},
+            {'label': 'Glossario de termos', 'href': '/glossario'},
+        ],
     },
     {
         'q': 'De onde vem os dados?',
-        'a': 'Todos os dados sao publicos e oficiais. Coletamos diretamente das fontes: TCE-PB (despesas municipais, licitacoes, servidores, receitas), Receita Federal (cadastro CNPJ — empresa, estabelecimento, socios), CGU (sancoes CEIS/CNEP/CEAF, acordos de leniencia), PGFN (divida ativa da Uniao), PNCP (contratacoes publicas), dados.pb.gov.br (orcamento estadual) e Portal da Transparencia (SIAPE, CPGF, Bolsa Familia).',
+        'a': 'Todos os dados sao publicos e oficiais. Coletamos diretamente das fontes: TCE-PB (despesas, licitacoes, servidores, receitas), Receita Federal (CNPJ, socios, endereco), CGU (sancoes CEIS/CNEP/CEAF, acordos de leniencia), PGFN (divida ativa), dados.pb.gov.br (orcamento estadual) e Portal da Transparencia (SIAPE, CPGF, Bolsa Familia).',
+        'links': [
+            {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
+            {'label': 'Receita Federal', 'href': 'https://www.gov.br/receitafederal', 'external': True},
+            {'label': 'CGU', 'href': 'https://www.gov.br/cgu', 'external': True},
+            {'label': 'PGFN', 'href': 'https://www.gov.br/pgfn', 'external': True},
+            {'label': 'dados.pb.gov.br', 'href': 'https://dados.pb.gov.br/', 'external': True},
+        ],
     },
     {
         'q': 'Os dados sao confiaveis?',
-        'a': 'Sim, os dados sao oficiais. A confiabilidade depende da fonte original: TCE-PB tem prazos de envio e correcao pelas prefeituras; cadastro RFB tem latencia ate ~30 dias; sancoes CEIS sao atualizadas semanalmente pela CGU. Sempre indicamos a data do snapshot. Os cruzamentos que fazemos sao deterministicos (mesmo CNPJ/CPF) — nao usamos heuristicas que poderiam gerar falsos positivos.',
+        'a': 'Os dados sao oficiais. A confiabilidade depende da fonte original: TCE-PB tem prazos de envio e correcao pelas prefeituras; cadastro RFB tem latencia ate ~30 dias; sancoes CEIS sao atualizadas semanalmente pela CGU. Sempre indicamos a data do snapshot. Os cruzamentos sao deterministicos (mesmo CNPJ/CPF) — nao usamos heuristicas que poderiam gerar falsos positivos.',
+        'links': [
+            {'label': 'Limites e atualizacao', 'href': '/sobre#limites'},
+        ],
     },
     {
         'q': 'Posso usar para fazer denuncia?',
-        'a': 'Os dados aqui sao um ponto de partida, nao conclusao. Para denuncias formais, recomendamos: (1) confirmar nas fontes oficiais (link de cada item leva a fonte); (2) reunir contexto adicional; (3) acionar Ministerio Publico, TCU, TCE ou Controladoria. As sinais de atencao que destacamos (sancoes ativas, divida PGFN, sem licitacao) nao implicam ilicito — sao informacoes objetivas pra triagem.',
+        'a': 'Os dados aqui sao um ponto de partida, nao conclusao. Para denuncias formais, recomendamos confirmar nas fontes oficiais, reunir contexto adicional, e acionar Ministerio Publico, TCU, TCE ou Controladoria. As sinais de atencao nao implicam ilicito — sao informacoes objetivas pra triagem.',
+        'links': [
+            {'label': 'MP-PB', 'href': 'https://www.mppb.mp.br/', 'external': True},
+            {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
+            {'label': 'CGU', 'href': 'https://www.gov.br/cgu', 'external': True},
+        ],
     },
     {
         'q': 'Como reportar uma irregularidade ou dado errado?',
-        'a': 'Para reportar dado incorreto na nossa plataforma, use a pagina de contato. Para reportar irregularidade administrativa, acione: Ministerio Publico da Paraiba (mppb.mp.br), TCE-PB (tce.pb.gov.br), CGU (gov.br/cgu) ou Camara Municipal/Vereador.',
+        'a': 'Para dado incorreto na nossa plataforma, use a pagina de contato. Para irregularidade administrativa, acione MP-PB, TCE-PB, CGU ou Camara Municipal.',
+        'links': [
+            {'label': 'Pagina de contato', 'href': '/contato'},
+            {'label': 'MP-PB', 'href': 'https://www.mppb.mp.br/', 'external': True},
+            {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
+        ],
     },
     {
         'q': 'O codigo eh aberto?',
         'a': 'Sim. O codigo-fonte do TransparenciaPB e publico no GitHub. Documentamos metodologia, queries e estrutura de dados.',
+        'links': [
+            {'label': 'Repositorio no GitHub', 'href': 'https://github.com/lucasdiniz/govbr-cruza-dados', 'external': True},
+            {'label': 'Glossario', 'href': '/glossario'},
+        ],
     },
     {
         'q': 'Por que so prefeituras paraibanas?',
         'a': 'O TCE-PB publica dados unitarios de despesa por empenho desde 2003 — uma cobertura unica no Brasil. Aplicar essa metodologia em outros estados depende de cada TCE liberar a mesma granularidade de dados. Hoje, e a Paraiba.',
+        'links': [
+            {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
+        ],
     }
 ] %}
 

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -538,6 +538,8 @@
     {% endfor %}
 </section>
 
+{% include "partials/seo/_faq_cidade.html" %}
+
 <md-dialog id="empresa-dialog" class="empresa-dialog" aria-labelledby="empresa-dialog-title">
     <div slot="headline" class="dialog-header">
         <md-icon-button class="dialog-back" data-dialog-back style="visibility:hidden" aria-label="Voltar">

--- a/web/templates/results/empresa.html
+++ b/web/templates/results/empresa.html
@@ -132,6 +132,8 @@
             <a href="/contato">Reportar correcao</a>
         </p>
     </section>
+
+    {% include "partials/seo/_faq_empresa.html" %}
 </article>
 
 {% include "partials/dialogs/_empresa_dialog.html" %}

--- a/web/templates/results/empresa_municipio.html
+++ b/web/templates/results/empresa_municipio.html
@@ -144,6 +144,8 @@
             <a href="/contato">Reportar correcao</a>
         </p>
     </section>
+
+    {% include "partials/seo/_faq_empresa_municipio.html" %}
 </article>
 
 {% include "partials/dialogs/_empresa_dialog.html" %}

--- a/web/templates/sobre.html
+++ b/web/templates/sobre.html
@@ -160,5 +160,7 @@
     <a href="/" class="btn-primary">Voltar para o mapa</a>
     <a href="/glossario" class="btn-secondary">Ver gloss&aacute;rio</a>
   </nav>
+
+  {% include "partials/seo/_faq_sobre.html" %}
 </article>
 {% endblock %}


### PR DESCRIPTION
## Problema

Searchers chegariam mais facilmente ao site via perguntas explicitas como:
- "quanto a prefeitura de [X] gastou em 2025?"
- "[empresa] tem divida ativa na PGFN?"
- "como denunciar irregularidade prefeitura PB"
- "como saber se uma empresa esta sancionada"

Hoje as paginas nao respondem essas perguntas de forma estruturada — Google precisa inferir relevancia. **FAQ schema** permite:
1. **Rich results no SERP** (accordion direto na busca) → +CTR
2. **Long-tail capture** (cada Q vira keyword indexavel)
3. **Conteudo educativo** escaneavel (UX cidadao/jornalista)

## Solucao

Macro reutilizavel `partials/seo/_faq.html` + 4 partials especificos (1 por superficie) + CSS.

**CRITICO**: Google penaliza FAQ schema com conteudo so em JSON-LD (politica out/2023). Renderizamos AMBOS:
- `<script type="application/ld+json">` com `FAQPage` schema
- `<section>` visivel com `<details>` colapsavel (nativo, acessivel, indexavel)

## Cobertura

| Superficie | URLs em prod | Partial | FAQs |
|---|---|---|---|
| `/sobre` | 1 | `_faq_sobre.html` | 7 estaticas |
| `/cidade/<slug>` | 228 | `_faq_cidade.html` | 7 dinamicas (scope mun) |
| `/empresa/<cnpj>` | ~145K | `_faq_empresa.html` | 7 dinamicas (scope empresa + KPIs) |
| `/empresa/<cnpj>/<mun>` | ~775K | `_faq_empresa_municipio.html` | 6 dinamicas (scope empresa × mun + KPIs locais) |

**~920K paginas ganham FAQ structured data**. Q&A unicas por combinacao CNPJ × municipio.

## Files

- `web/templates/partials/seo/_faq.html` (NOVO) — macros faq_jsonld, faq_visible, faq_section
- `web/templates/partials/seo/_faq_{sobre,cidade,empresa,empresa_municipio}.html` (NOVOS)
- `web/static/css/components/faq.css` (NOVO) — visual + responsive
- `web/static/css/index.css` — import faq.css
- `web/templates/sobre.html` — include FAQ
- `web/templates/results/cidade.html` — include FAQ
- `web/templates/results/empresa.html` — include FAQ
- `web/templates/results/empresa_municipio.html` — include FAQ
- `web/main.py` — ASSET_VERSION 100 → 101

## Smoke test pos-deploy

```bash
# Verifica JSON-LD FAQPage em /sobre
curl -sS https://transparenciapb.org/sobre | grep -A 2 '"FAQPage"' | head -5

# Verifica em cidade
curl -sS https://transparenciapb.org/cidade/joao-pessoa | grep '"FAQPage"' | head -3

# Verifica visual <details>
curl -sS https://transparenciapb.org/empresa/00360305000104 | grep 'class="faq-item"' | head -3

# Validar com Google Rich Results Test:
# https://search.google.com/test/rich-results
```

## Validacao SEO esperada

Apos GSC re-fetch (~24-72h):
- Rich Results no SERP: accordion expandivel nos resultados de busca
- Increased CTR em queries long-tail
- Indexacao adicional de Q como keywords

## Rollback safety

Adicoes apenas. Sem mudanca em schema/cache/route. Revert trivial.

## Out of scope (proximos PRs do plano SEO)

- **PR B**: paginas indice (`/empresas/sancionadas`, `/maiores-fornecedores/<mun>`)
- **PR C**: paginas educativas (`/como-investigar`, `/metodologia` expandido, `/lai-prefeituras`)
- **PR D**: hub de servidor
