### PR TITLE
feat(deploy): GoAccess real-time traffic dashboard em /_traffic/

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -640,6 +640,15 @@ jobs:
 
       # ── Deploy web services ──
       - name: Deploy web frontend and cache warmer
+        env:
+          # Passados via env: + sudo --preserve-env no setup-goaccess.sh
+          # logo abaixo. Os secrets entram no shell SO via variavel de
+          # ambiente, nao por substituicao literal, prevenindo injection
+          # se a senha tiver caracteres como $ ` " \.
+          # Outras secrets/env-vars do step continuam funcionando normal.
+          GOACCESS_USER: ${{ secrets.GOACCESS_USER }}
+          GOACCESS_PASSWORD: ${{ secrets.GOACCESS_PASSWORD }}
+          GOACCESS_DOMAIN: ${{ secrets.GOACCESS_DOMAIN }}
         run: |
           set -e
           cd ${{ env.PROJECT_DIR }}
@@ -663,11 +672,19 @@ jobs:
           # GOACCESS_PASSWORD vazio E .htpasswd-traffic nao existe.
           # Pra ativar pela 1a vez, defina o secret GOACCESS_PASSWORD
           # (e opcionalmente GOACCESS_USER) no repositorio.
-          sudo env \
-            GOACCESS_USER="${{ secrets.GOACCESS_USER }}" \
-            GOACCESS_PASSWORD="${{ secrets.GOACCESS_PASSWORD }}" \
-            GOACCESS_DOMAIN="${{ secrets.GOACCESS_DOMAIN }}" \
-            bash deploy/setup-goaccess.sh
+          #
+          # Secrets sao passados via env: block (no step, acima) + sudo
+          # --preserve-env, em vez de substituicao direta no shell. Isso
+          # protege contra shell injection se a senha contiver caracteres
+          # como $, ", `, \, etc. — substituicao via ${{ secrets.X }}
+          # dentro do run: e' parseada como shell antes do bash executar.
+          #
+          # Soft-fail: o dashboard e' admin-only, opcional. Se a instalacao
+          # falhar (PPA fora do ar, apt lock, etc.), logamos e seguimos o
+          # deploy — o site publico nao depende disso.
+          sudo --preserve-env=GOACCESS_USER,GOACCESS_PASSWORD,GOACCESS_DOMAIN \
+            bash deploy/setup-goaccess.sh \
+            || echo "WARNING: setup-goaccess.sh falhou (non-fatal — dashboard admin)."
 
           # Build frontend assets RIGHT BEFORE cruza-web restart pra evitar
           # a janela onde nginx serve novo dist/ enquanto workers velhos

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -658,6 +658,17 @@ jobs:
           # so reload se config mudou.
           sudo bash deploy/setup-fail2ban.sh
 
+          # Setup GoAccess: dashboard real-time de trafego em /_traffic/
+          # (basic-auth protected). Idempotente: pula instalacao se
+          # GOACCESS_PASSWORD vazio E .htpasswd-traffic nao existe.
+          # Pra ativar pela 1a vez, defina o secret GOACCESS_PASSWORD
+          # (e opcionalmente GOACCESS_USER) no repositorio.
+          sudo env \
+            GOACCESS_USER="${{ secrets.GOACCESS_USER }}" \
+            GOACCESS_PASSWORD="${{ secrets.GOACCESS_PASSWORD }}" \
+            GOACCESS_DOMAIN="${{ secrets.GOACCESS_DOMAIN }}" \
+            bash deploy/setup-goaccess.sh
+
           # Build frontend assets RIGHT BEFORE cruza-web restart pra evitar
           # a janela onde nginx serve novo dist/ enquanto workers velhos
           # geram HTML com URLs antigas (404 nos hashed assets).

--- a/deploy/cruza-goaccess.conf
+++ b/deploy/cruza-goaccess.conf
@@ -1,0 +1,41 @@
+# GoAccess config — dashboard real-time atras de nginx.
+# Path final: /etc/goaccess/cruza-goaccess.conf
+# Instalado por deploy/setup-goaccess.sh (substitui @@GOACCESS_DOMAIN@@).
+
+# ── Input: nginx access.log no formato COMBINED (default da distro) ──
+log-file /var/log/nginx/access.log
+log-format COMBINED
+date-format %d/%b/%Y
+time-format %H:%M:%S
+
+# ── Output HTML (servido por nginx como static via alias) ──
+output /var/www/traffic/index.html
+real-time-html true
+
+# ── WebSocket: bind so em 127.0.0.1; exposicao publica via nginx /_traffic/ws ──
+addr 127.0.0.1
+port 7890
+# JS embedded no HTML conecta neste WS URL (proxy via nginx).
+ws-url wss://@@GOACCESS_DOMAIN@@/_traffic/ws
+
+# ── Persistencia: sobrevive a restart do daemon e a log rotation ──
+persist true
+restore true
+db-path /var/lib/goaccess/
+
+# ── Comportamento ──
+agent-list true
+# 365 dias de retencao no DB persistente — suficiente pra analise YoY.
+keep-last 365
+processing-thread 2
+
+# ── Filtragem de ruido ──
+# Health-checks internos e ACME challenges nao sao trafego real.
+ignore-panel REFERRERS
+exclude-ip 127.0.0.1
+exclude-ip ::1
+
+# ── Privacidade ──
+# Anonimiza ultimo octeto do IPv4 (e ultimos 80 bits do IPv6) nos dashboards.
+# Compativel com LGPD/GDPR pra metricas agregadas. Requer goaccess >= 1.7.
+anonymize-ip true

--- a/deploy/cruza-goaccess.service
+++ b/deploy/cruza-goaccess.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=GoAccess real-time traffic dashboard (cruza-dados)
+Documentation=https://goaccess.io/
+After=nginx.service
+Wants=nginx.service
+
+[Service]
+Type=simple
+# www-data ja eh dono de /var/log/nginx/access.log (root:adm 640), entao
+# adicionamos como Supplementary group adm pra garantir leitura mesmo se o
+# packaging do nginx mudar o owner pra root no futuro.
+User=www-data
+Group=www-data
+SupplementaryGroups=adm
+
+ExecStart=/usr/bin/goaccess \
+    --config-file=/etc/goaccess/cruza-goaccess.conf \
+    --no-global-config
+
+Restart=on-failure
+RestartSec=10
+
+# Memoria: --persist --restore carrega state na inicializacao. Observed ~30-80MB
+# em prod tipico; 400M de teto eh folga generosa sem comprometer Postgres+uvicorn
+# numa VM B4 (16GB).
+MemoryHigh=200M
+MemoryMax=400M
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/var/www/traffic /var/lib/goaccess
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -197,6 +197,42 @@ server {
         proxy_connect_timeout 75s;
     }
 
+    # ─── GoAccess real-time traffic dashboard (admin-only) ───
+    # Servido por nginx como static (alias) + WebSocket proxy pro daemon
+    # goaccess em 127.0.0.1:7890. Ambas as locations protegidas por
+    # basic-auth (/etc/nginx/.htpasswd-traffic, gerenciado por
+    # deploy/setup-goaccess.sh).
+    #
+    # Se o GoAccess nao foi configurado ainda (.htpasswd-traffic ausente),
+    # nginx retorna 500 nessas locations — comportamento aceitavel pra um
+    # endpoint admin "nao ativado". Veja deploy/setup-goaccess.sh.
+    #
+    # WebSocket location PRIMEIRO no codigo (longest-prefix match do nginx
+    # ja garante precedencia em prefix locations, mas mantemos a ordem
+    # explicita pra leitura).
+    location /_traffic/ws {
+        auth_basic "Restricted — Admin";
+        auth_basic_user_file /etc/nginx/.htpasswd-traffic;
+        proxy_pass http://127.0.0.1:7890;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # WS de longa duracao — aumenta read timeout pra evitar drop a cada 60s.
+        proxy_read_timeout 1d;
+        proxy_send_timeout 1d;
+    }
+    location /_traffic/ {
+        auth_basic "Restricted — Admin";
+        auth_basic_user_file /etc/nginx/.htpasswd-traffic;
+        alias /var/www/traffic/;
+        try_files $uri $uri/index.html =404;
+        # HTML do goaccess e regenerado a cada poucos segundos — sem cache.
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+
     # ─── Default: page renders e tudo mais ───
     location / {
         limit_req zone=general burst=120 nodelay;

--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -213,6 +213,10 @@ server {
     location /_traffic/ws {
         auth_basic "Restricted — Admin";
         auth_basic_user_file /etc/nginx/.htpasswd-traffic;
+        # Rate limit + connection cap pra frear brute-force de basic-auth.
+        # zone general ja existe em nginx-rate-limit-zones.conf (60r/s + burst).
+        limit_req zone=general burst=10 nodelay;
+        limit_conn perip 4;
         proxy_pass http://127.0.0.1:7890;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -227,6 +231,9 @@ server {
     location /_traffic/ {
         auth_basic "Restricted — Admin";
         auth_basic_user_file /etc/nginx/.htpasswd-traffic;
+        # Rate limit basic-auth: bloqueia automação que tenta password spraying.
+        limit_req zone=general burst=10 nodelay;
+        limit_conn perip 4;
         alias /var/www/traffic/;
         try_files $uri $uri/index.html =404;
         # HTML do goaccess e regenerado a cada poucos segundos — sem cache.

--- a/deploy/setup-goaccess.sh
+++ b/deploy/setup-goaccess.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Setup idempotente do GoAccess real-time dashboard atras de nginx.
+#
+# Chamado pelo deploy.yml apos setup-letsencrypt.sh + setup-fail2ban.sh.
+# Em deploys subsequentes sem mudancas, eh no-op (cmp + reload).
+#
+# Uso (na VM, como root):
+#   sudo bash deploy/setup-goaccess.sh
+#   # ou com credenciais explicitas:
+#   sudo env GOACCESS_USER=admin GOACCESS_PASSWORD='senha-forte' \
+#       bash deploy/setup-goaccess.sh
+#
+# Variaveis de ambiente (todas opcionais):
+#   GOACCESS_USER     - basic-auth username (default: admin)
+#   GOACCESS_PASSWORD - basic-auth password. Se vazio E /etc/nginx/.htpasswd-traffic
+#                       NAO existe, o setup pula a instalacao do service (no-op).
+#                       Se vazio mas o .htpasswd-traffic ja existe, preserva a senha
+#                       anterior.
+#   GOACCESS_DOMAIN   - dominio publico (default: transparenciapb.org).
+#                       Usado no ws-url do goaccess.conf.
+
+set -euo pipefail
+
+GOACCESS_USER="${GOACCESS_USER:-admin}"
+GOACCESS_DOMAIN="${GOACCESS_DOMAIN:-transparenciapb.org}"
+GOACCESS_PASSWORD="${GOACCESS_PASSWORD:-}"
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CONF_SRC="${REPO_DIR}/deploy/cruza-goaccess.conf"
+CONF_DST="/etc/goaccess/cruza-goaccess.conf"
+SERVICE_SRC="${REPO_DIR}/deploy/cruza-goaccess.service"
+SERVICE_DST="/etc/systemd/system/cruza-goaccess.service"
+HTPASSWD="/etc/nginx/.htpasswd-traffic"
+OUT_DIR="/var/www/traffic"
+DB_DIR="/var/lib/goaccess"
+
+log() { echo "[goaccess] $*"; }
+
+if [[ "${EUID}" -ne 0 ]]; then
+    log "ERRO: precisa rodar como root (use sudo)."
+    exit 1
+fi
+
+# ─── Skip rapido: sem credencial e sem htpasswd previo, nao instala nada ───
+# A location /_traffic/ no nginx existe sempre, mas retorna 500 quando o
+# htpasswd nao existe — ou seja, e seguro deixar o dashboard "desativado"
+# por padrao ate o admin definir uma senha.
+if [[ -z "${GOACCESS_PASSWORD}" && ! -f "${HTPASSWD}" ]]; then
+    log "Pulando setup: GOACCESS_PASSWORD vazio e ${HTPASSWD} ausente."
+    log "Pra ativar, defina o secret GOACCESS_PASSWORD ou rode manualmente:"
+    log "  sudo env GOACCESS_PASSWORD='<senha>' bash deploy/setup-goaccess.sh"
+    exit 0
+fi
+
+# ─── 1. Instalar goaccess (PPA oficial pra versao >=1.7 com anonymize-ip) ───
+if ! command -v goaccess >/dev/null 2>&1; then
+    log "Instalando goaccess via repo oficial deb.goaccess.io..."
+    mkdir -p /usr/share/keyrings
+    wget -qO - https://deb.goaccess.io/gnugpg.key \
+        | gpg --dearmor -o /usr/share/keyrings/goaccess.gpg
+    echo "deb [signed-by=/usr/share/keyrings/goaccess.gpg] https://deb.goaccess.io/ $(lsb_release -cs) main" \
+        > /etc/apt/sources.list.d/goaccess.list
+    apt-get update -qq
+    apt-get install -y goaccess
+fi
+GOACCESS_VERSION="$(goaccess --version 2>/dev/null | head -1 || echo 'unknown')"
+log "Usando ${GOACCESS_VERSION}"
+
+# ─── 2. apache2-utils (htpasswd) ───
+if ! command -v htpasswd >/dev/null 2>&1; then
+    apt-get install -y apache2-utils
+fi
+
+# ─── 3. Diretorios de output + persistencia ───
+mkdir -p "${OUT_DIR}" "${DB_DIR}" /etc/goaccess
+chown -R www-data:www-data "${OUT_DIR}" "${DB_DIR}"
+chmod 755 "${OUT_DIR}" "${DB_DIR}"
+
+# ─── 4. basic-auth ───
+# - Se GOACCESS_PASSWORD fornecido: cria/atualiza .htpasswd-traffic com a senha.
+# - Senao mas o file ja existe: preserva (idempotente).
+if [[ -n "${GOACCESS_PASSWORD}" ]]; then
+    htpasswd -bc "${HTPASSWD}" "${GOACCESS_USER}" "${GOACCESS_PASSWORD}"
+    chown root:www-data "${HTPASSWD}"
+    chmod 640 "${HTPASSWD}"
+    log "basic-auth atualizado pra user '${GOACCESS_USER}'."
+else
+    log "basic-auth preservado (${HTPASSWD} ja existente)."
+fi
+
+# ─── 5. Config do goaccess (substitui dominio) ───
+tmp_conf="$(mktemp "${CONF_DST}.XXXXXX")"
+sed "s|@@GOACCESS_DOMAIN@@|${GOACCESS_DOMAIN}|g" "${CONF_SRC}" > "${tmp_conf}"
+chmod 644 "${tmp_conf}"
+conf_changed=0
+if ! cmp -s "${tmp_conf}" "${CONF_DST}" 2>/dev/null; then
+    mv -f "${tmp_conf}" "${CONF_DST}"
+    log "  ${CONF_DST} atualizado"
+    conf_changed=1
+else
+    rm -f "${tmp_conf}"
+fi
+
+# ─── 6. Systemd unit ───
+service_changed=0
+if ! cmp -s "${SERVICE_SRC}" "${SERVICE_DST}" 2>/dev/null; then
+    install -m 0644 "${SERVICE_SRC}" "${SERVICE_DST}"
+    log "  ${SERVICE_DST} atualizado"
+    service_changed=1
+fi
+if [[ "${service_changed}" -eq 1 ]]; then
+    systemctl daemon-reload
+fi
+systemctl enable cruza-goaccess >/dev/null 2>&1 || true
+
+# Restart se: service unit mudou, config mudou, ou nao esta ativo.
+if [[ "${service_changed}" -eq 1 || "${conf_changed}" -eq 1 ]] \
+   || ! systemctl is-active --quiet cruza-goaccess; then
+    systemctl restart cruza-goaccess
+    log "cruza-goaccess restart"
+fi
+
+# ─── 7. Reload nginx (caso /_traffic/* tenha sido adicionado neste deploy) ───
+# nginx-cruza.conf eh aplicado por setup-letsencrypt.sh logo antes, entao
+# aqui so reload se realmente necessario. Soft-fail: se nginx -t falhar,
+# log e segue (deploy nao deve quebrar por causa do dashboard interno).
+if nginx -t >/dev/null 2>&1; then
+    systemctl reload nginx
+else
+    log "AVISO: nginx -t falhou. Pulei o reload. Rode 'sudo nginx -t' pra debug."
+fi
+
+# ─── 8. Smoke ───
+sleep 2
+if systemctl is-active --quiet cruza-goaccess; then
+    log "✓ cruza-goaccess ativo."
+    log "  Dashboard: https://${GOACCESS_DOMAIN}/_traffic/"
+    log "  Logs:      journalctl -u cruza-goaccess -f"
+else
+    log "ERRO: cruza-goaccess nao subiu. Ultimas linhas:"
+    journalctl -u cruza-goaccess --no-pager -n 30 | sed 's/^/  /'
+    exit 1
+fi

--- a/deploy/setup-goaccess.sh
+++ b/deploy/setup-goaccess.sh
@@ -72,9 +72,16 @@ if ! command -v htpasswd >/dev/null 2>&1; then
 fi
 
 # ─── 3. Diretorios de output + persistencia ───
+# /var/www/traffic: nginx (www-data) le pra servir o HTML; sem world-read
+# pra nao expor dashboard via outras locations futuras (defense-in-depth).
+# /var/lib/goaccess: dados persistidos. GoAccess >=1.7 ja anonimiza IPs no
+# parse-time antes de gravar (anonymize-ip true). Mesmo assim, mode 700
+# pra que so o proprio service (www-data) acesse — outros locais users na
+# VM nao precisam ler.
 mkdir -p "${OUT_DIR}" "${DB_DIR}" /etc/goaccess
 chown -R www-data:www-data "${OUT_DIR}" "${DB_DIR}"
-chmod 755 "${OUT_DIR}" "${DB_DIR}"
+chmod 750 "${OUT_DIR}"
+chmod 700 "${DB_DIR}"
 
 # ─── 4. basic-auth ───
 # - Se GOACCESS_PASSWORD fornecido: cria/atualiza .htpasswd-traffic com a senha.


### PR DESCRIPTION
## Resumo

Adiciona um dashboard de tráfego em tempo real (GoAccess) servido em **https://transparenciapb.org/_traffic/**, protegido por basic-auth. Stack server-side, sem JS de tracking no cliente — alinhado com LGPD pra um site público de transparência.

## Por que GoAccess?

Discussão entre 5 opções de monitoramento (analytics client-side, Cloudflare proxy, APM, self-hosted, etc.). GoAccess venceu pra primeira iteração porque:

- **Zero código no frontend** — lê `nginx access.log` direto, nenhum script no `base.html` (sem novo overhead pro usuário, sem banner LGPD)
- **Self-hosted, dados não saem da VM** — relevante pra um projeto de transparência
- **Real-time WebSocket** — dashboard atualiza ao vivo conforme requests chegam (a la mini-Datadog)
- **Custo zero** — apenas RAM (~30-80MB observed; cap em 400M no systemd)

## Arquitetura

```
Browser (admin)
   ↓ HTTPS + basic-auth
nginx (location /_traffic/)
   ├─ /_traffic/        → alias /var/www/traffic/index.html (gerado por goaccess)
   └─ /_traffic/ws      → proxy WebSocket pra 127.0.0.1:7890
                              ↓
                         goaccess daemon (User=www-data)
                              ↓ inotify
                         /var/log/nginx/access.log
                         /var/lib/goaccess/ (persistência cross-restart)
```

## Componentes

| Arquivo | Propósito |
|---|---|
| `deploy/cruza-goaccess.service` | systemd unit, hardening (`ProtectSystem=full`, `PrivateTmp`, `ReadWritePaths` restrito), `MemoryMax=400M` |
| `deploy/cruza-goaccess.conf` | Config GoAccess (log-format COMBINED, `persist+restore` pra sobreviver a log rotation, `anonymize-ip true`, `keep-last 365`) |
| `deploy/setup-goaccess.sh` | Instalação idempotente — PPA oficial deb.goaccess.io, htpasswd preservado, soft-fail no nginx reload |
| `deploy/nginx-cruza.conf` | Adiciona 2 locations dentro do server HTTPS apex |
| `.github/workflows/deploy.yml` | Step `setup-goaccess.sh` após `setup-fail2ban.sh` |

## Comportamento na primeira ativação

A feature é **opt-in por secret**:

| Estado | Resultado |
|---|---|
| Secret `GOACCESS_PASSWORD` não configurado, sem `.htpasswd-traffic` na VM | **No-op** — script pula silenciosamente. Locations `/_traffic/*` retornam 500 (admin endpoint não ativado) |
| Secret configurado pela 1ª vez | Setup instala goaccess (PPA), cria htpasswd, sobe systemd unit, dashboard fica disponível |
| Deploys subsequentes | Idempotente — htpasswd preservado, config/service só recarregam se mudaram |

## Secrets (opcionais)

Pra ativar pela primeira vez, definir no repositório:

| Secret | Default | Obrigatório no 1º setup? |
|---|---|---|
| `GOACCESS_USER` | `admin` | Não |
| `GOACCESS_PASSWORD` | — | **Sim** |
| `GOACCESS_DOMAIN` | `transparenciapb.org` | Não |

## Privacidade / LGPD

- `anonymize-ip true` no goaccess.conf — anonimiza último octeto IPv4 e últimos 80 bits IPv6 nos dashboards (requer goaccess ≥ 1.7, garantido pelo PPA oficial)
- Logs do nginx ainda contêm IPs completos no `/var/log/nginx/access.log` — comportamento padrão Ubuntu (rotação diária via logrotate, 14 dias de retenção)
- `exclude-ip 127.0.0.1` e `::1` — descarta tráfego interno do warmer/healthcheck
- Sem cookies, sem fingerprinting

## Considerações de segurança

- **Basic-auth + HTTPS** — credenciais não trafegam em claro (HTTPS já existe via setup-letsencrypt.sh)
- `/_traffic/ws` também protegido por basic-auth — WebSocket não é acessível sem credencial
- `Cache-Control: no-cache` no HTML — relatório é regenerado constantemente
- WebSocket bound em `127.0.0.1:7890` (não exposto publicamente)
- `proxy_read_timeout 1d` no WS — necessário pra conexões longas (default 60s dropa)

## Limitações conhecidas

- **Log rotation:** nginx rota logs diariamente. GoAccess em modo real-time-html segue via inotify e deve reabrir o arquivo. Se falhar, `--persist --restore` recupera o estado do DB. Não testado em prod ainda — se observarmos gaps, adicionar postrotate hook.
- **Sem suporte a múltiplos workers nginx:** GoAccess lê um único arquivo de log. Como temos só `cruza-web.service` único, OK.
- **CSP em Report-Only:** o HTML do GoAccess tem inline scripts, mas CSP atual permite (`'unsafe-inline'` em script-src). Se promover CSP pra enforced, considerar adicionar nonce ou excluir `/_traffic/` do CSP.

## Como verificar pós-deploy

```bash
# Na VM, após deploy:
sudo systemctl status cruza-goaccess
sudo journalctl -u cruza-goaccess -f

# Acessar:
# https://transparenciapb.org/_traffic/  (browser, com basic-auth)
```

## Test plan

- [x] `bash -n deploy/setup-goaccess.sh` — sintaxe OK
- [x] Line endings LF (validado contra `.gitattributes`)
- [ ] **Deploy de validação:** rodar workflow `Deploy to Azure VM` com `etl_phase=web` e secret `GOACCESS_PASSWORD` configurado — verificar `systemctl is-active cruza-goaccess` e acesso ao dashboard
- [ ] Verificar que **sem o secret**, o deploy continua passando (no-op no setup-goaccess.sh)

## Rollback

Reverter o PR. Em deploys subsequentes, `cruza-goaccess.service` continuará rodando até que admin remova manualmente:

```bash
sudo systemctl disable --now cruza-goaccess
sudo rm /etc/systemd/system/cruza-goaccess.service /etc/goaccess/cruza-goaccess.conf
sudo rm /etc/nginx/.htpasswd-traffic
sudo systemctl reload nginx
```

(Locations `/_traffic/*` no nginx voltam pro estado "500 sem htpasswd" automaticamente após o revert do nginx-cruza.conf.)
