### PR TITLE
fix(deploy): remove diretiva processing-thread inexistente do goaccess.conf

### DIFF
--- a/deploy/cruza-goaccess.conf
+++ b/deploy/cruza-goaccess.conf
@@ -27,7 +27,6 @@ db-path /var/lib/goaccess/
 agent-list true
 # 365 dias de retencao no DB persistente — suficiente pra analise YoY.
 keep-last 365
-processing-thread 2
 
 # ── Filtragem de ruido ──
 # Health-checks internos e ACME challenges nao sao trafego real.


### PR DESCRIPTION
## Bug

cruza-goaccess.service falhava na 1a execucao apos PR #68:

\\\
/usr/bin/goaccess: unrecognized option '--processing-thread'
\\\

Verificado: \goaccess --help\ nao lista essa opcao em nenhuma versao recente. Eu aluciinei essa diretiva quando escrevi o config. GoAccess gerencia threading internamente, sem necessidade de tuning.

Como o \setup-goaccess.sh\ ja tem soft-fail no deploy.yml (\|| echo WARNING\), o deploy nao quebrou — apenas o daemon nao subiu. Fix de 1 linha: remove a directive.

## Validacao

Confirmado em duas fontes:
- VM (versao instalada via deb.goaccess.io): erro mostrado no log de deploy
- WSL (versao apt do Ubuntu): \goaccess --help | grep -i thread\ = vazio

Self-merge sem reviews adicionais — fix trivial e ja proven pela mensagem de erro do runtime.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>