### PR TITLE
fix(deploy): redirect /_traffic -> /_traffic/ pra evitar 404 do FastAPI

### DIFF
--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -210,6 +210,13 @@ server {
     # WebSocket location PRIMEIRO no codigo (longest-prefix match do nginx
     # ja garante precedencia em prefix locations, mas mantemos a ordem
     # explicita pra leitura).
+
+    # Redirect /_traffic (sem barra) -> /_traffic/. Sem isso, /_traffic
+    # cai no location / (catch-all) e bate em FastAPI, que retorna 404
+    # confundindo o admin. Exact match (=) tem precedencia maxima.
+    location = /_traffic {
+        return 301 /_traffic/;
+    }
     location /_traffic/ws {
         auth_basic "Restricted — Admin";
         auth_basic_user_file /etc/nginx/.htpasswd-traffic;


### PR DESCRIPTION
## Bug

Acessar https://transparenciapb.org/_traffic (sem barra final) retornava 404 do FastAPI em vez do popup de basic-auth.

## Causa

A location `/_traffic/` (com barra) e prefix-match — nao bate em `/_traffic` (sem barra). Sem regra explicita, request cai no catch-all `location /` → proxy_pass FastAPI → 404 (pagina nao existe la).

## Fix

Exact match com precedencia maxima:

\\\
ginx
location = /_traffic {
    return 301 /_traffic/;
}
\\\

## Validacao

- Hotpatch aplicado em prod via sed in-place (confirmado: `HTTP/2 301` na VM agora)
- Este commit persiste a mudanca pos-redeploy

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>