### PR TITLE
fix(deploy): WS conecta - remove auth_basic + sub_filter port 7890->443

### DIFF
--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -218,10 +218,18 @@ server {
         return 301 /_traffic/;
     }
     location /_traffic/ws {
-        auth_basic "Restricted — Admin";
-        auth_basic_user_file /etc/nginx/.htpasswd-traffic;
-        # Rate limit + connection cap pra frear brute-force de basic-auth.
-        # zone general ja existe em nginx-rate-limit-zones.conf (60r/s + burst).
+        # WS sem auth_basic: navegadores (Safari/Chrome/Firefox) NAO enviam
+        # o header Authorization no upgrade handshake do WebSocket, mesmo
+        # depois de autenticar no HTML em /_traffic/. Sem essa relaxacao,
+        # o JS do goaccess fica preso em "Authorizing WebSocket session...".
+        #
+        # Mitigacoes mantidas:
+        #   - WS daemon bound em 127.0.0.1 (nao expoe porta publica)
+        #   - rate limit + connection cap (zone general)
+        #   - path obscuro (/_traffic/ws nao linkado de lugar nenhum publico)
+        #   - dados expostos sao stats agregadas e anonimizadas
+        #     (anonymize-ip true no goaccess.conf, ultimo octeto zerado)
+        # Rate limit + connection cap pra frear brute-force de scanner.
         limit_req zone=general burst=10 nodelay;
         limit_conn perip 4;
         proxy_pass http://127.0.0.1:7890;
@@ -241,6 +249,14 @@ server {
         # Rate limit basic-auth: bloqueia automação que tenta password spraying.
         limit_req zone=general burst=10 nodelay;
         limit_conn perip 4;
+        # GoAccess embute "port": 7890 no HTML (porta interna do daemon),
+        # e o JS sempre usa esse port no URL do WebSocket — mesmo com
+        # ws-url configurado pro dominio publico (bug upstream do goaccess
+        # >=1.10). Reescreve on-the-fly pra 443 (porta HTTPS do nginx)
+        # pra que o browser conecte via wss://transparenciapb.org/_traffic/ws
+        # e nginx faca proxy pra 127.0.0.1:7890.
+        sub_filter '"port": 7890' '"port": 443';
+        sub_filter_once on;
         alias /var/www/traffic/;
         try_files $uri $uri/index.html =404;
         # HTML do goaccess e regenerado a cada poucos segundos — sem cache.


### PR DESCRIPTION
## Sintoma

Dashboard /_traffic/ carregava HTML mas ficava preso em "Authorizing WebSocket session... Please wait." indefinidamente.

## Bugs (2)

### #1: browsers nao mandam Authorization no WS upgrade

`auth_basic` em `/_traffic/ws` bloqueava — Safari/Chrome/Firefox nao reenviam credentials basic-auth pro handshake WebSocket, mesmo apos autenticar no HTML. (Opus review aprovou isso confiante; GPT-5.5 havia levantado suspeita correta.)

### #2: goaccess hardcoda port 7890 no HTML embebido

```js
return new URL(url).protocol + '//' + new URL(url).hostname
     + ':' + wsConn.port + new URL(url).pathname;
```

`wsConn.port` eh sempre 7890 (porta de listen interna), mesmo com `ws-url wss://transparenciapb.org/_traffic/ws` configurado. Browser tentava `wss://transparenciapb.org:7890` que nao esta exposto. Bug upstream do goaccess 1.10.x.

## Fixes

```nginx
location /_traffic/ws {
    # SEM auth_basic — browsers nao enviam Authorization no upgrade
    limit_req zone=general burst=10 nodelay;
    limit_conn perip 4;
    proxy_pass http://127.0.0.1:7890;
    # ... headers WS
}
location /_traffic/ {
    auth_basic "Restricted — Admin";     # mantido (HTML protegido)
    sub_filter '"port": 7890' '"port": 443';   # rewrite on-the-fly
    sub_filter_once on;
    alias /var/www/traffic/;
    # ...
}
```

## Trade-off de seguranca

WS sem basic-auth eh mitigado por:
- Daemon bound em `127.0.0.1:7890` (porta nao exposta)
- Rate limit + connection cap
- Path obscuro
- Dados anonimizados (`anonymize-ip true` — ultimo octeto zerado)
- Dashboard UI (HTML) continua gated por basic-auth

Risco residual: alguem que descubra o path `/_traffic/ws` pode ouvir o stream de stats anonimizadas. Aceitavel pra um site publico de transparencia.

## Validacao

Hotpatch ja em prod via SSH. Confirmado:
```
"GET /_traffic/ws HTTP/1.1" 101 181861
```
HTTP 101 Switching Protocols + 181KB streamados.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
