### PR TITLE
feat(web): integra Umami analytics self-hosted em /_traffic/analytics/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,20 @@ INDEXNOW_KEY=
 # Origem completa do site (usada pelo indexnow_submit pra montar URLs).
 SITE_URL=https://transparenciapb.org
 
+# ─── Umami analytics (self-hosted) ───
+# Painel rodando em /_traffic/analytics/ no mesmo dominio (mesmo subpath
+# admin de /_traffic/, protegido por basic-auth .htpasswd-traffic +
+# login do Umami). Servico systemd: deploy/cruza-umami.service.
+# Provisionado por deploy/setup-umami.sh no deploy.yml.
+#
+# Apos primeiro deploy:
+#   1. Acessar https://transparenciapb.org/_traffic/analytics/login
+#      (basic-auth primeiro, depois admin / umami no Umami).
+#   2. Trocar senha em Profile -> Change password.
+#   3. Settings -> Websites -> Add -> nome="TransparenciaPB",
+#      domain="transparenciapb.org".
+#   4. Copiar o "Website ID" gerado e colar abaixo, re-deploy do web.
+# O snippet so eh injetado no <head> quando AMBAS as vars estao preenchidas.
+UMAMI_SCRIPT_URL=/_traffic/analytics/script.js
+UMAMI_WEBSITE_ID=
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -686,6 +686,22 @@ jobs:
             bash deploy/setup-goaccess.sh \
             || echo "WARNING: setup-goaccess.sh falhou (non-fatal — dashboard admin)."
 
+          # Setup Umami analytics (self-hosted em /_traffic/analytics/).
+          # Idempotente: instala Node 22 + pnpm se ausentes, cria DB+role
+          # umami no Postgres, gera secrets, clona umami-software/umami no
+          # tag pinado, builda (skip se ja built com mesmo tag+BASE_PATH),
+          # roda Prisma migrations e instala cruza-umami.service.
+          #
+          # Primeiro build leva ~3min (pnpm install + next build). Builds
+          # subsequentes pulam (marker .next/.cruza-build-marker).
+          #
+          # Soft-fail: analytics e' admin-only / observabilidade, opcional.
+          # Site publico nao depende — se setup falhar, /_traffic/analytics/
+          # retorna 502 e o tracker no <head> (snippet condicional em
+          # base.html) so emite quando UMAMI_WEBSITE_ID estiver setado.
+          sudo bash deploy/setup-umami.sh \
+            || echo "WARNING: setup-umami.sh falhou (non-fatal — analytics admin)."
+
           # Build frontend assets RIGHT BEFORE cruza-web restart pra evitar
           # a janela onde nginx serve novo dist/ enquanto workers velhos
           # geram HTML com URLs antigas (404 nos hashed assets).
@@ -727,6 +743,7 @@ jobs:
           echo "=== Web services deployed ==="
           systemctl is-active nginx && echo "nginx: RUNNING" || echo "nginx: FAILED"
           systemctl is-active cruza-web && echo "cruza-web: RUNNING" || echo "cruza-web: FAILED"
+          systemctl is-active cruza-umami >/dev/null 2>&1 && echo "cruza-umami: RUNNING" || echo "cruza-umami: not active (admin-only, OK)"
           echo "cruza-warm-cache: oneshot instalado (executado sob demanda)"
 
       # ── SEO: notificar IndexNow (Bing/Yandex/Yahoo/Seznam/Naver) ──

--- a/deploy/cruza-umami.service
+++ b/deploy/cruza-umami.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Umami Analytics - self-hosted (transparenciapb.org)
+After=postgresql.service network.target
+Wants=postgresql.service
+
+[Service]
+Type=simple
+User=umami
+Group=umami
+WorkingDirectory=/opt/umami
+# HOME explicito pra pnpm/npm acharem o store local e o .npmrc.
+Environment=HOME=/opt/umami
+# Secrets (DATABASE_URL, APP_SECRET, HASH_SALT) sao gerados/persistidos
+# pelo setup-umami.sh em /etc/umami.env (root:umami 0640). PORT e HOSTNAME
+# tambem vem dali (bind 127.0.0.1:3001 — nginx faz proxy reverso pra
+# analytics.transparenciapb.org).
+EnvironmentFile=/etc/umami.env
+# `pnpm start` chama `next start`, que respeita PORT e HOSTNAME do env.
+# Saida vai pro journal (capturado por journalctl -u cruza-umami).
+ExecStart=/usr/bin/pnpm start
+Restart=always
+RestartSec=5
+
+# Hardening basico. Umami so precisa ler /opt/umami + /etc/umami.env
+# e conectar no Postgres local. /opt/umami precisa de write pra pnpm
+# atualizar lockfile/cache; nada mais.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/umami
+
+[Install]
+WantedBy=multi-user.target
+

--- a/deploy/cruza-umami.service
+++ b/deploy/cruza-umami.service
@@ -11,13 +11,17 @@ WorkingDirectory=/opt/umami
 # HOME explicito pra pnpm/npm acharem o store local e o .npmrc.
 Environment=HOME=/opt/umami
 # Secrets (DATABASE_URL, APP_SECRET, HASH_SALT) sao gerados/persistidos
-# pelo setup-umami.sh em /etc/umami.env (root:umami 0640). PORT e HOSTNAME
-# tambem vem dali (bind 127.0.0.1:3001 — nginx faz proxy reverso pra
-# analytics.transparenciapb.org).
+# pelo setup-umami.sh em /etc/umami.env (root:umami 0640). PORT tambem
+# vem dali, mas o hostname precisa ser CLI flag (next start le PORT do env
+# mas nao le HOSTNAME — ele so eh respeitado via --hostname/-H, ver
+# https://nextjs.org/docs/app/api-reference/cli/next#next-start-options).
+# Sem -H 127.0.0.1, Umami bindaria em 0.0.0.0:3001 e seria acessivel
+# fora do proxy nginx caso a porta fique aberta na rede.
 EnvironmentFile=/etc/umami.env
-# `pnpm start` chama `next start`, que respeita PORT e HOSTNAME do env.
-# Saida vai pro journal (capturado por journalctl -u cruza-umami).
-ExecStart=/usr/bin/pnpm start
+# `pnpm exec next start` chama o binario do Next direto (em vez de via
+# script `pnpm start`), facilitando o forward de flags --hostname/--port.
+# A saida vai pro journal (capturado por journalctl -u cruza-umami).
+ExecStart=/usr/bin/pnpm exec next start --hostname 127.0.0.1 --port 3001
 Restart=always
 RestartSec=5
 

--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -259,6 +259,67 @@ server {
         # Forca download/inline em UTF-8 (nginx default eh latin1 pra text/plain).
         charset utf-8;
     }
+
+    # ─── Umami analytics (self-hosted, dashboard admin-only) ───
+    # Path /_traffic/analytics/* → proxied pra Node em 127.0.0.1:3001.
+    # Umami v3 buildado com BASE_PATH=/_traffic/analytics (ver
+    # deploy/setup-umami.sh), entao todos os assets, login, API e o proprio
+    # tracker JS ficam sob esse prefixo. O servico systemd cruza-umami.service
+    # roda local-only (HOSTNAME=127.0.0.1, PORT=3001).
+    #
+    # Distincao critica:
+    #   - /_traffic/analytics/script.js   → PUBLICO (todo visitor carrega)
+    #   - /_traffic/analytics/api/send    → PUBLICO (browser POST eventos)
+    #   - /_traffic/analytics/...         → basic-auth + login do Umami
+    #
+    # A precedencia do nginx (exact-match > prefix mais longo) garante que
+    # script.js e api/send sao servidos sem auth mesmo estando dentro de
+    # /_traffic/analytics/. Mantemos rate limit em todas as locations.
+
+    # Tracker JS — publico (carregado pelo <script> em web/templates/base.html).
+    location = /_traffic/analytics/script.js {
+        limit_req zone=general burst=120 nodelay;
+        limit_conn perip 20;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Cache 1h no browser pra reduzir requests repetidos; o tracker
+        # raramente muda entre updates do Umami.
+        add_header Cache-Control "public, max-age=3600" always;
+    }
+
+    # Event ingestion — publico, recebe POST do tracker em cada pageview/evento.
+    # Rate limit api_light (~10 r/s + burst 20) eh suficiente: 223 municipios
+    # com trafego organico nunca chega perto.
+    location = /_traffic/analytics/api/send {
+        limit_req zone=api_light burst=20 nodelay;
+        limit_conn perip 8;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Dashboard + login + APIs admin — basic-auth + auth proprio do Umami.
+    # IMPORTANTE: exige basic-auth via .htpasswd-traffic mesmo apos login
+    # no Umami (defesa em profundidade, mesmo padrao do /_traffic/ goaccess).
+    # Trocar a senha default admin/umami no primeiro acesso e obrigatorio.
+    location /_traffic/analytics/ {
+        auth_basic "Restricted — Analytics admin";
+        auth_basic_user_file /etc/nginx/.htpasswd-traffic;
+        limit_req zone=general burst=30 nodelay;
+        limit_conn perip 8;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
     location /_traffic/ {
         auth_basic "Restricted — Admin";
         auth_basic_user_file /etc/nginx/.htpasswd-traffic;

--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -276,6 +276,16 @@ server {
     # script.js e api/send sao servidos sem auth mesmo estando dentro de
     # /_traffic/analytics/. Mantemos rate limit em todas as locations.
 
+    # /_traffic/analytics (sem trailing slash) NAO bate no prefix
+    # /_traffic/analytics/ — sem este redirect, a request cairia no
+    # location /_traffic/ abaixo (proxy do GoAccess) e o usuario veria HTML
+    # errado. nginx nao faz redirect automatico /x -> /x/ para proxy_pass
+    # (so faz pra diretorios de filesystem). 308 preserva method+body
+    # (relevante caso algum link interno do Umami chegue aqui).
+    location = /_traffic/analytics {
+        return 308 /_traffic/analytics/;
+    }
+
     # Tracker JS — publico (carregado pelo <script> em web/templates/base.html).
     location = /_traffic/analytics/script.js {
         limit_req zone=general burst=120 nodelay;
@@ -303,10 +313,32 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Dashboard + login + APIs admin — basic-auth + auth proprio do Umami.
-    # IMPORTANTE: exige basic-auth via .htpasswd-traffic mesmo apos login
-    # no Umami (defesa em profundidade, mesmo padrao do /_traffic/ goaccess).
+    # APIs admin do Umami — SEM basic-auth (so rate-limit + auth proprio).
+    # Motivo: o frontend do dashboard envia `Authorization: Bearer <jwt>`
+    # em toda chamada (src/components/hooks/useApi.ts), e o header
+    # Authorization eh tambem o que o basic-auth do nginx consome — colocar
+    # auth_basic aqui causa 401 antes de chegar no Umami, quebrando login
+    # e qualquer acao no painel. A protecao desses endpoints fica por conta
+    # do auth interno do Umami (bcrypt + JWT assinado com APP_SECRET).
+    # Login bruteforce eh contido pelo rate limit api_light + conn cap.
+    # Este prefix eh mais longo que /_traffic/analytics/ entao tem
+    # precedencia (longest non-`^~` prefix match).
+    location /_traffic/analytics/api/ {
+        limit_req zone=api_light burst=20 nodelay;
+        limit_conn perip 8;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # Dashboard HTML/assets (login page, /_next/*, /share/*, etc) —
+    # basic-auth + auth proprio do Umami (defesa em profundidade).
     # Trocar a senha default admin/umami no primeiro acesso e obrigatorio.
+    # IMPORTANTE: apenas a UI cai aqui — as APIs do dashboard (acima)
+    # usam Bearer JWT e NAO podem ter basic-auth (vide comentario acima).
     location /_traffic/analytics/ {
         auth_basic "Restricted — Analytics admin";
         auth_basic_user_file /etc/nginx/.htpasswd-traffic;

--- a/deploy/setup-umami.sh
+++ b/deploy/setup-umami.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# Setup idempotente do Umami analytics (self-hosted) em /opt/umami.
+#
+# O que faz:
+#   - Cria system user `umami` e diretorio /opt/umami
+#   - Instala Node 22 (NodeSource) + pnpm se ausentes
+#   - Cria DB+role `umami` no Postgres local (senha aleatoria persistida)
+#   - Gera APP_SECRET + HASH_SALT (uma vez, persistidos em /etc/umami.*)
+#   - Escreve /etc/umami.env (root:umami 0640) com DATABASE_URL, secrets,
+#     BASE_PATH=/_traffic/analytics, PORT=3001, HOSTNAME=127.0.0.1
+#   - Faz git clone --depth 1 do umami-software/umami no tag UMAMI_VERSION
+#   - pnpm install --frozen-lockfile + pnpm run build (com BASE_PATH baked in;
+#     skip se ja built no mesmo tag+BASE_PATH)
+#   - pnpm run update-db (prisma migrate deploy)
+#   - Instala cruza-umami.service e (re)inicia
+#
+# Pos-deploy (manual, uma vez):
+#   1. Acessar https://transparenciapb.org/_traffic/analytics/login.
+#      Primeiro o nginx pede basic-auth (.htpasswd-traffic, mesmo de
+#      /_traffic/). Depois o Umami pede login (admin / umami).
+#   2. Profile -> Change password.
+#   3. Settings -> Websites -> Add -> nome=TransparenciaPB,
+#      domain=transparenciapb.org -> salvar.
+#   4. Copiar o Website ID gerado pro secret UMAMI_WEBSITE_ID no ENV_FILE
+#      do GitHub Actions e re-deploy do web frontend.
+#
+# Variaveis de ambiente opcionais:
+#   UMAMI_VERSION    tag do repo umami-software/umami (default: v3.1.0)
+#   UMAMI_DIR        diretorio de instalacao (default: /opt/umami)
+#   UMAMI_USER       system user que roda o servico (default: umami)
+#   UMAMI_DB         nome do DB (default: umami)
+#   UMAMI_DB_USER    role Postgres (default: umami)
+#   UMAMI_BASE_PATH  path prefix HTTP (default: /_traffic/analytics).
+#                    Trocar exige rebuild (BASE_PATH eh baked in pelo
+#                    Next.js no `pnpm run build`).
+#
+# Uso (na VM, como root):
+#   sudo bash deploy/setup-umami.sh
+
+set -euo pipefail
+
+UMAMI_VERSION="${UMAMI_VERSION:-v3.1.0}"
+UMAMI_DIR="${UMAMI_DIR:-/opt/umami}"
+UMAMI_USER="${UMAMI_USER:-umami}"
+UMAMI_DB="${UMAMI_DB:-umami}"
+UMAMI_DB_USER="${UMAMI_DB_USER:-umami}"
+UMAMI_BASE_PATH="${UMAMI_BASE_PATH:-/_traffic/analytics}"
+
+UMAMI_ENV_FILE="/etc/umami.env"
+DB_PASS_FILE="/etc/umami.db-password"
+APP_SECRET_FILE="/etc/umami.app-secret"
+HASH_SALT_FILE="/etc/umami.hash-salt"
+BUILD_MARKER="${UMAMI_DIR}/.next/.cruza-build-marker"
+SYSTEMD_UNIT_PATH="/etc/systemd/system/cruza-umami.service"
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SERVICE_SRC="${REPO_DIR}/deploy/cruza-umami.service"
+
+log() { echo "[setup-umami] $*"; }
+
+if [[ "${EUID}" -ne 0 ]]; then
+    log "ERRO: precisa rodar como root (use sudo)."
+    exit 1
+fi
+
+# ─── 1) system user ──────────────────────────────────────────────────────────
+if ! id -u "${UMAMI_USER}" >/dev/null 2>&1; then
+    log "Criando system user ${UMAMI_USER} com home=${UMAMI_DIR}..."
+    useradd --system --create-home --home-dir "${UMAMI_DIR}" \
+            --shell /usr/sbin/nologin "${UMAMI_USER}"
+else
+    # Garante o diretorio mesmo que o user ja exista mas /opt/umami nao
+    mkdir -p "${UMAMI_DIR}"
+    chown "${UMAMI_USER}:${UMAMI_USER}" "${UMAMI_DIR}"
+fi
+
+# ─── 2) Node 22 + pnpm ───────────────────────────────────────────────────────
+NEED_NODE=1
+if command -v node >/dev/null 2>&1; then
+    NODE_MAJOR=$(node -v | sed -E 's/^v([0-9]+).*/\1/')
+    if [[ "${NODE_MAJOR}" -ge 20 ]]; then NEED_NODE=0; fi
+fi
+if [[ "${NEED_NODE}" -eq 1 ]]; then
+    log "Instalando Node 22 via NodeSource..."
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+    apt-get install -y nodejs
+else
+    log "Node $(node -v) ja instalado, ok."
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+    log "Instalando pnpm globalmente..."
+    npm install -g pnpm
+else
+    log "pnpm $(pnpm -v) ja instalado, ok."
+fi
+
+# ─── 3) Postgres: DB + role ─────────────────────────────────────────────────
+if [[ ! -f "${DB_PASS_FILE}" ]]; then
+    log "Gerando senha aleatoria pro role ${UMAMI_DB_USER}..."
+    (umask 077; openssl rand -hex 24 > "${DB_PASS_FILE}")
+    chown root:root "${DB_PASS_FILE}"
+    chmod 0600 "${DB_PASS_FILE}"
+fi
+DB_PASS=$(cat "${DB_PASS_FILE}")
+
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${UMAMI_DB_USER}'" | grep -q 1; then
+    log "Criando role ${UMAMI_DB_USER}..."
+    sudo -u postgres psql -c "CREATE ROLE ${UMAMI_DB_USER} WITH LOGIN PASSWORD '${DB_PASS}';"
+else
+    # Re-ALTER toda vez pra garantir que a senha persistida em
+    # /etc/umami.db-password bate com a senha do role (caso alguem tenha
+    # rodado manual). NAO gera nova senha — usa a que ja esta no arquivo.
+    sudo -u postgres psql -c "ALTER ROLE ${UMAMI_DB_USER} WITH LOGIN PASSWORD '${DB_PASS}';" >/dev/null
+fi
+
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${UMAMI_DB}'" | grep -q 1; then
+    log "Criando database ${UMAMI_DB} (owner=${UMAMI_DB_USER})..."
+    sudo -u postgres createdb -O "${UMAMI_DB_USER}" "${UMAMI_DB}"
+fi
+
+# ─── 4) Secrets (gerar uma vez, persistir) ──────────────────────────────────
+# CUIDADO: trocar HASH_SALT depois invalida a continuidade dos visitantes
+# (cada IP eh hasheado com o salt; sessoes ficam fragmentadas). APP_SECRET
+# tambem nao deve mudar — JWTs assinados ficam invalidos.
+for f in "${APP_SECRET_FILE}" "${HASH_SALT_FILE}"; do
+    if [[ ! -f "${f}" ]]; then
+        log "Gerando $(basename "${f}")..."
+        (umask 077; openssl rand -hex 32 > "${f}")
+        chown root:root "${f}"
+        chmod 0600 "${f}"
+    fi
+done
+APP_SECRET=$(cat "${APP_SECRET_FILE}")
+HASH_SALT=$(cat "${HASH_SALT_FILE}")
+
+# ─── 5) /etc/umami.env ──────────────────────────────────────────────────────
+# Re-escrito a cada deploy (atomico via mv) — reflete sempre os arquivos
+# de senha/secret atuais + UMAMI_BASE_PATH desta execucao.
+log "Escrevendo ${UMAMI_ENV_FILE} (BASE_PATH=${UMAMI_BASE_PATH})..."
+ENV_TMP=$(mktemp /etc/umami.env.XXXXXX)
+cat > "${ENV_TMP}" <<EOF
+# Generated by deploy/setup-umami.sh — DO NOT EDIT.
+# Os valores vem de /etc/umami.db-password, /etc/umami.app-secret e
+# /etc/umami.hash-salt. Pra rotacionar: troque o arquivo de origem e
+# rode este script novamente.
+DATABASE_URL=postgresql://${UMAMI_DB_USER}:${DB_PASS}@127.0.0.1:5432/${UMAMI_DB}
+DATABASE_TYPE=postgresql
+APP_SECRET=${APP_SECRET}
+HASH_SALT=${HASH_SALT}
+PORT=3001
+HOSTNAME=127.0.0.1
+NODE_ENV=production
+# BASE_PATH e baked in pelo Next.js no momento do `pnpm run build` (ver passo
+# 7 abaixo). Mantemos ele tambem em runtime pra qualquer codigo server-side
+# que leia process.env.BASE_PATH.
+BASE_PATH=${UMAMI_BASE_PATH}
+# Telemetria do Next.js — desabilitada.
+NEXT_TELEMETRY_DISABLED=1
+EOF
+chown "root:${UMAMI_USER}" "${ENV_TMP}"
+chmod 0640 "${ENV_TMP}"
+mv -f "${ENV_TMP}" "${UMAMI_ENV_FILE}"
+
+# ─── 6) Clone / checkout do Umami ───────────────────────────────────────────
+if [[ ! -d "${UMAMI_DIR}/.git" ]]; then
+    log "Clonando umami-software/umami @ ${UMAMI_VERSION} em ${UMAMI_DIR}..."
+    # Garante diretorio vazio (sem apagar /opt/umami como root caso ja exista
+    # com home do user — preserva o ponto de montagem).
+    find "${UMAMI_DIR}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+    sudo -u "${UMAMI_USER}" git clone --depth 1 --branch "${UMAMI_VERSION}" \
+        https://github.com/umami-software/umami.git "${UMAMI_DIR}"
+else
+    cd "${UMAMI_DIR}"
+    CUR_VER=$(sudo -u "${UMAMI_USER}" git describe --tags --exact-match 2>/dev/null || echo "unknown")
+    if [[ "${CUR_VER}" != "${UMAMI_VERSION}" ]]; then
+        log "Atualizando Umami: ${CUR_VER} -> ${UMAMI_VERSION}..."
+        sudo -u "${UMAMI_USER}" git fetch --tags --depth 1 origin \
+            "refs/tags/${UMAMI_VERSION}:refs/tags/${UMAMI_VERSION}"
+        sudo -u "${UMAMI_USER}" git checkout "${UMAMI_VERSION}"
+    else
+        log "Umami ja em ${UMAMI_VERSION}, pulando checkout."
+    fi
+fi
+chown -R "${UMAMI_USER}:${UMAMI_USER}" "${UMAMI_DIR}"
+
+# ─── 7) Build (skip se marker == versao+base-path atual) ────────────────────
+# BASE_PATH eh baked in pelo Next.js durante `pnpm run build` (next.config.js
+# usa process.env.BASE_PATH). Trocar UMAMI_BASE_PATH exige rebuild — por
+# isso o marker carrega versao+base-path.
+NEED_BUILD=1
+BUILD_KEY="${UMAMI_VERSION}|${UMAMI_BASE_PATH}"
+if [[ -f "${BUILD_MARKER}" ]]; then
+    if [[ "$(cat "${BUILD_MARKER}")" == "${BUILD_KEY}" ]]; then
+        NEED_BUILD=0
+    fi
+fi
+
+if [[ "${NEED_BUILD}" -eq 1 ]]; then
+    log "Buildando Umami ${UMAMI_VERSION} com BASE_PATH=${UMAMI_BASE_PATH} (pode levar ~3min)..."
+    # Build precisa de DATABASE_URL (prisma generate puxa schema do DB).
+    # `set -a; source ...; set +a` carrega todas as vars do env file pro
+    # subshell — mais robusto que `export $(cat | xargs)` frente a valores
+    # com caracteres especiais.
+    sudo -u "${UMAMI_USER}" env "HOME=${UMAMI_DIR}" bash -c "
+        cd '${UMAMI_DIR}' && \
+        set -a && source '${UMAMI_ENV_FILE}' && set +a && \
+        pnpm install --frozen-lockfile && \
+        pnpm run build
+    "
+    sudo -u "${UMAMI_USER}" mkdir -p "$(dirname "${BUILD_MARKER}")"
+    echo -n "${BUILD_KEY}" | sudo -u "${UMAMI_USER}" tee "${BUILD_MARKER}" >/dev/null
+else
+    log "Build ja existe pro tag ${UMAMI_VERSION} + BASE_PATH ${UMAMI_BASE_PATH}, pulando."
+fi
+
+# ─── 8) Migrations ──────────────────────────────────────────────────────────
+log "Aplicando Prisma migrations..."
+sudo -u "${UMAMI_USER}" env "HOME=${UMAMI_DIR}" bash -c "
+    cd '${UMAMI_DIR}' && \
+    set -a && source '${UMAMI_ENV_FILE}' && set +a && \
+    pnpm run update-db
+"
+
+# ─── 9) systemd unit ────────────────────────────────────────────────────────
+log "Instalando cruza-umami.service..."
+install -m 0644 "${SERVICE_SRC}" "${SYSTEMD_UNIT_PATH}"
+systemctl daemon-reload
+systemctl enable cruza-umami >/dev/null
+systemctl restart cruza-umami
+
+# Espera o servico ficar healthy (max 30s). Umami v3 leva alguns segundos
+# pra subir Next + abrir socket; testa via /api/heartbeat dentro do
+# BASE_PATH (com BASE_PATH=/_traffic/analytics, vira /_traffic/analytics/api/heartbeat).
+log "Aguardando cruza-umami responder em 127.0.0.1:3001${UMAMI_BASE_PATH}/api/heartbeat..."
+for i in $(seq 1 30); do
+    if curl -fsS -o /dev/null --max-time 2 "http://127.0.0.1:3001${UMAMI_BASE_PATH}/api/heartbeat" 2>/dev/null; then
+        log "OK: Umami healthy apos ${i}s."
+        break
+    fi
+    sleep 1
+    if [[ "${i}" -eq 30 ]]; then
+        log "ERRO: Umami nao respondeu em 30s. Veja journalctl -u cruza-umami -n 50"
+        systemctl status cruza-umami --no-pager -l || true
+        exit 1
+    fi
+done
+
+log "Setup concluido."
+log "  - Painel:    https://transparenciapb.org${UMAMI_BASE_PATH}/ (apos basic-auth + login)"
+log "  - Tracker:   https://transparenciapb.org${UMAMI_BASE_PATH}/script.js (publico)"
+log "  - Bind:      127.0.0.1:3001 (proxy via nginx + .htpasswd-traffic)"
+log "  - Logs:      journalctl -u cruza-umami -f"
+log "  - Versao:    ${UMAMI_VERSION}"
+log "  - BASE_PATH: ${UMAMI_BASE_PATH}"
+log ""
+log "Proximo passo: criar website no painel e copiar Website ID pro"
+log "secret UMAMI_WEBSITE_ID (variavel ENV_FILE do GitHub Actions)."

--- a/web/main.py
+++ b/web/main.py
@@ -324,6 +324,26 @@ templates.env.globals["BING_SITE_VERIFICATION"] = os.environ.get(
     "BING_SITE_VERIFICATION", ""
 ).strip()
 
+# Umami analytics (self-hosted em /_traffic/analytics/, ver
+# deploy/setup-umami.sh + deploy/cruza-umami.service).
+# O snippet so eh emitido em base.html quando AMBAS as vars estao setadas,
+# entao o app continua funcionando sem analytics enquanto o painel nao for
+# provisionado / nao tiver website cadastrado.
+#
+#   UMAMI_SCRIPT_URL    URL (relativa ou absoluta) do tracker JS, ex:
+#                       /_traffic/analytics/script.js
+#   UMAMI_WEBSITE_ID    UUID do "Website" cadastrado no painel Umami
+#                       (login admin -> Settings -> Websites -> Add).
+#
+# Manter a URL como env var (em vez de hardcoded) permite desligar o
+# tracker via .env sem mudanca de codigo.
+templates.env.globals["UMAMI_SCRIPT_URL"] = os.environ.get(
+    "UMAMI_SCRIPT_URL", ""
+).strip()
+templates.env.globals["UMAMI_WEBSITE_ID"] = os.environ.get(
+    "UMAMI_WEBSITE_ID", ""
+).strip()
+
 # JS load order. Each entry is a path relative to /static/js/, emitted as
 # an individual <script> tag in base.html. Order matters because the scripts
 # are plain (non-module) and rely on cross-file globals — files are loaded

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -142,10 +142,9 @@
        Snippet so eh emitido quando AMBAS as vars estao setadas no ambiente
        (UMAMI_SCRIPT_URL + UMAMI_WEBSITE_ID), entao o site funciona sem
        analytics enquanto o painel nao for provisionado.
-       data-do-not-track=true respeita o header DNT do navegador.
-       data-cache=true reusa cache local de page sessions ate 30min. #}
+       data-do-not-track=true respeita o header DNT do navegador. #}
     {% if UMAMI_SCRIPT_URL and UMAMI_WEBSITE_ID %}
-    <script async defer src="{{ UMAMI_SCRIPT_URL }}" data-website-id="{{ UMAMI_WEBSITE_ID }}" data-do-not-track="true" data-cache="true"></script>
+    <script async defer src="{{ UMAMI_SCRIPT_URL }}" data-website-id="{{ UMAMI_WEBSITE_ID }}" data-do-not-track="true"></script>
     {% endif %}
     {% block head_extra %}{% endblock %}
 </head>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -137,6 +137,16 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/static/icon-32.png">
     <link rel="icon" type="image/png" sizes="192x192" href="/static/icon-192.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/static/icon-180.png">
+    {# Umami analytics (self-hosted, cookieless, sem necessidade de consent
+       banner LGPD/GDPR). Carrega async/defer pra nao bloquear renderizacao.
+       Snippet so eh emitido quando AMBAS as vars estao setadas no ambiente
+       (UMAMI_SCRIPT_URL + UMAMI_WEBSITE_ID), entao o site funciona sem
+       analytics enquanto o painel nao for provisionado.
+       data-do-not-track=true respeita o header DNT do navegador.
+       data-cache=true reusa cache local de page sessions ate 30min. #}
+    {% if UMAMI_SCRIPT_URL and UMAMI_WEBSITE_ID %}
+    <script async defer src="{{ UMAMI_SCRIPT_URL }}" data-website-id="{{ UMAMI_WEBSITE_ID }}" data-do-not-track="true" data-cache="true"></script>
+    {% endif %}
     {% block head_extra %}{% endblock %}
 </head>
 <body class="dark-page {% block body_class %}{% endblock %}">


### PR DESCRIPTION
## Integra Umami analytics self-hosted em `/_traffic/analytics/`

Tracker privacy-first cookieless (sem necessidade de banner LGPD), self-hosted, alinhado com o esp├¡rito de transpar├¬ncia do site. Sob o mesmo subpath admin do GoAccess (`/_traffic/`), atr├ís do mesmo `.htpasswd-traffic` + autenticacao pr├│pria do Umami.

### Decisoes
- **Path em vez de subdom├¡nio** (`/_traffic/analytics/` no apex em vez de `analytics.transparenciapb.org`): same-origin = sem cert SAN novo, sem mudan├ºa de CSP, sem DNS extra.
- **Umami v3.1.0** pinado em `deploy/setup-umami.sh` (`UMAMI_VERSION`).
- **Public vs admin**: `script.js` e `api/send` p├║blicos (necess├írio pro tracker funcionar nos visitantes), tudo o mais behind basic-auth.
- **No-op enquanto vars n├úo populadas**: snippet em `base.html` s├│ emite quando `UMAMI_SCRIPT_URL` E `UMAMI_WEBSITE_ID` estao setados. Merge dele sozinho n├úo muda comportamento do site.
- **Soft-fail no deploy**: igual `setup-goaccess.sh`, se falhar o site p├║blico n├úo cai.

### Arquivos
| Tipo | Arquivo | O que muda |
|------|---------|------------|
| Frontend | `web/templates/base.html` | `<script async defer>` condicional no `<head>` |
| Frontend | `web/main.py` | Exp├╡e `UMAMI_SCRIPT_URL` + `UMAMI_WEBSITE_ID` como Jinja globals |
| Frontend | `.env.example` | Documenta vars + procedimento p├│s-deploy |
| Infra | `deploy/cruza-umami.service` (novo) | systemd unit (Node 22, `pnpm start`, `127.0.0.1:3001`, hardening) |
| Infra | `deploy/setup-umami.sh` (novo) | Provisionamento idempotente: Node, pnpm, DB+role, secrets, build com BASE_PATH, Prisma migrations, systemd |
| Infra | `deploy/nginx-cruza.conf` | 3 location blocks pra `/_traffic/analytics/*` |
| Infra | `.github/workflows/deploy.yml` | Invoca `setup-umami.sh` inline (soft-fail) ap├│s `setup-goaccess.sh` |

### P├│s-merge (manual, uma vez)
1. Pr├│ximo deploy roda `setup-umami.sh` automaticamente (├║nica primeira execu├º├úo demora ~3min: pnpm install + `next build`).
2. Acessar `https://transparenciapb.org/_traffic/analytics/login` (basic-auth `.htpasswd-traffic` primeiro, depois `admin` / `umami` no Umami).
3. Trocar senha default em **Profile ΓåÆ Change password**.
4. **Settings ΓåÆ Websites ΓåÆ Add** ΓåÆ nome `TransparenciaPB`, dom├¡nio `transparenciapb.org` ΓåÆ salvar.
5. Copiar o **Website ID** gerado pro secret `UMAMI_WEBSITE_ID` na vari├ível `ENV_FILE` do GitHub Actions e fazer re-deploy do web frontend.

### O que checar quando rodar
- `journalctl -u cruza-umami -n 50` ΓÇö servico subiu OK
- `curl -sI http://127.0.0.1:3001/_traffic/analytics/api/heartbeat` ΓÇö retorna 200
- `curl -sI https://transparenciapb.org/_traffic/analytics/script.js` ΓÇö retorna 200 (publico, `Content-Type: application/javascript`)
- `curl -sI https://transparenciapb.org/_traffic/analytics/` ΓÇö retorna 401 (basic-auth)
- Ap├│s setar `UMAMI_WEBSITE_ID`: View source da home, conferir que o `<script>` do Umami est├í no `<head>`.

### Validacao local
- `python -m compileall web -q` ΓÇö OK
- `bash -n deploy/setup-umami.sh` + `bash -n deploy/setup-letsencrypt.sh` ΓÇö OK (ap├│s CRLFΓåÆLF)
- Diff revisado manualmente: 7 arquivos, 418 inser├º├╡es, 0 dele├º├╡es.