### PR TITLE
fix(deploy): remove anonymize-ip — destrava user-agents no dashboard

### DIFF
--- a/deploy/cruza-goaccess.conf
+++ b/deploy/cruza-goaccess.conf
@@ -41,6 +41,13 @@ exclude-ip 127.0.0.1
 exclude-ip ::1
 
 # ── Privacidade ──
-# Anonimiza ultimo octeto do IPv4 (e ultimos 80 bits do IPv6) nos dashboards.
-# Compativel com LGPD/GDPR pra metricas agregadas. Requer goaccess >= 1.7.
-anonymize-ip true
+# anonymize-ip removido: ele suprime a lista de user-agents por IP no
+# dashboard (medida anti-reidentificacao do goaccess). Trade-off:
+#  - IPs completos aparecem agora no painel "Visitor Hostnames and IPs"
+#  - Em troca, e' possivel expandir cada IP e ver os user-agents
+# Mitigacoes mantidas:
+#  - Dashboard atras de basic-auth (so admin acessa)
+#  - access.log nativo do nginx ja contem IPs completos (pre-existente)
+#  - /_traffic/raw tambem expoe IPs completos (mesmo escopo de acesso)
+# Pra anonimizar de novo no futuro: 'anonymize-ip true' (custa a feature
+# de ver UAs).


### PR DESCRIPTION
## Sintoma

Clicar nas linhas do painel "Visitor Hostnames and IPs" no dashboard `/_traffic/` não expandia nada, mesmo com `agent-list true` no config.

## Causa

GoAccess **suprime** a lista de user-agents (`items` array no JSON) quando `anonymize-ip` está ativo. Medida anti-reidentificação upstream — a combinação "UA específico + IP anonimizado parcialmente" ainda poderia identificar usuário único.

Confirmado empiricamente:

```bash
# Mesmo access.log, mesma config exceto anonymize:
goaccess ... --agent-list -o test1.html       # items: [...] presente
goaccess ... --agent-list --anonymize-ip ...  # items: ausente
```

## Fix

Remove `anonymize-ip true` do `cruza-goaccess.conf`.

## Trade-off

| | Antes | Depois |
|---|---|---|
| IPs no painel Hosts | `216.73.217.0` (anonimizado) | `216.73.217.47` (completo) |
| Painel expansível com UAs | ❌ Vazio | ✅ Funciona |

## Mitigações de privacidade mantidas

- Dashboard atrás de basic-auth (só admin acessa)
- `access.log` nativo do nginx já tem IPs completos (não muda)
- `/_traffic/raw` já expõe IPs completos (mesmo escopo de acesso)
- Sem cookies, sem fingerprinting; só dados que já existem em outros logs

## Validação

Hotpatch já em prod via SSH:

```
rows=50 com_items=50
first IP: 216.73.217.47
UAs (1): Mozilla/5.0 ... ClaudeBot/1.0 ...
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
