### PR TITLE
fix(nginx): proxy /_traffic/analytics em vez de 308 redirect (loop com Next.js basePath)

### DIFF
--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -277,13 +277,29 @@ server {
     # /_traffic/analytics/. Mantemos rate limit em todas as locations.
 
     # /_traffic/analytics (sem trailing slash) NAO bate no prefix
-    # /_traffic/analytics/ — sem este redirect, a request cairia no
-    # location /_traffic/ abaixo (proxy do GoAccess) e o usuario veria HTML
-    # errado. nginx nao faz redirect automatico /x -> /x/ para proxy_pass
-    # (so faz pra diretorios de filesystem). 308 preserva method+body
-    # (relevante caso algum link interno do Umami chegue aqui).
+    # /_traffic/analytics/ — se nao tratado, cairia no location /_traffic/
+    # abaixo (proxy do GoAccess).
+    #
+    # Tentamos `return 308 /_traffic/analytics/` (com barra) na primeira
+    # iteracao, mas Next.js v16 com basePath usa trailingSlash:false como
+    # canonical: ao acessar /_traffic/analytics/ ele 308-redirect pra
+    # /_traffic/analytics (sem barra). Combinacao = REDIRECT LOOP infinito
+    # (browser aborta apos N redirects, vendo apenas o 308 final no log).
+    #
+    # Fix: tratar /_traffic/analytics como rota legitima do dashboard
+    # (proxy direto pro Umami, mesma config admin com basic-auth). Umami
+    # com basePath responde corretamente nessa URL canonica.
     location = /_traffic/analytics {
-        return 308 /_traffic/analytics/;
+        auth_basic "Restricted — Analytics admin";
+        auth_basic_user_file /etc/nginx/.htpasswd-traffic;
+        limit_req zone=general burst=30 nodelay;
+        limit_conn perip 8;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
     }
 
     # Tracker JS — publico (carregado pelo <script> em web/templates/base.html).


### PR DESCRIPTION
Login do Umami funcionava mas dashboard nao carregava — redirect loop com o 308 /_traffic/analytics -> /_traffic/analytics/ que adicionei no #73. Detalhes na commit message.