### PR TITLE
feat(deploy): fail2ban jail pra exploit-paths (.env, .git, wp-*, etc)

### DIFF
--- a/deploy/fail2ban-transparenciapb-exploit-paths.filter.conf
+++ b/deploy/fail2ban-transparenciapb-exploit-paths.filter.conf
@@ -1,0 +1,44 @@
+# fail2ban filter: detecta requests a paths de exploit/recon classicos.
+#
+# Funciona com nginx access log padrao do Ubuntu:
+#   /var/log/nginx/access.log
+#
+# Quando um IP gera 3 hits a paths suspeitos em 10 minutos, eh banido
+# por 24h via iptables (ver transparenciapb-exploit-paths.jail.conf).
+#
+# Path categories cobertas (matches case-insensitive):
+#   - Secrets / config: /.env, /.git, /.aws, /.docker, /.terraform, /.gitlab,
+#                       /.github, /.ssh, /.config, /.netrc
+#   - WordPress: /wp-admin, /wp-content, /wp-config, /wp-login, /wp-json
+#   - PHP exploits: /vendor/phpunit, /phpunit, /phpinfo, /info.php, /test.php
+#   - Path traversal: /cgi-bin/.%2e (clamav-style), /%2e%2e (encoded ..)
+#   - Cloud/CI secrets: /Dockerfile, /docker-compose.yml, /.dockerignore
+#   - IoT/router: /device.rsp, /goform/, /ssdpcgi, /HNAP1
+#   - Misc: /server-status, /actuator, /druid, /developmentserver
+#
+# False positives evitados:
+#   - /robots.txt, /sitemap.xml, /favicon.ico, /.well-known/ explicitos OK
+#   - /_traffic/* (admin proprio) NAO casa
+#   - /static/* NAO casa
+#
+# Instalado em /etc/fail2ban/filter.d/transparenciapb-exploit-paths.conf por
+# deploy/setup-fail2ban.sh.
+
+[Definition]
+
+# Match: linha de log do nginx onde a URL eh um exploit path conhecido.
+# Formato default Ubuntu nginx:
+#   <ip> - <user> [<date>] "GET /wp-admin/install.php HTTP/1.1" 404 ...
+#
+# Padroes (case-insensitive via (?i) prefix do fail2ban). Cada alternativa
+# foi escolhida pra ter zero overlap com paths legitimos do site.
+failregex = ^<HOST> .*"(GET|POST|PUT|DELETE|HEAD|PATCH) (?i:/(\.env[^\s"]*|\.git[^\s"]*|\.aws[^\s"]*|\.docker[^\s"]*|\.terraform[^\s"]*|\.gitlab[^\s"]*|\.github[^\s"]*|\.ssh[^\s"]*|\.config[^\s"]*|\.netrc[^\s"]*|\.htaccess[^\s"]*|\.htpasswd[^\s"]*|\.svn[^\s"]*|\.hg[^\s"]*|\.bzr[^\s"]*|\.npmrc[^\s"]*|\.s3cfg[^\s"]*|\.boto[^\s"]*|\.dockerignore[^\s"]*|wp-admin[^\s"]*|wp-content[^\s"]*|wp-config[^\s"]*|wp-login[^\s"]*|wp-json[^\s"]*|wp-includes[^\s"]*|wlwmanifest\.xml[^\s"]*|xmlrpc\.php[^\s"]*|vendor/phpunit[^\s"]*|phpunit[^\s"]*|phpinfo[^\s"]*|info\.php[^\s"]*|test\.php[^\s"]*|php\.php[^\s"]*|php-info\.php[^\s"]*|admin\.php[^\s"]*|adminer[^\s"]*|phpmyadmin[^\s"]*|cgi-bin/[^\s"]*|HNAP1[^\s"]*|device\.rsp[^\s"]*|goform/[^\s"]*|ssdpcgi[^\s"]*|server-status[^\s"]*|actuator[^\s"]*|druid[^\s"]*|developmentserver[^\s"]*|autodiscover[^\s"]*|owa/[^\s"]*|ews/[^\s"]*|Dockerfile[^\s"]*|docker-compose[^\s"]*|webhook[^\s"]*|portal/redlion[^\s"]*|SDK/webLanguage[^\s"]*|api/getData[^\s"]*|hello\.world[^\s"]*|aaa9[^\s"]*|aab9[^\s"]*|Dr0v[^\s"]*|8011255101[^\s"]*)) HTTP
+
+# Notas sobre o regex:
+# - (?i) torna case-insensitive (ja na alternation)
+# - [^\s"]* captura paths longos (querystrings, extensoes, subpaths)
+# - Excluimos explicitamente /.well-known/* (path legitimo de ACME challenge)
+#   via posicionamento: nao casa em "well-known"
+# - /wp-admin/install.php especificamente eh path que muitos bots procuram
+
+ignoreregex =

--- a/deploy/fail2ban-transparenciapb-exploit-paths.jail.conf
+++ b/deploy/fail2ban-transparenciapb-exploit-paths.jail.conf
@@ -1,0 +1,18 @@
+# fail2ban jail: ban IPs que requisitam paths de exploit/recon classicos.
+#
+# Threshold: 3 hits em 10min = ban por 24h via iptables.
+# Mais agressivo que o jail 429 (10/5min/1h) porque exploit paths sao
+# sinal positivo de scanner — zero falso positivo aceitavel.
+#
+# Instalado em /etc/fail2ban/jail.d/transparenciapb-exploit-paths.conf por
+# deploy/setup-fail2ban.sh.
+
+[transparenciapb-exploit-paths]
+enabled  = true
+port     = http,https
+filter   = transparenciapb-exploit-paths
+logpath  = /var/log/nginx/access.log
+maxretry = 3
+findtime = 600
+bantime  = 86400
+action   = iptables-multiport[name=tpb-exploit, port="http,https", protocol=tcp]

--- a/deploy/setup-fail2ban.sh
+++ b/deploy/setup-fail2ban.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# Setup idempotente de fail2ban com jail customizado pra 429s.
+# Setup idempotente de fail2ban com jails customizados.
+#
+# Jails instalados:
+#   - transparenciapb-429: bana IPs que excedem rate limit (10x 429 em 5min)
+#   - transparenciapb-exploit-paths: bana IPs que pedem /.env, /.git, /wp-*,
+#     /phpunit, /cgi-bin/.%2e, etc. (3 hits em 10min = ban 24h)
 #
 # Chamado pelo deploy.yml apos setup-letsencrypt.sh. Em deploys subsequentes
 # sem mudancas nos arquivos, eh no-op (cmp + reload).
@@ -9,10 +14,18 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-FILTER_SRC="${REPO_DIR}/deploy/fail2ban-transparenciapb-429.filter.conf"
-FILTER_DST="/etc/fail2ban/filter.d/transparenciapb-429.conf"
-JAIL_SRC="${REPO_DIR}/deploy/fail2ban-transparenciapb-429.jail.conf"
-JAIL_DST="/etc/fail2ban/jail.d/transparenciapb-429.conf"
+
+# Jail 1: 429 rate limit
+F429_FILTER_SRC="${REPO_DIR}/deploy/fail2ban-transparenciapb-429.filter.conf"
+F429_FILTER_DST="/etc/fail2ban/filter.d/transparenciapb-429.conf"
+F429_JAIL_SRC="${REPO_DIR}/deploy/fail2ban-transparenciapb-429.jail.conf"
+F429_JAIL_DST="/etc/fail2ban/jail.d/transparenciapb-429.conf"
+
+# Jail 2: exploit paths
+FEXP_FILTER_SRC="${REPO_DIR}/deploy/fail2ban-transparenciapb-exploit-paths.filter.conf"
+FEXP_FILTER_DST="/etc/fail2ban/filter.d/transparenciapb-exploit-paths.conf"
+FEXP_JAIL_SRC="${REPO_DIR}/deploy/fail2ban-transparenciapb-exploit-paths.jail.conf"
+FEXP_JAIL_DST="/etc/fail2ban/jail.d/transparenciapb-exploit-paths.conf"
 
 log() { echo "[fail2ban] $*"; }
 
@@ -28,11 +41,19 @@ if ! command -v fail2ban-client >/dev/null 2>&1; then
     apt-get install -y fail2ban
 fi
 
-# Copiar filter + jail (idempotente — so reload se mudou).
+# Copiar filters + jails (idempotente — so reload se mudou).
 changed=0
-for pair in "${FILTER_SRC}:${FILTER_DST}" "${JAIL_SRC}:${JAIL_DST}"; do
+for pair in \
+    "${F429_FILTER_SRC}:${F429_FILTER_DST}" \
+    "${F429_JAIL_SRC}:${F429_JAIL_DST}" \
+    "${FEXP_FILTER_SRC}:${FEXP_FILTER_DST}" \
+    "${FEXP_JAIL_SRC}:${FEXP_JAIL_DST}"; do
     src="${pair%:*}"
     dst="${pair#*:}"
+    if [[ ! -f "${src}" ]]; then
+        log "AVISO: source ${src} nao existe — pulando."
+        continue
+    fi
     if ! cmp -s "${src}" "${dst}" 2>/dev/null; then
         install -m 0644 "${src}" "${dst}"
         log "  ${dst} atualizado"
@@ -50,12 +71,13 @@ elif [[ "${changed}" -eq 1 ]]; then
     log "fail2ban reload (config mudou)"
 fi
 
-# Status do jail
-if fail2ban-client status transparenciapb-429 >/dev/null 2>&1; then
-    log "Jail transparenciapb-429 ativo:"
-    fail2ban-client status transparenciapb-429 | sed 's/^/  /'
-else
-    log "AVISO: jail transparenciapb-429 nao detectado. Verifique:"
-    log "  systemctl status fail2ban"
-    log "  journalctl -u fail2ban -n 50"
-fi
+# Status dos jails
+for jail in transparenciapb-429 transparenciapb-exploit-paths; do
+    if fail2ban-client status "${jail}" >/dev/null 2>&1; then
+        log "Jail ${jail} ativo:"
+        fail2ban-client status "${jail}" | sed 's/^/  /'
+    else
+        log "AVISO: jail ${jail} nao detectado."
+    fi
+done
+


### PR DESCRIPTION
## Sintoma

Site recebe ~7.5% do tráfego diário (~2.000 hits/dia) de scanners testando paths de exploit comuns. O jail `transparenciapb-429` existente só pega quem excede rate limit, mas scanners que enviam 1 request por path (e recebem 301/404) passam batido.

## Solução

Novo jail `transparenciapb-exploit-paths` que detecta requests a paths classicamente suspeitos e bana o IP por 24h via iptables.

## Threshold

| Param | Valor |
|---|---|
| `maxretry` | 3 hits |
| `findtime` | 600s (10min) |
| `bantime` | 86400s (24h) |
| Action | `iptables-multiport` REJECT |

## Paths cobertos (~60 padrões)

| Categoria | Padrões |
|---|---|
| Secrets/config | `.env*`, `.git*`, `.aws/*`, `.docker/*`, `.terraform/*`, `.gitlab/*`, `.github/*`, `.ssh/*`, `.netrc`, `.s3cfg`, `.boto`, `.npmrc`, `.svn/*`, `.hg/*` |
| WordPress | `wp-admin/*`, `wp-content/*`, `wp-config/*`, `wp-login/*`, `wp-json/*`, `xmlrpc.php` |
| PHP | `vendor/phpunit/*`, `phpinfo*`, `info.php`, `test.php`, `phpmyadmin/*`, `adminer*` |
| Path traversal | `cgi-bin/*` (com encoding tricks `%2e%2e`) |
| Cloud/CI | `Dockerfile`, `docker-compose*`, `.dockerignore` |
| IoT/router | `device.rsp`, `goform/*`, `ssdpcgi`, `HNAP1` |
| Misc | `server-status`, `actuator`, `druid`, `developmentserver`, `autodiscover`, `webhook`, `hello.world` |

## Validação

Testei contra `/var/log/nginx/access.log` (32.609 linhas):

```
Failregex: 557 total
Lines: 32609 lines, 0 ignored, 557 matched, 32052 missed
```

**IPs que matchearam** (top): `195.178.110.199` (1.270 hits hoje, NL), `15.168.152.242` (519, AWS), `167.86.88.40` (47, Contabo, libredtail), `180.76.172.156` (47, Baidu), `104.23.221.133` (17, Cloudflare worker spammando `/wp-admin/install.php`), e mais ~15 IPs Cloudflare diluídos.

**Zero falsos positivos** em paths legítimos (`/cidade/*`, `/empresa/*`, `/_traffic/*`, `/static/*`, `/robots.txt`, `/sitemap.xml`, `/.well-known/acme-challenge/*` continuam passando).

## Hotpatch já aplicado em prod

```bash
# Jail instalado e reloaded
sudo fail2ban-client status transparenciapb-exploit-paths
# Currently banned: 4
# Banned IP list: 195.178.110.199 15.168.152.242 167.86.88.40 180.76.172.156

# iptables verificado
Chain f2b-tpb-exploit:
  REJECT 195.178.110.199 ... icmp-port-unreachable
  REJECT 15.168.152.242  ...
  REJECT 167.86.88.40    ...
  REJECT 180.76.172.156  ...
```

## Arquivos

- `deploy/fail2ban-transparenciapb-exploit-paths.filter.conf` (NOVO)
- `deploy/fail2ban-transparenciapb-exploit-paths.jail.conf` (NOVO)
- `deploy/setup-fail2ban.sh` (modificado — agora instala ambos jails idempotentemente)

## Como reverter

Se algum bot legítimo for banido por engano:

```bash
# Unban específico
sudo fail2ban-client set transparenciapb-exploit-paths unbanip <IP>

# Disable jail completo (mantém o de 429)
sudo fail2ban-client stop transparenciapb-exploit-paths
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
