### PR TITLE
feat(deploy): jail recidive — bana repeat offenders por 1 semana

### DIFF
--- a/deploy/fail2ban-recidive.jail.conf
+++ b/deploy/fail2ban-recidive.jail.conf
@@ -1,0 +1,25 @@
+# fail2ban jail: recidive — bana IPs que sao banidos repetidamente em
+# outros jails.
+#
+# Funciona como meta-jail: monitora /var/log/fail2ban.log e detecta IPs
+# que aparecem em N "Ban" actions dentro de uma janela. Util pra atacantes
+# persistentes que esperam o ban expirar e voltam (ex: SSH brute force que
+# bate, espera 10min, volta, repete).
+#
+# Threshold conservador: 3 bans em 24h = ban 1 semana via iptables (todas
+# portas TCP).
+#
+# Usa o filter "recidive" ja distribuido com fail2ban
+# (/etc/fail2ban/filter.d/recidive.conf), nao precisa de filter customizado.
+#
+# Instalado em /etc/fail2ban/jail.d/recidive.conf por
+# deploy/setup-fail2ban.sh.
+
+[recidive]
+enabled  = true
+filter   = recidive
+logpath  = /var/log/fail2ban.log
+maxretry = 3
+findtime = 86400
+bantime  = 604800
+action   = iptables-allports[name=tpb-recidive, protocol=tcp]

--- a/deploy/setup-fail2ban.sh
+++ b/deploy/setup-fail2ban.sh
@@ -5,6 +5,8 @@
 #   - transparenciapb-429: bana IPs que excedem rate limit (10x 429 em 5min)
 #   - transparenciapb-exploit-paths: bana IPs que pedem /.env, /.git, /wp-*,
 #     /phpunit, /cgi-bin/.%2e, etc. (3 hits em 10min = ban 24h)
+#   - recidive: meta-jail que bana repeat offenders de qualquer outro jail
+#     (3 bans em 24h = ban 1 semana em todas as portas)
 #
 # Chamado pelo deploy.yml apos setup-letsencrypt.sh. Em deploys subsequentes
 # sem mudancas nos arquivos, eh no-op (cmp + reload).
@@ -27,6 +29,12 @@ FEXP_FILTER_DST="/etc/fail2ban/filter.d/transparenciapb-exploit-paths.conf"
 FEXP_JAIL_SRC="${REPO_DIR}/deploy/fail2ban-transparenciapb-exploit-paths.jail.conf"
 FEXP_JAIL_DST="/etc/fail2ban/jail.d/transparenciapb-exploit-paths.conf"
 
+# Jail 3: recidive (meta — bana repeat offenders de outros jails)
+# Filter eh standard do fail2ban (/etc/fail2ban/filter.d/recidive.conf),
+# so precisamos do jail config.
+FREC_JAIL_SRC="${REPO_DIR}/deploy/fail2ban-recidive.jail.conf"
+FREC_JAIL_DST="/etc/fail2ban/jail.d/recidive.conf"
+
 log() { echo "[fail2ban] $*"; }
 
 if [[ "${EUID}" -ne 0 ]]; then
@@ -47,7 +55,8 @@ for pair in \
     "${F429_FILTER_SRC}:${F429_FILTER_DST}" \
     "${F429_JAIL_SRC}:${F429_JAIL_DST}" \
     "${FEXP_FILTER_SRC}:${FEXP_FILTER_DST}" \
-    "${FEXP_JAIL_SRC}:${FEXP_JAIL_DST}"; do
+    "${FEXP_JAIL_SRC}:${FEXP_JAIL_DST}" \
+    "${FREC_JAIL_SRC}:${FREC_JAIL_DST}"; do
     src="${pair%:*}"
     dst="${pair#*:}"
     if [[ ! -f "${src}" ]]; then
@@ -72,7 +81,7 @@ elif [[ "${changed}" -eq 1 ]]; then
 fi
 
 # Status dos jails
-for jail in transparenciapb-429 transparenciapb-exploit-paths; do
+for jail in transparenciapb-429 transparenciapb-exploit-paths recidive; do
     if fail2ban-client status "${jail}" >/dev/null 2>&1; then
         log "Jail ${jail} ativo:"
         fail2ban-client status "${jail}" | sed 's/^/  /'


### PR DESCRIPTION
feat(deploy): jail recidive — bana repeat offenders por 1 semana

Adiciona terceiro jail no fail2ban: 'recidive' (meta-jail) que monitora
o proprio /var/log/fail2ban.log e bana IPs que aparecem em multiplas
acoes "Ban" dentro de uma janela.

## Motivacao

Hoje detectei 209.166.46.135 fazendo 763 tentativas de SSH brute force
no dia, em loop perfeito: o jail sshd default bana por 10min, IP espera
e volta. 25 bans + 21 unbans em 16h.

O recidive resolve isso: 3 bans em 24h pelo MESMO IP em qualquer jail
(sshd, exploit-paths, 429) = ban de 1 semana em TODAS as portas TCP
via iptables-allports.

## Threshold

| Param | Valor | Racional |
|---|---|---|
| maxretry | 3 | 3 bans = padrao malicioso confirmado |
| findtime | 86400 (24h) | janela ampla pra pegar repeat offenders |
| bantime | 604800 (7 dias) | suficiente pra desencorajar reagendamento |
| action | iptables-allports | bloqueia TODAS portas (nao so http/https) |

## Implementacao

- deploy/fail2ban-recidive.jail.conf (NOVO): jail config
- deploy/setup-fail2ban.sh: instala o jail (filter recidive ja vem com
  fail2ban via /etc/fail2ban/filter.d/recidive.conf)

## Hotpatch aplicado

```
sudo fail2ban-client set recidive banip 209.166.46.135
# iptables verificado:
Chain f2b-tpb-recidive:
  REJECT 209.166.46.135 ... icmp-port-unreachable
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
