### PR TITLE
feat(deploy): expande exploit-paths filter — SAML/Jira + VPN gateways

### DIFF
--- a/deploy/fail2ban-transparenciapb-exploit-paths.filter.conf
+++ b/deploy/fail2ban-transparenciapb-exploit-paths.filter.conf
@@ -14,6 +14,11 @@
 #   - Path traversal: /cgi-bin/.%2e (clamav-style), /%2e%2e (encoded ..)
 #   - Cloud/CI secrets: /Dockerfile, /docker-compose.yml, /.dockerignore
 #   - IoT/router: /device.rsp, /goform/, /ssdpcgi, /HNAP1
+#   - SAML/SSO exploit (Atlassian/Jira): /SamlResponseServlet, /samlLogin,
+#                       /rest/api/v1/version, /api/v3/version
+#   - VPN gateways: /CSCOSSLC/, /sslvpnclient, /global-protect/,
+#                       /dana-na/ (Ivanti/Pulse), /+CSCOE+/ (Cisco WebVPN),
+#                       /sonicui/, /remote/login, /remote/fgt_lang (Fortinet)
 #   - Misc: /server-status, /actuator, /druid, /developmentserver
 #
 # False positives evitados:
@@ -32,7 +37,7 @@
 #
 # Padroes (case-insensitive via (?i) prefix do fail2ban). Cada alternativa
 # foi escolhida pra ter zero overlap com paths legitimos do site.
-failregex = ^<HOST> .*"(GET|POST|PUT|DELETE|HEAD|PATCH) (?i:/(\.env[^\s"]*|\.git[^\s"]*|\.aws[^\s"]*|\.docker[^\s"]*|\.terraform[^\s"]*|\.gitlab[^\s"]*|\.github[^\s"]*|\.ssh[^\s"]*|\.config[^\s"]*|\.netrc[^\s"]*|\.htaccess[^\s"]*|\.htpasswd[^\s"]*|\.svn[^\s"]*|\.hg[^\s"]*|\.bzr[^\s"]*|\.npmrc[^\s"]*|\.s3cfg[^\s"]*|\.boto[^\s"]*|\.dockerignore[^\s"]*|wp-admin[^\s"]*|wp-content[^\s"]*|wp-config[^\s"]*|wp-login[^\s"]*|wp-json[^\s"]*|wp-includes[^\s"]*|wlwmanifest\.xml[^\s"]*|xmlrpc\.php[^\s"]*|vendor/phpunit[^\s"]*|phpunit[^\s"]*|phpinfo[^\s"]*|info\.php[^\s"]*|test\.php[^\s"]*|php\.php[^\s"]*|php-info\.php[^\s"]*|admin\.php[^\s"]*|adminer[^\s"]*|phpmyadmin[^\s"]*|cgi-bin/[^\s"]*|HNAP1[^\s"]*|device\.rsp[^\s"]*|goform/[^\s"]*|ssdpcgi[^\s"]*|server-status[^\s"]*|actuator[^\s"]*|druid[^\s"]*|developmentserver[^\s"]*|autodiscover[^\s"]*|owa/[^\s"]*|ews/[^\s"]*|Dockerfile[^\s"]*|docker-compose[^\s"]*|webhook[^\s"]*|portal/redlion[^\s"]*|SDK/webLanguage[^\s"]*|api/getData[^\s"]*|hello\.world[^\s"]*|aaa9[^\s"]*|aab9[^\s"]*|Dr0v[^\s"]*|8011255101[^\s"]*)) HTTP
+failregex = ^<HOST> .*"(GET|POST|PUT|DELETE|HEAD|PATCH) (?i:/(\.env[^\s"]*|\.git[^\s"]*|\.aws[^\s"]*|\.docker[^\s"]*|\.terraform[^\s"]*|\.gitlab[^\s"]*|\.github[^\s"]*|\.ssh[^\s"]*|\.config[^\s"]*|\.netrc[^\s"]*|\.htaccess[^\s"]*|\.htpasswd[^\s"]*|\.svn[^\s"]*|\.hg[^\s"]*|\.bzr[^\s"]*|\.npmrc[^\s"]*|\.s3cfg[^\s"]*|\.boto[^\s"]*|\.dockerignore[^\s"]*|wp-admin[^\s"]*|wp-content[^\s"]*|wp-config[^\s"]*|wp-login[^\s"]*|wp-json[^\s"]*|wp-includes[^\s"]*|wlwmanifest\.xml[^\s"]*|xmlrpc\.php[^\s"]*|vendor/phpunit[^\s"]*|phpunit[^\s"]*|phpinfo[^\s"]*|info\.php[^\s"]*|test\.php[^\s"]*|php\.php[^\s"]*|php-info\.php[^\s"]*|admin\.php[^\s"]*|adminer[^\s"]*|phpmyadmin[^\s"]*|cgi-bin/[^\s"]*|HNAP1[^\s"]*|device\.rsp[^\s"]*|goform/[^\s"]*|ssdpcgi[^\s"]*|server-status[^\s"]*|actuator[^\s"]*|druid[^\s"]*|developmentserver[^\s"]*|autodiscover[^\s"]*|owa/[^\s"]*|ews/[^\s"]*|Dockerfile[^\s"]*|docker-compose[^\s"]*|webhook[^\s"]*|portal/redlion[^\s"]*|SDK/webLanguage[^\s"]*|api/getData[^\s"]*|hello\.world[^\s"]*|aaa9[^\s"]*|aab9[^\s"]*|Dr0v[^\s"]*|8011255101[^\s"]*|SamlResponseServlet[^\s"]*|samlLogin[^\s"]*|rest/api/[^\s"]*/version[^\s"]*|api/v[0-9]+/version[^\s"]*|CSCOSSLC[^\s"]*|sslvpnclient[^\s"]*|global-protect[^\s"]*|dana-na[^\s"]*|\+CSCOE\+[^\s"]*|sonicui[^\s"]*|remote/login[^\s"]*|remote/fgt_lang[^\s"]*|fgt_lang[^\s"]*|portal/SessionEvents[^\s"]*)) HTTP
 
 # Notas sobre o regex:
 # - (?i) torna case-insensitive (ja na alternation)


### PR DESCRIPTION
feat(deploy): expande exploit-paths filter — SAML/Jira + VPN gateways

Adiciona padroes ao jail transparenciapb-exploit-paths pra cobrir
2 categorias de scanner observadas em prod hoje mas nao banidas:

## Atlassian/Jira SAML scanners
- `/SamlResponseServlet` (Jira/Confluence SAML callback)
- `/samlLogin`
- `/rest/api/v[N]/version` (Atlassian REST API version probe)
- `/api/v[N]/version` (generic API version probe)

IP exemplo: 213.108.3.46 (42 hits hoje, 40 × HTTP 400, single hour)

## VPN/SSL gateway exploit scanners
- `/CSCOSSLC/` (Cisco AnyConnect SSL VPN)
- `/+CSCOE+/` (Cisco WebVPN)
- `/sslvpnclient`
- `/global-protect/` (Palo Alto GlobalProtect)
- `/dana-na/` (Ivanti/Pulse Secure Connect)
- `/sonicui/` (SonicWall)
- `/remote/login`, `/remote/fgt_lang`, `/fgt_lang` (Fortinet)
- `/portal/SessionEvents` (Citrix/F5)

IP exemplo: 91.199.163.144 (10 hits hoje, probe completo de gateways)

## Validacao

Testado contra /var/log/nginx/access.log (40.965 linhas):
- Antes: 557 matches
- Depois: 619 matches (+62)
- 213.108.3.46: 39 matches ✓
- 91.199.163.144: 6 matches ✓
- Nenhum IP legitimo (Googlebot, Bingbot, ClaudeBot, etc.) bate no
  regex novo

## Hotpatch ja aplicado

```
sudo fail2ban-client status transparenciapb-exploit-paths
# Banned: 195.178.110.199 15.168.152.242 167.86.88.40 180.76.172.156
#         213.108.3.46 91.199.163.144  ← novos
```

Total 6 IPs banidos via iptables REJECT.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
