### PR TITLE
feat(seo): cache persistente de sitemaps em web_cache + warm phase

### DIFF
--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -72,15 +72,20 @@ _SITEMAP_CACHE: dict[str, Any] = {
 # Naming convention das keys L2 (em web_cache.municipio column):
 #   '<scope>-urlset'        -> sitemap unico (sem shards)
 #   '<scope>-shard:N'       -> shard N de sitemap shardado
-#   'root-index'            -> sitemap-index top-level que agrega tudo
 #
 # Mapping L1 (bucket names acima) -> L2 (keys em web_cache):
-#   _SITEMAP_CACHE["index"]                  -> "root-index"
+#   _SITEMAP_CACHE["index"]                  -> [L1 apenas, nao em L2 *]
 #   _SITEMAP_CACHE["cidades"]                -> "cidades-urlset"
 #   _SITEMAP_CACHE["empresas"][N]            -> "empresas-shard:N"
 #   _SITEMAP_CACHE["empresas_municipios"][N] -> "empresas-municipios-shard:N"
 #   _SITEMAP_CACHE["licitacoes"][N]          -> "licitacoes-shard:N"
 #   _SITEMAP_CACHE["cidade_resumo"]          -> "cidade-resumo-urlset"
+#
+# (*) root-index NAO eh persistido em L2 porque (a) build eh barato
+# (<50ms, sem queries pesadas) e (b) o XML reflete as flags
+# SITEMAP_INCLUDE_* ATUAIS do processo runtime — cachear flags=1 do
+# warmer e servir pra processo com flags=0 seria cache poisoning.
+# (HIGH GPT-5.5 round 4 PR #85.)
 #
 # Warmer (`web/warm_cache.py:_warm_sitemaps_phase`) pre-popula todos os
 # entries L2 ao fim do warm cycle. invalidate_cache_keys=SITEMAP_XML
@@ -567,20 +572,22 @@ async def sitemap_xml(request: Request) -> Response:
             media_type="application/xml",
             headers={"Cache-Control": "public, max-age=3600"},
         )
-    # L2: web_cache (PG) — sobrevive restart. NAO persiste em L2 aqui:
-    # o XML do index eh gerado com origin derivado de request headers
-    # (X-Forwarded-Host pode ser cliente-injetado). Persistencia em L2
-    # fica restrita ao warmer (SITE_ORIGIN env controlado) pra evitar
-    # cache poisoning (P1 GPT 5.5 PR #85).
-    pg_xml = _sitemap_pg_read("root-index")
-    if pg_xml:
-        # Hidrata L1 com versao persistida (origin canonico do warmer).
-        _SITEMAP_CACHE["index"] = {"ts": now, "xml": pg_xml}
-        return Response(
-            content=pg_xml,
-            media_type="application/xml",
-            headers={"Cache-Control": "public, max-age=3600"},
-        )
+    # NOTA: root-index NAO usa L2 (web_cache) por dois motivos:
+    #
+    # 1. _build_sitemap_index eh barato (<50ms — apenas string concat de
+    #    URLs dos sub-sitemaps, sem queries pesadas). Diferente dos shards
+    #    que carregam 8-9MB de XML, o index nao tem o problema de cold
+    #    timeout que motivou o L2 cache em primeiro lugar.
+    #
+    # 2. O XML do index reflete as flags SITEMAP_INCLUDE_EMPRESAS/
+    #    LICITACOES/CIDADE_RESUMO ATUAIS do processo cruza-web. Cachear em
+    #    L2 (escrito com todas as flags=1 pelo warmer pra pre-gerar)
+    #    faria a rota servir um index com families que o processo runtime
+    #    tem desabilitadas via drop-in systemd — cache poisoning entre
+    #    warmer flags e route flags. (HIGH GPT-5.5 round 4 PR #85.)
+    #
+    # L1 in-memory continua ativo com anti-cache parcial (is_complete
+    # check abaixo) que respeita flags. L3 build live cobre cold start.
 
     xml = _build_sitemap_index(origin)
     # Anti-cache parcial: nao cachear sitemap-index quando uma flag
@@ -602,7 +609,7 @@ async def sitemap_xml(request: Request) -> Response:
     )
     if is_complete:
         _SITEMAP_CACHE["index"] = {"ts": now, "xml": xml}
-        # L2 nao escrita aqui — apenas warmer (vide comentario acima).
+        # L2 NAO escrita aqui (vide comentario acima — root-index nunca em L2).
     else:
         _log.warning(
             "Sitemap-index parcial (flags emp=%s lic=%s res=%s; has emp=%s lic=%s res=%s) — nao cacheando",

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -59,6 +59,94 @@ _SITEMAP_CACHE: dict[str, Any] = {
     "cidade_resumo": {"ts": 0.0, "xml": ""},
 }
 
+# ─── Persistencia em web_cache (L2 cache) ───
+# Resolve "Couldn't fetch" reportado no GSC pos-restart do cruza-web:
+# o _SITEMAP_CACHE acima eh in-memory (L1) e nao sobrevive a restart;
+# primeiro hit pos-restart pagava ~20s de build live (8-9MB XML por shard),
+# que GSC marca como timeout. Agora cache eh 2-camadas:
+#
+#   L1 = _SITEMAP_CACHE (in-memory, 24h TTL, fast lookup)
+#   L2 = web_cache table (PG, sem TTL, sobrevive restart)
+#   L3 = build live (fallback)
+#
+# Naming convention das keys L2 (em web_cache.municipio column):
+#   '<scope>-urlset'        -> sitemap unico (sem shards)
+#   '<scope>-shard:N'       -> shard N de sitemap shardado
+#   'root-index'            -> sitemap-index top-level que agrega tudo
+#
+# Mapping L1 (bucket names acima) -> L2 (keys em web_cache):
+#   _SITEMAP_CACHE["index"]                  -> "root-index"
+#   _SITEMAP_CACHE["cidades"]                -> "cidades-urlset"
+#   _SITEMAP_CACHE["empresas"][N]            -> "empresas-shard:N"
+#   _SITEMAP_CACHE["empresas_municipios"][N] -> "empresas-municipios-shard:N"
+#   _SITEMAP_CACHE["licitacoes"][N]          -> "licitacoes-shard:N"
+#   _SITEMAP_CACHE["cidade_resumo"]          -> "cidade-resumo-urlset"
+#
+# Warmer (`web/warm_cache.py:_warm_sitemaps_phase`) pre-popula todos os
+# entries L2 ao fim do warm cycle. invalidate_cache_keys=SITEMAP_XML
+# em deploy.yml limpa L2 (forca re-geracao no proximo warm).
+_SITEMAP_CACHE_QUERY_ID = "SITEMAP_XML"
+
+
+def _sitemap_pg_read(key: str) -> str | None:
+    """Tenta ler XML do web_cache (L2). Retorna None em falha/ausencia.
+
+    NOTA: db.read_web_cache retorna sentinel CACHE_ERROR em DB error
+    (PR #181) que eh iteravel e desempacota como ([], []). Nesse caso
+    `rows[0]` levanta IndexError implicitamente nao — `rows and rows[0]`
+    eh False, retornamos None. Resultado: DB error vira "cache miss",
+    rota cai em L3 (build live). Tradeoff aceitavel — alternativa seria
+    503 explicito mas sitemaps publicos nao deveriam retornar 503.
+    """
+    cached = db.read_web_cache(_SITEMAP_CACHE_QUERY_ID, key)
+    # Trata CACHE_ERROR (DB error) e None (cache miss) igualmente: None.
+    if cached is None or cached is db.CACHE_ERROR:
+        return None
+    _cols, rows = cached
+    if rows and rows[0] and isinstance(rows[0][0], str):
+        return rows[0][0]
+    return None
+
+
+def _sitemap_pg_write(key: str, xml: str) -> bool:
+    """Persiste XML no web_cache (L2). Retorna True em sucesso, False em erro.
+
+    IMPORTANTE: caller deve verificar o retorno. Falha aqui significa que
+    a rota servindo o sitemap vai precisar rebuilder live no proximo hit —
+    degradacao aceitavel, nao site-down.
+
+    L1 (_SITEMAP_CACHE in-memory) eh atualizado pelo caller (rota), nao
+    aqui — quem chama isto ja tem acesso ao XML pra escrever em ambos.
+    """
+    try:
+        import json as _json
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO web_cache (query_id, municipio, columns, rows, row_count, updated_at)
+                    VALUES (%s, %s, %s, %s, %s, now())
+                    ON CONFLICT (query_id, municipio)
+                    DO UPDATE SET columns = EXCLUDED.columns,
+                                  rows = EXCLUDED.rows,
+                                  row_count = EXCLUDED.row_count,
+                                  updated_at = now()
+                    """,
+                    (
+                        _SITEMAP_CACHE_QUERY_ID,
+                        key,
+                        _json.dumps(["xml"]),
+                        _json.dumps([[xml]]),
+                        1,
+                    ),
+                )
+        return True
+    except Exception:
+        _log.exception("Falha ao persistir sitemap '%s' no web_cache", key)
+        return False
+
+
 # Tamanho de cada shard de empresas. Limite do protocolo eh 50K URLs por
 # arquivo; 49K deixa folga pra evitar overflow se o filtro mudar.
 EMPRESA_SHARD_SIZE = 49000
@@ -471,10 +559,25 @@ async def sitemap_xml(request: Request) -> Response:
     """
     origin = _site_origin(request)
     now = time.time()
+    # L1: in-memory cache
     cached = _SITEMAP_CACHE["index"]
     if cached["xml"] and (now - cached["ts"] < _SITEMAP_TTL):
         return Response(
             content=cached["xml"],
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L2: web_cache (PG) — sobrevive restart. NAO persiste em L2 aqui:
+    # o XML do index eh gerado com origin derivado de request headers
+    # (X-Forwarded-Host pode ser cliente-injetado). Persistencia em L2
+    # fica restrita ao warmer (SITE_ORIGIN env controlado) pra evitar
+    # cache poisoning (P1 GPT 5.5 PR #85).
+    pg_xml = _sitemap_pg_read("root-index")
+    if pg_xml:
+        # Hidrata L1 com versao persistida (origin canonico do warmer).
+        _SITEMAP_CACHE["index"] = {"ts": now, "xml": pg_xml}
+        return Response(
+            content=pg_xml,
             media_type="application/xml",
             headers={"Cache-Control": "public, max-age=3600"},
         )
@@ -499,6 +602,7 @@ async def sitemap_xml(request: Request) -> Response:
     )
     if is_complete:
         _SITEMAP_CACHE["index"] = {"ts": now, "xml": xml}
+        # L2 nao escrita aqui — apenas warmer (vide comentario acima).
     else:
         _log.warning(
             "Sitemap-index parcial (flags emp=%s lic=%s res=%s; has emp=%s lic=%s res=%s) — nao cacheando",
@@ -516,15 +620,31 @@ async def sitemap_cidades_xml(request: Request) -> Response:
     """Sub-sitemap: paginas estaticas + /cidade/<slug>. Cacheado 1h."""
     origin = _site_origin(request)
     now = time.time()
+    # L1: in-memory cache
     cached = _SITEMAP_CACHE["cidades"]
     if cached["xml"] and (now - cached["ts"] < _SITEMAP_TTL):
-        xml = cached["xml"]
+        return Response(
+            content=cached["xml"],
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L2: web_cache (PG)
+    pg_xml = _sitemap_pg_read("cidades-urlset")
+    if pg_xml:
+        _SITEMAP_CACHE["cidades"] = {"ts": now, "xml": pg_xml}
+        return Response(
+            content=pg_xml,
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L3: build live
+    xml = _build_cidades_sitemap(origin)
+    cidades_n = xml.count("/cidade/")
+    if cidades_n >= 100:
+        _SITEMAP_CACHE["cidades"] = {"ts": now, "xml": xml}
+        # L2 nao escrita aqui — risco de cache poisoning via Host header.
+        # Warmer (SITE_ORIGIN env canonico) eh quem popula L2.
     else:
-        xml = _build_cidades_sitemap(origin)
-        cidades_n = xml.count("/cidade/")
-        if cidades_n >= 100:
-            _SITEMAP_CACHE["cidades"] = {"ts": now, "xml": xml}
-        else:
             _log.warning(
                 "Sitemap-cidades parcial (cidades=%d) — nao cacheando",
                 cidades_n,
@@ -581,27 +701,43 @@ async def sitemap_empresas_shard_xml(request: Request, shard_n: int) -> Response
 
     origin = _site_origin(request)
     now = time.time()
+    # L1: in-memory cache
     shard_cache = _SITEMAP_CACHE["empresas"].get(n)
     if shard_cache and shard_cache.get("xml") and (now - shard_cache["ts"] < _SITEMAP_TTL):
-        xml = shard_cache["xml"]
-    else:
-        xml = _build_empresas_shard_sitemap(origin, n)
-        urls_n = xml.count("/empresa/")
-        # NUNCA cachear shard vazio. Cenario: MV cresce de 143K pra 200K
-        # entre 2 requests. Shard 4 (antes past-end, vazio) agora tem
-        # ~49K URLs reais. Se cacheamos vazio, Google lê 0 URLs por ate
-        # 1h apos crescimento — perde ~49K paginas indexaveis. Query past-
-        # end com OFFSET alto eh barata (LIMIT 49000 + index hit) entao
-        # rebuilda em ~ms. (P2 do Opus 4.7 review do PR #60.)
-        if urls_n > 0:
-            _SITEMAP_CACHE["empresas"][n] = {"ts": now, "xml": xml}
-        elif n == 1:
-            _log.warning(
-                "Sitemap-empresas shard 1 vazio — nao cacheando "
-                "(DB pode ter falhado)"
-            )
-        # else (n > 1, vazio): nao cacheia, mas serve urlset vazio agora.
-        # Proxima request rebuilda — se MV cresceu, vai retornar URLs.
+        return Response(
+            content=shard_cache["xml"],
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L2: web_cache (PG) — sobrevive restart
+    pg_xml = _sitemap_pg_read(f"empresas-shard:{n}")
+    if pg_xml:
+        _SITEMAP_CACHE["empresas"][n] = {"ts": now, "xml": pg_xml}
+        return Response(
+            content=pg_xml,
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L3: build live
+    xml = _build_empresas_shard_sitemap(origin, n)
+    urls_n = xml.count("/empresa/")
+    # NUNCA cachear shard vazio. Cenario: MV cresce de 143K pra 200K
+    # entre 2 requests. Shard 4 (antes past-end, vazio) agora tem
+    # ~49K URLs reais. Se cacheamos vazio, Google lê 0 URLs por ate
+    # 1h apos crescimento — perde ~49K paginas indexaveis. Query past-
+    # end com OFFSET alto eh barata (LIMIT 49000 + index hit) entao
+    # rebuilda em ~ms. (P2 do Opus 4.7 review do PR #60.)
+    if urls_n > 0:
+        _SITEMAP_CACHE["empresas"][n] = {"ts": now, "xml": xml}
+        # L2 nao escrita aqui — risco de cache poisoning via Host header.
+        # Warmer (SITE_ORIGIN env canonico) eh quem popula L2.
+    elif n == 1:
+        _log.warning(
+            "Sitemap-empresas shard 1 vazio — nao cacheando "
+            "(DB pode ter falhado)"
+        )
+    # else (n > 1, vazio): nao cacheia, mas serve urlset vazio agora.
+    # Proxima request rebuilda — se MV cresceu, vai retornar URLs.
     return Response(
         content=xml,
         media_type="application/xml",
@@ -635,19 +771,34 @@ async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: int) 
 
     origin = _site_origin(request)
     now = time.time()
+    # L1: in-memory cache
     shard_cache = _SITEMAP_CACHE["empresas_municipios"].get(n)
     if shard_cache and shard_cache.get("xml") and (now - shard_cache["ts"] < _SITEMAP_TTL):
-        xml = shard_cache["xml"]
-    else:
-        xml = _build_empresas_municipios_shard_sitemap(origin, n)
-        urls_n = xml.count("/empresa/")
-        if urls_n > 0:
-            _SITEMAP_CACHE["empresas_municipios"][n] = {"ts": now, "xml": xml}
-        elif n == 1:
-            _log.warning(
-                "Sitemap-empresas-municipios shard 1 vazio — nao cacheando "
-                "(DB pode ter falhado)"
-            )
+        return Response(
+            content=shard_cache["xml"],
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L2: web_cache (PG)
+    pg_xml = _sitemap_pg_read(f"empresas-municipios-shard:{n}")
+    if pg_xml:
+        _SITEMAP_CACHE["empresas_municipios"][n] = {"ts": now, "xml": pg_xml}
+        return Response(
+            content=pg_xml,
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L3: build live
+    xml = _build_empresas_municipios_shard_sitemap(origin, n)
+    urls_n = xml.count("/empresa/")
+    if urls_n > 0:
+        _SITEMAP_CACHE["empresas_municipios"][n] = {"ts": now, "xml": xml}
+        # L2 nao escrita aqui (vide comentario em sitemap_empresas_shard_xml).
+    elif n == 1:
+        _log.warning(
+            "Sitemap-empresas-municipios shard 1 vazio — nao cacheando "
+            "(DB pode ter falhado)"
+        )
     return Response(
         content=xml,
         media_type="application/xml",
@@ -780,16 +931,33 @@ async def sitemap_licitacoes_shard_xml(request: Request, shard_n: int) -> Respon
         raise HTTPException(status_code=404)
     origin = _site_origin(request)
     now = time.time()
+    # L1: in-memory cache
     shard_cache = _SITEMAP_CACHE["licitacoes"].get(shard_n)
     if shard_cache and shard_cache.get("xml") and (now - shard_cache["ts"] < _SITEMAP_TTL):
-        xml = shard_cache["xml"]
-    else:
-        xml = _build_licitacoes_shard_sitemap(origin, shard_n)
-        urls_n = xml.count("/licitacao/")
-        if urls_n > 0:
-            _SITEMAP_CACHE["licitacoes"][shard_n] = {"ts": now, "xml": xml}
-        elif shard_n == 1:
-            _log.warning("Sitemap-licitacoes shard 1 vazio — nao cacheando")
+        return Response(
+            content=shard_cache["xml"],
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L2: web_cache (PG) — adicionado no rebase 2026-05-19 (issue HIGH GPT 5.5
+    # PR #85 round 3: sem L2, /sitemap-licitacoes-N.xml ainda pagaria build
+    # live pos-restart embora cache exista pra outros sitemaps).
+    pg_xml = _sitemap_pg_read(f"licitacoes-shard:{shard_n}")
+    if pg_xml:
+        _SITEMAP_CACHE["licitacoes"][shard_n] = {"ts": now, "xml": pg_xml}
+        return Response(
+            content=pg_xml,
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L3: build live
+    xml = _build_licitacoes_shard_sitemap(origin, shard_n)
+    urls_n = xml.count("/licitacao/")
+    if urls_n > 0:
+        _SITEMAP_CACHE["licitacoes"][shard_n] = {"ts": now, "xml": xml}
+        # L2 nao escrita aqui (cache poisoning guard).
+    elif shard_n == 1:
+        _log.warning("Sitemap-licitacoes shard 1 vazio — nao cacheando")
     return Response(
         content=xml,
         media_type="application/xml",
@@ -876,16 +1044,31 @@ async def sitemap_cidade_resumo_xml(request: Request) -> Response:
     """Sub-sitemap unico com todas as cidade-mes paginas (~14k URLs)."""
     origin = _site_origin(request)
     now = time.time()
+    # L1: in-memory cache
     cached = _SITEMAP_CACHE["cidade_resumo"]
     if cached["xml"] and (now - cached["ts"] < _SITEMAP_TTL):
-        xml = cached["xml"]
+        return Response(
+            content=cached["xml"],
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L2: web_cache (PG) — adicionado no rebase 2026-05-19.
+    pg_xml = _sitemap_pg_read("cidade-resumo-urlset")
+    if pg_xml:
+        _SITEMAP_CACHE["cidade_resumo"] = {"ts": now, "xml": pg_xml}
+        return Response(
+            content=pg_xml,
+            media_type="application/xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    # L3: build live
+    xml = _build_cidade_resumo_sitemap(origin)
+    urls_n = xml.count("/cidade/")
+    if urls_n > 0:
+        _SITEMAP_CACHE["cidade_resumo"] = {"ts": now, "xml": xml}
+        # L2 nao escrita aqui (cache poisoning guard).
     else:
-        xml = _build_cidade_resumo_sitemap(origin)
-        urls_n = xml.count("/cidade/")
-        if urls_n > 0:
-            _SITEMAP_CACHE["cidade_resumo"] = {"ts": now, "xml": xml}
-        else:
-            _log.warning("Sitemap-cidade-resumo vazio — nao cacheando")
+        _log.warning("Sitemap-cidade-resumo vazio — nao cacheando")
     return Response(
         content=xml,
         media_type="application/xml",

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -1391,6 +1391,7 @@ def main():
         ok_em = fail_em = skip_em = 0
         ok_l = fail_l = skip_l = 0
         ok_r = fail_r = skip_r = 0
+        ok_sm = fail_sm = skip_sm = 0
         if not skip_empresas_flag:
             ok_e, fail_e, skip_e = _warm_empresas_phase()
             ok_em, fail_em, skip_em = _warm_empresas_municipios_phase()
@@ -1409,10 +1410,16 @@ def main():
         _swap_all_pending_shadows(verbose=True)
         # Reset tracking pra eventual proximo ciclo (mode --loop).
         _shadow_results.clear()
+        # Sitemaps sempre rodam por ULTIMO (rapido, ~30-60s pra ~40 entries)
+        # — pre-popula web_cache pra eliminar timeout pos-restart do
+        # cruza-web. Roda APOS shadow swap porque os counts() referenciam
+        # MVs que ja devem estar no estado final (qids SITEMAP_XML nao
+        # participam de shadow swap). PR #85 + rebase 2026-05-19.
+        ok_sm, fail_sm, skip_sm = _warm_sitemaps_phase()
         return (
-            ok_p + ok_e + ok_em + ok_l + ok_r,
-            fail_p + fail_e + fail_em + fail_l + fail_r,
-            skip_e + skip_em + skip_l + skip_r,
+            ok_p + ok_e + ok_em + ok_l + ok_r + ok_sm,
+            fail_p + fail_e + fail_em + fail_l + fail_r + fail_sm,
+            skip_e + skip_em + skip_l + skip_r + skip_sm,
         )
 
     if args.daemon:
@@ -2081,6 +2088,306 @@ def _warm_cidade_resumo_phase() -> tuple[int, int, int]:
     )
     _record_shadow_result(CACHE_QUERY_ID_RESUMO, ok, fail)
     return ok, fail, skipped_resume + skipped_empty
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _warm_sitemaps_phase — popula web_cache (query_id=SITEMAP_XML) com os
+# XMLs pre-gerados. Resolve o problema do GSC reportar "Couldn't fetch"
+# quando primeiro hit pos-restart do cruza-web bate em build live > 30s.
+#
+# Naming convention das keys (rebase 2026-05-19):
+#   - '<scope>-urlset'       -> sitemap unico (sem shards)
+#   - '<scope>-shard:N'      -> shard N de um sitemap shardado
+#   - 'root-index'           -> sitemap-index top-level que agrega tudo
+#
+# Keys cacheadas:
+#   - 'root-index'                       -> /sitemap.xml
+#   - 'cidades-urlset'                   -> /sitemap-cidades.xml
+#   - 'empresas-shard:N'                 -> /sitemap-empresas-N.xml
+#   - 'empresas-municipios-shard:N'      -> /sitemap-empresas-municipios-N.xml
+#   - 'licitacoes-shard:N'               -> /sitemap-licitacoes-N.xml (PR #108)
+#   - 'cidade-resumo-urlset'             -> /sitemap-cidade-resumo.xml (PR #108)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _warm_sitemaps_phase() -> tuple[int, int, int]:
+    """Pre-gera todos os sitemaps e armazena em web_cache (query_id=SITEMAP_XML).
+
+    Rapido (~30-60s pra ~40 entries em 145K empresas + 775K pares
+    + N licitacoes + 14K cidade-mes). Sempre roda (ignora SKIP_RECENT_HOURS)
+    — sitemaps sao baratos e essenciais pra primeiro hit pos-restart nao
+    quebrar.
+
+    DB pool: init_pool() + close_pool() balanceados em try/finally.
+    Sem close_pool, daemon mode vazaria conexoes a cada ciclo (Opus 4.7
+    P1 PR #85). As outras phases (_warm_empresas_phase,
+    _warm_empresas_municipios_phase) seguem o mesmo padrao.
+
+    Pruning: ao final, remove entries em web_cache cuja key nao foi
+    escrita neste ciclo (i.e., shards past-end ou tipo removido). Usa
+    expected_keys (built before write) nao written_keys, pra nao deletar
+    entries por causa de falhas transientes de write. skip_prune_prefixes
+    protege scopes onde a contagem falhou (nao conhecemos expected, nao
+    deletamos nada do scope).
+    """
+    print("--- Sitemaps: pre-gerando XML pra web_cache ---", flush=True)
+    t0 = time.time()
+
+    try:
+        from web import db as web_db
+        web_db.init_pool()
+    except Exception as exc:
+        print(f"  ERRO init pool DB: {exc}", flush=True)
+        return 0, 1, 0
+
+    # Origin canonico — sem Request object, ler de env ou hardcode.
+    # transparenciapb.org eh o unico host atual; futuras mudancas devem
+    # vir via SITE_ORIGIN env.
+    origin = os.environ.get(
+        "SITE_ORIGIN", "https://transparenciapb.org"
+    ).rstrip("/")
+
+    # Forca flags ON pra incluir TODOS os shards no index (mesmo que o
+    # processo cruza-web em prod tenha drop-in apenas pra empresas — aqui
+    # pre-geramos tudo, route decide quais expor).
+    prev_emp = os.environ.get("SITEMAP_INCLUDE_EMPRESAS")
+    prev_lic = os.environ.get("SITEMAP_INCLUDE_LICITACOES")
+    prev_res = os.environ.get("SITEMAP_INCLUDE_CIDADE_RESUMO")
+    os.environ["SITEMAP_INCLUDE_EMPRESAS"] = "1"
+    os.environ["SITEMAP_INCLUDE_LICITACOES"] = "1"
+    os.environ["SITEMAP_INCLUDE_CIDADE_RESUMO"] = "1"
+
+    ok = 0
+    fail = 0
+    expected_keys: set[str] = set()       # Keys que ESPERAMOS escrever (pra prune)
+    skip_prune_prefixes: set[str] = set()  # Scopes onde count falhou (no prune)
+
+    try:
+        from web.routes.seo import (
+            EMPRESA_SHARD_SIZE,
+            LICITACAO_SHARD_SIZE,
+            _build_cidade_resumo_sitemap,
+            _build_cidades_sitemap,
+            _build_empresas_municipios_shard_sitemap,
+            _build_empresas_shard_sitemap,
+            _build_licitacoes_shard_sitemap,
+            _build_sitemap_index,
+            _cidade_resumo_qualificados,
+            _empresas_municipios_qualificadas_count,
+            _empresas_qualificadas_count,
+            _licitacoes_qualificadas_count,
+            _sitemap_pg_write,
+        )
+
+        # 1. Index (root-index)
+        expected_keys.add("root-index")
+        try:
+            xml = _build_sitemap_index(origin)
+            if "/sitemap-empresas-" in xml:
+                if _sitemap_pg_write("root-index", xml):
+                    ok += 1
+                    print(f"  ok  root-index ({len(xml)} bytes)", flush=True)
+                else:
+                    fail += 1
+                    print("  fail  root-index (pg write retornou False)", flush=True)
+            else:
+                fail += 1
+                print("  fail  root-index (sem empresas shards — DB falhou?)", flush=True)
+        except Exception as exc:
+            fail += 1
+            print(f"  fail  root-index: {exc}", flush=True)
+
+        # 2. Cidades (cidades-urlset)
+        expected_keys.add("cidades-urlset")
+        try:
+            xml = _build_cidades_sitemap(origin)
+            cidades_n = xml.count("/cidade/")
+            if cidades_n >= 100:
+                if _sitemap_pg_write("cidades-urlset", xml):
+                    ok += 1
+                    print(f"  ok  cidades-urlset ({cidades_n} URLs)", flush=True)
+                else:
+                    fail += 1
+                    print("  fail  cidades-urlset (pg write retornou False)", flush=True)
+            else:
+                fail += 1
+                print(f"  fail  cidades-urlset ({cidades_n} URLs — < 100)", flush=True)
+        except Exception as exc:
+            fail += 1
+            print(f"  fail  cidades-urlset: {exc}", flush=True)
+
+        # 3. Empresas shards (empresas-shard:N)
+        try:
+            total_emp = _empresas_qualificadas_count()
+            num_shards_emp = math.ceil(total_emp / EMPRESA_SHARD_SIZE) if total_emp > 0 else 0
+            print(f"  Empresas: total={total_emp:,} shards={num_shards_emp}", flush=True)
+            for n in range(1, num_shards_emp + 1):
+                key = f"empresas-shard:{n}"
+                expected_keys.add(key)
+                try:
+                    xml = _build_empresas_shard_sitemap(origin, n)
+                    urls_n = xml.count("/empresa/")
+                    if urls_n > 0:
+                        if _sitemap_pg_write(key, xml):
+                            ok += 1
+                            print(f"  ok  {key} ({urls_n} URLs)", flush=True)
+                        else:
+                            fail += 1
+                            print(f"  fail  {key} (pg write retornou False)", flush=True)
+                    else:
+                        fail += 1
+                        print(f"  fail  {key} (vazio)", flush=True)
+                except Exception as exc:
+                    fail += 1
+                    print(f"  fail  {key}: {exc}", flush=True)
+        except Exception as exc:
+            fail += 1
+            skip_prune_prefixes.add("empresas-shard:")
+            print(f"  fail  contar empresas: {exc} (pruning de empresas-shard: pulado)", flush=True)
+
+        # 4. Empresas × Municipios shards (empresas-municipios-shard:N)
+        try:
+            total_mun = _empresas_municipios_qualificadas_count()
+            num_shards_mun = math.ceil(total_mun / EMPRESA_SHARD_SIZE) if total_mun > 0 else 0
+            print(f"  Empresas-Mun: total={total_mun:,} shards={num_shards_mun}", flush=True)
+            for n in range(1, num_shards_mun + 1):
+                key = f"empresas-municipios-shard:{n}"
+                expected_keys.add(key)
+                try:
+                    xml = _build_empresas_municipios_shard_sitemap(origin, n)
+                    urls_n = xml.count("/empresa/")
+                    if urls_n > 0:
+                        if _sitemap_pg_write(key, xml):
+                            ok += 1
+                            print(f"  ok  {key} ({urls_n} URLs)", flush=True)
+                        else:
+                            fail += 1
+                            print(f"  fail  {key} (pg write retornou False)", flush=True)
+                    else:
+                        fail += 1
+                        print(f"  fail  {key} (vazio)", flush=True)
+                except Exception as exc:
+                    fail += 1
+                    print(f"  fail  {key}: {exc}", flush=True)
+        except Exception as exc:
+            fail += 1
+            skip_prune_prefixes.add("empresas-municipios-shard:")
+            print(f"  fail  contar empresas-municipios: {exc} (pruning pulado)", flush=True)
+
+        # 5. Licitacoes shards (licitacoes-shard:N) — alinhado com main PR #108
+        try:
+            total_lic = _licitacoes_qualificadas_count()
+            num_shards_lic = math.ceil(total_lic / LICITACAO_SHARD_SIZE) if total_lic > 0 else 0
+            print(f"  Licitacoes: total={total_lic:,} shards={num_shards_lic}", flush=True)
+            for n in range(1, num_shards_lic + 1):
+                key = f"licitacoes-shard:{n}"
+                expected_keys.add(key)
+                try:
+                    xml = _build_licitacoes_shard_sitemap(origin, n)
+                    urls_n = xml.count("/licitacao/")
+                    if urls_n > 0:
+                        if _sitemap_pg_write(key, xml):
+                            ok += 1
+                            print(f"  ok  {key} ({urls_n} URLs)", flush=True)
+                        else:
+                            fail += 1
+                            print(f"  fail  {key} (pg write retornou False)", flush=True)
+                    else:
+                        fail += 1
+                        print(f"  fail  {key} (vazio)", flush=True)
+                except Exception as exc:
+                    fail += 1
+                    print(f"  fail  {key}: {exc}", flush=True)
+        except Exception as exc:
+            fail += 1
+            skip_prune_prefixes.add("licitacoes-shard:")
+            print(f"  fail  contar licitacoes: {exc} (pruning pulado)", flush=True)
+
+        # 6. Cidade resumo urlset (cidade-resumo-urlset)
+        expected_keys.add("cidade-resumo-urlset")
+        try:
+            qualificados = _cidade_resumo_qualificados()
+            total_res = len(qualificados)
+            print(f"  Cidade-resumo: total={total_res:,}", flush=True)
+            if total_res > 0:
+                xml = _build_cidade_resumo_sitemap(origin)
+                urls_n = xml.count("/cidade/")
+                if urls_n > 0:
+                    if _sitemap_pg_write("cidade-resumo-urlset", xml):
+                        ok += 1
+                        print(f"  ok  cidade-resumo-urlset ({urls_n} URLs)", flush=True)
+                    else:
+                        fail += 1
+                        print("  fail  cidade-resumo-urlset (pg write retornou False)", flush=True)
+                else:
+                    fail += 1
+                    print("  fail  cidade-resumo-urlset (vazio)", flush=True)
+        except Exception as exc:
+            fail += 1
+            print(f"  fail  cidade-resumo-urlset: {exc}", flush=True)
+
+        # ─── Prune ─── Remove entries cujo key nao esta em expected_keys
+        # (i.e., shards past-end ou tipo removido). USA expected_keys (built
+        # before write), nao written_keys: falhas transientes de write nao
+        # devem deletar entries previamente boas.
+        # skip_prune_prefixes protege scopes onde contagem falhou — sem
+        # expected_keys confiavel pra esse scope, nao deletamos nada dele.
+        # `if expected_keys` guarda contra prune destrutivo se todos os
+        # scopes falharem (warm catastrofico).
+        if expected_keys:
+            try:
+                with web_db.get_conn() as conn:
+                    conn.autocommit = True
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT municipio FROM web_cache WHERE query_id = %s",
+                            ("SITEMAP_XML",),
+                        )
+                        existing = {row[0] for row in cur.fetchall()}
+                        to_delete = []
+                        for k in existing:
+                            if k in expected_keys:
+                                continue
+                            # Skip se algum prefix esta protegido
+                            if any(k.startswith(p) for p in skip_prune_prefixes):
+                                continue
+                            to_delete.append(k)
+                        if to_delete:
+                            cur.execute(
+                                "DELETE FROM web_cache WHERE query_id = %s AND municipio = ANY(%s)",
+                                ("SITEMAP_XML", to_delete),
+                            )
+                            print(
+                                f"  prune  removidas {len(to_delete)} entries stale: "
+                                f"{', '.join(sorted(to_delete)[:5])}{'...' if len(to_delete) > 5 else ''}",
+                                flush=True,
+                            )
+            except Exception as exc:
+                print(f"  warn  prune falhou: {exc}", flush=True)
+
+    finally:
+        # Restaura env vars (preserva drop-ins reais do systemd se houver).
+        for var, prev in [
+            ("SITEMAP_INCLUDE_EMPRESAS", prev_emp),
+            ("SITEMAP_INCLUDE_LICITACOES", prev_lic),
+            ("SITEMAP_INCLUDE_CIDADE_RESUMO", prev_res),
+        ]:
+            if prev is not None:
+                os.environ[var] = prev
+            else:
+                os.environ.pop(var, None)
+        # Fecha pool DB pra evitar leak em daemon mode (Opus 4.7 P1 PR #85).
+        try:
+            web_db.close_pool()
+        except Exception:
+            pass
+
+    elapsed = time.time() - t0
+    print(
+        f"--- Sitemaps: {ok} ok, {fail} fail em {elapsed:.0f}s ---",
+        flush=True,
+    )
+    return ok, fail, 0
 
 
 if __name__ == "__main__":

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -2098,15 +2098,18 @@ def _warm_cidade_resumo_phase() -> tuple[int, int, int]:
 # Naming convention das keys (rebase 2026-05-19):
 #   - '<scope>-urlset'       -> sitemap unico (sem shards)
 #   - '<scope>-shard:N'      -> shard N de um sitemap shardado
-#   - 'root-index'           -> sitemap-index top-level que agrega tudo
 #
-# Keys cacheadas:
-#   - 'root-index'                       -> /sitemap.xml
+# Keys cacheadas em L2:
 #   - 'cidades-urlset'                   -> /sitemap-cidades.xml
 #   - 'empresas-shard:N'                 -> /sitemap-empresas-N.xml
 #   - 'empresas-municipios-shard:N'      -> /sitemap-empresas-municipios-N.xml
 #   - 'licitacoes-shard:N'               -> /sitemap-licitacoes-N.xml (PR #108)
 #   - 'cidade-resumo-urlset'             -> /sitemap-cidade-resumo.xml (PR #108)
+#
+# NAO cacheado em L2: /sitemap.xml (root index). Build eh barato (<50ms)
+# e o XML reflete flags SITEMAP_INCLUDE_* do processo runtime — cachear
+# com flags do warmer geraria cache poisoning vs flags da rota.
+# (HIGH GPT-5.5 round 4 PR #85.)
 # ─────────────────────────────────────────────────────────────────────────
 
 
@@ -2171,7 +2174,6 @@ def _warm_sitemaps_phase() -> tuple[int, int, int]:
             _build_empresas_municipios_shard_sitemap,
             _build_empresas_shard_sitemap,
             _build_licitacoes_shard_sitemap,
-            _build_sitemap_index,
             _cidade_resumo_qualificados,
             _empresas_municipios_qualificadas_count,
             _empresas_qualificadas_count,
@@ -2179,23 +2181,18 @@ def _warm_sitemaps_phase() -> tuple[int, int, int]:
             _sitemap_pg_write,
         )
 
-        # 1. Index (root-index)
-        expected_keys.add("root-index")
-        try:
-            xml = _build_sitemap_index(origin)
-            if "/sitemap-empresas-" in xml:
-                if _sitemap_pg_write("root-index", xml):
-                    ok += 1
-                    print(f"  ok  root-index ({len(xml)} bytes)", flush=True)
-                else:
-                    fail += 1
-                    print("  fail  root-index (pg write retornou False)", flush=True)
-            else:
-                fail += 1
-                print("  fail  root-index (sem empresas shards — DB falhou?)", flush=True)
-        except Exception as exc:
-            fail += 1
-            print(f"  fail  root-index: {exc}", flush=True)
+        # 1. Index (root-index) NAO cacheado em L2.
+        #
+        # Por que pular: _build_sitemap_index gera <50ms (apenas string concat
+        # de URLs dos sub-sitemaps, sem queries pesadas). Mais importante: o
+        # XML do index reflete as flags SITEMAP_INCLUDE_EMPRESAS/LICITACOES/
+        # CIDADE_RESUMO ATUAIS do processo cruza-web. Cachear em L2 (escrito
+        # com todas as flags=1 pelo warmer) faria a rota servir um index com
+        # families que o processo runtime tem desabilitadas via drop-in
+        # systemd (cache poisoning entre warmer flags e route flags).
+        # (HIGH GPT-5.5 round 4 PR #85.)
+        #
+        # L1 in-memory continua, com anti-cache parcial que respeita flags.
 
         # 2. Cidades (cidades-urlset)
         expected_keys.add("cidades-urlset")
@@ -2219,6 +2216,13 @@ def _warm_sitemaps_phase() -> tuple[int, int, int]:
         # 3. Empresas shards (empresas-shard:N)
         try:
             total_emp = _empresas_qualificadas_count()
+            # Defensive: count helpers em seo.py swallow Exception e retornam
+            # 0 em DB error. Sem este guard, transient hiccup => total=0 =>
+            # for-loop nao itera => expected_keys SEM os keys reais =>
+            # prune DELETE em todos os shards previamente cacheados.
+            # (HIGH Opus 4.7 + GPT-5.5 round 4 PR #85.)
+            if total_emp == 0:
+                skip_prune_prefixes.add("empresas-shard:")
             num_shards_emp = math.ceil(total_emp / EMPRESA_SHARD_SIZE) if total_emp > 0 else 0
             print(f"  Empresas: total={total_emp:,} shards={num_shards_emp}", flush=True)
             for n in range(1, num_shards_emp + 1):
@@ -2248,6 +2252,9 @@ def _warm_sitemaps_phase() -> tuple[int, int, int]:
         # 4. Empresas × Municipios shards (empresas-municipios-shard:N)
         try:
             total_mun = _empresas_municipios_qualificadas_count()
+            # Defensive prune protection (vide comentario em empresas-shard).
+            if total_mun == 0:
+                skip_prune_prefixes.add("empresas-municipios-shard:")
             num_shards_mun = math.ceil(total_mun / EMPRESA_SHARD_SIZE) if total_mun > 0 else 0
             print(f"  Empresas-Mun: total={total_mun:,} shards={num_shards_mun}", flush=True)
             for n in range(1, num_shards_mun + 1):
@@ -2277,6 +2284,9 @@ def _warm_sitemaps_phase() -> tuple[int, int, int]:
         # 5. Licitacoes shards (licitacoes-shard:N) — alinhado com main PR #108
         try:
             total_lic = _licitacoes_qualificadas_count()
+            # Defensive prune protection (vide comentario em empresas-shard).
+            if total_lic == 0:
+                skip_prune_prefixes.add("licitacoes-shard:")
             num_shards_lic = math.ceil(total_lic / LICITACAO_SHARD_SIZE) if total_lic > 0 else 0
             print(f"  Licitacoes: total={total_lic:,} shards={num_shards_lic}", flush=True)
             for n in range(1, num_shards_lic + 1):


### PR DESCRIPTION
## Problema

GSC reportou Couldnt fetch em /sitemap-empresas-N.xml apos restarts do cruza-web. Causa: '_SITEMAP_CACHE' eh in-memory; primeira request pos-restart pagava custo de geracao (8-9MB XML por shard, ~20s cold). Cache de 24h ajudava DEPOIS do primeiro hit.

## Solucao

Cache 2-camada read-through:

| Camada | Storage | TTL | Survive restart? |
|---|---|---|---|
| L1 | '_SITEMAP_CACHE' in-memory | 24h | Não |
| L2 | 'web_cache' PG (query_id='SITEMAP_XML') | sem TTL | **Sim** |
| L3 | Build live (fallback) | — | — |

Cada rota de sitemap agora:
1. Lê L1 (instantâneo) → hit: return
2. Lê L2 via '_sitemap_pg_read' → hit: hidrata L1 + return
3. Build live → persiste em ambos L1 e L2

## Keys lógicas no web_cache

| Key (municipio col) | Sitemap |
|---|---|
| 'index' | '/sitemap.xml' |
| 'cidades' | '/sitemap-cidades.xml' |
| 'empresas:1', 'empresas:2', ... | '/sitemap-empresas-N.xml' |
| 'empresas-municipios:1', ... | '/sitemap-empresas-municipios-N.xml' |

Total: ~20 entries (3 empresas shards + 17 mun shards + index + cidades).

## Warmer novo

'_warm_sitemaps_phase' em 'web/warm_cache.py':
- Roda no fim do warm cycle (após cidades + empresas + empresa-municipio)
- Pre-gera todos os XML (~30-60s total)
- Persiste em web_cache via '_sitemap_pg_write'
- Força 'SITEMAP_INCLUDE_EMPRESAS=1' durante geração do index

## Deploy

\\\ash
gh workflow run deploy.yml --ref main \\
  -f etl_phase=web \\
  -f warm_cache=true \\
  -f warm_skip_hours=24 \\
  -f invalidate_cache_keys=SITEMAP_XML \\
  -f expose_empresa_sitemap=keep
\\\

- 'warm_skip_hours=24': pula cidades+empresas+empresa-municipio (já cacheados)
- 'invalidate_cache_keys=SITEMAP_XML': força regen dos sitemaps
- '_warm_sitemaps_phase' SEMPRE roda (não respeita skip_hours — é rápido e crítico)

## Smoke test pos-deploy

\\\ash
# Restart simulation: primeira request pos-deploy deve responder < 1s
curl -sS -o /dev/null -w '%{time_total}s | %{http_code}\n' \\
  https://transparenciapb.org/sitemap-empresas-municipios-10.xml
# Esperado: <1s 200
\\\

## Rollback safety

Adições apenas. Fallback build live preservado. Revert remove tabela web_cache entries mas funcionalidade volta ao baseline (timeout no cold hit).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>