### PR TITLE
hotfix(web): remove links pro GitHub em /caso/{slug}

### DIFF
--- a/web/templates/caso.html
+++ b/web/templates/caso.html
@@ -218,7 +218,7 @@
 
   <nav class="caso-cta" aria-label="Acoes principais">
     <a class="cta-primary" href="{{ meta.painel_url }}">Ver no painel de Joao Pessoa</a>
-    <a class="cta-secondary" href="https://github.com/lucasdiniz/govbr-cruza-dados/blob/main/{{ meta.file }}" target="_blank" rel="noopener">Ver no GitHub</a>
+    <a class="cta-secondary" href="#6-fontes-oficiais">Ver fontes oficiais</a>
   </nav>
 
   <div class="caso-content">
@@ -227,9 +227,6 @@
 
   <footer class="caso-footer">
     <p>
-      Relatorio mantido em codigo aberto.
-      <a href="https://github.com/lucasdiniz/govbr-cruza-dados/blob/main/{{ meta.file }}" target="_blank" rel="noopener">Ver historico no GitHub</a>
-      &middot;
       <a href="/sobre">Sobre a metodologia</a>
       &middot;
       <a href="/contato">Reportar erro</a>


### PR DESCRIPTION
Remove CTA 'Ver no GitHub' e mencao 'Ver historico no GitHub' do rodape do template caso.html. Mantem apenas links internos (/sobre, /contato).