### PR TITLE
feat(deploy): exploit-paths filter cobre scanners enterprise

### DIFF
--- a/deploy/fail2ban-transparenciapb-exploit-paths.filter.conf
+++ b/deploy/fail2ban-transparenciapb-exploit-paths.filter.conf
@@ -19,6 +19,16 @@
 #   - VPN gateways: /CSCOSSLC/, /sslvpnclient, /global-protect/,
 #                       /dana-na/ (Ivanti/Pulse), /+CSCOE+/ (Cisco WebVPN),
 #                       /sonicui/, /remote/login, /remote/fgt_lang (Fortinet)
+#   - Enterprise apps: /solr/, /sugar_version, /owncloud/, /nextcloud/,
+#                       /webfig/ (MikroTik), /sitecore/, /showLogin.cc
+#                       (Lansweeper), /ssi.cgi/, /Web/Auth (Zimbra),
+#                       /identity/jsLibs (Confluence), /api/session/properties,
+#                       /historypage.js, /NewWindow_2_all.js, /status.php,
+#                       /jenkins/, /grafana/, /kibana/, /elasticsearch/,
+#                       /prometheus/, /consul/, /nomad/, /vault/,
+#                       /manager/html (Tomcat), /axis2/, /invoker/,
+#                       /struts2, /jmx-console, /web-console, /tmui/ (F5),
+#                       /hudson/, /console/login, /geoserver/
 #   - Misc: /server-status, /actuator, /druid, /developmentserver
 #
 # False positives evitados:
@@ -37,7 +47,7 @@
 #
 # Padroes (case-insensitive via (?i) prefix do fail2ban). Cada alternativa
 # foi escolhida pra ter zero overlap com paths legitimos do site.
-failregex = ^<HOST> .*"(GET|POST|PUT|DELETE|HEAD|PATCH) (?i:/+(\.env[^\s"]*|\.git[^\s"]*|\.aws[^\s"]*|\.docker[^\s"]*|\.terraform[^\s"]*|\.gitlab[^\s"]*|\.github[^\s"]*|\.ssh[^\s"]*|\.config[^\s"]*|\.netrc[^\s"]*|\.htaccess[^\s"]*|\.htpasswd[^\s"]*|\.svn[^\s"]*|\.hg[^\s"]*|\.bzr[^\s"]*|\.npmrc[^\s"]*|\.s3cfg[^\s"]*|\.boto[^\s"]*|\.dockerignore[^\s"]*|wp-admin[^\s"]*|wp-content[^\s"]*|wp-config[^\s"]*|wp-login[^\s"]*|wp-json[^\s"]*|wp-includes[^\s"]*|wlwmanifest\.xml[^\s"]*|xmlrpc\.php[^\s"]*|vendor/phpunit[^\s"]*|phpunit[^\s"]*|phpinfo[^\s"]*|info\.php[^\s"]*|test\.php[^\s"]*|php\.php[^\s"]*|php-info\.php[^\s"]*|admin\.php[^\s"]*|adminer[^\s"]*|phpmyadmin[^\s"]*|cgi-bin/[^\s"]*|HNAP1[^\s"]*|device\.rsp[^\s"]*|goform/[^\s"]*|ssdpcgi[^\s"]*|server-status[^\s"]*|actuator[^\s"]*|druid[^\s"]*|developmentserver[^\s"]*|autodiscover[^\s"]*|owa/[^\s"]*|ews/[^\s"]*|Dockerfile[^\s"]*|docker-compose[^\s"]*|webhook[^\s"]*|portal/redlion[^\s"]*|SDK/webLanguage[^\s"]*|api/getData[^\s"]*|hello\.world[^\s"]*|aaa9[^\s"]*|aab9[^\s"]*|Dr0v[^\s"]*|8011255101[^\s"]*|SamlResponseServlet[^\s"]*|samlLogin[^\s"]*|rest/api/[^\s"]*/version[^\s"]*|api/v[0-9]+/version[^\s"]*|CSCOSSLC[^\s"]*|sslvpnclient[^\s"]*|global-protect[^\s"]*|dana-na[^\s"]*|\+CSCOE\+[^\s"]*|sonicui[^\s"]*|remote/login[^\s"]*|remote/fgt_lang[^\s"]*|fgt_lang[^\s"]*|portal/SessionEvents[^\s"]*)) HTTP
+failregex = ^<HOST> .*"(GET|POST|PUT|DELETE|HEAD|PATCH) (?i:/+(\.env[^\s"]*|\.git[^\s"]*|\.aws[^\s"]*|\.docker[^\s"]*|\.terraform[^\s"]*|\.gitlab[^\s"]*|\.github[^\s"]*|\.ssh[^\s"]*|\.config[^\s"]*|\.netrc[^\s"]*|\.htaccess[^\s"]*|\.htpasswd[^\s"]*|\.svn[^\s"]*|\.hg[^\s"]*|\.bzr[^\s"]*|\.npmrc[^\s"]*|\.s3cfg[^\s"]*|\.boto[^\s"]*|\.dockerignore[^\s"]*|wp-admin[^\s"]*|wp-content[^\s"]*|wp-config[^\s"]*|wp-login[^\s"]*|wp-json[^\s"]*|wp-includes[^\s"]*|wlwmanifest\.xml[^\s"]*|xmlrpc\.php[^\s"]*|vendor/phpunit[^\s"]*|phpunit[^\s"]*|phpinfo[^\s"]*|info\.php[^\s"]*|test\.php[^\s"]*|php\.php[^\s"]*|php-info\.php[^\s"]*|admin\.php[^\s"]*|adminer[^\s"]*|phpmyadmin[^\s"]*|cgi-bin/[^\s"]*|HNAP1[^\s"]*|device\.rsp[^\s"]*|goform/[^\s"]*|ssdpcgi[^\s"]*|server-status[^\s"]*|actuator[^\s"]*|druid[^\s"]*|developmentserver[^\s"]*|autodiscover[^\s"]*|owa/[^\s"]*|ews/[^\s"]*|Dockerfile[^\s"]*|docker-compose[^\s"]*|webhook[^\s"]*|portal/redlion[^\s"]*|SDK/webLanguage[^\s"]*|api/getData[^\s"]*|hello\.world[^\s"]*|aaa9[^\s"]*|aab9[^\s"]*|Dr0v[^\s"]*|8011255101[^\s"]*|SamlResponseServlet[^\s"]*|samlLogin[^\s"]*|rest/api/[^\s"]*/version[^\s"]*|api/v[0-9]+/version[^\s"]*|CSCOSSLC[^\s"]*|sslvpnclient[^\s"]*|global-protect[^\s"]*|dana-na[^\s"]*|\+CSCOE\+[^\s"]*|sonicui[^\s"]*|remote/login[^\s"]*|remote/fgt_lang[^\s"]*|fgt_lang[^\s"]*|portal/SessionEvents[^\s"]*|solr/[^\s"]*|sugar_version[^\s"]*|sugarcrm/[^\s"]*|owncloud/[^\s"]*|nextcloud/[^\s"]*|webfig/[^\s"]*|sitecore/[^\s"]*|sitecore\.version[^\s"]*|showLogin\.cc[^\s"]*|ssi\.cgi/[^\s"]*|Web/Auth[^\s"]*|identity/jsLibs[^\s"]*|api/session/properties[^\s"]*|historypage\.js[^\s"]*|NewWindow_2_all\.js[^\s"]*|status\.php[^\s"]*|jenkins/[^\s"]*|grafana/[^\s"]*|kibana/[^\s"]*|elasticsearch/[^\s"]*|prometheus/[^\s"]*|consul/[^\s"]*|nomad/[^\s"]*|vault/[^\s"]*|manager/html[^\s"]*|axis2/[^\s"]*|invoker/[^\s"]*|struts2[^\s"]*|jmx-console[^\s"]*|web-console[^\s"]*|tmui/[^\s"]*|hudson/[^\s"]*|console/login[^\s"]*|geoserver/[^\s"]*)) HTTP
 
 # Notas sobre o regex:
 # - (?i) torna case-insensitive (ja na alternation)


### PR DESCRIPTION
feat(deploy): exploit-paths filter cobre scanners enterprise

Adiciona ~30 padroes ao regex pra cobrir scanners de produtos
enterprise observados em prod hoje (cluster 185.226.197.67-70 e
184.105.139.70).

## Novos padroes

### Enterprise apps
- `/solr/` (Apache Solr admin)
- `/sugar_version`, `/sugarcrm/` (SugarCRM)
- `/owncloud/`, `/nextcloud/` (file sync)
- `/webfig/` (MikroTik RouterOS)
- `/sitecore/`, `/sitecore.version` (Sitecore CMS)
- `/showLogin.cc` (Lansweeper)
- `/ssi.cgi/`, `/Web/Auth` (Zimbra)
- `/identity/jsLibs` (Confluence)
- `/api/session/properties`, `/historypage.js`, `/NewWindow_2_all.js`
- `/status.php` (Drupal/OwnCloud status endpoint)

### Monitoring/CI exploits
- `/jenkins/`, `/grafana/`, `/kibana/`, `/elasticsearch/`
- `/prometheus/`, `/consul/`, `/nomad/`, `/vault/`
- `/manager/html` (Tomcat manager)
- `/jmx-console`, `/web-console` (JBoss)
- `/hudson/` (Hudson CI)
- `/console/login` (Weblogic)
- `/geoserver/`
- `/tmui/` (F5 BIG-IP)
- `/axis2/`, `/invoker/`, `/struts2`

## Validacao

Testado contra /var/log/nginx/access.log atual:
- v3: 81 IPs unicos matched
- v4: 82 IPs unicos matched (+1 novo IP `184.105.139.70`)
- Cluster 185.226.197.67-70 ja estava em v3 via cgi-bin/.env paths
  mas v4 adiciona detecao MAIS RAPIDA (paths enterprise nao precisam
  esperar batch de exploit /.env)

## Hotpatch aplicado

Bans manuais:
- 185.226.197.67/68/69/70 (cluster enterprise scanner)
- 184.105.139.70
- 45.94.31.119 (//wp-includes evasion)

Total banidos no exploit-paths: 13 IPs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
