### PR TITLE
feat(web): foto do caso Socorro vira hero image no topo da /caso/{slug}

### DIFF
--- a/relatorios/relatorio_caso_socorro_gadelha_pb.md
+++ b/relatorios/relatorio_caso_socorro_gadelha_pb.md
@@ -10,9 +10,6 @@
 
 ## 1. Resumo Executivo
 
-![Maria do Socorro Gadelha Campos de Lira, Secretária Municipal de Habitação Social de João Pessoa, em audiência pública na Câmara Municipal em 04/06/2024.](/static/img/casos/socorro-foto.jpg)
-*Maria do Socorro Gadelha Campos de Lira, atual Secretária Municipal de Habitação Social de João Pessoa, em audiência pública na Câmara Municipal em 04/06/2024. Foto: Câmara Municipal de João Pessoa.*
-
 A servidora **Maria do Socorro Gadelha Campos de Lira** (CPF nº ***.256.054-**, matrícula federal nº 2933908) foi punida pela Controladoria-Geral da União (CGU) em 29 de dezembro de 2022 (publicação no DOU em 02/01/2023) com a sanção de **destituição de cargo em comissão**, com base no Art. 127, V, c/c Art. 135 da Lei nº 8.112/90, por **descumprir os deveres de zelo, observância às normas legais e regulamentares e moralidade administrativa** previstos nos incisos I, III e IX do Art. 116 da mesma Lei. O ato — Portaria CGU nº 3.655, de 29/12/2022 — converteu retroativamente sua exoneração de 1º de janeiro de 2019 (Portaria nº 438 do Ministro Chefe da Casa Civil) na penalidade de destituição, no Processo Administrativo Disciplinar nº 00190.101924/2020-94.
 
 A sanção foi registrada no Cadastro de Expulsões da Administração Federal (CEAF) sob o número 278654.

--- a/web/main.py
+++ b/web/main.py
@@ -715,6 +715,18 @@ CASOS: dict[str, dict[str, str]] = {
         ),
         "data_publicacao": "2026-05-11",
         "og_image": "/static/img/casos/socorro-foto.jpg",
+        "hero_image": "/static/img/casos/socorro-foto.jpg",
+        "hero_alt": (
+            "Maria do Socorro Gadelha Campos de Lira, Secretária Municipal de "
+            "Habitação Social de João Pessoa, em audiência pública na Câmara "
+            "Municipal em 04/06/2024."
+        ),
+        "hero_caption": (
+            "Maria do Socorro Gadelha Campos de Lira, atual Secretária "
+            "Municipal de Habitação Social de João Pessoa, em audiência "
+            "pública na Câmara Municipal em 04/06/2024. "
+            "Foto: Câmara Municipal de João Pessoa."
+        ),
     },
 }
 

--- a/web/templates/caso.html
+++ b/web/templates/caso.html
@@ -69,6 +69,24 @@
     border-radius: 999px;
     margin-bottom: 1.25rem;
   }
+  .caso-hero {
+    margin: 0 0 1.75rem;
+  }
+  .caso-hero img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 12px;
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+  .caso-hero figcaption {
+    margin-top: 0.6rem;
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.55);
+    line-height: 1.45;
+    text-align: center;
+    font-style: italic;
+  }
   .caso-cta {
     display: flex;
     flex-wrap: wrap;
@@ -249,6 +267,15 @@
 {% block content %}
 <article class="caso-page">
   <p class="caso-eyebrow">Caso investigativo</p>
+
+  {% if meta.hero_image %}
+  <figure class="caso-hero">
+    <img src="{{ meta.hero_image }}" alt="{{ meta.hero_alt or meta.title }}">
+    {% if meta.hero_caption %}
+    <figcaption>{{ meta.hero_caption }}</figcaption>
+    {% endif %}
+  </figure>
+  {% endif %}
 
   <nav class="caso-cta" aria-label="Acoes principais">
     <a class="cta-primary" href="{{ meta.painel_url }}">Ver no painel de Joao Pessoa</a>


### PR DESCRIPTION
Foto institucional sobe pra hero (entre eyebrow e CTAs), maior impacto visual ao abrir a pagina. Foto do CV continua inline na Secao 5.2. Apos merge, deploy web.