### PR TITLE
feat(web): titulo H1 antes do hero na pagina /caso/{slug}

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -771,12 +771,20 @@ async def caso(request: Request, slug: str):
     md_text = md_path.read_text(encoding="utf-8")
     html = _render_markdown(md_text)
 
+    # Extrai o H1 do markdown renderizado para colocar antes do hero;
+    # o resto do conteudo segue depois do hero e dos CTAs.
+    import re as _re
+    h1_match = _re.search(r"<h1[^>]*>.*?</h1>", html, flags=_re.DOTALL)
+    titulo_html = h1_match.group(0) if h1_match else ""
+    corpo_html = html[h1_match.end():] if h1_match else html
+
     return templates.TemplateResponse(
         request,
         "caso.html",
         {
             "slug": slug,
             "meta": meta,
-            "conteudo_html": html,
+            "titulo_html": titulo_html,
+            "conteudo_html": corpo_html,
         },
     )

--- a/web/templates/caso.html
+++ b/web/templates/caso.html
@@ -119,6 +119,19 @@
   }
   .caso-cta .cta-secondary:hover { background: rgba(255, 255, 255, 0.1); }
 
+  /* Titulo extraido do markdown e renderizado antes do hero, para o H1
+     ficar imediatamente abaixo do eyebrow 'Caso investigativo' e acima
+     da imagem hero. */
+  .caso-titulo h1 {
+    font-size: 1.95rem;
+    line-height: 1.25;
+    margin: 0 0 1.5rem;
+    color: #fff;
+  }
+  @media (max-width: 600px) {
+    .caso-titulo h1 { font-size: 1.6rem; }
+  }
+
   /* Markdown rendering */
   .caso-content {
     font-size: 1.04rem;
@@ -267,6 +280,10 @@
 {% block content %}
 <article class="caso-page">
   <p class="caso-eyebrow">Caso investigativo</p>
+
+  {% if titulo_html %}
+  <div class="caso-titulo">{{ titulo_html | safe }}</div>
+  {% endif %}
 
   {% if meta.hero_image %}
   <figure class="caso-hero">


### PR DESCRIPTION
Move o titulo H1 do relatorio markdown para uma area dedicada antes do hero image. Ordem final: eyebrow -> titulo -> hero -> CTAs -> conteudo.