### PR TITLE
fix(web): umami identify via data-before-send pra eliminar race condition

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -426,7 +426,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "105"
+templates.env.globals["ASSET_VERSION"] = "106"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/lib/umami-track.js
+++ b/web/static/js/lib/umami-track.js
@@ -57,13 +57,37 @@ window.trackEvent = function trackEvent(name, props) {
 //   setUmamiIdentity('lucas')          -> tagga todos eventos com id='lucas'
 //   clearUmamiIdentity()               -> remove a tag
 //
-// A identidade fica em localStorage ('umami.identity') e eh re-aplicada
-// automaticamente em cada pageview / navegacao. No painel Umami, sessoes
-// com identity setada aparecem com o id atrelado (visivel em
-// Sessions > Detalhes).
+// A identidade fica em localStorage ('umami.identity') e eh re-injetada
+// em CADA payload via o hook data-before-send do tracker (ver base.html).
+// Esse hook intercepta todos os sends — incluindo o pageview inicial do
+// init() — antes do fetch acontecer, eliminando race condition entre o
+// tracker dispatchar pageview ANTES de identify() rodar.
 //
-// O umami tracker carrega assincrono, entao fazemos poll ate window.umami
-// existir antes de chamar identify(). Limite 5s pra desistir.
+// O alternativo seria poll de window.umami + chamar identify(), mas isso
+// tem race: o init() do tracker dispara track() (pageview inicial) ANTES
+// do nosso poll chamar identify, entao a sessao anonima eh criada e
+// pageviews ficam la em vez de na sessao identificada.
+//
+// Mantemos tambem a chamada explicita a umami.identify() no setUmamiIdentity,
+// pra que quando o user roda no DevTools imediatamente uma session record
+// com distinct_id seja criada no DB (alem dos payloads subsequentes).
+
+// Hook before-send: intercepta TODO payload (event/identify/performance) e
+// injeta payload.id do localStorage se setado. Roda ANTES do fetch pro
+// /api/send, entao mesmo o pageview inicial (que o init() dispara
+// sincronamente) vai com id atrelado.
+window.umamiBeforeSend = function umamiBeforeSend(_type, payload) {
+    try {
+        const me = localStorage.getItem('umami.identity');
+        if (me && payload && typeof payload === 'object') {
+            payload.id = me;
+        }
+    } catch (_) {
+        // localStorage indisponivel (private mode etc) — payload segue inalterado
+    }
+    return payload;
+};
+
 window.setUmamiIdentity = function setUmamiIdentity(name) {
     try { localStorage.setItem('umami.identity', String(name)); } catch (_) {}
     try {
@@ -75,18 +99,3 @@ window.setUmamiIdentity = function setUmamiIdentity(name) {
 window.clearUmamiIdentity = function clearUmamiIdentity() {
     try { localStorage.removeItem('umami.identity'); } catch (_) {}
 };
-(function _applyIdentityWhenReady() {
-    let me;
-    try { me = localStorage.getItem('umami.identity'); } catch (_) { return; }
-    if (!me) return;
-    let tries = 0;
-    const tick = () => {
-        if (window.umami && typeof window.umami.identify === 'function') {
-            try { window.umami.identify(me); } catch (_) {}
-            return;
-        }
-        if (++tries > 50) return;
-        setTimeout(tick, 100);
-    };
-    tick();
-})();

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -142,9 +142,15 @@
        Snippet so eh emitido quando AMBAS as vars estao setadas no ambiente
        (UMAMI_SCRIPT_URL + UMAMI_WEBSITE_ID), entao o site funciona sem
        analytics enquanto o painel nao for provisionado.
-       data-do-not-track=true respeita o header DNT do navegador. #}
+       data-do-not-track=true respeita o header DNT do navegador.
+       data-before-send aponta pra window.umamiBeforeSend (definido em
+       lib/umami-track.js) que injeta identity do localStorage em TODO
+       payload — incluindo o pageview inicial. Sem isso, ha race
+       condition: init() do tracker dispara pageview antes do nosso
+       identify() rodar -> sessao anonima criada -> distinct_id NAO
+       atrelado. #}
     {% if UMAMI_SCRIPT_URL and UMAMI_WEBSITE_ID %}
-    <script async defer src="{{ UMAMI_SCRIPT_URL }}" data-website-id="{{ UMAMI_WEBSITE_ID }}" data-do-not-track="true"></script>
+    <script async defer src="{{ UMAMI_SCRIPT_URL }}" data-website-id="{{ UMAMI_WEBSITE_ID }}" data-do-not-track="true" data-before-send="umamiBeforeSend"></script>
     {% endif %}
     {% block head_extra %}{% endblock %}
 </head>


### PR DESCRIPTION
setUmamiIdentity() funcionava no DB mas pageviews ficavam em outra sessao anonima por causa de race condition: init() do tracker dispara pageview inicial antes do nosso poll de identify rodar. Fix: usar hook data-before-send do tracker que injeta payload.id de localStorage em TODO send (incluindo o pageview inicial). Detalhes na commit message.