### PR TITLE
fix(deploy): nao logar GOACCESS_PASSWORD no audit log do sudo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -648,7 +648,7 @@ jobs:
       # ── Deploy web services ──
       - name: Deploy web frontend and cache warmer
         env:
-          # Passados via env: + sudo --preserve-env no setup-goaccess.sh
+          # Passados via env: + arquivo temp (chmod 600) no setup-goaccess.sh
           # logo abaixo. Os secrets entram no shell SO via variavel de
           # ambiente, nao por substituicao literal, prevenindo injection
           # se a senha tiver caracteres como $ ` " \.
@@ -680,17 +680,29 @@ jobs:
           # Pra ativar pela 1a vez, defina o secret GOACCESS_PASSWORD
           # (e opcionalmente GOACCESS_USER) no repositorio.
           #
-          # Secrets sao passados via env: block (no step, acima) + sudo
-          # --preserve-env, em vez de substituicao direta no shell. Isso
-          # protege contra shell injection se a senha contiver caracteres
-          # como $, ", `, \, etc. — substituicao via ${{ secrets.X }}
-          # dentro do run: e' parseada como shell antes do bash executar.
+          # Secrets sao passados via arquivo temp (chmod 600) em vez de
+          # `sudo --preserve-env=GOACCESS_PASSWORD`, porque sudo loga no
+          # audit do journal o conteudo de cada var preservada
+          # (`ENV=GOACCESS_PASSWORD=<senha> COMMAND=...`). Escrevemos as
+          # vars com printf %q (shell-quoted, safe contra $, `, ", \) em
+          # /tmp/<random>, dropamos pra sudo bash -c '. arquivo; bash
+          # setup-goaccess.sh', e o trap remove o arquivo no exit. O
+          # audit log fica com apenas `COMMAND=/bin/bash -c . /tmp/...; bash
+          # deploy/setup-goaccess.sh` — sem a senha.
           #
           # Soft-fail: o dashboard e' admin-only, opcional. Se a instalacao
           # falhar (PPA fora do ar, apt lock, etc.), logamos e seguimos o
           # deploy — o site publico nao depende disso.
-          sudo --preserve-env=GOACCESS_USER,GOACCESS_PASSWORD,GOACCESS_DOMAIN \
-            bash deploy/setup-goaccess.sh \
+          GOACCESS_SECRETS_FILE=$(mktemp)
+          chmod 600 "$GOACCESS_SECRETS_FILE"
+          trap 'rm -f "$GOACCESS_SECRETS_FILE"' EXIT
+          {
+            printf 'export GOACCESS_USER=%q\n'     "${GOACCESS_USER:-}"
+            printf 'export GOACCESS_PASSWORD=%q\n' "${GOACCESS_PASSWORD:-}"
+            printf 'export GOACCESS_DOMAIN=%q\n'   "${GOACCESS_DOMAIN:-}"
+          } > "$GOACCESS_SECRETS_FILE"
+
+          sudo bash -c ". '$GOACCESS_SECRETS_FILE'; bash deploy/setup-goaccess.sh" \
             || echo "WARNING: setup-goaccess.sh falhou (non-fatal — dashboard admin)."
 
           # Setup Umami analytics (self-hosted em /_traffic/analytics/).


### PR DESCRIPTION
## Problema

Cada deploy escrevia o conteudo de `GOACCESS_PASSWORD` em **plaintext** no audit log do sudo (journald). Achei 20 entradas no journal da VM entre 2026-05-11 e 2026-05-12 com a senha em claro:

```
sudo[PID]: govbr : PWD=... ; USER=root ;
  ENV=GOACCESS_USER=admin GOACCESS_PASSWORD=<senha> GOACCESS_DOMAIN=... ;
  COMMAND=/usr/bin/bash deploy/setup-goaccess.sh
```

Qualquer usuario com acesso ao journal (membros de `adm`/`systemd-journal` ou root) podia ver a senha do dashboard `/_traffic/`.

## Causa

`sudo --preserve-env=VAR1,VAR2,...` instrui o sudo a (1) propagar essas vars pra processo filho **e** (2) logar o conteudo delas no audit log no campo `ENV=`. Esse comportamento e' do sudoers (`Defaults log_env` default em Ubuntu) e nao tem como desativar so pra alguns vars.

Ate o PR #71 o secret era interpolado diretamente no shell (`sudo env GOACCESS_PASSWORD='${{ secrets.GOACCESS_PASSWORD }}'`), o que era ainda pior (shell injection + log). PR #71 mudou pra `env:` block + `--preserve-env`, removendo injection mas mantendo o log.

## Fix

Passa secrets via arquivo temp `mode 600` em vez do `--preserve-env`:

```bash
GOACCESS_SECRETS_FILE=$(mktemp)
chmod 600 "$GOACCESS_SECRETS_FILE"
trap 'rm -f "$GOACCESS_SECRETS_FILE"' EXIT
{
  printf 'export GOACCESS_USER=%q\n'     "${GOACCESS_USER:-}"
  printf 'export GOACCESS_PASSWORD=%q\n' "${GOACCESS_PASSWORD:-}"
  printf 'export GOACCESS_DOMAIN=%q\n'   "${GOACCESS_DOMAIN:-}"
} > "$GOACCESS_SECRETS_FILE"

sudo bash -c ". '$GOACCESS_SECRETS_FILE'; bash deploy/setup-goaccess.sh" \
  || echo "WARNING: setup-goaccess.sh falhou (non-fatal — dashboard admin)."
```

Pontos:
- `mktemp` cria com `mode 600` por default; `chmod 600` reforcado por defesa
- `trap` no `EXIT` garante remocao mesmo em falha/sinal/erro
- `printf '%q\n'` shell-quoting protege contra senhas com `$`, `` ` ``, `"`, `\`
- O `sudo bash -c "..."` agora loga apenas `COMMAND=/bin/bash -c . /tmp/tmp.XXXX; bash deploy/setup-goaccess.sh` (sem secret)
- `setup-goaccess.sh` nao precisou de mudancas — continua lendo `GOACCESS_*` do ambiente

## Verificacao apos merge

```bash
ssh govbr@transparenciapb.org \
  'sudo journalctl --since "10 minutes ago" | grep -iE "GOACCESS_PASSWORD"'
# (vazio = fixed)
```

## Nao mexido

- **Journal historico (20 entradas)**: senha continua no journal de 2026-05-11/12. Como senha `kong1029` continua valida e o journal e' tecnicamente acessivel so a `adm`/root, escolhemos nao limpar. Se quiser remover, rotacionar `GOACCESS_PASSWORD` no secret do GH e o historico fica invalidado de fato.
- **setup-goaccess.sh comentario `Uso`**: continua sugerindo `sudo env GOACCESS_PASSWORD='...' bash deploy/setup-goaccess.sh` pra uso manual. Manual one-off pode logar (uma vez) no audit do admin — aceitavel.
- **GitHub Actions log**: o `printf` no step nao expoe a senha (e' escrita pro arquivo, nao pro stdout). `set -x` nao esta habilitado.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
