### PR TITLE
fix(web): restaura padding-inline do md-secondary-tab (tabs colados no mobile)

### DIFF
--- a/web/static/css/components/md-host-padding-fix.css
+++ b/web/static/css/components/md-host-padding-fix.css
@@ -39,6 +39,15 @@
     padding: 0;
 }
 
-/* Icon buttons / FAB / dialog / divider / chip-set / tabs / list / menu /
+/* Secondary/primary tabs: MWC bundle defines `:host { padding: 0 16px }` so
+   each tab has 16dp leading/trailing. The universal reset (* { padding: 0 })
+   beats that :host rule (same Chromium quirk explained at the top of this
+   file), so without restoring it here the tab labels render edge-to-edge
+   and visually collapse into each other on narrow viewports. */
+:where(md-secondary-tab, md-primary-tab) {
+    padding-inline: 16px;
+}
+
+/* Icon buttons / FAB / dialog / divider / chip-set / list / menu /
    text-field / etc. handle their own internal layout via shadow CSS; no
    light-tree padding needed (these don't have :host padding rules). */


### PR DESCRIPTION
Follow-up do PR #100. Causa raiz das tabs grudadas era o universal reset zerar o padding via cascade quirk (light DOM \* { padding: 0 }\ venceu \:host { padding: 0 16px }\ do shadow DOM do MWC).

\md-host-padding-fix.css\ ja restaurava padding pra outros components (buttons etc) mas o comentario afirmava — incorretamente — que tabs nao precisavam. Verificado no bundle: \Fr\ (style compartilhado md-primary-tab + md-secondary-tab) tem \:host { padding: 0 16px }\.

## Validacao headless

Chromium 380x800, UA iOS Safari, com a regra simulada via \<style>\ injetado:
- paddingLeft/Right: 0px -> **16px**
- Resumo: 51px -> **83px**
- Pagamentos: 79px -> **111px**
- .tabs total: 419px -> **611px** (excede host 348px, ativa o scroll horizontal do PR #100)

Screenshot capturado confere visualmente: \Resumo | Resumo | Sancoes | Pagamentos\ com gap natural e o resto fora do viewport, scrollavel.