### PR TITLE
fix(web): tab 'PagamentosEmpenhos em' vira 'Empenhos'

### DIFF
--- a/web/static/js/components/dialog-decorate.js
+++ b/web/static/js/components/dialog-decorate.js
@@ -118,7 +118,14 @@ function _decorateDialogBody(body) {
     sections.forEach((section, idx) => {
         if (!section.id) section.id = `dialog-section-${idx + 1}`;
         const heading = section.querySelector('h4');
-        section.dataset.dialogLabel = _dialogSectionNavLabel(heading ? heading.textContent : `Secao ${idx + 1}`);
+        // Allow section authors to override the auto-derived tab label by
+        // setting data-nav-label on the section root. Useful when the h4
+        // contains concatenated citizen/auditor spans + dynamic content
+        // (e.g. a <select>) that no auto-detect regex can safely match.
+        const explicit = section.dataset.navLabel;
+        section.dataset.dialogLabel = explicit
+            ? explicit
+            : _dialogSectionNavLabel(heading ? heading.textContent : `Secao ${idx + 1}`);
         section.setAttribute('aria-labelledby', `${section.id}-tab`);
         section.classList.add('dialog-tab-panel');
         section.setAttribute('role', 'tabpanel');

--- a/web/static/js/components/fornecedor-dialog.js
+++ b/web/static/js/components/fornecedor-dialog.js
@@ -384,7 +384,7 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
             munSelect = `<select class="mun-selector" data-forn-cnpj="${_esc(cnpjBasico)}" data-forn-nome="${_esc(fornecedorNome)}" data-forn-nome-credor="${_esc(nomeCredor || '')}" data-forn-cpf-cnpj="${_esc(cpfCnpj || '')}">${opts}</select>`;
         }
 
-        html += `<div class="dialog-section" id="forn-empenhos"><h4>${dualLabel('Pagamentos','Empenhos')} ${munSelect ? 'em' : 'neste municipio'} ${munSelect}</h4>`;
+        html += `<div class="dialog-section" id="forn-empenhos" data-nav-label="Empenhos"><h4>${dualLabel('Pagamentos','Empenhos')} ${munSelect ? 'em' : 'neste municipio'} ${munSelect}</h4>`;
         // Container montado pelo empenhos-controller. Initial empenhos vem
         // do payload do /detalhes (50 mais recentes); paginas 2+ ou
         // filtros chamam /api/fornecedor/empenhos.


### PR DESCRIPTION
Tab 'PagamentosEmpenhos em' do empresa-dialog vira 'Empenhos'.

Causa: o h4 da section #forn-empenhos tem dualLabel('Pagamentos','Empenhos') + ' em ' + <select> de municipios. textContent concatena os dois spans + opcoes do select = 'PagamentosEmpenhos em Alagoa Nova...', sem casar nenhum regex de _dialogSectionNavLabel, fallback split(' ').slice(0,2) = 'PagamentosEmpenhos em'.

Fix: introduz override declarativo via `data-nav-label` na section. Mais robusto pra futuros casos com h4 dinamicos.