### PR TITLE
feat(web): dialog-tab-change + drilled_from no dialog-aberto

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -428,7 +428,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "107"
+templates.env.globals["ASSET_VERSION"] = "108"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/components/dialog-decorate.js
+++ b/web/static/js/components/dialog-decorate.js
@@ -196,9 +196,23 @@ function _decorateDialogBody(body) {
         if (!active) return;
         const id = active.dataset.dialogTarget;
         if (id && id !== body._activeDialogSectionId) {
+            const previousId = body._activeDialogSectionId || '';
             setActive(id, { scroll: true });
             // Reflete a tab atual no URL pra share-link incluir o estado.
             if (typeof _dialogUrlUpdateTab === 'function') _dialogUrlUpdateTab(id);
+            if (typeof trackEvent === 'function') {
+                // Label da tab (kebab-like) vem de _dialogSectionNavLabel,
+                // baseada no h4 da secao — estavel e semantica. Preferimos
+                // ela em vez do id da secao (autogen tipo "dialog-section-3"
+                // sem significado).
+                trackEvent('dialog-tab-change', {
+                    tipo: _currentDialogType || '',
+                    para: (active.textContent || '').trim().slice(0, 40),
+                    de: previousId
+                        ? (sections.find(s => s.id === previousId)?.dataset.dialogLabel || '').slice(0, 40)
+                        : '',
+                });
+            }
         }
     });
 

--- a/web/static/js/components/dialog-decorate.js
+++ b/web/static/js/components/dialog-decorate.js
@@ -352,6 +352,12 @@ function _decorateDialogBody(body) {
         const target = getNeighbor(direction);
         if (!target) { snapBack(); return; }
         const { current } = drag;
+        // Captura label das tabs (de/para) ANTES do setActive trocar
+        // _activeDialogSectionId. Caminho de swipe nao passa pelo
+        // tabs.change listener no setActive direto desta funcao, entao
+        // disparamos dialog-tab-change manualmente aqui.
+        const fromLabel = (current.dataset.dialogLabel || '').slice(0, 40);
+        const toLabel = (target.dataset.dialogLabel || '').slice(0, 40);
         const startX = drag.lastVisibleDx || 0;
         const width = body.clientWidth || window.innerWidth || 360;
         const exitX = direction > 0 ? -width : width;
@@ -375,6 +381,17 @@ function _decorateDialogBody(body) {
             // Hide outgoing FIRST (display:none) so any single-frame snap
             // to the underlying transform during cancel() isn't visible.
             setActive(target.id, { scroll: false });
+            // Mantem paridade com tabs.change listener: atualiza URL state
+            // + dispara analytics. Sem isso, swipe ficaria "invisivel"
+            // pra share-link e pro painel.
+            if (typeof _dialogUrlUpdateTab === 'function') _dialogUrlUpdateTab(target.id);
+            if (typeof trackEvent === 'function') {
+                trackEvent('dialog-tab-change', {
+                    tipo: _currentDialogType || '',
+                    de: fromLabel,
+                    para: toLabel,
+                });
+            }
             try { out.cancel(); } catch { /* already finished */ }
             restoreSectionStyles(current, snapshot);
             // Phase 2: target slides in from the opposite side.

--- a/web/static/js/components/dialog-nav.js
+++ b/web/static/js/components/dialog-nav.js
@@ -1,7 +1,13 @@
 // === components/dialog-nav.js ===
 // ── Dialog navigation stack ─────────────────────────────────────
 let _currentMunicipio = '';
-const _dialogStack = []; // [{title, html, activePanelId, urlState}]
+const _dialogStack = []; // [{title, html, activePanelId, urlState, tipo}]
+
+// Tipo do dialog atualmente aberto (empenho|servidor|fornecedor|licitacao|
+// heatmap). Vazio quando nenhum dialog aberto. Usado pra trackear drill
+// chains (ex: dialog-aberto vem com drilled_from='fornecedor' quando user
+// abriu um empenho a partir do dialog de fornecedor).
+let _currentDialogType = '';
 
 function _dialogPush() {
     const dialog = document.getElementById('empresa-dialog');
@@ -13,7 +19,7 @@ function _dialogPush() {
     // Salva snapshot do URL state atual (antes de a próxima open()
     // chamar _dialogStateApply replaceState com o novo state).
     const urlState = (history.state && history.state.dialogState) ? { ...history.state.dialogState } : null;
-    _dialogStack.push({ title, html, activePanelId, urlState });
+    _dialogStack.push({ title, html, activePanelId, urlState, tipo: _currentDialogType });
     dialog.querySelector('.dialog-back').style.visibility = 'visible';
 }
 
@@ -28,6 +34,10 @@ function _dialogPop() {
     _decorateDialogBody(body);
     if (prev.activePanelId) _activateDialogSection(body, prev.activePanelId, { focus: false, scroll: false });
     if (!_dialogStack.length) dialog.querySelector('.dialog-back').style.visibility = 'hidden';
+    // Restaura tipo do nivel anterior pra que drill chain subsequente
+    // (ex: voltar pra fornecedor e abrir outro empenho) tenha drilled_from
+    // correto.
+    _currentDialogType = prev.tipo || '';
     // Atualiza URL pro state do nivel anterior (sem nova history entry).
     // Race guard: bumpa seq pra cancelar fetches inflight da camada que
     // estamos saindo.
@@ -47,6 +57,7 @@ function _activateDialogSection(body, id, opts = {}) {
 
 function _dialogReset() {
     _dialogStack.length = 0;
+    _currentDialogType = '';
     const dialog = document.getElementById('empresa-dialog');
     if (dialog) dialog.querySelector('.dialog-back').style.visibility = 'hidden';
     document.body.classList.remove('dialog-open');

--- a/web/static/js/components/empenho-dialog.js
+++ b/web/static/js/components/empenho-dialog.js
@@ -4,7 +4,11 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     if (!dialog) return;
     const fromUrl = !!options.fromUrl;
     const isInitialOpen = !dialog.open;
+    // Captura tipo do dialog atual ANTES do push (perdido depois). Vazio
+    // quando isInitialOpen=true.
+    const drilledFrom = isInitialOpen ? '' : _currentDialogType;
     if (dialog.open) { _dialogPush(); } else { _dialogReset(); }
+    _currentDialogType = 'empenho';
     if (typeof _dialogStateApply === 'function') {
         _dialogStateApply({ d: 'empenho', id: String(empenhoId || '') }, fromUrl, isInitialOpen);
     }
@@ -19,6 +23,12 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
         tipo: 'empenho',
         empenho: String(empenhoId || ''),
         municipio: _currentMunicipio || '',
+    });
+    else if (drilledFrom) trackEvent && trackEvent('dialog-aberto', {
+        tipo: 'empenho',
+        empenho: String(empenhoId || ''),
+        municipio: _currentMunicipio || '',
+        drilled_from: drilledFrom,
     });
 
     const data = await _cachedPost('/api/empenho/detalhes', `emp:${empenhoId}`, { id: parseInt(empenhoId) });

--- a/web/static/js/components/fornecedor-dialog.js
+++ b/web/static/js/components/fornecedor-dialog.js
@@ -11,11 +11,13 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
     }
     const fromUrl = !!options.fromUrl;
     const isInitialOpen = !dialog.open && !switchMun;
+    const drilledFrom = isInitialOpen ? '' : _currentDialogType;
     if (!switchMun) {
         if (dialog.open) { _dialogPush(); } else { _dialogReset(); }
     } else {
         _dialogPush();
     }
+    _currentDialogType = 'fornecedor';
     // URL state (fromUrl=true skips push pra evitar duplicar history entry).
     if (typeof _dialogStateApply === 'function') {
         _dialogStateApply({
@@ -38,6 +40,13 @@ async function openFornecedorDialog(cnpjBasico, fornecedorNome, municipioOverrid
         cnpj: exactDoc,
         nome: fornecedorNome || nomeCredor || '',
         municipio: municipioOverride || _currentMunicipio || '',
+    });
+    else if (drilledFrom && !switchMun) trackEvent && trackEvent('dialog-aberto', {
+        tipo: 'fornecedor',
+        cnpj: exactDoc,
+        nome: fornecedorNome || nomeCredor || '',
+        municipio: municipioOverride || _currentMunicipio || '',
+        drilled_from: drilledFrom,
     });
 
     const viewMunicipio = municipioOverride || _currentMunicipio;

--- a/web/static/js/components/heatmap-dialog.js
+++ b/web/static/js/components/heatmap-dialog.js
@@ -4,8 +4,10 @@ async function openHeatmapMonthDialog(municipio, ano, mes, options = {}) {
     if (!dialog) return;
     const fromUrl = !!options.fromUrl;
     const isInitialOpen = !dialog.open;
+    const drilledFrom = (isInitialOpen || options.inPlace) ? '' : _currentDialogType;
     if (dialog.open && !options.inPlace) { _dialogPush(); }
     else if (!dialog.open) { _dialogReset(); }
+    _currentDialogType = 'heatmap';
     if (typeof _dialogStateApply === 'function' && !options.inPlace) {
         _dialogStateApply({
             d: 'heatmap',
@@ -28,6 +30,13 @@ async function openHeatmapMonthDialog(municipio, ano, mes, options = {}) {
         ano: String(ano || ''),
         mes: String(mes || ''),
         municipio: municipio || '',
+    });
+    else if (drilledFrom) trackEvent && trackEvent('dialog-aberto', {
+        tipo: 'heatmap',
+        ano: String(ano || ''),
+        mes: String(mes || ''),
+        municipio: municipio || '',
+        drilled_from: drilledFrom,
     });
 
     let data;

--- a/web/static/js/components/licitacao-dialog.js
+++ b/web/static/js/components/licitacao-dialog.js
@@ -9,7 +9,9 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
     if (!dialog) return;
     const fromUrl = !!options.fromUrl;
     const isInitialOpen = !dialog.open;
+    const drilledFrom = isInitialOpen ? '' : _currentDialogType;
     if (dialog.open) { _dialogPush(); } else { _dialogReset(); }
+    _currentDialogType = 'licitacao';
     if (typeof _dialogStateApply === 'function') {
         _dialogStateApply({
             d: 'licitacao',
@@ -32,6 +34,14 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
         ano: String(anoLicitacao || ''),
         modalidade: modalidade || '',
         municipio: municipio || _currentMunicipio || '',
+    });
+    else if (drilledFrom) trackEvent && trackEvent('dialog-aberto', {
+        tipo: 'licitacao',
+        numero: String(numeroLicitacao || ''),
+        ano: String(anoLicitacao || ''),
+        modalidade: modalidade || '',
+        municipio: municipio || _currentMunicipio || '',
+        drilled_from: drilledFrom,
     });
 
     const data = await _fetchLicitacaoDetails(numeroLicitacao, anoLicitacao, municipio, modalidade);

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -4,7 +4,9 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
     if (!dialog) return;
     const fromUrl = !!options.fromUrl;
     const isInitialOpen = !dialog.open;
+    const drilledFrom = isInitialOpen ? '' : _currentDialogType;
     if (dialog.open) { _dialogPush(); } else { _dialogReset(); }
+    _currentDialogType = 'servidor';
     // URL state push/replace.
     if (typeof _dialogStateApply === 'function') {
         const cnpjsStr = (Array.isArray(cnpjs) ? cnpjs : [])
@@ -31,6 +33,13 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
         cpf6: String(cpf6 || ''),
         nome: servidorNome || nome || '',
         municipio: _currentMunicipio || '',
+    });
+    else if (drilledFrom) trackEvent && trackEvent('dialog-aberto', {
+        tipo: 'servidor',
+        cpf6: String(cpf6 || ''),
+        nome: servidorNome || nome || '',
+        municipio: _currentMunicipio || '',
+        drilled_from: drilledFrom,
     });
 
     const data = await _fetchServidorDetails(cpf6, nome, cnpjs, _currentMunicipio);

--- a/web/static/js/lib/umami-track.js
+++ b/web/static/js/lib/umami-track.js
@@ -17,12 +17,17 @@
 //   cidade-visita         - {municipio, uf}  (top-of-funnel da cidade)
 //   mapa-cidade-click     - {cidade, metrica}
 //   mapa-metrica-mudou    - {metrica}
-//   dialog-aberto         - {tipo, municipio, ...id-fields conforme tipo}:
+//   dialog-aberto         - {tipo, municipio, ...id-fields conforme tipo,
+//                            drilled_from? (tipo do dialog anterior quando
+//                            usuario navegou de um dialog pra outro sem
+//                            fechar — ex: fornecedor->empenho)}:
 //                             tipo=empenho     -> {empenho}
 //                             tipo=servidor    -> {cpf6, nome}
 //                             tipo=fornecedor  -> {cnpj, nome}
 //                             tipo=licitacao   -> {numero, ano, modalidade}
 //                             tipo=heatmap     -> {ano, mes}
+//   dialog-tab-change     - {tipo, de, para}  (label das tabs do dialog
+//                            quando user troca via click/keyboard/swipe)
 //   empresa-visita        - {cnpj, nome, escopo: 'global'|'municipio', municipio?}
 //   pagina-caso-visita    - {slug}
 //   date-filter-aplicado  - {preset, de?, ate?, municipio?}


### PR DESCRIPTION
Cobre 2 gaps: navegacao entre tabs do dialog (click/keyboard/swipe) e drill chain entre tipos de dialog (ex: fornecedor->empenho->licitacao). Detalhes na commit message.