### PR TITLE
feat(deploy): warm cache antes do restart + skip-if-cached default + shadow rewarm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ on:
         type: string
         default: ''
       rewarm_cache_keys:
-        description: 'Lista CSV de prefixos/substrings de query_id para SHADOW rewarm (ZERO-DOWNTIME) no web_cache (ex: "Q65,HEATMAP"). Warm escreve em <qid>__pending; live rows continuam servindo. Apos warm completar com 100% sucesso, swap atomico promove shadow → live. Auto-expansao: se uma source dep (PERFIL/TOP_FORN/TOP_SERV) for shadow-warmed, KPI_SUMMARY (mesmo prefixo) entra em shadow tb. Apenas [a-zA-Z0-9_:] permitidos.'
+        description: 'Lista CSV de query_ids para SHADOW rewarm (ZERO-DOWNTIME) no web_cache (ex: "Q65,HEATMAP"). Match EXATO de qid ou base (NAO substring): "PERFIL" casa PERFIL/ANO:PERFIL/12M:PERFIL mas NAO casa EMPRESA_PERFIL. Warm escreve em <qid>__pending; live rows continuam servindo. Apos warm completar com 100% sucesso, swap atomico promove shadow → live. Auto-expansao: shadow de PERFIL/TOP_FORN/TOP_SERV (qq prefixo) entra KPI_SUMMARY (mesmo prefixo) tambem. Apenas [a-zA-Z0-9_:] permitidos.'
         required: false
         type: string
         default: ''
@@ -835,40 +835,64 @@ jobs:
 
       # ── Configure warm cache skip mode ──
       # Define WARM_SKIP_RECENT_HOURS no drop-in systemd:
-      #   -1 (default): warm skipa qualquer entrada cacheada (qualquer idade).
-      #                 Dados sao estaticos pos-ETL, reprocessar eh waste.
-      #   0           : rebuild completo (sem skip), forcado quando drop_cache=true.
+      #   -1 (default web-only): warm skipa qualquer entrada cacheada (any age).
+      #                          Dados sao estaticos pos-ETL, reprocessar eh waste.
+      #   0           : rebuild completo (sem skip).
       #   N > 0       : legacy resume mode (skip cacheados nas ultimas N horas).
-      # Se drop_cache=true, override pra 0 (cache acabou de ser TRUNCATE-ado).
+      #
+      # Override automatico pra SKIP_HRS=0 quando:
+      #   - drop_cache=true (cache acabou de ser TRUNCATE-ado, sem o que skip)
+      #   - etl_phase in (all, sql, incremental) — ETL/MVs/views mudaram, cache
+      #     ja existente esta STALE; precisa rebuild. (P1 GPT 5.5 review PR #105.)
+      # Operador pode forcar `-1` via input warm_skip_hours mesmo nesses casos
+      # se souber que os dados realmente nao mudaram (raro).
       - name: Configure warm cache skip mode
         if: |
           inputs.warm_cache == true ||
           inputs.etl_phase == 'all' ||
           inputs.etl_phase == 'sql' ||
+          inputs.etl_phase == 'incremental' ||
           inputs.rewarm_cache_keys != ''
         run: |
           set -euo pipefail
+          # Sanitiza warm_skip_hours: aceita inteiro (com -1 sinalizando
+          # "skip if cached at all"). Default -1 do input ja eh seguro;
+          # validacao via regex pra opt-in explicito.
+          RAW_SKIP="${{ inputs.warm_skip_hours }}"
+          if echo "$RAW_SKIP" | grep -qE '^-?[0-9]+$'; then
+            USER_SKIP="$RAW_SKIP"
+          else
+            USER_SKIP=-1
+            echo "::warning::warm_skip_hours invalido ('$RAW_SKIP'), usando default -1"
+          fi
+
           if [ "${{ inputs.drop_cache }}" = "true" ]; then
             SKIP_HRS=0
             echo "Full rebuild mode (drop_cache=true → SKIP_HRS=0)"
+          elif [ "${{ inputs.etl_phase }}" = "all" ] \
+            || [ "${{ inputs.etl_phase }}" = "sql" ] \
+            || [ "${{ inputs.etl_phase }}" = "incremental" ]; then
+            # ETL mudou dados/MVs. Default -1 deixaria cache stale eternamente.
+            # Override forca rebuild — a menos que operador explicitamente
+            # passe warm_skip_hours=-1 (sabe que dados nao mudaram de fato).
+            if [ "$USER_SKIP" = "-1" ] && [ "$RAW_SKIP" = "-1" ]; then
+              SKIP_HRS=0
+              echo "ETL fase '${{ inputs.etl_phase }}' mudou dados/MVs → forcando SKIP_HRS=0 (rebuild completo)"
+              echo "  (pra preservar cache mesmo apos ETL, passe warm_skip_hours=-1 explicitamente)"
+            else
+              SKIP_HRS="$USER_SKIP"
+              echo "ETL fase '${{ inputs.etl_phase }}' mudou dados, mas operador escolheu SKIP_HRS=$SKIP_HRS explicitamente"
+            fi
           else
-            # Sanitiza warm_skip_hours: aceita inteiro (com -1 sinalizando
-            # "skip if cached at all"). Default -1 do input ja eh seguro;
-            # validacao via regex pra opt-in explicito.
-            RAW_SKIP="${{ inputs.warm_skip_hours }}"
-            if echo "$RAW_SKIP" | grep -qE '^-?[0-9]+$'; then
-              SKIP_HRS="$RAW_SKIP"
-            else
-              SKIP_HRS=-1
-              echo "::warning::warm_skip_hours invalido ('$RAW_SKIP'), usando default -1"
-            fi
-            if [ "$SKIP_HRS" -lt 0 ]; then
-              echo "Default skip-if-cached: warm pula qualquer muni com entrada existente"
-            elif [ "$SKIP_HRS" -eq 0 ]; then
-              echo "Rebuild completo: warm reprocessa tudo"
-            else
-              echo "Legacy resume mode: pula munis cacheados nas ultimas ${SKIP_HRS}h"
-            fi
+            SKIP_HRS="$USER_SKIP"
+          fi
+
+          if [ "$SKIP_HRS" -lt 0 ]; then
+            echo "Mode: skip-if-cached (warm pula qualquer muni com entrada existente)"
+          elif [ "$SKIP_HRS" -eq 0 ]; then
+            echo "Mode: rebuild completo (warm reprocessa tudo)"
+          else
+            echo "Mode: legacy resume (pula cacheados nas ultimas ${SKIP_HRS}h)"
           fi
           # Tb passa WARM_REWARM_KEYS pro warm (lido pelo warm_cache.py
           # como REWARM_KEYS — patterns substring pra shadow rewarm).
@@ -1071,16 +1095,17 @@ jobs:
       # code + OLD cache (servindo rapido); apos restart, cruza-web sobe com
       # NEW code + cache JA QUENTE (queries pre-computadas em web_cache).
       #
-      # `if: always()` garante restart mesmo se Warm cache step retornou
-      # falha parcial (>5% queries com erro). Postflight tem `needs.deploy
-      # == success`; o continue-on-error do warm permite que o job continue
-      # ate aqui. NAO usamos always() puro porque queremos pular restart se
-      # algum step CRITICO anterior (ex: ETL, sync code) falhou — nesse
-      # caso o codigo em disco pode estar inconsistente e seria pior
-      # promove-lo. Por isso usamos `success() || failure()` (skipa em
-      # `cancelled()`).
+      # `if: success()` (sem `failure()`) — restart so se NENHUM step
+      # critico anterior falhou. Warm tem `continue-on-error: true`, entao
+      # falha parcial do warm (>5% queries) NAO transforma o job em failure()
+      # — restart ainda roda nesse caso, que eh o desejado. Mas se algum step
+      # ANTES do warm falhou catastroficamente (ETL crash, sync de codigo
+      # quebrado, build de assets falhou), o job esta em failure() e o
+      # restart SKIPa — promover codigo inconsistente seria pior que manter
+      # o cruza-web no estado anterior. Comportamento corrigido apos review
+      # GPT 5.5 + Opus 4.7 (PR #105).
       - name: Restart cruza-web (after warm)
-        if: success() || failure()
+        if: success()
         run: |
           set -euo pipefail
           echo "=== Restart cruza-web (codigo NOVO + cache QUENTE) ==="

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,10 +68,10 @@ on:
         type: string
         default: ''
       warm_skip_hours:
-        description: 'Modo de skip do warm. Default "-1" (NOVO): pula qualquer muni cacheado (qualquer idade) pq os dados sao estaticos pos-ETL. "0": rebuild completo (sem skip), opt-in. "N > 0": legacy resume mode — pula cacheados nas ultimas N horas. Ignorado se drop_cache=true (forca rebuild). Pra forcar rewarm de uma key especifica sem cache-miss, use rewarm_cache_keys.'
+        description: 'Modo de skip do warm. Vazio (default) = contextual: forca rebuild (0) apos etl_phase in (all/sql/incremental) que mudou dados; pula tudo cacheado (-1) caso contrario. "-1" = skip-if-cached SEMPRE (opt-out explicito do rebuild pos-ETL — use se sabe que dados nao mudaram). "0" = rebuild SEMPRE. "N > 0" = legacy resume mode (pula cacheados nas ultimas N horas). Ignorado se drop_cache=true (forca rebuild). Pra rewarm de key especifica sem cache-miss, use rewarm_cache_keys.'
         required: false
         type: string
-        default: '-1'
+        default: ''
       expose_empresa_sitemap:
         description: 'Toggle das paginas /empresa/<cnpj> no sitemap.xml. "keep" (default) preserva estado atual. "enable" exige cache cheio (warm_cache=true antes ou anteriormente) — escreve drop-in systemd, restart cruza-web, smoke test 3 CNPJs, IndexNow submit. "disable" remove drop-in (URLs somem do sitemap; cache web_cache permanece).'
         required: false
@@ -834,18 +834,29 @@ jobs:
           "
 
       # ── Configure warm cache skip mode ──
-      # Define WARM_SKIP_RECENT_HOURS no drop-in systemd:
-      #   -1 (default web-only): warm skipa qualquer entrada cacheada (any age).
-      #                          Dados sao estaticos pos-ETL, reprocessar eh waste.
-      #   0           : rebuild completo (sem skip).
-      #   N > 0       : legacy resume mode (skip cacheados nas ultimas N horas).
+      # Define WARM_SKIP_RECENT_HOURS no drop-in systemd. Comportamento por input:
       #
-      # Override automatico pra SKIP_HRS=0 quando:
-      #   - drop_cache=true (cache acabou de ser TRUNCATE-ado, sem o que skip)
-      #   - etl_phase in (all, sql, incremental) — ETL/MVs/views mudaram, cache
-      #     ja existente esta STALE; precisa rebuild. (P1 GPT 5.5 review PR #105.)
-      # Operador pode forcar `-1` via input warm_skip_hours mesmo nesses casos
-      # se souber que os dados realmente nao mudaram (raro).
+      #   warm_skip_hours vazio (default): CONTEXTUAL
+      #     - etl_phase in (all, sql, incremental): forca SKIP_HRS=0 (rebuild).
+      #       ETL mudou dados/MVs → cache existente esta stale.
+      #     - resto (web, phase N, etc): SKIP_HRS=-1 (skip-if-cached).
+      #
+      #   warm_skip_hours=-1: skip-if-cached SEMPRE, mesmo apos ETL. Opt-out
+      #     explicito do rebuild forcado, pra quando user sabe que dados nao
+      #     mudaram de fato (raro). Distingue do default vazio: se user passa
+      #     -1 explicitamente, RAW_SKIP=="-1" != "" (default).
+      #
+      #   warm_skip_hours=0: rebuild SEMPRE.
+      #   warm_skip_hours=N>0: legacy resume mode.
+      #
+      #   drop_cache=true: override pra SKIP_HRS=0 (cache acabou de ser
+      #     TRUNCATE-ado).
+      #
+      # Invalido (regex falha): fallback CONTEXTUAL (mesma logica do vazio) —
+      # safe-by-default, evita stale cache silencioso apos ETL.
+      #
+      # Round 2 fixes do review GPT 5.5 PR #105: separar "default contextual"
+      # de "user passou -1 explicito" via input default '' (vazio).
       - name: Configure warm cache skip mode
         if: |
           inputs.warm_cache == true ||
@@ -855,38 +866,49 @@ jobs:
           inputs.rewarm_cache_keys != ''
         run: |
           set -euo pipefail
-          # Sanitiza warm_skip_hours: aceita inteiro (com -1 sinalizando
-          # "skip if cached at all"). Default -1 do input ja eh seguro;
-          # validacao via regex pra opt-in explicito.
-          RAW_SKIP="${{ inputs.warm_skip_hours }}"
-          if echo "$RAW_SKIP" | grep -qE '^-?[0-9]+$'; then
-            USER_SKIP="$RAW_SKIP"
-          else
-            USER_SKIP=-1
-            echo "::warning::warm_skip_hours invalido ('$RAW_SKIP'), usando default -1"
+
+          # Detecta contexto de ETL pesado: dados/MVs mudaram, cache existente
+          # esta stale → default deve ser rebuild completo.
+          ETL_HEAVY=false
+          if [ "${{ inputs.etl_phase }}" = "all" ] \
+            || [ "${{ inputs.etl_phase }}" = "sql" ] \
+            || [ "${{ inputs.etl_phase }}" = "incremental" ]; then
+            ETL_HEAVY=true
           fi
+
+          RAW_SKIP="${{ inputs.warm_skip_hours }}"
 
           if [ "${{ inputs.drop_cache }}" = "true" ]; then
             SKIP_HRS=0
-            echo "Full rebuild mode (drop_cache=true → SKIP_HRS=0)"
-          elif [ "${{ inputs.etl_phase }}" = "all" ] \
-            || [ "${{ inputs.etl_phase }}" = "sql" ] \
-            || [ "${{ inputs.etl_phase }}" = "incremental" ]; then
-            # ETL mudou dados/MVs. Default -1 deixaria cache stale eternamente.
-            # Override forca rebuild — a menos que operador explicitamente
-            # passe warm_skip_hours=-1 (sabe que dados nao mudaram de fato).
-            if [ "$USER_SKIP" = "-1" ] && [ "$RAW_SKIP" = "-1" ]; then
+            REASON="drop_cache=true → TRUNCATE feito, rebuild forcado"
+          elif [ -z "$RAW_SKIP" ]; then
+            # Vazio = default contextual
+            if [ "$ETL_HEAVY" = "true" ]; then
               SKIP_HRS=0
-              echo "ETL fase '${{ inputs.etl_phase }}' mudou dados/MVs → forcando SKIP_HRS=0 (rebuild completo)"
-              echo "  (pra preservar cache mesmo apos ETL, passe warm_skip_hours=-1 explicitamente)"
+              REASON="default contextual: etl_phase '${{ inputs.etl_phase }}' mudou dados → rebuild forcado (passe warm_skip_hours=-1 pra opt-out se sabe que dados nao mudaram)"
             else
-              SKIP_HRS="$USER_SKIP"
-              echo "ETL fase '${{ inputs.etl_phase }}' mudou dados, mas operador escolheu SKIP_HRS=$SKIP_HRS explicitamente"
+              SKIP_HRS=-1
+              REASON="default contextual: nao-ETL → skip-if-cached"
             fi
+          elif echo "$RAW_SKIP" | grep -qE '^-?[0-9]+$'; then
+            # Valor explicito valido — respeita SEMPRE (incluindo -1 apos ETL).
+            SKIP_HRS="$RAW_SKIP"
+            REASON="warm_skip_hours='$RAW_SKIP' (explicito)"
           else
-            SKIP_HRS="$USER_SKIP"
+            # Input invalido: fallback CONTEXTUAL (mesmo do vazio) — safe.
+            # NUNCA fazemos fallback pra -1 silencioso apos ETL, pois deixaria
+            # cache stale sem o operador perceber.
+            if [ "$ETL_HEAVY" = "true" ]; then
+              SKIP_HRS=0
+              REASON="warm_skip_hours invalido ('$RAW_SKIP') + ETL_HEAVY → fallback safe SKIP_HRS=0"
+            else
+              SKIP_HRS=-1
+              REASON="warm_skip_hours invalido ('$RAW_SKIP') + non-ETL → fallback SKIP_HRS=-1"
+            fi
+            echo "::warning::warm_skip_hours invalido ('$RAW_SKIP'), aplicando fallback contextual"
           fi
 
+          echo "$REASON"
           if [ "$SKIP_HRS" -lt 0 ]; then
             echo "Mode: skip-if-cached (warm pula qualquer muni com entrada existente)"
           elif [ "$SKIP_HRS" -eq 0 ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,15 +58,20 @@ on:
         type: boolean
         default: false
       invalidate_cache_keys:
-        description: 'Lista CSV de prefixos/substrings de query_id para DELETE cirurgico no web_cache (ex: "PERFIL,KPI_SUMMARY,TOP_SERVIDORES"). Aplica DELETE WHERE query_id LIKE "%term%" para cada termo. Usado quando uma fix afeta so algumas queries — evita drop_cache=true full. Apenas [a-zA-Z0-9_:] permitidos por seguranca.'
+        description: 'Lista CSV de prefixos/substrings de query_id para DELETE cirurgico (HARD) no web_cache (ex: "PERFIL,KPI_SUMMARY"). Apaga LIVE rows: site sofre cache miss ate o warm reconstruir. Use APENAS se a data live esta BROKEN (ex: bug na query produziu lixo). Pra atualizar com zero downtime, prefira `rewarm_cache_keys`. Apenas [a-zA-Z0-9_:] permitidos.'
+        required: false
+        type: string
+        default: ''
+      rewarm_cache_keys:
+        description: 'Lista CSV de prefixos/substrings de query_id para SHADOW rewarm (ZERO-DOWNTIME) no web_cache (ex: "Q65,HEATMAP"). Warm escreve em <qid>__pending; live rows continuam servindo. Apos warm completar com 100% sucesso, swap atomico promove shadow → live. Auto-expansao: se uma source dep (PERFIL/TOP_FORN/TOP_SERV) for shadow-warmed, KPI_SUMMARY (mesmo prefixo) entra em shadow tb. Apenas [a-zA-Z0-9_:] permitidos.'
         required: false
         type: string
         default: ''
       warm_skip_hours:
-        description: 'Janela em horas que warm_cache pula (resume mode). Default 24: pula munis cacheados nas ultimas 24h. Aumente quando o ultimo warm foi ha mais tempo mas voce so quer reprocessar queries especificas via invalidate_cache_keys (ex: 72 = pula tudo cacheado nas ultimas 72h). Ignorado se drop_cache=true (forca SKIP_HRS=0).'
+        description: 'Modo de skip do warm. Default "-1" (NOVO): pula qualquer muni cacheado (qualquer idade) pq os dados sao estaticos pos-ETL. "0": rebuild completo (sem skip), opt-in. "N > 0": legacy resume mode — pula cacheados nas ultimas N horas. Ignorado se drop_cache=true (forca rebuild). Pra forcar rewarm de uma key especifica sem cache-miss, use rewarm_cache_keys.'
         required: false
         type: string
-        default: '24'
+        default: '-1'
       expose_empresa_sitemap:
         description: 'Toggle das paginas /empresa/<cnpj> no sitemap.xml. "keep" (default) preserva estado atual. "enable" exige cache cheio (warm_cache=true antes ou anteriormente) — escreve drop-in systemd, restart cruza-web, smoke test 3 CNPJs, IndexNow submit. "disable" remove drop-in (URLs somem do sitemap; cache web_cache permanece).'
         required: false
@@ -130,12 +135,15 @@ jobs:
           # Resize UP para B4 (16GB) sempre que houver trabalho pesado:
           #   - qualquer etl_phase != web (ETL/SQL/N usam mais RAM e CPU)
           #   - warm_cache=true (1 ciclo de warm leva ~20h, beneficia muito de B4)
-          # Caso contrario (etl_phase=web sem warm), mantem B2 (8GB) para economizar.
+          #   - rewarm_cache_keys != '' (warm shadow tb roda — precisa B4)
+          # Caso contrario (etl_phase=web sem warm sem rewarm), mantem B2 (8GB).
           # Disco segue a VM: Premium para trabalho pesado, Standard para web.
-          if [ "${{ inputs.etl_phase }}" = "web" ] && [ "${{ inputs.warm_cache }}" != "true" ]; then
+          if [ "${{ inputs.etl_phase }}" = "web" ] \
+             && [ "${{ inputs.warm_cache }}" != "true" ] \
+             && [ -z "${{ inputs.rewarm_cache_keys }}" ]; then
             echo "target_size=${{ env.VM_SIZE_WEB }}" >> "$GITHUB_OUTPUT"
             echo "target_disk_sku=${{ env.DISK_SKU_LIGHT }}" >> "$GITHUB_OUTPUT"
-            echo "etl_phase=web warm_cache=false → B2 + Standard SSD (web)"
+            echo "etl_phase=web warm_cache=false rewarm=empty → B2 + Standard SSD (web)"
           else
             echo "target_size=${{ env.VM_SIZE_ETL }}" >> "$GITHUB_OUTPUT"
             echo "target_disk_sku=${{ env.DISK_SKU_HEAVY }}" >> "$GITHUB_OUTPUT"
@@ -742,48 +750,27 @@ jobs:
           sudo systemctl daemon-reload
           sudo systemctl enable cruza-web
 
-          # Restart cruza-web to pick up new code AND new asset manifest.
-          # Importante: build acima + restart aqui = sem gap onde workers
-          # com manifest antigo coexistem com nginx servindo dist/ novo.
-          sudo systemctl restart cruza-web
+          # IMPORTANTE: o restart de cruza-web acontece SO no final, apos o warm
+          # terminar (step "Restart cruza-web (after warm)"). Isso evita o usuario
+          # ver 12-18h de cache miss enquanto o warm reconstroi web_cache: o
+          # processo OLD continua servindo OLD cache; quando o warm termina o
+          # restart faz cruza-web pegar codigo NOVO + cache JA QUENTE.
+          #
+          # Mas no PRIMEIRO deploy (cruza-web ainda nao rodando), precisamos
+          # subir alguma coisa pra o resto da pipeline (SEO IndexNow, smoke
+          # tests) ter cruza-web up. `systemctl start` eh no-op se ja ativo.
+          if ! systemctl is-active --quiet cruza-web; then
+            echo "cruza-web nao estava ativo — starting (primeiro deploy?)"
+            sudo systemctl start cruza-web
+          else
+            echo "cruza-web ja ativo — restart adiado pra apos o warm"
+          fi
 
-          echo "=== Web services deployed ==="
+          echo "=== Web services deployed (cruza-web restart adiado pra apos warm) ==="
           systemctl is-active nginx && echo "nginx: RUNNING" || echo "nginx: FAILED"
-          systemctl is-active cruza-web && echo "cruza-web: RUNNING" || echo "cruza-web: FAILED"
+          systemctl is-active cruza-web && echo "cruza-web: RUNNING (codigo OLD ate restart pos-warm)" || echo "cruza-web: FAILED"
           systemctl is-active cruza-umami >/dev/null 2>&1 && echo "cruza-umami: RUNNING" || echo "cruza-umami: not active (admin-only, OK)"
           echo "cruza-warm-cache: oneshot instalado (executado sob demanda)"
-
-      # ── SEO: notificar IndexNow (Bing/Yandex/Yahoo/Seznam/Naver) ──
-      # Roda apos cruza-web restart pra que /<INDEXNOW_KEY>.txt esteja
-      # acessivel quando os crawlers vierem validar. Submissao usa o
-      # sitemap dinamico (web.routes.seo._build_sitemap_xml), que ja
-      # inclui as 223 cidades + paginas estaticas. Tolerante a falha:
-      # `continue-on-error: true` + `|| true` no script garantem que
-      # IndexNow flaky nao quebra o deploy. Skip silencioso se a env
-      # var INDEXNOW_KEY nao estiver no .env.
-      - name: SEO - IndexNow submit (Bing/Yandex/Yahoo)
-        if: inputs.etl_phase == 'web' || inputs.etl_phase == 'all'
-        continue-on-error: true
-        run: |
-          set -e
-          cd ${{ env.PROJECT_DIR }}
-          source venv/bin/activate
-          # `set -a` faz `source .env` exportar as vars pro ambiente do
-          # subprocesso (sem isso, `python -m` nao enxergaria INDEXNOW_KEY
-          # mesmo com a var setada no .env). web/indexnow_submit.py tambem
-          # chama load_dotenv() como defesa em profundidade.
-          set -a
-          source .env 2>/dev/null || true
-          set +a
-          if [ -z "${INDEXNOW_KEY:-}" ]; then
-            echo "INDEXNOW_KEY nao setada no .env — skipping IndexNow submit"
-            exit 0
-          fi
-          echo "=== IndexNow submit (host=${SITE_URL:-https://transparenciapb.org}) ==="
-          # Aguarda alguns segundos pra garantir que o cruza-web reiniciou
-          # e a rota /<key>.txt esta servindo (caso crawlers validem na hora).
-          sleep 5
-          python -m web.indexnow_submit 2>&1 || echo "::warning::IndexNow submit falhou — verificar log acima"
 
       # ── Atualizar estatisticas das tabelas hot ANTES do warm ──
       # Sem stats atualizadas, o planner pode escolher planos ruins (ex: hash
@@ -795,7 +782,8 @@ jobs:
         if: |
           inputs.warm_cache == true ||
           inputs.etl_phase == 'all' ||
-          inputs.etl_phase == 'sql'
+          inputs.etl_phase == 'sql' ||
+          inputs.rewarm_cache_keys != ''
         run: |
           set -euo pipefail
           cd ${{ env.PROJECT_DIR }}
@@ -845,50 +833,119 @@ jobs:
             END \$\$;
           "
 
-      # ── Configure warm cache resume mode ──
-      # Se drop_cache=false (default): cache eh preservado, ativa resume mode
-      # (skip 24h) pra retomar warms interrompidos rapidamente. Trabalho ja
-      # feito eh preservado via UPSERT.
-      # Se drop_cache=true: cache foi TRUNCATE-ado, sem o que skip-ar.
-      - name: Configure warm cache resume mode
+      # ── Configure warm cache skip mode ──
+      # Define WARM_SKIP_RECENT_HOURS no drop-in systemd:
+      #   -1 (default): warm skipa qualquer entrada cacheada (qualquer idade).
+      #                 Dados sao estaticos pos-ETL, reprocessar eh waste.
+      #   0           : rebuild completo (sem skip), forcado quando drop_cache=true.
+      #   N > 0       : legacy resume mode (skip cacheados nas ultimas N horas).
+      # Se drop_cache=true, override pra 0 (cache acabou de ser TRUNCATE-ado).
+      - name: Configure warm cache skip mode
         if: |
           inputs.warm_cache == true ||
           inputs.etl_phase == 'all' ||
-          inputs.etl_phase == 'sql'
+          inputs.etl_phase == 'sql' ||
+          inputs.rewarm_cache_keys != ''
         run: |
           set -euo pipefail
           if [ "${{ inputs.drop_cache }}" = "true" ]; then
             SKIP_HRS=0
-            echo "Full rebuild mode (drop_cache=true)"
+            echo "Full rebuild mode (drop_cache=true → SKIP_HRS=0)"
           else
-            # Sanitiza input warm_skip_hours: apenas digitos
+            # Sanitiza warm_skip_hours: aceita inteiro (com -1 sinalizando
+            # "skip if cached at all"). Default -1 do input ja eh seguro;
+            # validacao via regex pra opt-in explicito.
             RAW_SKIP="${{ inputs.warm_skip_hours }}"
-            if echo "$RAW_SKIP" | grep -qE '^[0-9]+$'; then
+            if echo "$RAW_SKIP" | grep -qE '^-?[0-9]+$'; then
               SKIP_HRS="$RAW_SKIP"
             else
-              SKIP_HRS=24
-              echo "::warning::warm_skip_hours invalido ('$RAW_SKIP'), usando default 24"
+              SKIP_HRS=-1
+              echo "::warning::warm_skip_hours invalido ('$RAW_SKIP'), usando default -1"
             fi
-            echo "Resume mode: pula munis cacheados nas ultimas ${SKIP_HRS}h"
+            if [ "$SKIP_HRS" -lt 0 ]; then
+              echo "Default skip-if-cached: warm pula qualquer muni com entrada existente"
+            elif [ "$SKIP_HRS" -eq 0 ]; then
+              echo "Rebuild completo: warm reprocessa tudo"
+            else
+              echo "Legacy resume mode: pula munis cacheados nas ultimas ${SKIP_HRS}h"
+            fi
+          fi
+          # Tb passa WARM_REWARM_KEYS pro warm (lido pelo warm_cache.py
+          # como REWARM_KEYS — patterns substring pra shadow rewarm).
+          # Sanitiza via regex: aceita CSV de termos [A-Za-z0-9_:]+.
+          REWARM_RAW="${{ inputs.rewarm_cache_keys }}"
+          REWARM_VAL=""
+          if [ -n "$REWARM_RAW" ]; then
+            IFS=',' read -ra RTERMS <<< "$REWARM_RAW"
+            for term in "${RTERMS[@]}"; do
+              term=$(echo "$term" | tr -d ' ')
+              [ -z "$term" ] && continue
+              if ! echo "$term" | grep -qE '^[A-Za-z0-9_:]+$'; then
+                echo "::error::rewarm_cache_keys term invalido: '$term' (apenas [A-Za-z0-9_:] permitidos)"
+                exit 1
+              fi
+              if [ -n "$REWARM_VAL" ]; then
+                REWARM_VAL="$REWARM_VAL,$term"
+              else
+                REWARM_VAL="$term"
+              fi
+            done
+            echo "Shadow rewarm ativo: WARM_REWARM_KEYS=$REWARM_VAL"
           fi
           sudo mkdir -p /etc/systemd/system/cruza-warm-cache.service.d
           cat <<EOF | sudo tee /etc/systemd/system/cruza-warm-cache.service.d/runtime-env.conf > /dev/null
           [Service]
           Environment=WARM_SKIP_RECENT_HOURS=$SKIP_HRS
+          Environment=WARM_REWARM_KEYS=$REWARM_VAL
           EOF
           sudo systemctl daemon-reload
-          echo "WARM_SKIP_RECENT_HOURS=$SKIP_HRS configurado"
+          echo "WARM_SKIP_RECENT_HOURS=$SKIP_HRS, WARM_REWARM_KEYS='$REWARM_VAL' configurados"
 
-      # ── Invalidate selected cache keys ──
-      # DELETE cirurgico no web_cache para queries afetadas por uma fix
-      # especifica. Mais cirurgico que drop_cache=true (que apaga TUDO).
+      # ── Reset shadow rows (limpa __pending de deploys anteriores) ──
+      # Shadow rewarm escreve em <qid>__pending. Se um deploy anterior foi
+      # interrompido OU mudou a SQL entre deploys, os __pending podem estar
+      # stale. Pra garantir que o shadow desse deploy parte do zero, apagamos
+      # TODOS os __pending no inicio. Isso evita: (a) shadow stale ser
+      # "completado" e swapado (promove data velha pra live), (b) warm pular
+      # munis ja em __pending mas computados com SQL antigo.
+      #
+      # Roda sempre que o warm vai rodar (mesmo sem rewarm_cache_keys), pra
+      # higiene geral — orfaos __pending sao sempre indesejados.
+      - name: Reset shadow rows (clean __pending from previous deploys)
+        if: |
+          inputs.warm_cache == true ||
+          inputs.etl_phase == 'all' ||
+          inputs.etl_phase == 'sql' ||
+          inputs.rewarm_cache_keys != ''
+        run: |
+          set -euo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          source .env 2>/dev/null || true
+          PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
+          echo "=== Reset shadow rows (DELETE %__pending) ==="
+          PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 -c "
+            DO \$\$
+            DECLARE
+              n bigint;
+            BEGIN
+              IF to_regclass('public.web_cache') IS NOT NULL THEN
+                DELETE FROM web_cache WHERE query_id LIKE '%__pending';
+                GET DIAGNOSTICS n = ROW_COUNT;
+                RAISE NOTICE 'shadow __pending rows deleted: %', n;
+              ELSE
+                RAISE NOTICE 'web_cache nao existe ainda — nada a limpar';
+              END IF;
+            END \$\$;
+          "
+
+      # ── Invalidate selected cache keys (HARD delete, cache miss durante warm) ──
+      # DELETE cirurgico nas rows LIVE. Use APENAS se a data live esta BROKEN
+      # (ex: bug numa query produziu lixo); pra atualizar com zero-downtime,
+      # prefira `rewarm_cache_keys`.
       # Aceita CSV de termos: para cada termo T, executa
       # DELETE FROM web_cache WHERE query_id LIKE '%T%'.
       # Sanitiza input: apenas [a-zA-Z0-9_:] permitidos por termo, para
       # evitar SQL injection via patterns LIKE arbitrarios.
-      # Roda APOS Configure resume mode (que ja deixou skip=24h em modo
-      # nao-drop), porque queremos que o warm subsequente retrate as
-      # chaves deletadas (sem skip).
       - name: Invalidate selected cache keys
         if: inputs.invalidate_cache_keys != ''
         run: |
@@ -956,7 +1013,8 @@ jobs:
         if: |
           inputs.warm_cache == true ||
           inputs.etl_phase == 'all' ||
-          inputs.etl_phase == 'sql'
+          inputs.etl_phase == 'sql' ||
+          inputs.rewarm_cache_keys != ''
         continue-on-error: true
         run: |
           set -uo pipefail  # SEM -e: queremos capturar exit do systemctl
@@ -1005,6 +1063,75 @@ jobs:
             exit "$STATUS"
           fi
           echo "=== Cache warming complete ==="
+
+      # ── Restart cruza-web (apos warm) ──
+      # Aqui eh ONDE cruza-web pega o codigo novo. A inversao "warm primeiro,
+      # restart depois" garante que o usuario nao sofre 12-18h de cache miss
+      # enquanto o warm reconstroi: durante o warm, cruza-web rodou com OLD
+      # code + OLD cache (servindo rapido); apos restart, cruza-web sobe com
+      # NEW code + cache JA QUENTE (queries pre-computadas em web_cache).
+      #
+      # `if: always()` garante restart mesmo se Warm cache step retornou
+      # falha parcial (>5% queries com erro). Postflight tem `needs.deploy
+      # == success`; o continue-on-error do warm permite que o job continue
+      # ate aqui. NAO usamos always() puro porque queremos pular restart se
+      # algum step CRITICO anterior (ex: ETL, sync code) falhou — nesse
+      # caso o codigo em disco pode estar inconsistente e seria pior
+      # promove-lo. Por isso usamos `success() || failure()` (skipa em
+      # `cancelled()`).
+      - name: Restart cruza-web (after warm)
+        if: success() || failure()
+        run: |
+          set -euo pipefail
+          echo "=== Restart cruza-web (codigo NOVO + cache QUENTE) ==="
+          # restart funciona em servico ativo OU inativo (alias de stop+start).
+          sudo systemctl restart cruza-web
+          # Aguarda port 8000 responder (workers spawnam em ~3-5s).
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -sf --max-time 3 -o /dev/null \
+              -H "Host: transparenciapb.org" \
+              http://127.0.0.1:8000/static/manifest.webmanifest; then
+              echo "cruza-web ready (tentativa $i)"
+              break
+            fi
+            sleep 2
+          done
+          systemctl is-active cruza-web && echo "cruza-web: RUNNING (codigo NOVO)" || {
+            echo "::error::cruza-web FAILED apos restart pos-warm"
+            sudo systemctl status cruza-web --no-pager --lines=30 || true
+            exit 1
+          }
+
+      # ── SEO: notificar IndexNow (Bing/Yandex/Yahoo/Seznam/Naver) ──
+      # Roda APOS o restart pos-warm pra garantir que /<INDEXNOW_KEY>.txt
+      # esteja servindo a chave NOVA quando os crawlers vierem validar.
+      # Submissao usa sitemap gerado localmente em Python (NAO via HTTP),
+      # entao independente do estado do cruza-web. Tolerante a falha:
+      # `continue-on-error: true` + `|| true` no script garantem que
+      # IndexNow flaky nao quebra o deploy. Skip silencioso se a env
+      # var INDEXNOW_KEY nao estiver no .env.
+      - name: SEO - IndexNow submit (Bing/Yandex/Yahoo)
+        if: inputs.etl_phase == 'web' || inputs.etl_phase == 'all'
+        continue-on-error: true
+        run: |
+          set -e
+          cd ${{ env.PROJECT_DIR }}
+          source venv/bin/activate
+          # `set -a` faz `source .env` exportar as vars pro ambiente do
+          # subprocesso (sem isso, `python -m` nao enxergaria INDEXNOW_KEY
+          # mesmo com a var setada no .env). web/indexnow_submit.py tambem
+          # chama load_dotenv() como defesa em profundidade.
+          set -a
+          source .env 2>/dev/null || true
+          set +a
+          if [ -z "${INDEXNOW_KEY:-}" ]; then
+            echo "INDEXNOW_KEY nao setada no .env — skipping IndexNow submit"
+            exit 0
+          fi
+          echo "=== IndexNow submit (host=${SITE_URL:-https://transparenciapb.org}) ==="
+          # cruza-web ja foi restartado no step anterior; rota /<key>.txt
+          # serve a chave nova caso ela tenha mudado.
+          python -m web.indexnow_submit 2>&1 || echo "::warning::IndexNow submit falhou — verificar log acima"
 
       # ── Toggle empresa sitemap (enable/disable/keep) ──
       # Controla SITEMAP_INCLUDE_EMPRESAS via drop-in systemd em
@@ -1313,7 +1440,7 @@ jobs:
     if: |
       always() &&
       needs.deploy.result == 'success' &&
-      (inputs.etl_phase != 'web' || inputs.warm_cache == true)
+      (inputs.etl_phase != 'web' || inputs.warm_cache == true || inputs.rewarm_cache_keys != '')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/deploy/cruza-warm-cache.service
+++ b/deploy/cruza-warm-cache.service
@@ -13,9 +13,15 @@ WorkingDirectory=/home/govbr/govbr-project
 EnvironmentFile=/home/govbr/govbr-project/.env
 # Env vars opcionais (configurados via drop-in /etc/systemd/system/cruza-warm-cache.service.d/):
 #   WARM_CACHE_WORKERS=N         (default 4) — paralelismo
-#   WARM_SKIP_RECENT_HOURS=N     (default 0) — resume mode: pula munis cacheados ha < N horas
-#                                              0 = rebuild completo (default seguro)
-#                                              24 = skip cacheados ha <24h (apos web-only deploy)
+#   WARM_SKIP_RECENT_HOURS=N     (default -1) — modo de skip do cache
+#                                              -1 = skip qualquer entrada cacheada (any age) — dados estaticos
+#                                               0 = rebuild completo (sem skip)
+#                                               N > 0 = skip se cacheado nas ultimas N horas (legacy)
+#   WARM_REWARM_KEYS=csv         (default vazio) — patterns substring de query_id
+#                                              para shadow rewarm (zero-downtime). Warm escreve em
+#                                              <qid>__pending; live continua servindo; swap atomico
+#                                              ao fim do ciclo se fail==0. Auto-expansao de deps
+#                                              (PERFIL/TOP_FORN/TOP_SERV → KPI_SUMMARY mesmo prefix).
 # --daemon (sem --loop) roda 1 ciclo completo e termina. Atualizar todos os
 # municipios PB pode demorar varias horas; sem timeout aqui.
 ExecStart=/home/govbr/govbr-project/venv/bin/python -u -m web.warm_cache --daemon

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -98,17 +98,24 @@ def _skip_mode_label() -> str:
 # Durante o warm, resultados novos sao escritos em <query_id>__pending; live
 # rows continuam sendo lidos pelo cruza-web normalmente. Apos warm completar
 # com sucesso (fail == 0 pra essa qid), swap atomico move shadow → live numa
-# transacao curta com UPSERT (nao DELETE+RENAME) pra ser safe com warms
-# parciais (ex: --mun X promove apenas X sem apagar outras munis em live):
+# UNICA transacao cobrindo TODOS os qids elegiveis (atomicity all-or-nothing):
 #
 #   BEGIN;
+#     -- repete por qid em shadow com fail==0:
 #     INSERT INTO web_cache (qid, muni, ...) SELECT '<qid>', muni, ...
 #       FROM web_cache WHERE query_id = '<qid>__pending'
 #       ON CONFLICT (query_id, municipio) DO UPDATE SET ...;
 #     DELETE FROM web_cache WHERE query_id = '<qid>__pending';
 #   COMMIT;
 #
-# Disparado via env WARM_REWARM_KEYS (CSV de substring patterns), populado
+# A unica transacao garante que readers do cruza-web nunca vejam derived
+# (KPI_SUMMARY) na versao NEW enquanto source (PERFIL) ainda esta OLD, ou
+# vice-versa — todos os qids do shadow swap "rolam" simultaneamente do
+# ponto de vista de reads concorrentes (read committed semantics).
+# UPSERT (nao DELETE+RENAME) preserva munis fora do escopo do warm
+# (importante em warms parciais via --mun X).
+#
+# Disparado via env WARM_REWARM_KEYS (CSV de patterns exatos), populado
 # pelo deploy.yml a partir do input `rewarm_cache_keys`. Diferenca pro
 # `invalidate_cache_keys` (que faz hard DELETE): shadow rewarm zera o
 # downtime durante o warm (que pode demorar 12-18h).
@@ -155,14 +162,19 @@ def _skip_mode_label() -> str:
 # shadow KPI_SUMMARY le shadow PERFIL (sem misturar).
 #
 # ─── Limitacoes ──────────────────────────────────────────────────────────
-#   - Swap exige fail == 0 pra essa qid. Senao mantem shadow pra retry
-#     no proximo deploy (que reusa o shadow se ainda existir).
+#   - Swap exige fail == 0 pra essa qid. Senao swap abortado e shadow rows
+#     daquele ciclo sao descartados no inicio do PROXIMO deploy (via Reset
+#     shadow rows step). Nao ha "reuso de shadow parcial" entre deploys —
+#     decisao tomada pra evitar shadow stale quando SQL muda entre deploys
+#     (P1 Opus 4.7 review PR #105). Pra que swap aconteca, todos os munis
+#     da qid precisam ter sucesso num unico ciclo do warm.
 #   - Shadow rows sao DELETADOS no inicio de cada deploy ("Reset shadow
 #     rows" step no deploy.yml), evitando stale entre deploys que
 #     mudaram a SQL.
-#   - Match eh por substring (igual invalidate_cache_keys), entao
-#     pattern "PERFIL" casa PERFIL, ANO:PERFIL, 12M:PERFIL E
-#     EMPRESA_PERFIL. Use prefixos pra escopar (ANO:PERFIL).
+#   - Match eh EXATO (pattern == query_id OR pattern == base), NAO substring.
+#     Pattern "PERFIL" casa "PERFIL", "ANO:PERFIL", "12M:PERFIL" mas
+#     NAO casa "EMPRESA_PERFIL". Use prefixos explicitos pra escopar
+#     (ANO:Q65 vs Q65 sem prefixo).
 # ─────────────────────────────────────────────────────────────────────────
 
 # Sufixo aplicado a query_id pra denotar shadow rows. Reads do cruza-web
@@ -170,7 +182,7 @@ def _skip_mode_label() -> str:
 # _effective_qid.
 SHADOW_SUFFIX = "__pending"
 
-# Patterns de query_id em modo shadow (substring match). Vazio = sem shadow.
+# Patterns de query_id em modo shadow (match EXATO de qid ou base). Vazio = sem shadow.
 REWARM_KEYS = {
     k.strip() for k in os.getenv("WARM_REWARM_KEYS", "").split(",") if k.strip()
 }
@@ -201,23 +213,29 @@ def _qid_prefix(qid: str) -> str:
 def _is_shadow_for(query_id: str) -> bool:
     """True se este query_id deve usar shadow rows ao inves de live.
 
-    Regras:
-      1. Match direto por substring contra REWARM_KEYS.
-      2. Auto-expansao: se query_id eh derived (base em
-         CACHE_DEPENDENCY_GRAPH) E alguma source dep (mesmo prefixo) casa
-         REWARM_KEYS → derived entra em shadow tb.
+    Match semantics (exact base/qid, NAO substring):
+      - Pattern == query_id literal (ex: "ANO:Q65" casa exato).
+      - Pattern == base (qid sem prefixo): ex: "Q65" casa "Q65",
+        "ANO:Q65", "12M:Q65". MAS "PERFIL" NAO casa "EMPRESA_PERFIL"
+        (base de EMPRESA_PERFIL eh "EMPRESA_PERFIL" inteiro).
+      - Auto-expansao: se query_id eh derived (base em
+        CACHE_DEPENDENCY_GRAPH) E alguma source dep (mesmo prefixo) casa
+        REWARM_KEYS → derived entra em shadow tb.
+
+    Por que match exato e nao substring: evita "PERFIL" disparar warm
+    de ~143K empresas via EMPRESA_PERFIL (P1 GPT 5.5 review PR #105).
     """
     if not REWARM_KEYS:
         return False
-    if any(p in query_id for p in REWARM_KEYS):
-        return True
     base = _qid_base(query_id)
+    if any(p == query_id or p == base for p in REWARM_KEYS):
+        return True
     deps = CACHE_DEPENDENCY_GRAPH.get(base)
     if deps:
         prefix = _qid_prefix(query_id)
         for dep_base in deps:
             dep_qid = f"{prefix}{dep_base}"
-            if any(p in dep_qid for p in REWARM_KEYS):
+            if any(p == dep_qid or p == dep_base for p in REWARM_KEYS):
                 return True
     return False
 
@@ -242,114 +260,129 @@ def _record_shadow_result(query_id: str, ok: int, fail: int) -> None:
     _shadow_results[query_id] = (prev_ok + ok, prev_fail + fail)
 
 
-def _swap_shadow(query_id: str) -> tuple[bool, str]:
-    """Atomically promove shadow rows → live rows pra essa query_id.
-
-    Transacao curta com UPSERT (nao DELETE+RENAME) pra que warms parciais
-    (ex: warm_cache --mun "Joao Pessoa") promovam APENAS as munis processadas
-    sem apagar outras munis ja cacheadas em live:
-
-      BEGIN
-        INSERT live FROM shadow rows ON CONFLICT(query_id, muni) DO UPDATE
-        DELETE shadow rows
-      COMMIT
-
-    Em warms full (todos os munis em shadow), o efeito eh equivalente ao
-    DELETE+RENAME — todas as live rows da qid sao substituidas.
-
-    Caller deve verificar fail == 0 ANTES de chamar — swap com fail > 0
-    promoveria shadow incompleto, podendo (a) deixar munis ausentes do
-    shadow sem refresh (UPSERT nao apaga; old data permaneceria) ou
-    (b) gerar inconsistencia parcial. Politica atual: so swap se fail==0.
-
-    Returns (success, message). Em erro DB, rollback + (False, msg).
-    """
-    shadow_qid = f"{query_id}{SHADOW_SUFFIX}"
-    conn = psycopg2.connect(DSN)
-    conn.autocommit = False
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                f"""
-                INSERT INTO {CACHE_TABLE}
-                    (query_id, municipio, columns, rows, row_count, updated_at)
-                SELECT %s, municipio, columns, rows, row_count, now()
-                FROM {CACHE_TABLE}
-                WHERE query_id = %s
-                ON CONFLICT (query_id, municipio) DO UPDATE SET
-                    columns = EXCLUDED.columns,
-                    rows = EXCLUDED.rows,
-                    row_count = EXCLUDED.row_count,
-                    updated_at = EXCLUDED.updated_at
-                """,
-                (query_id, shadow_qid),
-            )
-            promoted = cur.rowcount
-            cur.execute(
-                f"DELETE FROM {CACHE_TABLE} WHERE query_id = %s", (shadow_qid,)
-            )
-            cleaned = cur.rowcount
-        conn.commit()
-        return True, f"promoted {promoted} shadow → live, cleaned {cleaned} shadow rows"
-    except Exception as e:
-        conn.rollback()
-        return False, f"swap failed: {str(e).splitlines()[0]}"
-    finally:
-        conn.close()
-
-
 def _swap_all_pending_shadows(verbose: bool = True) -> tuple[int, int]:
     """Apos warm cycle, swap atomico de cada qid que estava em shadow E
-    completou sem falhas. Mantem shadow rows pra qids com falhas (pra
-    retry no proximo deploy).
+    completou sem falhas (fail == 0).
+
+    Importante (alinhado com Reset shadow step no deploy.yml):
+      - Qids com fail > 0: shadow NAO promovido nesse ciclo. As rows shadow
+        ficam no banco mas serao APAGADAS no inicio do proximo deploy
+        (Reset). Sem reuso entre deploys — evita shadow stale quando SQL
+        muda entre deploys.
+      - Swap ATOMICO entre todas as qids: uma unica transacao cobre
+        UPSERT+DELETE pra todos os qids elegíveis. Elimina janela onde
+        derived (KPI) e source (PERFIL) ficam temporariamente em versoes
+        diferentes em live. (P2 Opus 4.7 + GPT 5.5 review PR #105.)
 
     Returns (swapped_count, kept_count).
     """
     if not _shadow_results:
         return 0, 0
-    swapped = kept = 0
-    if verbose:
-        print(
-            f"\n--- Shadow swap: {len(_shadow_results)} qids candidatas ---",
-            flush=True,
-        )
+
+    swappable: list[str] = []
+    skipped_zero: list[str] = []
+    aborted: list[tuple[str, int, int]] = []
     for qid, (ok, fail) in sorted(_shadow_results.items()):
         if fail > 0:
-            kept += 1
-            if verbose:
-                print(
-                    f"  KEEP shadow {qid}: {ok} ok, {fail} fail — swap "
-                    f"abortado, retry no proximo deploy",
-                    flush=True,
-                )
+            aborted.append((qid, ok, fail))
             continue
         if ok == 0:
-            # Sem rows na shadow: warm pulou tudo (ja cacheado em deploy
-            # anterior). Limpa shadow vazio sem swap.
-            kept += 1
-            if verbose:
-                print(
-                    f"  SKIP shadow {qid}: 0 rows escritas (warm encontrou "
-                    f"tudo ja na shadow de deploy anterior — verifique "
-                    f"se reset rodou)",
-                    flush=True,
-                )
+            skipped_zero.append(qid)
             continue
-        success, msg = _swap_shadow(qid)
-        if success:
-            swapped += 1
-            if verbose:
-                print(f"  SWAP {qid}: {msg}", flush=True)
-        else:
-            kept += 1
-            if verbose:
-                print(f"  FAIL {qid}: {msg}", flush=True)
+        swappable.append(qid)
+
     if verbose:
         print(
-            f"--- Shadow swap done: {swapped} swapped, {kept} kept ---",
+            f"\n--- Shadow swap: {len(swappable)} swap, "
+            f"{len(aborted)} abort (fail>0), {len(skipped_zero)} skip (0 rows) ---",
             flush=True,
         )
-    return swapped, kept
+        for qid, ok, fail in aborted:
+            print(
+                f"  ABORT {qid}: {ok} ok, {fail} fail — shadow descartado "
+                f"no proximo deploy (rerun com mesmo rewarm_cache_keys)",
+                flush=True,
+            )
+        for qid in skipped_zero:
+            print(
+                f"  SKIP {qid}: 0 rows escritas (warm filtrou tudo — "
+                f"verifique se Reset shadow rows step rodou)",
+                flush=True,
+            )
+
+    if not swappable:
+        if verbose:
+            print("--- Shadow swap done: 0 swapped ---", flush=True)
+        return 0, len(aborted) + len(skipped_zero)
+
+    # SWAP ATOMICO entre todos os qids: uma unica transacao. Garante que
+    # readers do cruza-web nunca vejam KPI v=NEW + PERFIL v=OLD durante
+    # a transicao. Read-committed do PG ainda permite que uma request
+    # individual veja snapshot consistente pos-COMMIT. (P2 review.)
+    conn = psycopg2.connect(DSN)
+    conn.autocommit = False
+    swapped = 0
+    failed_qids: list[tuple[str, str]] = []
+    try:
+        with conn.cursor() as cur:
+            for qid in swappable:
+                shadow_qid = f"{qid}{SHADOW_SUFFIX}"
+                try:
+                    cur.execute(
+                        f"""
+                        INSERT INTO {CACHE_TABLE}
+                            (query_id, municipio, columns, rows, row_count, updated_at)
+                        SELECT %s, municipio, columns, rows, row_count, now()
+                        FROM {CACHE_TABLE}
+                        WHERE query_id = %s
+                        ON CONFLICT (query_id, municipio) DO UPDATE SET
+                            columns = EXCLUDED.columns,
+                            rows = EXCLUDED.rows,
+                            row_count = EXCLUDED.row_count,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        (qid, shadow_qid),
+                    )
+                    promoted = cur.rowcount
+                    cur.execute(
+                        f"DELETE FROM {CACHE_TABLE} WHERE query_id = %s",
+                        (shadow_qid,),
+                    )
+                    cleaned = cur.rowcount
+                    if verbose:
+                        print(
+                            f"  SWAP {qid}: promoted {promoted}, cleaned {cleaned}",
+                            flush=True,
+                        )
+                    swapped += 1
+                except Exception as e:
+                    msg = str(e).splitlines()[0]
+                    failed_qids.append((qid, msg))
+                    if verbose:
+                        print(f"  FAIL {qid}: {msg}", flush=True)
+                    # Re-raise pra rollback de TODA a transacao —
+                    # consistencia all-or-nothing entre as qids.
+                    raise
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        if verbose:
+            print(
+                f"--- Shadow swap ROLLBACK (atomico): {len(swappable)} qids "
+                f"NAO promovidos. Re-run com mesmo rewarm_cache_keys. ---",
+                flush=True,
+            )
+        return 0, len(swappable) + len(aborted) + len(skipped_zero)
+    finally:
+        conn.close()
+
+    if verbose:
+        print(
+            f"--- Shadow swap done: {swapped} swapped, "
+            f"{len(aborted) + len(skipped_zero)} kept/skipped ---",
+            flush=True,
+        )
+    return swapped, len(aborted) + len(skipped_zero)
 
 # Timeouts (segundos) usados pelo warmer. Sao MAIORES que os do frontend
 # porque rodamos em background e queremos popular o cache mesmo para queries
@@ -1181,10 +1214,11 @@ def main():
             ok_e, fail_e, skip_e = _warm_empresas_phase()
             ok_em, fail_em, skip_em = _warm_empresas_municipios_phase()
         # Shadow swap: apos TODO trabalho do ciclo terminar, fazemos os
-        # swaps atomicos das qids que estavam em shadow E completaram
-        # sem falhas. Mantemos shadow das que falharam (retry no proximo
-        # deploy via mesmo rewarm_cache_keys, que reusa o shadow porque
-        # _filter_cached_munis filtra pelo __pending tb).
+        # swaps atomicos (UMA transacao cobrindo todos os qids elegiveis)
+        # das qids que estavam em shadow E completaram sem falhas.
+        # Qids com fail > 0 ficam SEM swap nesse ciclo; o "Reset shadow
+        # rows" step no proximo deploy descarta o shadow stale antes de
+        # reprocessar.
         # Importante: swap acontece UMA VEZ por ciclo, depois das fases
         # PB + empresas + empresas_municipios. Garante que KPI_SUMMARY
         # (derived) ja foi computado contra o shadow de PERFIL antes do

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -66,12 +66,290 @@ PARALLEL_WORKERS = int(os.getenv("WARM_CACHE_WORKERS", "4"))
 # como um todo). cruza-web abre suas proprias conexoes e nao eh afetado.
 WARM_WORK_MEM = "192MB"
 
-# Resume mode: pula queries cacheadas ha menos de N horas.
-# Usado quando os DADOS nao mudaram (ex: etl_phase=web warm_cache=true).
-# 0 = sem skip (rebuild completo), tipico apos ETL/SQL que recriou MVs.
-# 24 = pula tudo cacheado nas ultimas 24h (resume de warm interrompido).
-# Configurado via env var pelo deploy.yml conforme etl_phase.
-SKIP_RECENT_HOURS = int(os.getenv("WARM_SKIP_RECENT_HOURS", "0"))
+# Modo de skip do warm. Dados das fontes governamentais sao ESTATICOS apos o
+# ETL terminar, entao por padrao NAO recomputamos cache ja gerado — apenas
+# preenchemos chaves ausentes ou recem-invalidadas (via TRUNCATE web_cache
+# com drop_cache=true ou DELETE cirurgico com invalidate_cache_keys=...).
+#
+# Valores:
+#   -1 (DEFAULT): skip qualquer entrada cacheada, qualquer idade. Eh o modo
+#                 normal porque os dados sao estaticos. Para forcar rebuild,
+#                 use drop_cache (TRUNCATE) ou invalidate_cache_keys (DELETE).
+#    0: rebuild completo (sem skip). Opt-in explicito; raramente necessario.
+#    N > 0: skip se cacheado nas ultimas N horas (resume mode legacy, usado
+#           quando se quer um upper-bound de idade — ex: forcar reprocessar
+#           tudo cacheado ha >72h).
+SKIP_RECENT_HOURS = int(os.getenv("WARM_SKIP_RECENT_HOURS", "-1"))
+
+
+def _skip_mode_label() -> str:
+    """Etiqueta humana do modo de skip para logs."""
+    if SKIP_RECENT_HOURS < 0:
+        return "skip-if-cached (any age)"
+    if SKIP_RECENT_HOURS == 0:
+        return "rebuild completo"
+    return f"skip se cacheado nas ultimas {SKIP_RECENT_HOURS}h"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# SHADOW REWARM — zero-downtime cache key versioning
+# ─────────────────────────────────────────────────────────────────────────
+# Permite re-popular uma chave do cache SEM cache-miss enquanto o warm roda.
+# Durante o warm, resultados novos sao escritos em <query_id>__pending; live
+# rows continuam sendo lidos pelo cruza-web normalmente. Apos warm completar
+# com sucesso (fail == 0 pra essa qid), swap atomico move shadow → live numa
+# transacao curta com UPSERT (nao DELETE+RENAME) pra ser safe com warms
+# parciais (ex: --mun X promove apenas X sem apagar outras munis em live):
+#
+#   BEGIN;
+#     INSERT INTO web_cache (qid, muni, ...) SELECT '<qid>', muni, ...
+#       FROM web_cache WHERE query_id = '<qid>__pending'
+#       ON CONFLICT (query_id, municipio) DO UPDATE SET ...;
+#     DELETE FROM web_cache WHERE query_id = '<qid>__pending';
+#   COMMIT;
+#
+# Disparado via env WARM_REWARM_KEYS (CSV de substring patterns), populado
+# pelo deploy.yml a partir do input `rewarm_cache_keys`. Diferenca pro
+# `invalidate_cache_keys` (que faz hard DELETE): shadow rewarm zera o
+# downtime durante o warm (que pode demorar 12-18h).
+#
+# ─── Adicionando shadow rewarm para uma NOVA "LEAF" query ────────────────
+# Leaf = query computada direto do banco/MV, NAO le de outras keys do cache
+# (ex: HEATMAP, Q01-Q310 do registry, PERFIL, EMPRESA_PERFIL).
+#
+#   Nao requer mudancas no codigo. Basta o user passar o pattern em
+#   rewarm_cache_keys; _warm_query_across_munis e _filter_cached_munis ja
+#   consultam _effective_qid internamente.
+#
+# ─── Adicionando shadow rewarm para uma NOVA "DERIVED" query ─────────────
+# Derived = query computada lendo OUTRAS keys do web_cache (ex:
+# KPI_SUMMARY le PERFIL/TOP_FORNECEDORES/TOP_SERVIDORES e agrega em Python).
+#
+#   1. Registre as deps em CACHE_DEPENDENCY_GRAPH abaixo. Bases sao
+#      sem prefixo (PERFIL, nao ANO:PERFIL) — a expansao por prefixo
+#      eh automatica via _is_shadow_for.
+#   2. Na funcao que computa o derived, leia cada dep do cache via
+#        cache = _read_cache(conn, _effective_qid(f"{prefix}DEP"), mun)
+#      (translation shadow/live automatica).
+#   3. Strict no-fallback: se _is_shadow_for(derived_qid) AND
+#      _is_shadow_for(dep_qid) AND cache vazio pra essa muni → retorne
+#      False (a funcao FALHA pra essa muni). Sem isso, computaria
+#      misturando OLD live + NEW shadow e geraria stale apos swap.
+#      Ver _compute_and_cache_kpi_summary como modelo.
+#   4. Em warm_cycle_pb, garanta que as deps rodam ANTES do derived
+#      (ordem das fases). Hoje: PERFIL → TOP_FORN → TOP_SERV →
+#      KPI_SUMMARY.
+#
+# ─── Por que o derived precisa entrar em shadow quando um dep entra? ─────
+# Sem auto-expansao, o cenario seria:
+#   - User pede rewarm_cache_keys=PERFIL
+#   - Warm escreve PERFIL__pending (shadow). Live PERFIL continua VELHO.
+#   - Warm chega no KPI_SUMMARY; le PERFIL do cache → le do live →
+#     PERFIL VELHO. Computa KPI_SUMMARY baseado em VELHO. Escreve em
+#     live KPI_SUMMARY (porque KPI_SUMMARY nao entrou em shadow).
+#   - Swap do PERFIL: live PERFIL = NOVO.
+#   - Live KPI_SUMMARY = computado do VELHO PERFIL → inconsistente
+#     com NOVO PERFIL no UI.
+# Solucao: _is_shadow_for auto-inclui o derived quando alguma dep esta
+# em shadow (mesmo prefixo). Idem strict no-fallback: garante que
+# shadow KPI_SUMMARY le shadow PERFIL (sem misturar).
+#
+# ─── Limitacoes ──────────────────────────────────────────────────────────
+#   - Swap exige fail == 0 pra essa qid. Senao mantem shadow pra retry
+#     no proximo deploy (que reusa o shadow se ainda existir).
+#   - Shadow rows sao DELETADOS no inicio de cada deploy ("Reset shadow
+#     rows" step no deploy.yml), evitando stale entre deploys que
+#     mudaram a SQL.
+#   - Match eh por substring (igual invalidate_cache_keys), entao
+#     pattern "PERFIL" casa PERFIL, ANO:PERFIL, 12M:PERFIL E
+#     EMPRESA_PERFIL. Use prefixos pra escopar (ANO:PERFIL).
+# ─────────────────────────────────────────────────────────────────────────
+
+# Sufixo aplicado a query_id pra denotar shadow rows. Reads do cruza-web
+# leem apenas live (query_id sem sufixo); only o warm le shadow via
+# _effective_qid.
+SHADOW_SUFFIX = "__pending"
+
+# Patterns de query_id em modo shadow (substring match). Vazio = sem shadow.
+REWARM_KEYS = {
+    k.strip() for k in os.getenv("WARM_REWARM_KEYS", "").split(",") if k.strip()
+}
+
+# Mapa derived → [source bases]. Adicione aqui novas derived queries pra
+# que a auto-expansao funcione: shadow de uma source dispara shadow do
+# derived (mesmo prefixo). Bases SEM prefixo.
+CACHE_DEPENDENCY_GRAPH: dict[str, list[str]] = {
+    "KPI_SUMMARY": ["PERFIL", "TOP_FORNECEDORES", "TOP_SERVIDORES"],
+}
+
+# Tracking dos resultados de queries que estavam em shadow durante esta
+# execucao do warm. qid (logical, sem __pending) → (ok, fail). Usado no
+# final do ciclo pra decidir quais qids podem ter swap (so se fail == 0).
+_shadow_results: dict[str, tuple[int, int]] = {}
+
+
+def _qid_base(qid: str) -> str:
+    """Retorna o segmento 'base' do query_id, removendo prefixos ANO:/12M:."""
+    return qid.split(":", 1)[-1] if ":" in qid else qid
+
+
+def _qid_prefix(qid: str) -> str:
+    """Retorna o prefixo incluindo ':', ou string vazia."""
+    return qid.split(":", 1)[0] + ":" if ":" in qid else ""
+
+
+def _is_shadow_for(query_id: str) -> bool:
+    """True se este query_id deve usar shadow rows ao inves de live.
+
+    Regras:
+      1. Match direto por substring contra REWARM_KEYS.
+      2. Auto-expansao: se query_id eh derived (base em
+         CACHE_DEPENDENCY_GRAPH) E alguma source dep (mesmo prefixo) casa
+         REWARM_KEYS → derived entra em shadow tb.
+    """
+    if not REWARM_KEYS:
+        return False
+    if any(p in query_id for p in REWARM_KEYS):
+        return True
+    base = _qid_base(query_id)
+    deps = CACHE_DEPENDENCY_GRAPH.get(base)
+    if deps:
+        prefix = _qid_prefix(query_id)
+        for dep_base in deps:
+            dep_qid = f"{prefix}{dep_base}"
+            if any(p in dep_qid for p in REWARM_KEYS):
+                return True
+    return False
+
+
+def _effective_qid(query_id: str) -> str:
+    """Retorna o query_id efetivo pra leitura/escrita do cache durante warm.
+
+    Em modo shadow: anexa SHADOW_SUFFIX. Live rows (sem sufixo) continuam
+    sendo servidos pelo cruza-web ate o swap final.
+    """
+    return f"{query_id}{SHADOW_SUFFIX}" if _is_shadow_for(query_id) else query_id
+
+
+def _record_shadow_result(query_id: str, ok: int, fail: int) -> None:
+    """Acumula resultado de um shadow warm (chamado por warm_query/warm_kpi).
+
+    Mantido como agregado: chamadas multiplas pra mesma qid somam ok/fail.
+    """
+    if not _is_shadow_for(query_id):
+        return
+    prev_ok, prev_fail = _shadow_results.get(query_id, (0, 0))
+    _shadow_results[query_id] = (prev_ok + ok, prev_fail + fail)
+
+
+def _swap_shadow(query_id: str) -> tuple[bool, str]:
+    """Atomically promove shadow rows → live rows pra essa query_id.
+
+    Transacao curta com UPSERT (nao DELETE+RENAME) pra que warms parciais
+    (ex: warm_cache --mun "Joao Pessoa") promovam APENAS as munis processadas
+    sem apagar outras munis ja cacheadas em live:
+
+      BEGIN
+        INSERT live FROM shadow rows ON CONFLICT(query_id, muni) DO UPDATE
+        DELETE shadow rows
+      COMMIT
+
+    Em warms full (todos os munis em shadow), o efeito eh equivalente ao
+    DELETE+RENAME — todas as live rows da qid sao substituidas.
+
+    Caller deve verificar fail == 0 ANTES de chamar — swap com fail > 0
+    promoveria shadow incompleto, podendo (a) deixar munis ausentes do
+    shadow sem refresh (UPSERT nao apaga; old data permaneceria) ou
+    (b) gerar inconsistencia parcial. Politica atual: so swap se fail==0.
+
+    Returns (success, message). Em erro DB, rollback + (False, msg).
+    """
+    shadow_qid = f"{query_id}{SHADOW_SUFFIX}"
+    conn = psycopg2.connect(DSN)
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {CACHE_TABLE}
+                    (query_id, municipio, columns, rows, row_count, updated_at)
+                SELECT %s, municipio, columns, rows, row_count, now()
+                FROM {CACHE_TABLE}
+                WHERE query_id = %s
+                ON CONFLICT (query_id, municipio) DO UPDATE SET
+                    columns = EXCLUDED.columns,
+                    rows = EXCLUDED.rows,
+                    row_count = EXCLUDED.row_count,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                (query_id, shadow_qid),
+            )
+            promoted = cur.rowcount
+            cur.execute(
+                f"DELETE FROM {CACHE_TABLE} WHERE query_id = %s", (shadow_qid,)
+            )
+            cleaned = cur.rowcount
+        conn.commit()
+        return True, f"promoted {promoted} shadow → live, cleaned {cleaned} shadow rows"
+    except Exception as e:
+        conn.rollback()
+        return False, f"swap failed: {str(e).splitlines()[0]}"
+    finally:
+        conn.close()
+
+
+def _swap_all_pending_shadows(verbose: bool = True) -> tuple[int, int]:
+    """Apos warm cycle, swap atomico de cada qid que estava em shadow E
+    completou sem falhas. Mantem shadow rows pra qids com falhas (pra
+    retry no proximo deploy).
+
+    Returns (swapped_count, kept_count).
+    """
+    if not _shadow_results:
+        return 0, 0
+    swapped = kept = 0
+    if verbose:
+        print(
+            f"\n--- Shadow swap: {len(_shadow_results)} qids candidatas ---",
+            flush=True,
+        )
+    for qid, (ok, fail) in sorted(_shadow_results.items()):
+        if fail > 0:
+            kept += 1
+            if verbose:
+                print(
+                    f"  KEEP shadow {qid}: {ok} ok, {fail} fail — swap "
+                    f"abortado, retry no proximo deploy",
+                    flush=True,
+                )
+            continue
+        if ok == 0:
+            # Sem rows na shadow: warm pulou tudo (ja cacheado em deploy
+            # anterior). Limpa shadow vazio sem swap.
+            kept += 1
+            if verbose:
+                print(
+                    f"  SKIP shadow {qid}: 0 rows escritas (warm encontrou "
+                    f"tudo ja na shadow de deploy anterior — verifique "
+                    f"se reset rodou)",
+                    flush=True,
+                )
+            continue
+        success, msg = _swap_shadow(qid)
+        if success:
+            swapped += 1
+            if verbose:
+                print(f"  SWAP {qid}: {msg}", flush=True)
+        else:
+            kept += 1
+            if verbose:
+                print(f"  FAIL {qid}: {msg}", flush=True)
+    if verbose:
+        print(
+            f"--- Shadow swap done: {swapped} swapped, {kept} kept ---",
+            flush=True,
+        )
+    return swapped, kept
 
 # Timeouts (segundos) usados pelo warmer. Sao MAIORES que os do frontend
 # porque rodamos em background e queremos popular o cache mesmo para queries
@@ -211,13 +489,50 @@ def _compute_and_cache_kpi_summary(conn, mun: str, periodo: str, verbose: bool):
 
     periodo='' -> all-time (chaves PERFIL, TOP_FORNECEDORES, TOP_SERVIDORES);
     periodo='ANO'/'12M' -> chaves prefixadas equivalentes.
+
+    Shadow rewarm: KPI_SUMMARY eh "derived" (le PERFIL/TOP_FORN/TOP_SERV
+    do cache pra computar). Se qualquer dep esta em shadow neste deploy
+    (REWARM_KEYS casa), KPI_SUMMARY entra em shadow auto (via
+    _is_shadow_for + CACHE_DEPENDENCY_GRAPH).
+
+    Strict no-fallback: se KPI_SUMMARY esta em shadow E uma dep tb esta
+    em shadow E o shadow da dep ESTA VAZIO pra essa muni → retorna False.
+    Sem isso, computariamos misturando NEW shadow + OLD live e ficaria
+    stale apos o swap dos deps. Munis que falham aqui sao reprocessadas
+    no proximo deploy (junto com a dep que falhou).
     """
     prefix = f"{periodo}:" if periodo else ""
     qid = f"{prefix}KPI_SUMMARY"
     try:
-        perfil_cache = _read_cache(conn, f"{prefix}PERFIL", mun)
-        forn_cache = _read_cache(conn, f"{prefix}TOP_FORNECEDORES", mun)
-        serv_cache = _read_cache(conn, f"{prefix}TOP_SERVIDORES", mun)
+        # Leitura via _effective_qid: em shadow mode (REWARM casa PERFIL),
+        # le PERFIL__pending; senao le live PERFIL. Mesmo pra TOP_*.
+        perfil_qid = f"{prefix}PERFIL"
+        forn_qid = f"{prefix}TOP_FORNECEDORES"
+        serv_qid = f"{prefix}TOP_SERVIDORES"
+        perfil_cache = _read_cache(conn, _effective_qid(perfil_qid), mun)
+        forn_cache = _read_cache(conn, _effective_qid(forn_qid), mun)
+        serv_cache = _read_cache(conn, _effective_qid(serv_qid), mun)
+
+        # Strict no-fallback: se SOMOS shadow E alguma dep tb eh shadow E
+        # o shadow da dep esta vazio pra essa muni, abortamos. Caso
+        # contrario contaminariamos o shadow KPI_SUMMARY com OLD data.
+        if _is_shadow_for(qid):
+            missing: list[str] = []
+            if _is_shadow_for(perfil_qid) and not (perfil_cache and perfil_cache[1]):
+                missing.append("PERFIL")
+            if _is_shadow_for(forn_qid) and not forn_cache:
+                missing.append("TOP_FORNECEDORES")
+            if _is_shadow_for(serv_qid) and not serv_cache:
+                missing.append("TOP_SERVIDORES")
+            if missing:
+                if verbose:
+                    print(
+                        f"  [SKIP] {qid} mun={mun}: shadow deps vazios "
+                        f"({','.join(missing)}) — strict no-fallback",
+                        flush=True,
+                    )
+                return False
+
         perfil = {}
         if perfil_cache and perfil_cache[1]:
             perfil = _row_to_dict(perfil_cache[0], perfil_cache[1][0])
@@ -236,15 +551,17 @@ def _compute_and_cache_kpi_summary(conn, mun: str, periodo: str, verbose: bool):
         # tem risco_score=NULL (PERFIL_MUNICIPIO_LIVE forca NULL), entao buscamos
         # do PERFIL all-time (cache sem prefix). Garante que a "Nota de atencao"
         # bate 1:1 com o mapa em todos os filtros temporais.
+        # Tambem via _effective_qid pra honrar shadow do PERFIL all-time
+        # quando REWARM casa.
         score_canonical = perfil.get("risco_score") if not prefix else None
         if score_canonical is None and prefix:
-            alltime_perfil_cache = _read_cache(conn, "PERFIL", mun)
+            alltime_perfil_cache = _read_cache(conn, _effective_qid("PERFIL"), mun)
             if alltime_perfil_cache and alltime_perfil_cache[1]:
                 alltime_perfil = _row_to_dict(alltime_perfil_cache[0], alltime_perfil_cache[1][0])
                 score_canonical = alltime_perfil.get("risco_score")
         summary["score_canonical"] = score_canonical
         with conn.cursor() as cur:
-            _upsert(cur, qid, mun, ["payload"], [[json.dumps(summary, default=str)]])
+            _upsert(cur, _effective_qid(qid), mun, ["payload"], [[json.dumps(summary, default=str)]])
         conn.commit()
         return True
     except Exception as e:
@@ -265,17 +582,23 @@ def _run_query_for_muni(query_id: str, sql: str, mun: str, extra_params: dict | 
 
     Usado pelo loop invertido (1 query × N munis em paralelo). Por design,
     nao printa nada — o caller agrega resultados e decide o que logar.
+
+    Em modo shadow (REWARM_KEYS casa query_id), escreve em
+    <query_id>__pending em vez de live. Caller usa _effective_qid pra
+    decidir; aqui aplicamos _effective_qid antes do upsert pra centralizar
+    a logica.
     """
     conn = _thread_conn()
     if extra_params:
         params = {**extra_params, "municipio": mun}
     else:
         params = {"municipio": mun}
+    write_qid = _effective_qid(query_id)
     try:
         cols, rows = _execute(conn, sql, params, timeout_sec)
         conn.commit()
         with conn.cursor() as cur:
-            _upsert(cur, query_id, mun, cols, rows)
+            _upsert(cur, write_qid, mun, cols, rows)
         conn.commit()
         return True, None
     except Exception as e:
@@ -285,23 +608,40 @@ def _run_query_for_muni(query_id: str, sql: str, mun: str, extra_params: dict | 
 
 
 def _filter_cached_munis(query_id: str, municipios: list[str]) -> tuple[list[str], int]:
-    """Em resume mode (SKIP_RECENT_HOURS > 0), remove munis cujo cache para
-    `query_id` foi atualizado nas ultimas SKIP_RECENT_HOURS horas.
+    """Filtra munis ja cacheados conforme WARM_SKIP_RECENT_HOURS:
+      * -1 (default): skip QUALQUER muni cacheado, qualquer idade. Dados
+        sao estaticos, reprocessar eh waste. Para forcar rebuild use
+        drop_cache=true ou invalidate_cache_keys=... no deploy.yml.
+      *  0: nao pula nada (rebuild completo).
+      *  N > 0: skip munis com cache atualizado nas ultimas N horas.
+
+    Em modo shadow (query_id casa REWARM_KEYS), filtramos pelo
+    _effective_qid (<query_id>__pending), pra permitir RESUME de uma
+    shadow warm interrompida no MESMO deploy. Entre deploys, "Reset
+    shadow rows" no deploy.yml apaga os __pending antes do warm.
 
     Returns (munis_to_process, num_skipped).
     """
-    if SKIP_RECENT_HOURS <= 0:
+    if SKIP_RECENT_HOURS == 0:
         return municipios, 0
 
+    effective_qid = _effective_qid(query_id)
     conn = psycopg2.connect(DSN)
     conn.autocommit = True
     try:
         with conn.cursor() as cur:
-            cur.execute(
-                f"SELECT municipio FROM {CACHE_TABLE} "
-                f"WHERE query_id = %s AND updated_at > now() - interval %s",
-                (query_id, f"{SKIP_RECENT_HOURS} hours"),
-            )
+            if SKIP_RECENT_HOURS < 0:
+                # Skip qualquer entrada existente, independente de idade.
+                cur.execute(
+                    f"SELECT municipio FROM {CACHE_TABLE} WHERE query_id = %s",
+                    (effective_qid,),
+                )
+            else:
+                cur.execute(
+                    f"SELECT municipio FROM {CACHE_TABLE} "
+                    f"WHERE query_id = %s AND updated_at > now() - interval %s",
+                    (effective_qid, f"{SKIP_RECENT_HOURS} hours"),
+                )
             cached = {r[0] for r in cur.fetchall()}
     finally:
         conn.close()
@@ -320,14 +660,19 @@ def _warm_query_across_munis(query_id: str, sql: str, municipios: list[str],
     apos a primeira muni, os indexes/tables relevantes ficam quentes no
     shared_buffers/host cache, beneficiando as munis seguintes.
 
-    Em resume mode (SKIP_RECENT_HOURS > 0), pula munis ja cacheados
-    recentemente para essa query.
+    Por padrao (WARM_SKIP_RECENT_HOURS=-1), pula munis ja cacheados,
+    qualquer idade — dados sao estaticos. Ver _filter_cached_munis para
+    detalhes dos modos suportados.
     """
     original_total = len(municipios)
     municipios, skipped = _filter_cached_munis(query_id, municipios)
     if not municipios:
         if verbose:
-            print(f"  {query_id}: skipped {skipped}/{original_total} (resume mode)", flush=True)
+            print(
+                f"  {query_id}: skipped {skipped}/{original_total} "
+                f"({_skip_mode_label()})",
+                flush=True,
+            )
         return skipped, 0  # contam como ok porque ja estao cacheados
 
     total = len(municipios)
@@ -378,8 +723,9 @@ def _warm_query_across_munis(query_id: str, sql: str, municipios: list[str],
         rate = total / elapsed if elapsed > 0 else 0
         suffix = f" ({timeouts} timeouts)" if timeouts else ""
         skip_msg = f", {skipped} skipped" if skipped else ""
+        shadow_msg = " [SHADOW]" if _is_shadow_for(query_id) else ""
         print(
-            f"  {query_id}: {ok}/{total} ok, {fail} fail{suffix}{skip_msg} "
+            f"  {query_id}{shadow_msg}: {ok}/{total} ok, {fail} fail{suffix}{skip_msg} "
             f"({elapsed:.0f}s, {rate:.1f}/s)",
             flush=True,
         )
@@ -393,6 +739,8 @@ def _warm_query_across_munis(query_id: str, sql: str, municipios: list[str],
             if len(failed_munis) > 10:
                 print(f"    ... +{len(failed_munis) - 10} outras falhas (ver journal)", flush=True)
     # Skipped contam como ok no agregado: ja estao cacheados.
+    # Em shadow mode, registra resultado pra decisao de swap no fim do ciclo.
+    _record_shadow_result(query_id, ok, fail)
     return ok + skipped, fail
 
 
@@ -404,7 +752,11 @@ def _warm_kpi_summary_across_munis(municipios: list[str], periodo: str, verbose:
     municipios, skipped = _filter_cached_munis(qid, municipios)
     if not municipios:
         if verbose:
-            print(f"  {qid}: skipped {skipped}/{original_total} (resume mode)", flush=True)
+            print(
+                f"  {qid}: skipped {skipped}/{original_total} "
+                f"({_skip_mode_label()})",
+                flush=True,
+            )
         return skipped, 0
 
     total = len(municipios)
@@ -446,13 +798,20 @@ def _warm_kpi_summary_across_munis(municipios: list[str], periodo: str, verbose:
     elapsed = time.time() - t0
     if verbose:
         skip_msg = f", {skipped} skipped" if skipped else ""
-        print(f"  {qid}: {ok}/{total} ok, {fail} fail{skip_msg} ({elapsed:.0f}s)", flush=True)
+        shadow_msg = " [SHADOW]" if _is_shadow_for(qid) else ""
+        print(
+            f"  {qid}{shadow_msg}: {ok}/{total} ok, {fail} fail{skip_msg} "
+            f"({elapsed:.0f}s)",
+            flush=True,
+        )
         if failed_munis:
             shown = failed_munis[:10]
             for mun_failed in shown:
                 print(f"    FAIL {qid} {mun_failed}", flush=True)
             if len(failed_munis) > 10:
                 print(f"    ... +{len(failed_munis) - 10} outras falhas", flush=True)
+    # Registra resultado pra decisao de swap no fim do ciclo (shadow mode).
+    _record_shadow_result(qid, ok, fail)
     return ok + skipped, fail
 
 
@@ -686,7 +1045,7 @@ def _warm_one_empresa(cnpj_completo: str) -> tuple[bool, str | None]:
         with conn.cursor() as cur:
             _upsert(
                 cur,
-                EMPRESA_CACHE_QID,
+                _effective_qid(EMPRESA_CACHE_QID),
                 cnpj_completo,
                 ["payload"],
                 [[data]],
@@ -771,10 +1130,11 @@ def warm_cycle_empresas(cnpjs: list[str], verbose: bool = True) -> tuple[int, in
         f"({elapsed/60:.1f}min)",
         flush=True,
     )
+    # Registra resultado pra swap atomico no fim do ciclo (shadow mode).
+    # Importamos CACHE_QUERY_ID = "EMPRESA_PERFIL" do escopo de _warm_one_empresa,
+    # mas aqui usamos literal pra evitar import circular topo-do-modulo.
+    _record_shadow_result("EMPRESA_PERFIL", ok, fail)
     return ok, fail, skipped
-
-
-
 
 
 def main():
@@ -820,6 +1180,18 @@ def main():
         if not skip_empresas_flag:
             ok_e, fail_e, skip_e = _warm_empresas_phase()
             ok_em, fail_em, skip_em = _warm_empresas_municipios_phase()
+        # Shadow swap: apos TODO trabalho do ciclo terminar, fazemos os
+        # swaps atomicos das qids que estavam em shadow E completaram
+        # sem falhas. Mantemos shadow das que falharam (retry no proximo
+        # deploy via mesmo rewarm_cache_keys, que reusa o shadow porque
+        # _filter_cached_munis filtra pelo __pending tb).
+        # Importante: swap acontece UMA VEZ por ciclo, depois das fases
+        # PB + empresas + empresas_municipios. Garante que KPI_SUMMARY
+        # (derived) ja foi computado contra o shadow de PERFIL antes do
+        # swap dos deps.
+        _swap_all_pending_shadows(verbose=True)
+        # Reset tracking pra eventual proximo ciclo (mode --loop).
+        _shadow_results.clear()
         return ok_p + ok_e + ok_em, fail_p + fail_e + fail_em, skip_e + skip_em
 
     if args.daemon:
@@ -889,7 +1261,7 @@ def _warm_empresas_phase() -> tuple[int, int, int]:
         )
         return 0, 0, 0
 
-    # Resume mode: skip CNPJs cacheados nas ultimas WARM_SKIP_RECENT_HOURS.
+    # Skip mode: pula CNPJs ja cacheados conforme WARM_SKIP_RECENT_HOURS.
     # Mesma logica de cidades — reusa _filter_cached_munis (generico em
     # query_id e lista de keys).
     cnpjs, skipped_resume = _filter_cached_munis(
@@ -897,8 +1269,8 @@ def _warm_empresas_phase() -> tuple[int, int, int]:
     )
     if skipped_resume > 0:
         print(
-            f"[empresas] Resume mode: {skipped_resume} ja cacheadas nas "
-            f"ultimas {SKIP_RECENT_HOURS}h, processando {len(cnpjs)} restantes."
+            f"[empresas] {_skip_mode_label()}: {skipped_resume} ja cacheadas, "
+            f"processando {len(cnpjs)} restantes."
         )
 
     if not cnpjs:
@@ -1035,7 +1407,7 @@ def _warm_one_empresa_municipio(par: tuple[str, str]) -> tuple[bool, str | None]
         with conn.cursor() as cur:
             _upsert(
                 cur,
-                EMPRESA_MUN_CACHE_QID,
+                _effective_qid(EMPRESA_MUN_CACHE_QID),
                 key,
                 ["payload"],
                 [[data]],
@@ -1113,6 +1485,7 @@ def warm_cycle_empresas_municipios(
         f"({elapsed/60:.1f}min)",
         flush=True,
     )
+    _record_shadow_result("EMPRESA_PERFIL_MUN", ok, fail)
     return ok, fail, skipped
 
 
@@ -1157,9 +1530,8 @@ def _warm_empresas_municipios_phase() -> tuple[int, int, int]:
     )
     if skipped_resume > 0:
         print(
-            f"[empresas-mun] Resume mode: {skipped_resume} ja cacheados nas "
-            f"ultimas {SKIP_RECENT_HOURS}h, processando {len(remaining_keys)} "
-            f"restantes."
+            f"[empresas-mun] {_skip_mode_label()}: {skipped_resume} ja "
+            f"cacheados, processando {len(remaining_keys)} restantes."
         )
 
     if not remaining_keys:

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -1164,9 +1164,11 @@ def warm_cycle_empresas(cnpjs: list[str], verbose: bool = True) -> tuple[int, in
         flush=True,
     )
     # Registra resultado pra swap atomico no fim do ciclo (shadow mode).
-    # Importamos CACHE_QUERY_ID = "EMPRESA_PERFIL" do escopo de _warm_one_empresa,
-    # mas aqui usamos literal pra evitar import circular topo-do-modulo.
-    _record_shadow_result("EMPRESA_PERFIL", ok, fail)
+    # Usa a constante canonica de web.routes.empresa em vez de literal pra
+    # nao desincronizar se a constante mudar (P2 Opus 4.7 review PR #105).
+    # Import diferido pra evitar cycle no topo do modulo.
+    from web.routes.empresa import CACHE_QUERY_ID as _EMPRESA_QID
+    _record_shadow_result(_EMPRESA_QID, ok, fail)
     return ok, fail, skipped
 
 
@@ -1519,7 +1521,9 @@ def warm_cycle_empresas_municipios(
         f"({elapsed/60:.1f}min)",
         flush=True,
     )
-    _record_shadow_result("EMPRESA_PERFIL_MUN", ok, fail)
+    # Mesma logica: usa constante canonica em vez de literal.
+    from web.routes.empresa import CACHE_QUERY_ID_MUN as _EMPRESA_MUN_QID
+    _record_shadow_result(_EMPRESA_MUN_QID, ok, fail)
     return ok, fail, skipped
 
 


### PR DESCRIPTION
## Resumo

Tres mudancas inter-relacionadas pra reduzir cache-miss durante upgrades do site:

### 1. Inversao de ordem (warm primeiro, restart depois)

**Antes:** `deploy.yml` fazia `systemctl restart cruza-web` DENTRO do step de web deploy (codigo novo), e SO DEPOIS rodava `warm_cache`. Isso deixava o usuario com 12-18h de cache miss enquanto o warm reconstruia.

**Agora:**
- Web deploy step instala unit files mas NAO faz restart (apenas `start` se nao estiver ativo, pra fresh deploys).
- Warm cache step roda. Cruza-web continua servindo OLD code com OLD cache durante esse tempo.
- Novo step `Restart cruza-web (after warm)` pega o codigo NOVO com cache JA QUENTE.
- `SEO IndexNow` movido pra depois do restart pra garantir que `/<INDEXNOW_KEY>.txt` sirva a chave NOVA quando crawlers validarem.

### 2. Novo default `WARM_SKIP_RECENT_HOURS=-1` (skip-if-cached)

Dados das fontes governamentais sao ESTATICOS pos-ETL. Por padrao o warm agora pula qualquer entrada cacheada (qualquer idade), nao so "recente".

Valores aceitos:
- `-1` (NOVO default): skip qualquer muni cacheado, qualquer idade.
- `0`: rebuild completo (sem skip), opt-in explicito.
- `N > 0`: legacy resume mode (skip cacheados nas ultimas N horas).

Pra forcar rebuild use `drop_cache=true` (TRUNCATE) ou `invalidate_cache_keys=...` (DELETE cirurgico). Input `warm_skip_hours` default mudou de `''24''` pra `''-1''`; regex aceita valores negativos.

### 3. Shadow rewarm (zero-downtime cache versioning)

Novo input `rewarm_cache_keys` (CSV de substring patterns). Quando casa um `query_id`, warm escreve em `<qid>__pending`; live continua servindo o cruza-web sem interrupcao. Ao fim do ciclo, swap atomico:

```sql
BEGIN;
  INSERT INTO web_cache (...) SELECT ''<qid>'', muni, ...
    FROM web_cache WHERE query_id = ''<qid>__pending''
    ON CONFLICT (query_id, municipio) DO UPDATE SET ...;
  DELETE FROM web_cache WHERE query_id = ''<qid>__pending'';
COMMIT;
```

UPSERT em vez de DELETE+RENAME preserva munis fora do escopo do warm (importante quando se usa `--mun X` pra testar local).

**Auto-expansao via `CACHE_DEPENDENCY_GRAPH`:** se PERFIL/TOP_FORN/TOP_SERV entra em shadow, KPI_SUMMARY (mesmo prefixo) tambem entra automaticamente. Caso contrario KPI_SUMMARY ficaria stale pos-swap (computado lendo OLD live de PERFIL).

**Strict no-fallback:** no `_compute_and_cache_kpi_summary`, se KPI esta em shadow E dep tb em shadow E muni faltando no shadow do dep → retorna False. Sem isso, computaria misturando NEW shadow + OLD live e ficaria stale apos swap dos deps.

**Politica do swap:** so swap se `fail == 0` pra essa `qid`. Senao mantem shadow pra retry no proximo deploy (mesmo `rewarm_cache_keys` reusa o shadow pendente).

**Higiene:** novo step `Reset shadow rows` no deploy.yml apaga `%__pending` no inicio de cada warm pra evitar stale shadow entre deploys que mudaram SQL.

### Como usar (exemplos)

```yaml
# Caso 1: web-only deploy sem rewarm (default)
etl_phase: web
warm_cache: false
# Resultado: code sync + nginx + restart cruza-web. Sem warm. Sem mudanca de cache.

# Caso 2: web-only deploy + warm de chaves ausentes
etl_phase: web
warm_cache: true
# Resultado: warm processa SO chaves ausentes (skip-if-cached). Mais rapido.

# Caso 3: rewarm de Q65 com zero-downtime
etl_phase: web
rewarm_cache_keys: "Q65"
# Resultado: warm escreve Q65__pending; live Q65 continua servindo. Apos warm,
# swap atomico. Usuario nao ve cache-miss.

# Caso 4: rewarm de PERFIL com auto-expansao do KPI_SUMMARY
etl_phase: web
rewarm_cache_keys: "PERFIL"
# Resultado: PERFIL E KPI_SUMMARY (todos os prefixos) entram em shadow.
# Apos warm, swap atomico de ambos. Consistencia preservada.

# Caso 5: hard invalidate (data BROKEN, prefere mostrar nada vs mostrar lixo)
etl_phase: web
invalidate_cache_keys: "Q65"
warm_cache: true
# Resultado: DELETE LIVE Q65 → cache miss imediato. Warm reconstroi (~minutos).
# So use isso se a data live esta REALMENTE quebrada.
```

### Extensibilidade

Header gigante em `web/warm_cache.py` documenta como adicionar futuras chaves:
- **Leaf queries** (sem dependencias do cache): nada a fazer, ja funciona via `_effective_qid`.
- **Derived queries** (le outras keys do cache): registre em `CACHE_DEPENDENCY_GRAPH` + leia deps via `_effective_qid` + strict no-fallback. Ver `_compute_and_cache_kpi_summary` como modelo.

### Validacao

- `python -m py_compile web/warm_cache.py` ✓
- `python -m compileall web etl` ✓
- `python -c "yaml.safe_load(open(deploy.yml))"` ✓

### Reviewers — angulos pra analisar

**COMPLEXIDADE:** o mesmo objetivo poderia ser atingido com solucao mais simples? Especialmente shadow + auto-expansao + swap atomico — eh overengineering? Existe alternativa menor com mesma garantia de zero-downtime?

**UX DO USUARIO LIVE:** usuario navegando o site durante um upgrade de cache (12-18h do warm com shadow) eh atrapalhado em quais cenarios? O restart final causa downtime perceptivel? Algum edge case de inconsistencia que escapou da auto-expansao?
