### PR TITLE
feat(analytics): GeoIP City + pagina-saida + dialog-fechado + digest diario por email

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -656,6 +656,8 @@ jobs:
           GOACCESS_USER: ${{ secrets.GOACCESS_USER }}
           GOACCESS_PASSWORD: ${{ secrets.GOACCESS_PASSWORD }}
           GOACCESS_DOMAIN: ${{ secrets.GOACCESS_DOMAIN }}
+          TRAFFIC_DIGEST_EMAIL_TO: ${{ secrets.TRAFFIC_DIGEST_EMAIL_TO }}
+          TRAFFIC_DIGEST_EMAIL_FROM: ${{ secrets.TRAFFIC_DIGEST_EMAIL_FROM }}
         run: |
           set -e
           cd ${{ env.PROJECT_DIR }}
@@ -692,6 +694,18 @@ jobs:
           sudo --preserve-env=GOACCESS_USER,GOACCESS_PASSWORD,GOACCESS_DOMAIN \
             bash deploy/setup-goaccess.sh \
             || echo "WARNING: setup-goaccess.sh falhou (non-fatal — dashboard admin)."
+
+          # Setup digest diario de trafego: script + systemd timer que roda
+          # diariamente as 07:00 BRT (10:00 UTC), parseia access.log.1 (rotated
+          # log de ontem) e escreve um resumo em markdown em
+          # /var/log/cruza-traffic-digest/YYYY-MM-DD.md. Se TRAFFIC_DIGEST_EMAIL_TO
+          # estiver setado como secret, tenta enviar o resumo via msmtp/mail/
+          # sendmail (admin configura MTA na VM — ver header do setup script).
+          #
+          # Idempotente: cmp + reload-conditional. Soft-fail.
+          sudo --preserve-env=TRAFFIC_DIGEST_EMAIL_TO,TRAFFIC_DIGEST_EMAIL_FROM \
+            bash deploy/setup-traffic-digest.sh \
+            || echo "WARNING: setup-traffic-digest.sh falhou (non-fatal — digest opcional)."
 
           # Setup Umami analytics (self-hosted em /_traffic/analytics/).
           # Idempotente: instala Node 22 + pnpm se ausentes, cria DB+role

--- a/TODO.md
+++ b/TODO.md
@@ -398,6 +398,14 @@ Items #i0a-#i0d listados acima na seção "Framework reutilizavel".
 - Problema mais comum: CNPJ citado sem nome oficial ao lado
 - CNPJs nao encontrados na RFB: ver `relatorio_laranjas_bolsa_familia_pb.md`
 
+### Observabilidade — analytics pipeline
+- [ ] **Ingestao access.log -> PostgreSQL** — Vector/Filebeat ou daemon Python que tail+parse+COPY do nginx access.log
+  pra uma tabela `access_log_raw(ts, ip, ua, path, status, referer, bytes, ua_category, geo_city)`. Habilita SQL ad-hoc
+  sobre todo o trafego com retencao configuravel — resolve o que `/_traffic/raw` (so ultimas 1000 linhas) e a skill
+  `analyze-prod-traffic` (on-demand, sem persistencia) nao cobrem. JOINs com tabela `cidades` permitem perguntar
+  "quantos hits em /cidade/X agrupados por dia/mes". Complementa o digest diario (cruza-traffic-digest) que da resumo
+  mas nao permite drill-down. Esforco: 1-2 dias (parser + schema + retencao + dashboard SQL).
+
 ## Referencia tecnica
 
 ### Banco de dados

--- a/deploy/cruza-goaccess.conf
+++ b/deploy/cruza-goaccess.conf
@@ -24,11 +24,12 @@ restore true
 db-path /var/lib/goaccess/
 
 # ── GeoIP ──
-# GeoLite2-Country no formato .mmdb (libmaxminddb). Baixado pelo
+# GeoLite2-City no formato .mmdb (libmaxminddb). Baixado pelo
 # deploy/setup-goaccess.sh a partir de db-ip.com/free (lite version,
-# sem signup). Atualizado mensalmente — pra refresh, basta rodar o
-# setup-goaccess.sh de novo (idempotente).
-geoip-database /var/lib/goaccess/dbip-country-lite.mmdb
+# sem signup). Resolucao cidade+regiao+pais — substitui a Country DB
+# que so dava pais. Atualizado mensalmente — pra refresh, basta rodar
+# o setup-goaccess.sh de novo (idempotente).
+geoip-database /var/lib/goaccess/dbip-city-lite.mmdb
 
 # ── Comportamento ──
 agent-list true

--- a/deploy/cruza-goaccess.conf
+++ b/deploy/cruza-goaccess.conf
@@ -24,11 +24,11 @@ restore true
 db-path /var/lib/goaccess/
 
 # ── GeoIP ──
-# GeoLite2-City no formato .mmdb (libmaxminddb). Baixado pelo
-# deploy/setup-goaccess.sh a partir de db-ip.com/free (lite version,
-# sem signup). Resolucao cidade+regiao+pais — substitui a Country DB
-# que so dava pais. Atualizado mensalmente — pra refresh, basta rodar
-# o setup-goaccess.sh de novo (idempotente).
+# DB-IP City Lite no formato .mmdb (libmaxminddb). Note: DB-IP eh fonte
+# gratuita SEPARADA da MaxMind GeoLite2 — usamos DB-IP por nao exigir
+# signup. Baixado pelo deploy/setup-goaccess.sh a partir de
+# db-ip.com/free. Resolucao cidade+regiao+pais. Atualizado mensalmente
+# — pra refresh, basta rodar o setup-goaccess.sh de novo (idempotente).
 geoip-database /var/lib/goaccess/dbip-city-lite.mmdb
 
 # ── Comportamento ──

--- a/deploy/cruza-traffic-digest.service
+++ b/deploy/cruza-traffic-digest.service
@@ -14,6 +14,15 @@ ProtectSystem=strict
 ProtectHome=true
 NoNewPrivileges=true
 PrivateTmp=true
+RestrictSUIDSGID=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
 ReadOnlyPaths=/var/log/nginx /etc
 ReadWritePaths=/var/log/cruza-traffic-digest
 # Limites

--- a/deploy/cruza-traffic-digest.service
+++ b/deploy/cruza-traffic-digest.service
@@ -24,7 +24,7 @@ RestrictNamespaces=true
 RestrictRealtime=true
 SystemCallArchitectures=native
 ReadOnlyPaths=/var/log/nginx /etc
-ReadWritePaths=/var/log/cruza-traffic-digest
+ReadWritePaths=/var/log/cruza-traffic-digest /var/log/msmtp.log
 # Limites
 TimeoutStartSec=300
 Nice=10

--- a/deploy/cruza-traffic-digest.service
+++ b/deploy/cruza-traffic-digest.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Digest diario do access.log (transparenciapb)
+After=network.target nginx.service
+Documentation=https://github.com/lucasdiniz/govbr-cruza-dados/blob/main/deploy/cruza-traffic-digest.sh
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/cruza-traffic-digest.sh
+# Roda como root pra ler /var/log/nginx/access.log* sem ajustar perms.
+# O script nao expoe rede; so escreve arquivo + opcionalmente chama MTA.
+User=root
+# Hardening basico
+ProtectSystem=strict
+ProtectHome=true
+NoNewPrivileges=true
+PrivateTmp=true
+ReadOnlyPaths=/var/log/nginx /etc
+ReadWritePaths=/var/log/cruza-traffic-digest
+# Limites
+TimeoutStartSec=300
+Nice=10
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/cruza-traffic-digest.sh
+++ b/deploy/cruza-traffic-digest.sh
@@ -53,22 +53,41 @@ grep "\[${YESTERDAY_NGINX}:" "${LOG}" > "${FILTERED}" || true
 total_hits=$(wc -l < "${FILTERED}" | tr -d ' ')
 unique_ips=$(awk '{print $1}' "${FILTERED}" | sort -u | wc -l | tr -d ' ')
 
+# Sanitiza strings de header pra evitar header injection via env file.
+sanitize_header() {
+    printf '%s' "$1" | tr -d '\r\n'
+}
+
 # Top paths (excluindo /static/* e /api/*)
-top_paths=$(awk '{print $7}' "${FILTERED}" \
-    | grep -vE '^/static/|^/api/|^/_traffic/' \
-    | sed 's/?.*//' \
+top_paths=$(awk -F\" '
+    {
+        req = $2
+        split(req, a, " ")
+        path = a[2]
+        if (path == "") next
+        sub(/\?.*/, "", path)
+        if (path ~ /^\/static\// || path ~ /^\/api\// || path ~ /^\/_traffic\//) next
+        print path
+    }
+' "${FILTERED}" \
     | sort | uniq -c | sort -rn | head -15 \
     | awk '{printf "  - `%s` (%s hits)\n", $2, $1}')
 
 # Top referers (excluindo own domain + empty)
 top_refs=$(awk -F\" '{print $4}' "${FILTERED}" \
-    | grep -vE '^$|^-$|transparenciapb\.org' \
+    | awk '$0 != "" && $0 != "-" && $0 !~ /transparenciapb\.org/' \
     | sort | uniq -c | sort -rn | head -10 \
-    | awk '{$1=$1; sub(/^[0-9]+ /, ""); print "  - " $0}' \
+    | awk '{count=$1; $1=""; sub(/^ /, ""); printf "  - %s (%s hits)\n", $0, count}' \
     | head -10)
 
 # Status code breakdown
-status_breakdown=$(awk '{print $9}' "${FILTERED}" \
+status_breakdown=$(awk -F\" '
+    {
+        split($3, a, " ")
+        code = a[2]
+        if (code ~ /^[0-9][0-9][0-9]$/) print code
+    }
+' "${FILTERED}" \
     | sort | uniq -c | sort -rn \
     | awk '{printf "  - HTTP %s: %s\n", $2, $1}')
 
@@ -78,17 +97,36 @@ top_ips=$(awk '{print $1}' "${FILTERED}" \
     | awk '{printf "  - %s (%s hits)\n", $2, $1}')
 
 # 4xx/5xx errors — quais paths bombam?
-top_errors=$(awk '$9 ~ /^[45][0-9][0-9]$/ {print $9, $7}' "${FILTERED}" \
-    | sed 's/?.*//' \
+top_errors=$(awk -F\" '
+    {
+        req = $2
+        split(req, a, " ")
+        path = a[2]
+        if (path == "") next
+        split($3, b, " ")
+        code = b[2]
+        if (code !~ /^[45][0-9][0-9]$/) next
+        sub(/\?.*/, "", path)
+        print code, path
+    }
+' "${FILTERED}" \
     | sort | uniq -c | sort -rn | head -10 \
     | awk '{printf "  - HTTP %s `%s` (%s vezes)\n", $2, $3, $1}')
 
 # Exploit attempts (paths suspeitos — mesmas heuristicas do fail2ban
 # transparenciapb-exploit-paths.filter)
-exploits=$(awk '{print $1, $7}' "${FILTERED}" \
+exploits=$(awk -F\" '
+    {
+        req = $2
+        split(req, a, " ")
+        path = a[2]
+        if (path == "") next
+        print $1, path
+    }
+' "${FILTERED}" \
     | grep -iE '\.env|\.git|wp-admin|wp-login|/admin|/phpmyadmin|/php\.ini|/web-console|/saml|/vpn|/v[12345]/api|/actuator|/manager/html' \
     | sort | uniq -c | sort -rn | head -10 \
-    | awk '{printf "  - %s -> `%s` (%s)\n", $2, $3, $1}')
+    | awk '{printf "  - %s -> `%s` (%s)\n", $2, $3, $1}') || true
 
 # IPs identificados (>100 hits + sao usuarios reais provaveis pelo UA)
 # Heuristica simples — Mozilla + nao-bot UA
@@ -145,32 +183,33 @@ echo "[digest] Escrito: ${OUT}"
 
 # Envia por email se configurado
 if [[ -n "${TRAFFIC_DIGEST_EMAIL_TO:-}" ]]; then
-    SUBJECT="${TRAFFIC_DIGEST_SUBJECT:-[transparenciapb] Digest de trafego ${YESTERDAY}}"
-    FROM="${TRAFFIC_DIGEST_EMAIL_FROM:-digest@$(hostname -f 2>/dev/null || hostname)}"
+    SUBJECT="$(sanitize_header "${TRAFFIC_DIGEST_SUBJECT:-[transparenciapb] Digest de trafego ${YESTERDAY}}")"
+    FROM="$(sanitize_header "${TRAFFIC_DIGEST_EMAIL_FROM:-digest@$(hostname -f 2>/dev/null || hostname)}")"
+    TO="$(sanitize_header "${TRAFFIC_DIGEST_EMAIL_TO}")"
 
     if command -v msmtp >/dev/null 2>&1; then
         {
             echo "From: ${FROM}"
-            echo "To: ${TRAFFIC_DIGEST_EMAIL_TO}"
+            echo "To: ${TO}"
             echo "Subject: ${SUBJECT}"
             echo "Content-Type: text/plain; charset=UTF-8"
             echo
             cat "${OUT}"
         } | msmtp --read-recipients
-        echo "[digest] Enviado por msmtp para ${TRAFFIC_DIGEST_EMAIL_TO}"
+        echo "[digest] Enviado por msmtp para ${TO}"
     elif command -v mail >/dev/null 2>&1; then
-        mail -s "${SUBJECT}" -a "From: ${FROM}" "${TRAFFIC_DIGEST_EMAIL_TO}" < "${OUT}"
-        echo "[digest] Enviado por mail(1) para ${TRAFFIC_DIGEST_EMAIL_TO}"
+        mail -s "${SUBJECT}" -a "From: ${FROM}" "${TO}" < "${OUT}"
+        echo "[digest] Enviado por mail(1) para ${TO}"
     elif command -v sendmail >/dev/null 2>&1; then
         {
             echo "From: ${FROM}"
-            echo "To: ${TRAFFIC_DIGEST_EMAIL_TO}"
+            echo "To: ${TO}"
             echo "Subject: ${SUBJECT}"
             echo "Content-Type: text/plain; charset=UTF-8"
             echo
             cat "${OUT}"
         } | sendmail -t
-        echo "[digest] Enviado por sendmail para ${TRAFFIC_DIGEST_EMAIL_TO}"
+        echo "[digest] Enviado por sendmail para ${TO}"
     else
         echo "[digest] AVISO: TRAFFIC_DIGEST_EMAIL_TO setado mas nenhum MTA encontrado (msmtp/mail/sendmail). Arquivo gravado em ${OUT}, sem envio."
     fi

--- a/deploy/cruza-traffic-digest.sh
+++ b/deploy/cruza-traffic-digest.sh
@@ -38,10 +38,32 @@ YESTERDAY="$(date -u -d 'yesterday' '+%Y-%m-%d')"
 YESTERDAY_NGINX="$(date -u -d 'yesterday' '+%d/%b/%Y')"
 OUT="${OUTDIR}/${YESTERDAY}.md"
 
-# Load env if present
+# Load env if present.
+#
+# Seguranca: nao usamos `source` pra evitar execucao arbitraria de
+# shell caso o arquivo seja editado manualmente com metacharacters
+# ($(...), backticks, pipes). Parseamos linha a linha exigindo formato
+# KEY="VALUE" com whitelist de chaves. Backslash e aspas duplas
+# internas precisam estar escaped (\" / \\) — o setup-traffic-digest.sh
+# grava no formato correto. Newlines/CR no input sao rejeitados na
+# escrita (anti header-injection).
 if [[ -f /etc/cruza-traffic-digest.env ]]; then
-    # shellcheck disable=SC1091
-    set -a; source /etc/cruza-traffic-digest.env; set +a
+    while IFS= read -r _envline; do
+        [[ -z "${_envline}" || "${_envline:0:1}" == "#" ]] && continue
+        if [[ "${_envline}" =~ ^([A-Z_]+)=\"(.*)\"$ ]]; then
+            _k="${BASH_REMATCH[1]}"
+            _v="${BASH_REMATCH[2]}"
+            # Desescape: \\ -> \, \" -> "
+            _v="${_v//\\\\/\\}"
+            _v="${_v//\\\"/\"}"
+            case "${_k}" in
+                TRAFFIC_DIGEST_EMAIL_TO|TRAFFIC_DIGEST_EMAIL_FROM|TRAFFIC_DIGEST_SUBJECT)
+                    export "${_k}=${_v}"
+                    ;;
+            esac
+        fi
+    done < /etc/cruza-traffic-digest.env
+    unset _envline _k _v
 fi
 
 # ── Filtra so as linhas de ontem (UTC). Combined log format: o timestamp
@@ -124,7 +146,7 @@ exploits=$(awk -F\" '
         print $1, path
     }
 ' "${FILTERED}" \
-    | { grep -iE '\.env|\.git|wp-admin|wp-login|/admin|/phpmyadmin|/php\.ini|/web-console|/saml|/vpn|/v[12345]/api|/actuator|/manager/html' || true; } \
+    | { grep -iE '\.env|\.aws|\.git|\.docker|\.ssh|wp-admin|wp-login|wp-json|xmlrpc\.php|/admin|/phpmyadmin|/php\.ini|/web-console|/saml|/vpn|/v[12345]/api|/actuator|/manager/html|/cgi-bin' || true; } \
     | sort | uniq -c | sort -rn | head -10 \
     | awk '{printf "  - %s -> `%s` (%s)\n", $2, $3, $1}')
 

--- a/deploy/cruza-traffic-digest.sh
+++ b/deploy/cruza-traffic-digest.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Daily traffic digest — gera um resumo do access.log do dia anterior e
+# envia por email. Roda via systemd timer (cruza-traffic-digest.timer).
+#
+# Por que existe:
+#   - GoAccess so tem dashboard real-time, sem digest historico
+#   - Umami mostra eventos mas nao da o "panorama operacional" diario
+#     (top paths, status codes, exploits tentados, IPs novos, anomalias)
+#   - Skill local analyze-prod-traffic so roda on-demand via dev console
+#
+# Output:
+#   1. Sempre escreve markdown em /var/log/cruza-traffic-digest/YYYY-MM-DD.md
+#   2. Se TRAFFIC_DIGEST_EMAIL_TO estiver setado em /etc/cruza-traffic-digest.env,
+#      envia o markdown por email usando msmtp/mailx (admin configura o
+#      MTA separadamente — setup-traffic-digest.sh documenta).
+#
+# Envvars (lidas de /etc/cruza-traffic-digest.env se existir):
+#   TRAFFIC_DIGEST_EMAIL_TO   - destinatario(s), separados por virgula
+#                               (vazio = so escreve arquivo, nao envia)
+#   TRAFFIC_DIGEST_EMAIL_FROM - remetente (default: digest@<hostname>)
+#   TRAFFIC_DIGEST_SUBJECT    - assunto (default: [transparenciapb]
+#                               Digest de trafego YYYY-MM-DD)
+
+set -euo pipefail
+
+LOG="/var/log/nginx/access.log.1"   # log rotacionado de ontem
+if [[ ! -r "${LOG}" ]]; then
+    # Fallback pra log atual + filtro por data de ontem (caso logrotate
+    # nao tenha rodado ainda quando o timer dispara).
+    LOG="/var/log/nginx/access.log"
+fi
+
+OUTDIR="/var/log/cruza-traffic-digest"
+mkdir -p "${OUTDIR}"
+chmod 750 "${OUTDIR}"
+
+YESTERDAY="$(date -u -d 'yesterday' '+%Y-%m-%d')"
+YESTERDAY_NGINX="$(date -u -d 'yesterday' '+%d/%b/%Y')"
+OUT="${OUTDIR}/${YESTERDAY}.md"
+
+# Load env if present
+if [[ -f /etc/cruza-traffic-digest.env ]]; then
+    # shellcheck disable=SC1091
+    set -a; source /etc/cruza-traffic-digest.env; set +a
+fi
+
+# ── Filtra so as linhas de ontem (UTC). Combined log format: o timestamp
+#    nginx default vem em [DD/Mon/YYYY:HH:MM:SS +0000]. ──
+FILTERED=$(mktemp)
+trap "rm -f '${FILTERED}'" EXIT
+grep "\[${YESTERDAY_NGINX}:" "${LOG}" > "${FILTERED}" || true
+
+total_hits=$(wc -l < "${FILTERED}" | tr -d ' ')
+unique_ips=$(awk '{print $1}' "${FILTERED}" | sort -u | wc -l | tr -d ' ')
+
+# Top paths (excluindo /static/* e /api/*)
+top_paths=$(awk '{print $7}' "${FILTERED}" \
+    | grep -vE '^/static/|^/api/|^/_traffic/' \
+    | sed 's/?.*//' \
+    | sort | uniq -c | sort -rn | head -15 \
+    | awk '{printf "  - `%s` (%s hits)\n", $2, $1}')
+
+# Top referers (excluindo own domain + empty)
+top_refs=$(awk -F\" '{print $4}' "${FILTERED}" \
+    | grep -vE '^$|^-$|transparenciapb\.org' \
+    | sort | uniq -c | sort -rn | head -10 \
+    | awk '{$1=$1; sub(/^[0-9]+ /, ""); print "  - " $0}' \
+    | head -10)
+
+# Status code breakdown
+status_breakdown=$(awk '{print $9}' "${FILTERED}" \
+    | sort | uniq -c | sort -rn \
+    | awk '{printf "  - HTTP %s: %s\n", $2, $1}')
+
+# Top IPs (potencial bot/scanner)
+top_ips=$(awk '{print $1}' "${FILTERED}" \
+    | sort | uniq -c | sort -rn | head -10 \
+    | awk '{printf "  - %s (%s hits)\n", $2, $1}')
+
+# 4xx/5xx errors — quais paths bombam?
+top_errors=$(awk '$9 ~ /^[45][0-9][0-9]$/ {print $9, $7}' "${FILTERED}" \
+    | sed 's/?.*//' \
+    | sort | uniq -c | sort -rn | head -10 \
+    | awk '{printf "  - HTTP %s `%s` (%s vezes)\n", $2, $3, $1}')
+
+# Exploit attempts (paths suspeitos — mesmas heuristicas do fail2ban
+# transparenciapb-exploit-paths.filter)
+exploits=$(awk '{print $1, $7}' "${FILTERED}" \
+    | grep -iE '\.env|\.git|wp-admin|wp-login|/admin|/phpmyadmin|/php\.ini|/web-console|/saml|/vpn|/v[12345]/api|/actuator|/manager/html' \
+    | sort | uniq -c | sort -rn | head -10 \
+    | awk '{printf "  - %s -> `%s` (%s)\n", $2, $3, $1}')
+
+# IPs identificados (>100 hits + sao usuarios reais provaveis pelo UA)
+# Heuristica simples — Mozilla + nao-bot UA
+real_users=$(awk -F\" '$6 ~ /Mozilla/ && $6 !~ /[Bb]ot|[Cc]rawler|[Ss]craper|[Ss]pider/' "${FILTERED}" \
+    | awk '{print $1}' | sort | uniq -c | sort -rn | head -10 \
+    | awk '{printf "  - %s (%s hits)\n", $2, $1}')
+
+# Compose markdown
+cat > "${OUT}" <<EOF
+# Digest de trafego — ${YESTERDAY}
+
+> Resumo do access.log do dia anterior. Gerado por cruza-traffic-digest.
+
+## Resumo numerico
+
+- **Hits totais:** ${total_hits}
+- **IPs unicos:** ${unique_ips}
+
+## Top paths (excluindo /static, /api, /_traffic)
+
+${top_paths:-_nenhum dado_}
+
+## Top referers (externos)
+
+${top_refs:-_nenhum dado_}
+
+## Distribuicao de status codes
+
+${status_breakdown:-_nenhum dado_}
+
+## Top IPs (volume)
+
+${top_ips:-_nenhum dado_}
+
+## Top paginas com erro 4xx/5xx
+
+${top_errors:-_nenhum dado_}
+
+## Tentativas de exploit (paths suspeitos)
+
+${exploits:-_nenhum dado_}
+
+## Usuarios reais provaveis (top 10 por hits)
+
+${real_users:-_nenhum dado_}
+
+---
+
+_Gerado automaticamente em $(date -u '+%Y-%m-%d %H:%M:%S UTC'). Para forcar regerar: \`sudo systemctl start cruza-traffic-digest.service\`._
+EOF
+
+chmod 640 "${OUT}"
+echo "[digest] Escrito: ${OUT}"
+
+# Envia por email se configurado
+if [[ -n "${TRAFFIC_DIGEST_EMAIL_TO:-}" ]]; then
+    SUBJECT="${TRAFFIC_DIGEST_SUBJECT:-[transparenciapb] Digest de trafego ${YESTERDAY}}"
+    FROM="${TRAFFIC_DIGEST_EMAIL_FROM:-digest@$(hostname -f 2>/dev/null || hostname)}"
+
+    if command -v msmtp >/dev/null 2>&1; then
+        {
+            echo "From: ${FROM}"
+            echo "To: ${TRAFFIC_DIGEST_EMAIL_TO}"
+            echo "Subject: ${SUBJECT}"
+            echo "Content-Type: text/plain; charset=UTF-8"
+            echo
+            cat "${OUT}"
+        } | msmtp --read-recipients
+        echo "[digest] Enviado por msmtp para ${TRAFFIC_DIGEST_EMAIL_TO}"
+    elif command -v mail >/dev/null 2>&1; then
+        mail -s "${SUBJECT}" -a "From: ${FROM}" "${TRAFFIC_DIGEST_EMAIL_TO}" < "${OUT}"
+        echo "[digest] Enviado por mail(1) para ${TRAFFIC_DIGEST_EMAIL_TO}"
+    elif command -v sendmail >/dev/null 2>&1; then
+        {
+            echo "From: ${FROM}"
+            echo "To: ${TRAFFIC_DIGEST_EMAIL_TO}"
+            echo "Subject: ${SUBJECT}"
+            echo "Content-Type: text/plain; charset=UTF-8"
+            echo
+            cat "${OUT}"
+        } | sendmail -t
+        echo "[digest] Enviado por sendmail para ${TRAFFIC_DIGEST_EMAIL_TO}"
+    else
+        echo "[digest] AVISO: TRAFFIC_DIGEST_EMAIL_TO setado mas nenhum MTA encontrado (msmtp/mail/sendmail). Arquivo gravado em ${OUT}, sem envio."
+    fi
+else
+    echo "[digest] TRAFFIC_DIGEST_EMAIL_TO vazio em /etc/cruza-traffic-digest.env — arquivo gravado mas nao enviado."
+fi
+
+# Retencao: mantem 60 dias
+find "${OUTDIR}" -name '*.md' -mtime +60 -delete 2>/dev/null || true

--- a/deploy/cruza-traffic-digest.sh
+++ b/deploy/cruza-traffic-digest.sh
@@ -124,9 +124,9 @@ exploits=$(awk -F\" '
         print $1, path
     }
 ' "${FILTERED}" \
-    | grep -iE '\.env|\.git|wp-admin|wp-login|/admin|/phpmyadmin|/php\.ini|/web-console|/saml|/vpn|/v[12345]/api|/actuator|/manager/html' \
+    | { grep -iE '\.env|\.git|wp-admin|wp-login|/admin|/phpmyadmin|/php\.ini|/web-console|/saml|/vpn|/v[12345]/api|/actuator|/manager/html' || true; } \
     | sort | uniq -c | sort -rn | head -10 \
-    | awk '{printf "  - %s -> `%s` (%s)\n", $2, $3, $1}') || true
+    | awk '{printf "  - %s -> `%s` (%s)\n", $2, $3, $1}')
 
 # IPs identificados (>100 hits + sao usuarios reais provaveis pelo UA)
 # Heuristica simples — Mozilla + nao-bot UA

--- a/deploy/cruza-traffic-digest.timer
+++ b/deploy/cruza-traffic-digest.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Timer diario do digest de trafego (transparenciapb)
+Documentation=https://github.com/lucasdiniz/govbr-cruza-dados/blob/main/deploy/cruza-traffic-digest.sh
+
+[Timer]
+# Diariamente as 07:00 America/Recife (UTC-3). Logrotate do nginx roda
+# em ~06:25, entao access.log.1 ja contem ontem inteiro quando o timer
+# dispara.
+OnCalendar=*-*-* 10:00:00 UTC
+Persistent=true
+# Se a VM ficar off no horario, roda assim que voltar.
+AccuracySec=15min
+
+[Install]
+WantedBy=timers.target

--- a/deploy/setup-goaccess.sh
+++ b/deploy/setup-goaccess.sh
@@ -112,11 +112,10 @@ chmod 640 "${HTPASSWD}"
 # Atualizada mensalmente; idempotente — pula download se ja existe e tem
 # menos de 30 dias. Pra forcar refresh: sudo rm ${GEOIP_DB}.
 #
-# Limpa Country DB legada na primeira vez que rodar pos-upgrade.
-if [[ -f "${LEGACY_COUNTRY_DB}" ]]; then
-    log "Removendo Country DB legado (${LEGACY_COUNTRY_DB}) — agora usamos City."
-    rm -f "${LEGACY_COUNTRY_DB}"
-fi
+# Upgrade atomico: baixamos pra mktemp, validamos com gunzip -t, e SO
+# ENTAO movemos pro destino + removemos a Country DB legada. Se algum
+# passo falhar (wget 404, gunzip corrompido), nao perdemos o fallback —
+# o painel Geo continua funcionando com a DB que ja estava la.
 needs_geoip=0
 if [[ ! -f "${GEOIP_DB}" ]]; then
     needs_geoip=1
@@ -127,16 +126,26 @@ fi
 if [[ "${needs_geoip}" -eq 1 ]]; then
     YYYYMM="$(date +%Y-%m)"
     URL="https://download.db-ip.com/free/dbip-city-lite-${YYYYMM}.mmdb.gz"
+    TMP_GZ="$(mktemp --tmpdir dbip-city-XXXXXX.mmdb.gz)"
+    TMP_MMDB="${TMP_GZ%.gz}"
     log "Baixando GeoIP City de ${URL}..."
-    if wget -q -O "${GEOIP_DB}.gz" "${URL}"; then
-        gunzip -f "${GEOIP_DB}.gz"
-        chown www-data:www-data "${GEOIP_DB}"
-        chmod 644 "${GEOIP_DB}"
+    if wget -q -O "${TMP_GZ}" "${URL}" \
+        && gunzip -t "${TMP_GZ}" 2>/dev/null \
+        && gunzip -f "${TMP_GZ}" \
+        && [[ -s "${TMP_MMDB}" ]]; then
+        chown www-data:www-data "${TMP_MMDB}"
+        chmod 644 "${TMP_MMDB}"
+        mv -f "${TMP_MMDB}" "${GEOIP_DB}"
         log "GeoIP City DB instalado em ${GEOIP_DB}"
+        # SO depois do mv bem sucedido eh seguro remover a Country legada.
+        if [[ -f "${LEGACY_COUNTRY_DB}" ]]; then
+            log "Removendo Country DB legado (${LEGACY_COUNTRY_DB})."
+            rm -f "${LEGACY_COUNTRY_DB}"
+        fi
     else
-        log "AVISO: download do GeoIP City falhou. Painel Geo Location vai ficar vazio."
+        log "AVISO: download/validacao do GeoIP City falhou. Mantendo DB anterior."
         log "       URL tentada: ${URL}"
-        rm -f "${GEOIP_DB}.gz"
+        rm -f "${TMP_GZ}" "${TMP_MMDB}" 2>/dev/null
     fi
 fi
 

--- a/deploy/setup-goaccess.sh
+++ b/deploy/setup-goaccess.sh
@@ -35,7 +35,11 @@ TAIL_SERVICE_DST="/etc/systemd/system/cruza-traffic-tail.service"
 HTPASSWD="/etc/nginx/.htpasswd-traffic"
 OUT_DIR="/var/www/traffic"
 DB_DIR="/var/lib/goaccess"
-GEOIP_DB="${DB_DIR}/dbip-country-lite.mmdb"
+GEOIP_DB="${DB_DIR}/dbip-city-lite.mmdb"
+# Country DB legado (db-ip.com gratuita, sem signup). Removida apos
+# upgrade pra City DB que oferece resolucao cidade/regiao alem de pais
+# (uteis pra entender em qual cidade da PB o trafego se concentra).
+LEGACY_COUNTRY_DB="${DB_DIR}/dbip-country-lite.mmdb"
 
 log() { echo "[goaccess] $*"; }
 
@@ -100,9 +104,19 @@ fi
 chown root:www-data "${HTPASSWD}"
 chmod 640 "${HTPASSWD}"
 
-# ─── 4b. GeoIP database (db-ip.com free lite, sem signup) ───
+# ─── 4b. GeoIP database (db-ip.com free lite City, sem signup) ─────
+# A City DB inclui resolucao geografica de pais + regiao + cidade ate
+# o nivel de "Joao Pessoa", "Campina Grande", etc. Util pra entender
+# concentracao geografica do trafego dentro do estado-foco (PB).
+# Tamanho: ~70MB (vs ~3MB da Country). Aceitavel num VPS.
 # Atualizada mensalmente; idempotente — pula download se ja existe e tem
 # menos de 30 dias. Pra forcar refresh: sudo rm ${GEOIP_DB}.
+#
+# Limpa Country DB legada na primeira vez que rodar pos-upgrade.
+if [[ -f "${LEGACY_COUNTRY_DB}" ]]; then
+    log "Removendo Country DB legado (${LEGACY_COUNTRY_DB}) — agora usamos City."
+    rm -f "${LEGACY_COUNTRY_DB}"
+fi
 needs_geoip=0
 if [[ ! -f "${GEOIP_DB}" ]]; then
     needs_geoip=1
@@ -112,15 +126,15 @@ elif [[ -n "$(find "${GEOIP_DB}" -mtime +30 2>/dev/null)" ]]; then
 fi
 if [[ "${needs_geoip}" -eq 1 ]]; then
     YYYYMM="$(date +%Y-%m)"
-    URL="https://download.db-ip.com/free/dbip-country-lite-${YYYYMM}.mmdb.gz"
-    log "Baixando GeoIP de ${URL}..."
+    URL="https://download.db-ip.com/free/dbip-city-lite-${YYYYMM}.mmdb.gz"
+    log "Baixando GeoIP City de ${URL}..."
     if wget -q -O "${GEOIP_DB}.gz" "${URL}"; then
         gunzip -f "${GEOIP_DB}.gz"
         chown www-data:www-data "${GEOIP_DB}"
         chmod 644 "${GEOIP_DB}"
-        log "GeoIP DB instalado em ${GEOIP_DB}"
+        log "GeoIP City DB instalado em ${GEOIP_DB}"
     else
-        log "AVISO: download do GeoIP falhou. Painel Geo Location vai ficar vazio."
+        log "AVISO: download do GeoIP City falhou. Painel Geo Location vai ficar vazio."
         log "       URL tentada: ${URL}"
         rm -f "${GEOIP_DB}.gz"
     fi

--- a/deploy/setup-traffic-digest.sh
+++ b/deploy/setup-traffic-digest.sh
@@ -79,12 +79,24 @@ EXISTING_EMAIL_TO=""
 EXISTING_EMAIL_FROM=""
 EXISTING_SUBJECT=""
 
+# Le valores existentes do env file SEM usar `source` (anti-injection).
+# Mesmo parser do cruza-traffic-digest.sh — exige formato KEY="VALUE".
 if [[ -f "${ENV_FILE}" ]]; then
-    # shellcheck disable=SC1090
-    source "${ENV_FILE}" || true
-    EXISTING_EMAIL_TO="${TRAFFIC_DIGEST_EMAIL_TO:-}"
-    EXISTING_EMAIL_FROM="${TRAFFIC_DIGEST_EMAIL_FROM:-}"
-    EXISTING_SUBJECT="${TRAFFIC_DIGEST_SUBJECT:-}"
+    while IFS= read -r _envline; do
+        [[ -z "${_envline}" || "${_envline:0:1}" == "#" ]] && continue
+        if [[ "${_envline}" =~ ^([A-Z_]+)=\"(.*)\"$ ]]; then
+            _k="${BASH_REMATCH[1]}"
+            _v="${BASH_REMATCH[2]}"
+            _v="${_v//\\\\/\\}"
+            _v="${_v//\\\"/\"}"
+            case "${_k}" in
+                TRAFFIC_DIGEST_EMAIL_TO)   EXISTING_EMAIL_TO="${_v}"   ;;
+                TRAFFIC_DIGEST_EMAIL_FROM) EXISTING_EMAIL_FROM="${_v}" ;;
+                TRAFFIC_DIGEST_SUBJECT)    EXISTING_SUBJECT="${_v}"    ;;
+            esac
+        fi
+    done < "${ENV_FILE}"
+    unset _envline _k _v
 fi
 
 FINAL_EMAIL_TO="${EMAIL_TO:-${EXISTING_EMAIL_TO:-}}"
@@ -94,12 +106,33 @@ FINAL_SUBJECT="${SUBJECT:-${EXISTING_SUBJECT:-}}"
 if [[ -z "${EMAIL_TO}" && -z "${EMAIL_FROM}" && -z "${SUBJECT}" && -f "${ENV_FILE}" ]]; then
     log "TRAFFIC_DIGEST_EMAIL_TO vazio no env do deploy — preservando ${ENV_FILE} existente."
 else
+    # Anti header-injection: rejeita newlines/CR (\n, \r) nos valores.
+    # Esses chars sao perigosos em headers de email (From/To/Subject).
+    for _val in "${FINAL_EMAIL_TO}" "${FINAL_EMAIL_FROM}" "${FINAL_SUBJECT}"; do
+        if [[ "${_val}" == *$'\n'* || "${_val}" == *$'\r'* ]]; then
+            log "ERRO: valor de email contem newline/CR — rejeitado por seguranca."
+            exit 1
+        fi
+    done
+    unset _val
+
+    # Escapa \\ e \" pra formato KEY="VALUE" parseavel pelo digest.
+    _quote_env() {
+        local v="$1"
+        v="${v//\\/\\\\}"
+        v="${v//\"/\\\"}"
+        printf '"%s"' "$v"
+    }
+
     log "Escrevendo ${ENV_FILE}"
     {
-        echo "# Gerado por deploy/setup-traffic-digest.sh — editavel mas pode ser sobrescrito"
-        if [[ -n "${FINAL_EMAIL_TO}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_TO=${FINAL_EMAIL_TO}"; fi
-        if [[ -n "${FINAL_EMAIL_FROM}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_FROM=${FINAL_EMAIL_FROM}"; fi
-        if [[ -n "${FINAL_SUBJECT}" ]]; then echo "TRAFFIC_DIGEST_SUBJECT=${FINAL_SUBJECT}"; fi
+        echo "# MANAGED BY deploy/setup-traffic-digest.sh"
+        echo "# Formato: KEY=\"valor\" (sempre quoted; backslash e aspas duplas"
+        echo "# internas precisam estar escaped). Newlines/CR sao rejeitados."
+        echo "# Edicoes manuais podem ser sobrescritas no proximo deploy."
+        if [[ -n "${FINAL_EMAIL_TO}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_TO=$(_quote_env "${FINAL_EMAIL_TO}")"; fi
+        if [[ -n "${FINAL_EMAIL_FROM}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_FROM=$(_quote_env "${FINAL_EMAIL_FROM}")"; fi
+        if [[ -n "${FINAL_SUBJECT}" ]]; then echo "TRAFFIC_DIGEST_SUBJECT=$(_quote_env "${FINAL_SUBJECT}")"; fi
     } > "${ENV_FILE}"
     chmod 640 "${ENV_FILE}"
     chown root:root "${ENV_FILE}"

--- a/deploy/setup-traffic-digest.sh
+++ b/deploy/setup-traffic-digest.sh
@@ -75,16 +75,31 @@ fi
 EMAIL_TO="${TRAFFIC_DIGEST_EMAIL_TO:-}"
 EMAIL_FROM="${TRAFFIC_DIGEST_EMAIL_FROM:-}"
 SUBJECT="${TRAFFIC_DIGEST_SUBJECT:-}"
+EXISTING_EMAIL_TO=""
+EXISTING_EMAIL_FROM=""
+EXISTING_SUBJECT=""
 
-if [[ -z "${EMAIL_TO}" && -f "${ENV_FILE}" ]]; then
+if [[ -f "${ENV_FILE}" ]]; then
+    # shellcheck disable=SC1090
+    source "${ENV_FILE}" || true
+    EXISTING_EMAIL_TO="${TRAFFIC_DIGEST_EMAIL_TO:-}"
+    EXISTING_EMAIL_FROM="${TRAFFIC_DIGEST_EMAIL_FROM:-}"
+    EXISTING_SUBJECT="${TRAFFIC_DIGEST_SUBJECT:-}"
+fi
+
+FINAL_EMAIL_TO="${EMAIL_TO:-${EXISTING_EMAIL_TO:-}}"
+FINAL_EMAIL_FROM="${EMAIL_FROM:-${EXISTING_EMAIL_FROM:-}}"
+FINAL_SUBJECT="${SUBJECT:-${EXISTING_SUBJECT:-}}"
+
+if [[ -z "${EMAIL_TO}" && -z "${EMAIL_FROM}" && -z "${SUBJECT}" && -f "${ENV_FILE}" ]]; then
     log "TRAFFIC_DIGEST_EMAIL_TO vazio no env do deploy — preservando ${ENV_FILE} existente."
 else
     log "Escrevendo ${ENV_FILE}"
     {
         echo "# Gerado por deploy/setup-traffic-digest.sh — editavel mas pode ser sobrescrito"
-        if [[ -n "${EMAIL_TO}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_TO=${EMAIL_TO}"; fi
-        if [[ -n "${EMAIL_FROM}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_FROM=${EMAIL_FROM}"; fi
-        if [[ -n "${SUBJECT}" ]]; then echo "TRAFFIC_DIGEST_SUBJECT=${SUBJECT}"; fi
+        if [[ -n "${FINAL_EMAIL_TO}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_TO=${FINAL_EMAIL_TO}"; fi
+        if [[ -n "${FINAL_EMAIL_FROM}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_FROM=${FINAL_EMAIL_FROM}"; fi
+        if [[ -n "${FINAL_SUBJECT}" ]]; then echo "TRAFFIC_DIGEST_SUBJECT=${FINAL_SUBJECT}"; fi
     } > "${ENV_FILE}"
     chmod 640 "${ENV_FILE}"
     chown root:root "${ENV_FILE}"
@@ -110,8 +125,8 @@ systemctl enable --now cruza-traffic-digest.timer >/dev/null 2>&1 || true
 log "Timer status:"
 systemctl list-timers cruza-traffic-digest.timer --no-pager 2>/dev/null || true
 
-if [[ -n "${EMAIL_TO}" ]]; then
-    log "Email destinatario: ${EMAIL_TO}"
+if [[ -n "${FINAL_EMAIL_TO}" ]]; then
+    log "Email destinatario: ${FINAL_EMAIL_TO}"
     if ! command -v msmtp >/dev/null 2>&1 && ! command -v mail >/dev/null 2>&1 && ! command -v sendmail >/dev/null 2>&1; then
         log "AVISO: nenhum MTA encontrado (msmtp/mail/sendmail). Instale um deles + configure SMTP."
         log "       Sugestao: sudo apt-get install msmtp msmtp-mta + /etc/msmtprc com SMTP relay."

--- a/deploy/setup-traffic-digest.sh
+++ b/deploy/setup-traffic-digest.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Setup idempotente do digest diario de trafego.
+#
+# Chamado pelo deploy.yml apos setup-goaccess.sh. Em deploys subsequentes
+# sem mudancas, eh no-op (cmp + reload-conditional).
+#
+# Uso (na VM, como root):
+#   sudo bash deploy/setup-traffic-digest.sh
+#   # ou com email destinatario:
+#   sudo env TRAFFIC_DIGEST_EMAIL_TO=admin@example.com \
+#       bash deploy/setup-traffic-digest.sh
+#
+# Variaveis de ambiente (todas opcionais):
+#   TRAFFIC_DIGEST_EMAIL_TO    - destinatario(s) do email diario.
+#                                 Se vazio E /etc/cruza-traffic-digest.env
+#                                 ja existir, preserva valor anterior.
+#   TRAFFIC_DIGEST_EMAIL_FROM  - remetente do email
+#   TRAFFIC_DIGEST_SUBJECT     - assunto custom
+#
+# MTA: o script de digest tenta msmtp -> mail -> sendmail nessa ordem.
+# Pra usar msmtp com Gmail/SES SMTP relay:
+#   sudo apt-get install msmtp msmtp-mta
+#   sudo tee /etc/msmtprc <<'EOF'
+#   defaults
+#   auth on
+#   tls on
+#   tls_starttls on
+#   tls_trust_file /etc/ssl/certs/ca-certificates.crt
+#   logfile /var/log/msmtp.log
+#
+#   account default
+#   host smtp.gmail.com
+#   port 587
+#   from <seu-email>@gmail.com
+#   user <seu-email>@gmail.com
+#   password <app-password>
+#   EOF
+#   sudo chmod 600 /etc/msmtprc
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_SRC="${REPO_DIR}/deploy/cruza-traffic-digest.sh"
+SCRIPT_DST="/usr/local/bin/cruza-traffic-digest.sh"
+SERVICE_SRC="${REPO_DIR}/deploy/cruza-traffic-digest.service"
+SERVICE_DST="/etc/systemd/system/cruza-traffic-digest.service"
+TIMER_SRC="${REPO_DIR}/deploy/cruza-traffic-digest.timer"
+TIMER_DST="/etc/systemd/system/cruza-traffic-digest.timer"
+ENV_FILE="/etc/cruza-traffic-digest.env"
+OUTDIR="/var/log/cruza-traffic-digest"
+
+log() { echo "[traffic-digest] $*"; }
+
+if [[ "${EUID}" -ne 0 ]]; then
+    log "ERRO: precisa rodar como root (use sudo)."
+    exit 1
+fi
+
+# ─── 1. Output dir ───
+mkdir -p "${OUTDIR}"
+chmod 750 "${OUTDIR}"
+
+# ─── 2. Script principal ───
+needs_reload_unit=0
+if [[ ! -f "${SCRIPT_DST}" ]] || ! cmp -s "${SCRIPT_SRC}" "${SCRIPT_DST}"; then
+    log "Instalando ${SCRIPT_DST}"
+    install -m 755 -o root -g root "${SCRIPT_SRC}" "${SCRIPT_DST}"
+fi
+
+# ─── 3. Env file ───
+# Se ${TRAFFIC_DIGEST_EMAIL_TO} vier do env do deploy, atualiza; senao
+# preserva o que ja existir no arquivo. Permite o admin setar o email
+# uma vez via secret do GitHub Actions e nao precisar manter na config
+# do repo.
+EMAIL_TO="${TRAFFIC_DIGEST_EMAIL_TO:-}"
+EMAIL_FROM="${TRAFFIC_DIGEST_EMAIL_FROM:-}"
+SUBJECT="${TRAFFIC_DIGEST_SUBJECT:-}"
+
+if [[ -z "${EMAIL_TO}" && -f "${ENV_FILE}" ]]; then
+    log "TRAFFIC_DIGEST_EMAIL_TO vazio no env do deploy — preservando ${ENV_FILE} existente."
+else
+    log "Escrevendo ${ENV_FILE}"
+    {
+        echo "# Gerado por deploy/setup-traffic-digest.sh — editavel mas pode ser sobrescrito"
+        if [[ -n "${EMAIL_TO}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_TO=${EMAIL_TO}"; fi
+        if [[ -n "${EMAIL_FROM}" ]]; then echo "TRAFFIC_DIGEST_EMAIL_FROM=${EMAIL_FROM}"; fi
+        if [[ -n "${SUBJECT}" ]]; then echo "TRAFFIC_DIGEST_SUBJECT=${SUBJECT}"; fi
+    } > "${ENV_FILE}"
+    chmod 640 "${ENV_FILE}"
+    chown root:root "${ENV_FILE}"
+fi
+
+# ─── 4. Systemd units ───
+if [[ ! -f "${SERVICE_DST}" ]] || ! cmp -s "${SERVICE_SRC}" "${SERVICE_DST}"; then
+    log "Instalando ${SERVICE_DST}"
+    install -m 644 -o root -g root "${SERVICE_SRC}" "${SERVICE_DST}"
+    needs_reload_unit=1
+fi
+if [[ ! -f "${TIMER_DST}" ]] || ! cmp -s "${TIMER_SRC}" "${TIMER_DST}"; then
+    log "Instalando ${TIMER_DST}"
+    install -m 644 -o root -g root "${TIMER_SRC}" "${TIMER_DST}"
+    needs_reload_unit=1
+fi
+
+if [[ "${needs_reload_unit}" -eq 1 ]]; then
+    systemctl daemon-reload
+fi
+
+systemctl enable --now cruza-traffic-digest.timer >/dev/null 2>&1 || true
+log "Timer status:"
+systemctl list-timers cruza-traffic-digest.timer --no-pager 2>/dev/null || true
+
+if [[ -n "${EMAIL_TO}" ]]; then
+    log "Email destinatario: ${EMAIL_TO}"
+    if ! command -v msmtp >/dev/null 2>&1 && ! command -v mail >/dev/null 2>&1 && ! command -v sendmail >/dev/null 2>&1; then
+        log "AVISO: nenhum MTA encontrado (msmtp/mail/sendmail). Instale um deles + configure SMTP."
+        log "       Sugestao: sudo apt-get install msmtp msmtp-mta + /etc/msmtprc com SMTP relay."
+    fi
+else
+    log "TRAFFIC_DIGEST_EMAIL_TO vazio. Digest sera gerado em ${OUTDIR}/YYYY-MM-DD.md mas nao enviado."
+fi
+
+log "Setup completo."

--- a/web/main.py
+++ b/web/main.py
@@ -364,6 +364,13 @@ JS_FILES: list[str] = [
     "lib/umami-track.js",
     # scroll-deep: depende do trackEvent helper acima.
     "lib/scroll-deep.js",
+    # page-engagement: tempo na pagina + scroll max no pagehide.
+    # Depende do trackEvent helper. Init em pages/main.js.
+    "lib/page-engagement.js",
+    # dialog-engagement: pareia dialog-aberto com dialog-fechado.
+    # Listener self-attaching via lib/umami-track.js -> document
+    # 'tpb:tracked' CustomEvent. Init em pages/main.js.
+    "lib/dialog-engagement.js",
     "components/search-tabs.js",
     "components/mode-toggle.js",
     # md3-ready helper. Must load early so any later script can register
@@ -428,7 +435,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "108"
+templates.env.globals["ASSET_VERSION"] = "109"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/components/dialog-nav.js
+++ b/web/static/js/components/dialog-nav.js
@@ -27,6 +27,21 @@ function _dialogPop() {
     const dialog = document.getElementById('empresa-dialog');
     if (!dialog || !_dialogStack.length) return;
     const prev = _dialogStack.pop();
+
+    // Engagement tracking: dispara `dialog-restored` ANTES de substituir
+    // o body.innerHTML. O listener de dialog-engagement faz flush() das
+    // metricas (dwell/scroll/tabs) do tipo atual lendo as dimensions do
+    // .dialog-body ainda intactas — i.e. ainda exibindo o conteudo do
+    // dialog que estamos saindo. Depois disso o body eh trocado e o
+    // listener tambem chama start(prev.tipo) pra reiniciar tracking limpo.
+    // Sem essa ordem, flush() leria scrollHeight/clientHeight do conteudo
+    // ja restaurado e atribuiria scroll_max errado ao tipo que estamos
+    // fechando (achado do review: gpt-5.5).
+    _currentDialogType = prev.tipo || '';
+    if (typeof trackEvent === 'function' && _currentDialogType) {
+        trackEvent('dialog-restored', { tipo: _currentDialogType });
+    }
+
     dialog.querySelector('.dialog-title').textContent = prev.title;
     const body = dialog.querySelector('.dialog-body');
     body.innerHTML = prev.html;
@@ -34,20 +49,6 @@ function _dialogPop() {
     _decorateDialogBody(body);
     if (prev.activePanelId) _activateDialogSection(body, prev.activePanelId, { focus: false, scroll: false });
     if (!_dialogStack.length) dialog.querySelector('.dialog-back').style.visibility = 'hidden';
-    // Restaura tipo do nivel anterior pra que drill chain subsequente
-    // (ex: voltar pra fornecedor e abrir outro empenho) tenha drilled_from
-    // correto.
-    _currentDialogType = prev.tipo || '';
-    // Engagement tracking: emite novo evento `dialog-restored` pro
-    // listener de dialog-engagement saber que o user voltou pra um
-    // dialog anterior (mesma md-dialog, conteudo diferente do que
-    // estava no momento do back). Sem isso, dwell/scroll/tabs do nivel
-    // restaurado ficam atribuidos ao tipo errado (ultimo aberto antes
-    // do back). Como evento separado de dialog-aberto pra permitir
-    // contar "voltei" distinto de "abri novo" nas metricas.
-    if (typeof trackEvent === 'function' && _currentDialogType) {
-        trackEvent('dialog-restored', { tipo: _currentDialogType });
-    }
     // Atualiza URL pro state do nivel anterior (sem nova history entry).
     // Race guard: bumpa seq pra cancelar fetches inflight da camada que
     // estamos saindo.

--- a/web/static/js/components/dialog-nav.js
+++ b/web/static/js/components/dialog-nav.js
@@ -38,6 +38,16 @@ function _dialogPop() {
     // (ex: voltar pra fornecedor e abrir outro empenho) tenha drilled_from
     // correto.
     _currentDialogType = prev.tipo || '';
+    // Engagement tracking: emite novo evento `dialog-restored` pro
+    // listener de dialog-engagement saber que o user voltou pra um
+    // dialog anterior (mesma md-dialog, conteudo diferente do que
+    // estava no momento do back). Sem isso, dwell/scroll/tabs do nivel
+    // restaurado ficam atribuidos ao tipo errado (ultimo aberto antes
+    // do back). Como evento separado de dialog-aberto pra permitir
+    // contar "voltei" distinto de "abri novo" nas metricas.
+    if (typeof trackEvent === 'function' && _currentDialogType) {
+        trackEvent('dialog-restored', { tipo: _currentDialogType });
+    }
     // Atualiza URL pro state do nivel anterior (sem nova history entry).
     // Race guard: bumpa seq pra cancelar fetches inflight da camada que
     // estamos saindo.

--- a/web/static/js/lib/dialog-engagement.js
+++ b/web/static/js/lib/dialog-engagement.js
@@ -34,7 +34,7 @@
 //     no dialog-aberto, nao o id do md-dialog.
 
 (function () {
-    let active = null;   // { tipo, t0, tabsCount, maxScrollPct }
+    let active = null;   // { tipo, t0, tabsCount, maxScrollPct, initialTabLabel?, tabsVisited:Set }
     let scrollEl = null;
     let scrollTicking = false;
 
@@ -94,6 +94,8 @@
             t0: performance.now(),
             tabsCount: 1, // tab inicial sempre conta
             maxScrollPct: 0,
+            initialTabLabel: null,
+            tabsVisited: new Set(),
         };
         // Faz uma leitura imediata pra capturar conteudos curtos
         // (que cabem na viewport, scroll_max=100 sem o usuario rolar).
@@ -117,7 +119,11 @@
                 return;
             }
             if (name === 'dialog-tab-change' && active) {
-                active.tabsCount += 1;
+                const de = typeof props.de === 'string' ? props.de.trim() : '';
+                const para = typeof props.para === 'string' ? props.para.trim() : '';
+                if (!active.initialTabLabel && de) active.initialTabLabel = de;
+                if (para && para !== active.initialTabLabel) active.tabsVisited.add(para);
+                active.tabsCount = 1 + active.tabsVisited.size;
                 return;
             }
         });

--- a/web/static/js/lib/dialog-engagement.js
+++ b/web/static/js/lib/dialog-engagement.js
@@ -1,0 +1,143 @@
+// === lib/dialog-engagement.js ===
+// Dispara evento `dialog-fechado` pareado com `dialog-aberto`, medindo
+// engagement REAL por dialog: dwell time, tabs exploradas, profundidade
+// do scroll. Sem este evento, so sabemos "abriu" — nao "leu/explorou".
+//
+// Como funciona:
+//   1. Hook em document `tpb:tracked` (dispatchado pelo trackEvent em
+//      lib/umami-track.js).
+//   2. Quando vem `dialog-aberto` com props.tipo, comecamos a sessao:
+//        { tipo, t0, tabsCount, maxScrollPct }
+//      Se ja havia sessao ativa (drilldown — usuario abriu outro tipo
+//      de dialog SEM fechar o md-dialog), fechamos a sessao anterior
+//      com `drilled_to = props.tipo` e iniciamos nova.
+//   3. Quando vem `dialog-tab-change`, incrementamos tabsCount. Nao
+//      armazenamos os nomes das tabs (privacidade + payload menor);
+//      apenas a quantidade DISTINTA de tabs visitadas alem da inicial.
+//   4. Scroll listener no #empresa-dialog .dialog-body atualiza
+//      maxScrollPct. A dialog-body eh reutilizada entre drilldowns —
+//      resetamos maxScrollPct a cada novo dialog-aberto.
+//   5. Quando o md-dialog fecha de verdade (event `closed`), emitimos
+//      o evento final SEM drilled_to.
+//
+// Notas:
+//   - tabs_visitadas comeca em 1 (tab inicial) e aumenta com cada
+//     dialog-tab-change. Se o usuario nunca trocar de tab, sai 1.
+//   - dwell_ms eh tempo absoluto desde o open ate o close/drilldown.
+//     Diferente do pagina-saida, NAO descontamos visibility — dialogs
+//     sao sessoes interativas curtas e descontar background piora a
+//     leitura (e dialog raramente fica aberto com aba inativa).
+//   - scroll_max_pct soma o scroll DA DIALOG-BODY apenas. Scroll da
+//     pagina por baixo eh medido em pagina-saida separadamente.
+//   - O dialog #empresa-dialog hospeda 5 tipos diferentes (fornecedor,
+//     servidor, empenho, licitacao, heatmap). Usamos o tipo capturado
+//     no dialog-aberto, nao o id do md-dialog.
+
+(function () {
+    let active = null;   // { tipo, t0, tabsCount, maxScrollPct }
+    let scrollEl = null;
+    let scrollTicking = false;
+
+    function updateMaxScroll() {
+        scrollTicking = false;
+        if (!active || !scrollEl) return;
+        const total = Math.max(scrollEl.scrollHeight, 1);
+        const view = scrollEl.clientHeight;
+        if (total <= view) {
+            // Conteudo cabe no viewport do dialog — considera 100%.
+            if (active.maxScrollPct < 100) active.maxScrollPct = 100;
+            return;
+        }
+        const scrolled = scrollEl.scrollTop + view;
+        const pct = Math.min(100, Math.round((scrolled / total) * 100));
+        if (pct > active.maxScrollPct) active.maxScrollPct = pct;
+    }
+
+    function onDialogScroll() {
+        if (scrollTicking) return;
+        scrollTicking = true;
+        requestAnimationFrame(updateMaxScroll);
+    }
+
+    function flush(drilledTo) {
+        if (!active) return;
+        const dwellMs = Math.max(0, Math.round(performance.now() - active.t0));
+        // Captura ultima leitura do scroll antes de emitir
+        updateMaxScroll();
+        if (typeof trackEvent === 'function') {
+            const props = {
+                tipo: active.tipo,
+                dwell_ms: dwellMs,
+                tabs_visitadas: active.tabsCount,
+                scroll_max_pct: active.maxScrollPct,
+            };
+            if (drilledTo) props.drilled_to = drilledTo;
+            trackEvent('dialog-fechado', props);
+        }
+        active = null;
+    }
+
+    function start(tipo) {
+        // Inicializa scroll listener no body do empresa-dialog. O elemento
+        // eh estavel ao longo de drilldowns (so o innerHTML muda), entao
+        // attach uma vez e reaproveita.
+        if (!scrollEl) {
+            const dialog = document.getElementById('empresa-dialog');
+            const body = dialog ? dialog.querySelector('.dialog-body') : null;
+            if (body) {
+                scrollEl = body;
+                scrollEl.addEventListener('scroll', onDialogScroll, { passive: true });
+            }
+        }
+        active = {
+            tipo: String(tipo || 'unknown'),
+            t0: performance.now(),
+            tabsCount: 1, // tab inicial sempre conta
+            maxScrollPct: 0,
+        };
+        // Faz uma leitura imediata pra capturar conteudos curtos
+        // (que cabem na viewport, scroll_max=100 sem o usuario rolar).
+        updateMaxScroll();
+    }
+
+    function init() {
+        if (typeof document === 'undefined') return;
+
+        document.addEventListener('tpb:tracked', (e) => {
+            const detail = e && e.detail;
+            if (!detail || !detail.name) return;
+            const name = detail.name;
+            const props = detail.props || {};
+
+            if (name === 'dialog-aberto' && props.tipo) {
+                // Drilldown: dialog ja estava aberto e usuario abriu outro
+                // tipo. Fecha a sessao anterior marcando drilled_to.
+                if (active) flush(String(props.tipo));
+                start(props.tipo);
+                return;
+            }
+            if (name === 'dialog-tab-change' && active) {
+                active.tabsCount += 1;
+                return;
+            }
+        });
+
+        // Quando o md-dialog efetivamente fecha (post-animacao), emitimos
+        // o evento final. Esperamos pelo MD3 ready pra garantir que o
+        // 'closed' event listener nao seja conectado antes do upgrade.
+        const attachClose = () => {
+            const dialog = document.getElementById('empresa-dialog');
+            if (!dialog) return;
+            dialog.addEventListener('closed', () => { flush(null); });
+        };
+        if (typeof window.whenMD3Ready === 'function') {
+            window.whenMD3Ready(attachClose);
+        } else if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', attachClose);
+        } else {
+            attachClose();
+        }
+    }
+
+    window.initDialogEngagement = init;
+})();

--- a/web/static/js/lib/dialog-engagement.js
+++ b/web/static/js/lib/dialog-engagement.js
@@ -122,6 +122,7 @@
                 const de = typeof props.de === 'string' ? props.de.trim() : '';
                 const para = typeof props.para === 'string' ? props.para.trim() : '';
                 if (!active.initialTabLabel && de) active.initialTabLabel = de;
+                if (!active.initialTabLabel && !de && para) active.initialTabLabel = para;
                 if (para && para !== active.initialTabLabel) active.tabsVisited.add(para);
                 active.tabsCount = 1 + active.tabsVisited.size;
                 return;

--- a/web/static/js/lib/dialog-engagement.js
+++ b/web/static/js/lib/dialog-engagement.js
@@ -34,23 +34,21 @@
 //     no dialog-aberto, nao o id do md-dialog.
 
 (function () {
-    let active = null;   // { tipo, t0, tabsCount, maxScrollPct, initialTabLabel?, tabsVisited:Set }
+    let active = null;   // { tipo, t0, tabsVisited:Set, maxScrolledPx, initialTabLabel? }
     let scrollEl = null;
     let scrollTicking = false;
+    let _inited = false;
+
+    function readScrolledPx() {
+        if (!scrollEl) return 0;
+        return scrollEl.scrollTop + scrollEl.clientHeight;
+    }
 
     function updateMaxScroll() {
         scrollTicking = false;
         if (!active || !scrollEl) return;
-        const total = Math.max(scrollEl.scrollHeight, 1);
-        const view = scrollEl.clientHeight;
-        if (total <= view) {
-            // Conteudo cabe no viewport do dialog — considera 100%.
-            if (active.maxScrollPct < 100) active.maxScrollPct = 100;
-            return;
-        }
-        const scrolled = scrollEl.scrollTop + view;
-        const pct = Math.min(100, Math.round((scrolled / total) * 100));
-        if (pct > active.maxScrollPct) active.maxScrollPct = pct;
+        const px = readScrolledPx();
+        if (px > active.maxScrolledPx) active.maxScrolledPx = px;
     }
 
     function onDialogScroll() {
@@ -59,17 +57,33 @@
         requestAnimationFrame(updateMaxScroll);
     }
 
+    // Computa scroll_max_pct SO no flush(), nao no start(). Isso evita
+    // o bug de "travar em 100%" quando o body comeca como placeholder
+    // ("Carregando...") que cabe na viewport: se calculassemos no
+    // start() e setassemos maxScrollPct=100, o valor nao reduziria
+    // quando o conteudo real chegasse (que pode ser muito maior).
+    // Avaliamos AGORA usando scrollHeight ATUAL.
+    function computeScrollMaxPct() {
+        if (!scrollEl || !active) return 0;
+        const total = Math.max(scrollEl.scrollHeight, 1);
+        const view = scrollEl.clientHeight;
+        if (total <= view) return 100;
+        const px = Math.max(active.maxScrolledPx, readScrolledPx());
+        return Math.min(100, Math.round((px / total) * 100));
+    }
+
     function flush(drilledTo) {
         if (!active) return;
         const dwellMs = Math.max(0, Math.round(performance.now() - active.t0));
-        // Captura ultima leitura do scroll antes de emitir
-        updateMaxScroll();
+        // tabs_visitadas conta distintas (initialTabLabel + Set de
+        // tabs `para`). Se nunca trocou de tab, sai 1.
+        const tabsCount = 1 + active.tabsVisited.size;
         if (typeof trackEvent === 'function') {
             const props = {
                 tipo: active.tipo,
                 dwell_ms: dwellMs,
-                tabs_visitadas: active.tabsCount,
-                scroll_max_pct: active.maxScrollPct,
+                tabs_visitadas: tabsCount,
+                scroll_max_pct: computeScrollMaxPct(),
             };
             if (drilledTo) props.drilled_to = drilledTo;
             trackEvent('dialog-fechado', props);
@@ -78,9 +92,6 @@
     }
 
     function start(tipo) {
-        // Inicializa scroll listener no body do empresa-dialog. O elemento
-        // eh estavel ao longo de drilldowns (so o innerHTML muda), entao
-        // attach uma vez e reaproveita.
         if (!scrollEl) {
             const dialog = document.getElementById('empresa-dialog');
             const body = dialog ? dialog.querySelector('.dialog-body') : null;
@@ -92,18 +103,20 @@
         active = {
             tipo: String(tipo || 'unknown'),
             t0: performance.now(),
-            tabsCount: 1, // tab inicial sempre conta
-            maxScrollPct: 0,
-            initialTabLabel: null,
             tabsVisited: new Set(),
+            maxScrolledPx: 0,
+            initialTabLabel: null,
         };
-        // Faz uma leitura imediata pra capturar conteudos curtos
-        // (que cabem na viewport, scroll_max=100 sem o usuario rolar).
-        updateMaxScroll();
     }
 
     function init() {
         if (typeof document === 'undefined') return;
+        // Idempotencia: HMR / hot-reload / chamadas duplicadas de
+        // bootstrap podem invocar initDialogEngagement() multiplas
+        // vezes. Sem este guard duplicariamos listeners (tabs contadas
+        // 2x, dialog-fechado disparado 2x por close).
+        if (_inited) return;
+        _inited = true;
 
         document.addEventListener('tpb:tracked', (e) => {
             const detail = e && e.detail;
@@ -112,9 +125,14 @@
             const props = detail.props || {};
 
             if (name === 'dialog-aberto' && props.tipo) {
-                // Drilldown: dialog ja estava aberto e usuario abriu outro
-                // tipo. Fecha a sessao anterior marcando drilled_to.
                 if (active) flush(String(props.tipo));
+                start(props.tipo);
+                return;
+            }
+            if (name === 'dialog-restored' && props.tipo) {
+                // Back-button: flush atual marcando como 'back-<tipo>'
+                // pra distinguir nas metricas de drilldown puro.
+                if (active) flush('back-' + String(props.tipo));
                 start(props.tipo);
                 return;
             }
@@ -124,14 +142,10 @@
                 if (!active.initialTabLabel && de) active.initialTabLabel = de;
                 if (!active.initialTabLabel && !de && para) active.initialTabLabel = para;
                 if (para && para !== active.initialTabLabel) active.tabsVisited.add(para);
-                active.tabsCount = 1 + active.tabsVisited.size;
                 return;
             }
         });
 
-        // Quando o md-dialog efetivamente fecha (post-animacao), emitimos
-        // o evento final. Esperamos pelo MD3 ready pra garantir que o
-        // 'closed' event listener nao seja conectado antes do upgrade.
         const attachClose = () => {
             const dialog = document.getElementById('empresa-dialog');
             if (!dialog) return;

--- a/web/static/js/lib/dialog-engagement.js
+++ b/web/static/js/lib/dialog-engagement.js
@@ -1,54 +1,84 @@
 // === lib/dialog-engagement.js ===
 // Dispara evento `dialog-fechado` pareado com `dialog-aberto`, medindo
-// engagement REAL por dialog: dwell time, tabs exploradas, profundidade
-// do scroll. Sem este evento, so sabemos "abriu" — nao "leu/explorou".
+// engagement REAL por dialog: dwell time, tabs distintas exploradas,
+// profundidade do scroll. Sem este evento, so sabemos "abriu" — nao
+// "leu/explorou".
 //
 // Como funciona:
 //   1. Hook em document `tpb:tracked` (dispatchado pelo trackEvent em
 //      lib/umami-track.js).
 //   2. Quando vem `dialog-aberto` com props.tipo, comecamos a sessao:
-//        { tipo, t0, tabsCount, maxScrollPct }
+//        { tipo, t0, tabsVisited:Set, maxScrollPct, initialTabLabel }
 //      Se ja havia sessao ativa (drilldown — usuario abriu outro tipo
 //      de dialog SEM fechar o md-dialog), fechamos a sessao anterior
 //      com `drilled_to = props.tipo` e iniciamos nova.
-//   3. Quando vem `dialog-tab-change`, incrementamos tabsCount. Nao
-//      armazenamos os nomes das tabs (privacidade + payload menor);
-//      apenas a quantidade DISTINTA de tabs visitadas alem da inicial.
-//   4. Scroll listener no #empresa-dialog .dialog-body atualiza
-//      maxScrollPct. A dialog-body eh reutilizada entre drilldowns —
-//      resetamos maxScrollPct a cada novo dialog-aberto.
-//   5. Quando o md-dialog fecha de verdade (event `closed`), emitimos
-//      o evento final SEM drilled_to.
+//   3. Quando vem `dialog-restored` (botao "voltar" do dialog stack),
+//      fechamos a sessao atual marcando `drilled_to = 'back-<tipo>'`
+//      e iniciamos nova sessao com tipo restaurado.
+//      IMPORTANTE: `dialog-nav.js _dialogPop()` dispara dialog-restored
+//      ANTES de substituir o body.innerHTML — pra que esse flush leia
+//      dimensoes do conteudo que esta saindo, nao do que esta entrando.
+//   4. Quando vem `dialog-tab-change`, adicionamos `de` e `para` ao Set
+//      de tabs visitadas + capturamos initialTabLabel se ainda nulo.
+//      Reportamos `tabs_visitadas = 1 + tabsVisited.size` (1 conta a
+//      tab inicial). Se zero tab-changes ocorreram, size=0 e reportamos 1.
+//   5. Scroll: tracking PROGRESSIVO de maxScrollPct. updateMaxScroll
+//      computa pct usando scrollHeight/clientHeight ATUAIS a cada
+//      scroll event e armazena o max. NAO faz calc-at-flush porque:
+//        a) Calc-at-close-time: o evento `closed` do md-dialog fire
+//           APOS display:none ter sido aplicado, entao scrollHeight=0
+//           e clientHeight=0 — calc-at-flush produziria 100 ou 0
+//           binario (achado do review: opus-4.7).
+//        b) Calc-at-restore-time: em dialog-restored o body.innerHTML
+//           ja eh do dialog restaurado quando o evento fire — calc
+//           leria dimensoes do nivel errado (achado: gpt-5.5).
+//      Como mitigamos as duas: tracking progressivo evita ler dimensoes
+//      no momento da flush; valor armazenado eh o max ja computado em
+//      momentos validos.
+//   6. Para capturar o caso "user abriu conteudo pequeno que cabia na
+//      viewport e fechou sem scrollar" (que progressivo nao captura
+//      porque nao ha scroll events): adicionamos listener pro evento
+//      `close` do md-dialog. Esse evento fire ANTES da animacao de
+//      close e ANTES do display:none — dimensions ainda validas. Fazemos
+//      uma leitura final que captura 100% quando content fits viewport.
+//      Para drilldown/restored, o updateMaxScroll a cada scroll ja
+//      capturou o max corretamente.
+//   7. No `closed` (post display:none), apenas flushamos o valor ja
+//      armazenado. Nao re-medimos.
 //
-// Notas:
-//   - tabs_visitadas comeca em 1 (tab inicial) e aumenta com cada
-//     dialog-tab-change. Se o usuario nunca trocar de tab, sai 1.
-//   - dwell_ms eh tempo absoluto desde o open ate o close/drilldown.
-//     Diferente do pagina-saida, NAO descontamos visibility — dialogs
-//     sao sessoes interativas curtas e descontar background piora a
-//     leitura (e dialog raramente fica aberto com aba inativa).
-//   - scroll_max_pct soma o scroll DA DIALOG-BODY apenas. Scroll da
-//     pagina por baixo eh medido em pagina-saida separadamente.
-//   - O dialog #empresa-dialog hospeda 5 tipos diferentes (fornecedor,
-//     servidor, empenho, licitacao, heatmap). Usamos o tipo capturado
-//     no dialog-aberto, nao o id do md-dialog.
+// Idempotencia: `_inited` flag protege contra duplo-init (HMR,
+// hot-reload). Re-anexar listeners faria contar tabs em dobro e flushar
+// 2x cada dialog-fechado.
 
 (function () {
-    let active = null;   // { tipo, t0, tabsVisited:Set, maxScrolledPx, initialTabLabel? }
+    let active = null;   // { tipo, t0, tabsVisited:Set, maxScrollPct, initialTabLabel? }
     let scrollEl = null;
     let scrollTicking = false;
     let _inited = false;
 
-    function readScrolledPx() {
-        if (!scrollEl) return 0;
-        return scrollEl.scrollTop + scrollEl.clientHeight;
-    }
-
+    // Atualiza maxScrollPct progressivamente. Computa pct usando
+    // scrollHeight/clientHeight CORRENTES (validos enquanto o dialog
+    // estiver visivel). Stored max nunca diminui — entao quando o
+    // dialog fecha (dimensions=0) o valor preserva o pct medido em
+    // momentos validos.
     function updateMaxScroll() {
         scrollTicking = false;
         if (!active || !scrollEl) return;
-        const px = readScrolledPx();
-        if (px > active.maxScrolledPx) active.maxScrolledPx = px;
+        const view = scrollEl.clientHeight;
+        if (view === 0) return; // dialog hidden — dimensions invalidas
+        const total = Math.max(scrollEl.scrollHeight, 1);
+        let pct;
+        if (total <= view) {
+            // Conteudo cabe inteiro na viewport do dialog — user "viu
+            // tudo" sem precisar rolar. Mas SO seta 100 se essa for a
+            // condicao no momento (nao trava 100 do passado se conteudo
+            // crescer e ultrapassar a viewport depois).
+            pct = 100;
+        } else {
+            const scrolled = scrollEl.scrollTop + view;
+            pct = Math.min(100, Math.round((scrolled / total) * 100));
+        }
+        if (pct > active.maxScrollPct) active.maxScrollPct = pct;
     }
 
     function onDialogScroll() {
@@ -57,33 +87,21 @@
         requestAnimationFrame(updateMaxScroll);
     }
 
-    // Computa scroll_max_pct SO no flush(), nao no start(). Isso evita
-    // o bug de "travar em 100%" quando o body comeca como placeholder
-    // ("Carregando...") que cabe na viewport: se calculassemos no
-    // start() e setassemos maxScrollPct=100, o valor nao reduziria
-    // quando o conteudo real chegasse (que pode ser muito maior).
-    // Avaliamos AGORA usando scrollHeight ATUAL.
-    function computeScrollMaxPct() {
-        if (!scrollEl || !active) return 0;
-        const total = Math.max(scrollEl.scrollHeight, 1);
-        const view = scrollEl.clientHeight;
-        if (total <= view) return 100;
-        const px = Math.max(active.maxScrolledPx, readScrolledPx());
-        return Math.min(100, Math.round((px / total) * 100));
-    }
-
     function flush(drilledTo) {
         if (!active) return;
+        // Uma ultima leitura: enquanto scrollEl estiver visivel
+        // (clientHeight>0), atualiza maxScrollPct. Cobre drilldown
+        // (dialog-aberto/restored com body ainda montado) e flushes
+        // pre-close (chamados pelo listener 'close' abaixo).
+        updateMaxScroll();
         const dwellMs = Math.max(0, Math.round(performance.now() - active.t0));
-        // tabs_visitadas conta distintas (initialTabLabel + Set de
-        // tabs `para`). Se nunca trocou de tab, sai 1.
         const tabsCount = 1 + active.tabsVisited.size;
         if (typeof trackEvent === 'function') {
             const props = {
                 tipo: active.tipo,
                 dwell_ms: dwellMs,
                 tabs_visitadas: tabsCount,
-                scroll_max_pct: computeScrollMaxPct(),
+                scroll_max_pct: active.maxScrollPct,
             };
             if (drilledTo) props.drilled_to = drilledTo;
             trackEvent('dialog-fechado', props);
@@ -104,17 +122,22 @@
             tipo: String(tipo || 'unknown'),
             t0: performance.now(),
             tabsVisited: new Set(),
-            maxScrolledPx: 0,
+            maxScrollPct: 0,
             initialTabLabel: null,
         };
+        // Sample inicial deferred: depois de 1 raf o conteudo da primeira
+        // renderizacao tipicamente ja foi layoutado. Captura o caso "user
+        // abriu dialog com conteudo curto que cabia, fechou sem scrollar"
+        // mesmo quando o user fecha muito rapido (antes do listener
+        // 'close' do md-dialog chegar a fazer sua leitura).
+        requestAnimationFrame(updateMaxScroll);
     }
 
     function init() {
         if (typeof document === 'undefined') return;
         // Idempotencia: HMR / hot-reload / chamadas duplicadas de
         // bootstrap podem invocar initDialogEngagement() multiplas
-        // vezes. Sem este guard duplicariamos listeners (tabs contadas
-        // 2x, dialog-fechado disparado 2x por close).
+        // vezes. Sem este guard duplicariamos listeners.
         if (_inited) return;
         _inited = true;
 
@@ -132,6 +155,12 @@
             if (name === 'dialog-restored' && props.tipo) {
                 // Back-button: flush atual marcando como 'back-<tipo>'
                 // pra distinguir nas metricas de drilldown puro.
+                // Importante: dialog-nav.js emite dialog-restored ANTES
+                // de substituir body.innerHTML, entao flush() le
+                // dimensoes do conteudo que esta saindo. Depois start()
+                // reinicia tracking; quando o body for substituido logo
+                // depois, o proximo scroll event do user ja captura
+                // pct do novo conteudo corretamente.
                 if (active) flush('back-' + String(props.tipo));
                 start(props.tipo);
                 return;
@@ -142,21 +171,34 @@
                 if (!active.initialTabLabel && de) active.initialTabLabel = de;
                 if (!active.initialTabLabel && !de && para) active.initialTabLabel = para;
                 if (para && para !== active.initialTabLabel) active.tabsVisited.add(para);
+                // Re-sample apos tab-change: conteudo novo da tab pode
+                // ter altura diferente. Aproveita pra capturar 100 se o
+                // novo conteudo tambem cabe na viewport.
+                requestAnimationFrame(updateMaxScroll);
                 return;
             }
         });
 
-        const attachClose = () => {
+        const attachDialogListeners = () => {
             const dialog = document.getElementById('empresa-dialog');
             if (!dialog) return;
+            // 'close' (cancelable, pre-animation): fire enquanto dialog
+            // AINDA esta visivel — dimensions validas. Fazemos uma
+            // ultima leitura pra capturar o caso "user abriu conteudo
+            // pequeno que cabia na viewport, fechou sem scroll" (que
+            // updateMaxScroll progressivo nao pegaria sem scroll events).
+            // NAO chamamos preventDefault — apenas snapshot.
+            dialog.addEventListener('close', () => { updateMaxScroll(); });
+            // 'closed' (post display:none): dimensions invalidas (0).
+            // Apenas flusha o valor ja armazenado, sem re-medir.
             dialog.addEventListener('closed', () => { flush(null); });
         };
         if (typeof window.whenMD3Ready === 'function') {
-            window.whenMD3Ready(attachClose);
+            window.whenMD3Ready(attachDialogListeners);
         } else if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', attachClose);
+            document.addEventListener('DOMContentLoaded', attachDialogListeners);
         } else {
-            attachClose();
+            attachDialogListeners();
         }
     }
 

--- a/web/static/js/lib/page-engagement.js
+++ b/web/static/js/lib/page-engagement.js
@@ -61,6 +61,7 @@ function initPageEngagement() {
     let totalVisibleMs = 0;
     let fired = false;
     let scrollTicking = false;
+    let hiddenFireTimer = null;
 
     const updateScroll = () => {
         scrollTicking = false;
@@ -95,20 +96,40 @@ function initPageEngagement() {
         if (fired) return;
         if (document.visibilityState === 'hidden') {
             totalVisibleMs += performance.now() - visibleSinceMs;
-            // Hidden eh nosso primary fire trigger.
-            fire();
+            // Em mobile/iOS Safari, hidden pode ocorrer em transicoes
+            // temporarias (share sheet, app switch curto). Atrasamos um
+            // pouco e cancelamos se a aba voltar a visible.
+            if (hiddenFireTimer) clearTimeout(hiddenFireTimer);
+            hiddenFireTimer = setTimeout(() => {
+                hiddenFireTimer = null;
+                if (!fired && document.visibilityState === 'hidden') fire();
+            }, 300);
         } else {
+            if (hiddenFireTimer) {
+                clearTimeout(hiddenFireTimer);
+                hiddenFireTimer = null;
+            }
             visibleSinceMs = performance.now();
         }
     });
 
     // pagehide eh o fallback / segundo disparo em browsers onde
     // visibilitychange nao roda no caminho de unload (raro mas existe).
-    window.addEventListener('pagehide', () => { if (!fired) fire(); });
+    window.addEventListener('pagehide', () => {
+        if (hiddenFireTimer) {
+            clearTimeout(hiddenFireTimer);
+            hiddenFireTimer = null;
+        }
+        if (!fired) fire();
+    });
 
     function fire() {
         if (fired) return;
         fired = true;
+        if (hiddenFireTimer) {
+            clearTimeout(hiddenFireTimer);
+            hiddenFireTimer = null;
+        }
         if (document.visibilityState !== 'hidden') {
             totalVisibleMs += performance.now() - visibleSinceMs;
         }

--- a/web/static/js/lib/page-engagement.js
+++ b/web/static/js/lib/page-engagement.js
@@ -59,6 +59,12 @@ function initPageEngagement() {
     let maxScrollPct = 0;
     let visibleSinceMs = performance.now();
     let totalVisibleMs = 0;
+    // True apos visibilitychange->hidden (o trecho visivel desde visibleSinceMs
+    // ja foi somado a totalVisibleMs). False apos visibilitychange->visible ou
+    // apos reset de bfcache. Impede double-counting quando fire() eh chamado
+    // logo apos o visibilitychange handler — inclui o caso de pagehide sem
+    // visibilitychange anterior (bug documentado em iOS Safari).
+    let visibleTimeAccounted = false;
     let fired = false;
     let scrollTicking = false;
     let hiddenFireTimer = null;
@@ -96,6 +102,7 @@ function initPageEngagement() {
         if (fired) return;
         if (document.visibilityState === 'hidden') {
             totalVisibleMs += performance.now() - visibleSinceMs;
+            visibleTimeAccounted = true;
             // Em mobile/iOS Safari, hidden pode ocorrer em transicoes
             // temporarias (share sheet, app switch curto). Atrasamos um
             // pouco e cancelamos se a aba voltar a visible.
@@ -110,18 +117,43 @@ function initPageEngagement() {
                 hiddenFireTimer = null;
             }
             visibleSinceMs = performance.now();
+            visibleTimeAccounted = false;
         }
     });
 
-    // pagehide eh o fallback / segundo disparo em browsers onde
-    // visibilitychange nao roda no caminho de unload (raro mas existe).
-    window.addEventListener('pagehide', () => {
+    // pagehide eh o fallback quando visibilitychange nao dispara antes do
+    // unload (bug documentado em alguns cenarios iOS Safari). Recebe o
+    // evento pra detectar bfcache (e.persisted=true).
+    window.addEventListener('pagehide', (e) => {
         if (hiddenFireTimer) {
             clearTimeout(hiddenFireTimer);
             hiddenFireTimer = null;
         }
         if (!fired) fire();
+        // Se a pagina entra no bfcache (e.persisted=true), pode ser restaurada
+        // pelo botao Voltar. Reiniciamos o estado pra medir a proxima sessao
+        // de engajamento sem carregar os acumuladores da sessao anterior.
+        if (e.persisted) resetEngagementState();
     });
+
+    // Restauracao do bfcache (iOS Safari/Chrome back-forward): reinicia o
+    // tracking pra medir a sessao de re-visita corretamente.
+    window.addEventListener('pageshow', (e) => {
+        if (e.persisted) resetEngagementState();
+    });
+
+    function resetEngagementState() {
+        if (hiddenFireTimer) {
+            clearTimeout(hiddenFireTimer);
+            hiddenFireTimer = null;
+        }
+        fired = false;
+        maxScrollPct = 0;
+        totalVisibleMs = 0;
+        visibleTimeAccounted = false;
+        visibleSinceMs = performance.now();
+        updateScroll();
+    }
 
     function fire() {
         if (fired) return;
@@ -130,7 +162,10 @@ function initPageEngagement() {
             clearTimeout(hiddenFireTimer);
             hiddenFireTimer = null;
         }
-        if (document.visibilityState !== 'hidden') {
+        // Se fire() eh chamado pelo pagehide sem visibilitychange anterior
+        // (bug iOS Safari em alguns cenarios de unload), o trecho visivel
+        // desde visibleSinceMs ainda nao foi acumulado em totalVisibleMs.
+        if (!visibleTimeAccounted) {
             totalVisibleMs += performance.now() - visibleSinceMs;
         }
         // Refresh scroll max uma ultima vez (caso scroll handler ainda

--- a/web/static/js/lib/page-engagement.js
+++ b/web/static/js/lib/page-engagement.js
@@ -1,0 +1,126 @@
+// === lib/page-engagement.js ===
+// Dispara evento Umami `pagina-saida` UMA UNICA VEZ por page load quando
+// a aba fica oculta (visibilitychange -> hidden) ou no pagehide. Mede:
+//
+//   tempo_ms        - tempo total entre pageshow/load e o disparo, em ms
+//                     (apenas enquanto a aba esteve visivel; descontamos
+//                     periodos em background quando o usuario alterna
+//                     de aba e volta)
+//   scroll_max_pct  - profundidade maxima do scroll alcancada (0-100,
+//                     arredondado pra inteiro). Usa o mesmo calculo do
+//                     scroll-deep mas reportando o valor continuo.
+//   pagina          - mesma classificacao do scroll-deep
+//                     (cidade|empresa|caso|home|mapa|sobre|glossario|outro)
+//
+// Por que `pagina-saida` E NAO um proxy de scroll-deep:
+//   - scroll-deep dispara em marcos discretos (50/75/100); user que para
+//     em 65% nao gera evento. pagina-saida sempre reporta o maximo real.
+//   - Sem pagina-saida, "tempo na pagina" tem que ser inferido por
+//     diferenca de pageviews — impreciso e nao funciona pra visitas de
+//     pagina unica (bounces).
+//   - Combinado com scroll-deep + pagina-saida, a tabela Umami fica:
+//        bounce real (sem scroll, baixo tempo)
+//        leu rapidamente (alto scroll, baixo tempo)
+//        leu profundamente (alto scroll, alto tempo)
+//        abriu e largou aberto (baixo scroll, alto tempo — distrai)
+//
+// Entrega:
+//   - Usa `pagehide` (fire-and-forget) como caminho primario quando
+//     disponivel. visibilitychange -> hidden eh o caminho mais confiavel
+//     em mobile (especialmente iOS Safari, que nao garante pagehide
+//     consistente quando app vai pro background).
+//   - umami.track usa fetch() com keepalive=true no v3, entao envia
+//     mesmo durante unload. Sem keepalive, o evento poderia ser
+//     cancelado pelo browser ao fechar a aba.
+//   - Dedup: depois do primeiro disparo, listeners ficam no-op pra nao
+//     dobrar o evento (visibilitychange + pagehide podem ambos fire em
+//     sequencia em alguns browsers).
+//
+// Whitelist: mesma do scroll-deep — paginas onde "tempo na pagina" eh um
+// sinal de leitura genuina. Em listings/forms efêmeros (outro), pular.
+
+function _pageEngagementKind() {
+    const p = window.location.pathname;
+    if (p.startsWith('/cidade/')) return 'cidade';
+    if (p.startsWith('/empresa/') && p.split('/').length >= 4) return 'empresa-municipio';
+    if (p.startsWith('/empresa/')) return 'empresa';
+    if (p.startsWith('/caso/')) return 'caso';
+    if (p === '/' || p === '/index') return 'home';
+    if (p === '/mapa') return 'mapa';
+    if (p === '/sobre') return 'sobre';
+    if (p === '/glossario') return 'glossario';
+    return 'outro';
+}
+
+function initPageEngagement() {
+    const pagina = _pageEngagementKind();
+    if (pagina === 'outro') return;
+
+    let maxScrollPct = 0;
+    let visibleSinceMs = performance.now();
+    let totalVisibleMs = 0;
+    let fired = false;
+    let scrollTicking = false;
+
+    const updateScroll = () => {
+        scrollTicking = false;
+        const doc = document.documentElement;
+        const total = Math.max(doc.scrollHeight, doc.offsetHeight, 1);
+        if (total <= window.innerHeight) {
+            // Pagina cabe na viewport — define scroll_max_pct como 100
+            // (o usuario "viu tudo" sem precisar rolar).
+            maxScrollPct = 100;
+            return;
+        }
+        const scrolled = (window.scrollY || window.pageYOffset || 0) + window.innerHeight;
+        const pct = Math.min(100, Math.round((scrolled / total) * 100));
+        if (pct > maxScrollPct) maxScrollPct = pct;
+    };
+
+    const onScroll = () => {
+        if (scrollTicking) return;
+        scrollTicking = true;
+        requestAnimationFrame(updateScroll);
+    };
+
+    // Captura o scroll maximo inicial (caso a pagina abra no meio via
+    // anchor ou deep-link com scroll preservado).
+    updateScroll();
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    // Visibility tracking: descontamos periodos em background do tempo
+    // total. Quando aba volta a visible, retomamos o relogio.
+    document.addEventListener('visibilitychange', () => {
+        if (fired) return;
+        if (document.visibilityState === 'hidden') {
+            totalVisibleMs += performance.now() - visibleSinceMs;
+            // Hidden eh nosso primary fire trigger.
+            fire();
+        } else {
+            visibleSinceMs = performance.now();
+        }
+    });
+
+    // pagehide eh o fallback / segundo disparo em browsers onde
+    // visibilitychange nao roda no caminho de unload (raro mas existe).
+    window.addEventListener('pagehide', () => { if (!fired) fire(); });
+
+    function fire() {
+        if (fired) return;
+        fired = true;
+        if (document.visibilityState !== 'hidden') {
+            totalVisibleMs += performance.now() - visibleSinceMs;
+        }
+        // Refresh scroll max uma ultima vez (caso scroll handler ainda
+        // estivesse pendente em requestAnimationFrame).
+        updateScroll();
+        if (typeof trackEvent === 'function') {
+            trackEvent('pagina-saida', {
+                pagina,
+                tempo_ms: Math.round(totalVisibleMs),
+                scroll_max_pct: maxScrollPct,
+            });
+        }
+    }
+}

--- a/web/static/js/lib/page-engagement.js
+++ b/web/static/js/lib/page-engagement.js
@@ -56,7 +56,7 @@ function initPageEngagement() {
     const pagina = _pageEngagementKind();
     if (pagina === 'outro') return;
 
-    let maxScrollPct = 0;
+    let maxScrolledPx = 0;
     let visibleSinceMs = performance.now();
     let totalVisibleMs = 0;
     // True apos visibilitychange->hidden (o trecho visivel desde visibleSinceMs
@@ -71,17 +71,8 @@ function initPageEngagement() {
 
     const updateScroll = () => {
         scrollTicking = false;
-        const doc = document.documentElement;
-        const total = Math.max(doc.scrollHeight, doc.offsetHeight, 1);
-        if (total <= window.innerHeight) {
-            // Pagina cabe na viewport — define scroll_max_pct como 100
-            // (o usuario "viu tudo" sem precisar rolar).
-            maxScrollPct = 100;
-            return;
-        }
-        const scrolled = (window.scrollY || window.pageYOffset || 0) + window.innerHeight;
-        const pct = Math.min(100, Math.round((scrolled / total) * 100));
-        if (pct > maxScrollPct) maxScrollPct = pct;
+        const px = (window.scrollY || window.pageYOffset || 0) + window.innerHeight;
+        if (px > maxScrolledPx) maxScrolledPx = px;
     };
 
     const onScroll = () => {
@@ -148,11 +139,25 @@ function initPageEngagement() {
             hiddenFireTimer = null;
         }
         fired = false;
-        maxScrollPct = 0;
+        maxScrolledPx = 0;
         totalVisibleMs = 0;
         visibleTimeAccounted = false;
         visibleSinceMs = performance.now();
         updateScroll();
+    }
+
+    // Computa scroll_max_pct SO no fire(), usando scrollHeight ATUAL.
+    // Evita o bug de "travar em 100%" quando a pagina inicial cabia na
+    // viewport mas cresceu depois (imagens lazy, fontes, expansoes).
+    function computeScrollMaxPct() {
+        const doc = document.documentElement;
+        const total = Math.max(doc.scrollHeight, doc.offsetHeight, 1);
+        if (total <= window.innerHeight) return 100;
+        const px = Math.max(
+            maxScrolledPx,
+            (window.scrollY || window.pageYOffset || 0) + window.innerHeight
+        );
+        return Math.min(100, Math.round((px / total) * 100));
     }
 
     function fire() {
@@ -168,14 +173,14 @@ function initPageEngagement() {
         if (!visibleTimeAccounted) {
             totalVisibleMs += performance.now() - visibleSinceMs;
         }
-        // Refresh scroll max uma ultima vez (caso scroll handler ainda
+        // Refresh scroll position uma ultima vez (caso scroll handler ainda
         // estivesse pendente em requestAnimationFrame).
         updateScroll();
         if (typeof trackEvent === 'function') {
             trackEvent('pagina-saida', {
                 pagina,
                 tempo_ms: Math.round(totalVisibleMs),
-                scroll_max_pct: maxScrollPct,
+                scroll_max_pct: computeScrollMaxPct(),
             });
         }
     }

--- a/web/static/js/lib/umami-track.js
+++ b/web/static/js/lib/umami-track.js
@@ -50,6 +50,25 @@
 //   empenho-table-sort    - {coluna, direcao: 'asc'|'desc'}
 //   api-error             - {endpoint, status}  (drilldown falhou;
 //                            status=0 = network error)
+//   pagina-saida          - {pagina, tempo_ms, scroll_max_pct}
+//                           Disparado UMA UNICA VEZ por page load quando
+//                           a aba fica oculta (visibilitychange) ou no
+//                           pagehide. Mede tempo real de engajamento
+//                           (vs scroll-deep que so dispara em marcos
+//                           discretos) e profundidade maxima do scroll.
+//                           Implementado em lib/page-engagement.js;
+//                           respeita o mesmo whitelist de paginas do
+//                           scroll-deep (cidade, empresa, caso, etc).
+//   dialog-fechado        - {tipo, dwell_ms, tabs_visitadas, scroll_max_pct,
+//                            drilled_to?}
+//                           Pareado com dialog-aberto. Mede engagement
+//                           real por dialog: quanto tempo o user ficou,
+//                           quantas tabs explorou (contador, nao lista),
+//                           quanto do conteudo rolou. `drilled_to` so
+//                           presente quando o dialog "fechou" porque o
+//                           user navegou pra outro tipo de dialog (chain
+//                           sem fechar o md-dialog). Implementado em
+//                           lib/dialog-engagement.js.
 window.trackEvent = function trackEvent(name, props) {
     try {
         if (typeof window.umami !== 'undefined' && typeof window.umami.track === 'function') {
@@ -61,6 +80,18 @@ window.trackEvent = function trackEvent(name, props) {
         }
     } catch (_) {
         // noop: analytics nunca pode quebrar a pagina
+    }
+    // Dispatch CustomEvent espelhando o track. Permite que listeners
+    // internos (dialog-engagement, futuros agregadores) reajam a eventos
+    // SEM precisar ser invocados explicitamente por cada call-site. O
+    // dispatch acontece mesmo em dev sem Umami carregado — desacopla
+    // analytics do estado do tracker.
+    try {
+        document.dispatchEvent(new CustomEvent('tpb:tracked', {
+            detail: { name: String(name), props: (props && typeof props === 'object') ? props : null },
+        }));
+    } catch (_) {
+        // CustomEvent nao suportado / document indisponivel — ignora.
     }
 };
 

--- a/web/static/js/lib/umami-track.js
+++ b/web/static/js/lib/umami-track.js
@@ -63,12 +63,23 @@
 //                            drilled_to?}
 //                           Pareado com dialog-aberto. Mede engagement
 //                           real por dialog: quanto tempo o user ficou,
-//                           quantas tabs explorou (contador, nao lista),
-//                           quanto do conteudo rolou. `drilled_to` so
-//                           presente quando o dialog "fechou" porque o
-//                           user navegou pra outro tipo de dialog (chain
-//                           sem fechar o md-dialog). Implementado em
-//                           lib/dialog-engagement.js.
+//                           quantas tabs DISTINTAS explorou, quanto do
+//                           conteudo rolou. `drilled_to` so presente
+//                           quando o dialog "fechou" porque o user
+//                           navegou pra outro tipo de dialog (chain sem
+//                           fechar o md-dialog), ou clicou voltar e
+//                           restaurou o nivel anterior
+//                           (`drilled_to='back-<tipo>'`). Implementado
+//                           em lib/dialog-engagement.js.
+//   dialog-restored       - {tipo} Disparado quando o user clica
+//                           "voltar" do dialog stack e o conteudo de um
+//                           dialog anterior eh re-renderizado.
+//                           tipo = nivel restaurado. Permite distinguir
+//                           "abri novo" (dialog-aberto) de "voltei"
+//                           (dialog-restored). dialog-engagement usa pra
+//                           flushar a sessao do nivel atual marcando
+//                           drilled_to='back-<tipo>' e comecar nova
+//                           sessao com o tipo restaurado.
 window.trackEvent = function trackEvent(name, props) {
     try {
         if (typeof window.umami !== 'undefined' && typeof window.umami.track === 'function') {

--- a/web/static/js/pages/main.js
+++ b/web/static/js/pages/main.js
@@ -22,6 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
     initDenunciaDialog();
     initReportSections();
     initScrollDeep();
+    initPageEngagement();
+    if (typeof window.initDialogEngagement === 'function') window.initDialogEngagement();
 
     // Outbound link tracking: listener delegado captura clicks em <a href>
     // que apontem pra dominios externos (TCE-PB, PNCP, dados.pb, Portal da

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -9,7 +9,7 @@
 // Fallback estatico (FALLBACK_CACHE_VERSION) é usado quando manifest indisponível
 // (dev mode sem build, ou race no deploy).
 
-const FALLBACK_CACHE_VERSION = 'tpb-v45-fallback';
+const FALLBACK_CACHE_VERSION = 'tpb-v46-fallback';
 
 // Lista mínima usada APENAS quando manifest.json não pode ser fetched.
 // Mantém PWA instalável mesmo em deploy race / 404 transitorio.


### PR DESCRIPTION
## Resumo

Pacote de 4 melhorias na pipeline de observabilidade do portal (GoAccess + Umami + nova rotina diaria), discutidas em sessao Copilot CLI sobre "como melhorar nosso setup de goaccess com umami".

Escopo deliberadamente focado em **dados que ja capturamos mal ou nao capturamos** — sem trocar de ferramenta, sem dashboard novo, sem auth nova. Ingestao do access.log no Postgres (proxima evolucao logica) ficou registrada no `TODO.md` como item futuro.

## Mudancas

### 1) GeoIP City no GoAccess (`#1`)

`deploy/setup-goaccess.sh` + `deploy/cruza-goaccess.conf`:

- Troca DB Country (`dbip-country-lite.mmdb`, ~3MB) por City (`dbip-city-lite.mmdb`, ~70MB) — mesma fonte (db-ip.com gratuita, sem signup).
- Apaga DB legada na primeira execucao pos-upgrade.
- Resolucao agora cidade+regiao+pais — permite ver se o trafego PB se concentra em Joao Pessoa, Campina Grande, interior, etc.

### 2) Evento `pagina-saida` (`#2`)

`web/static/js/lib/page-engagement.js` (novo):

- Dispara UMA UNICA VEZ por page load no `visibilitychange -> hidden` ou `pagehide`.
- Props: `{pagina, tempo_ms, scroll_max_pct}`.
- `tempo_ms` desconta periodos em background (visibility tracking) — nao infla pra abas esquecidas abertas.
- Combinado com `scroll-deep` existente, agora distingue:
  - bounce real (sem scroll, baixo tempo)
  - leu rapidamente (alto scroll, baixo tempo)
  - leu profundamente (alto scroll, alto tempo)
  - abriu e largou (baixo scroll, alto tempo)
- Whitelist identica do `scroll-deep` (cidade, empresa, caso, etc).

### 3) Evento `dialog-fechado` (`#4`)

`web/static/js/lib/dialog-engagement.js` (novo) + `lib/umami-track.js`:

- Pareado com `dialog-aberto` existente.
- Props: `{tipo, dwell_ms, tabs_visitadas, scroll_max_pct, drilled_to?}`.
- Trata corretamente drilldown chains (usuario abre empenho a partir de fornecedor sem fechar o `md-dialog`): emite `dialog-fechado` da sessao anterior marcando `drilled_to=novotipo` antes de comecar a nova.
- Implementacao desacoplada: `trackEvent` agora dispatcha `CustomEvent 'tpb:tracked'` no `document`. `dialog-engagement` se auto-conecta listando o evento. Backward-compat — nenhum call-site existente precisa mudar.
- Critico pra avaliar interesse real de imprensa identificada via `distinct_id`: hoje so sabemos "abriu CNPJ X". Agora distinguimos "abriu e fechou em 2s" vs "explorou 4 tabs em 90s".

### 4) Digest diario por email (`#9`)

`deploy/cruza-traffic-digest.{sh,service,timer}` + `deploy/setup-traffic-digest.sh`:

- Bash script + systemd timer (`OnCalendar=*-*-* 10:00:00 UTC` = 07:00 BRT — apos `logrotate` do nginx).
- Parseia `/var/log/nginx/access.log.1` (rotated de ontem).
- Output markdown em `/var/log/cruza-traffic-digest/YYYY-MM-DD.md`, retencao 60 dias (auto-cleanup).
- Secoes: hits totais, IPs unicos, top paths, top referers externos, status codes, top IPs por volume, top erros 4xx/5xx, exploit attempts (mesmas heuristicas do fail2ban-exploit-paths), top usuarios reais.
- Envia por email se `TRAFFIC_DIGEST_EMAIL_TO` setado em `/etc/cruza-traffic-digest.env` (lido como secret no deploy.yml). Tenta `msmtp -> mail -> sendmail` nessa ordem. Admin configura MTA na VM separadamente — documentado no header do setup script.
- Soft-fail no deploy (digest e' admin-only, opcional).

### 5) TODO.md (`#11`)

Registrado como proximo passo: ingestao do access.log em tabela PostgreSQL (`access_log_raw`) pra habilitar SQL ad-hoc com retencao configuravel e JOINs com tabelas de dominio (cidades, etc).

## Validacao

- `node --check` OK em todos os JS modificados/criados
- `python -m py_compile web/main.py` OK
- `bash -n` OK em todos os scripts shell
- Sintaxe dos systemd unit files: padrao validado

## Notas pra deploy

- Novo secret opcional pra setar no repo (admin only): `TRAFFIC_DIGEST_EMAIL_TO` (e opcionalmente `TRAFFIC_DIGEST_EMAIL_FROM`).
- Sem setar o secret, o digest roda mas so escreve arquivo (sem envio).
- Pra ativar email: admin precisa instalar+configurar msmtp/mail na VM apos o primeiro deploy. Header do `setup-traffic-digest.sh` traz exemplo de `/etc/msmtprc` com Gmail relay.
- GeoIP City DB sera baixado na proxima execucao do `setup-goaccess.sh` (idempotente, ~70MB download unico).

## **NAO mergear ainda**

Por favor revisem antes:
- `@gpt-5.5`
- `@claude-opus-4.7`

Quero feedback antes de fazer merge.
