### PR TITLE
feat(web): /licitacao + /cidade/<slug>/<yyyy>-<mm>  long-tail SEO transacional

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1533,8 +1533,10 @@ jobs:
           PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
 
           # 1. Coverage check: cache cobre >= 80% das licitacoes qualificadas.
-          # Usa o mesmo SQL que o sitemap-index (LICITACOES_QUALIFICADAS_COUNT)
-          # pra evitar drift entre coverage check e o que vai pro sitemap.
+          # SQL DEVE bater 1:1 com LICITACOES_QUALIFICADAS_COUNT (queries/licitacao.py)
+          # — incluindo o filtro MEI/EI. Sem isso, denominador inflado deixa
+          # cobertura artificial baixa e bloqueia enable mesmo com warm completo.
+          # (P2 GPT 5.5 round 2 PR #108.)
           QUALIFYING=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
             SELECT COUNT(*) FROM (
                 SELECT DISTINCT l.municipio, l.ano_licitacao, l.codigo_ug,
@@ -1548,16 +1550,21 @@ jobs:
                   AND EXISTS (
                       SELECT 1
                       FROM tce_pb_licitacao l2
-                      LEFT JOIN estabelecimento est
+                      JOIN estabelecimento est
                           ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
                          AND est.cnpj_ordem = '0001'
+                      JOIN empresa e2 ON e2.cnpj_basico = est.cnpj_basico
+                                     AND e2.natureza_juridica IS DISTINCT FROM '2135'
+                                     AND NOT EXISTS (
+                                         SELECT 1 FROM simples s2
+                                         WHERE s2.cnpj_basico = e2.cnpj_basico AND s2.opcao_mei = 'S'
+                                     )
                       WHERE l2.municipio = l.municipio
                         AND l2.ano_licitacao = l.ano_licitacao
                         AND l2.codigo_ug = l.codigo_ug
                         AND l2.modalidade = l.modalidade
                         AND l2.numero_licitacao = l.numero_licitacao
                         AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
-                        AND est.cnpj_basico IS NOT NULL
                   )
             ) q
           ")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,24 @@ on:
           - enable
           - disable
         default: keep
+      expose_licitacoes_sitemap:
+        description: 'Toggle das paginas /licitacao/<mun>/<ano>/<ug>/<modnum> no sitemap. "keep" preserva. "enable" escreve drop-in SITEMAP_INCLUDE_LICITACOES=1 + restart cruza-web. "disable" remove. Exige warm_cache=true antes (caso contrario URLs retornarao 503).'
+        required: false
+        type: choice
+        options:
+          - keep
+          - enable
+          - disable
+        default: keep
+      expose_cidade_resumo_sitemap:
+        description: 'Toggle das paginas /cidade/<slug>/<yyyy-mm> (resumo mensal) no sitemap. "keep" preserva. "enable" escreve drop-in SITEMAP_INCLUDE_CIDADE_RESUMO=1 + restart cruza-web. "disable" remove. Exige warm_cache=true antes.'
+        required: false
+        type: choice
+        options:
+          - keep
+          - enable
+          - disable
+        default: keep
       download_sources:
         description: 'CSV de fontes para baixar via etl.00_download --only ANTES do ETL phase (ex: "tce_pb,dados_pb"). Vazio = sem download. Usado pra restore quando uma fase destructive (ex: etl.19_tce_pb) precisa dos CSVs mas o cleanup automatico ja apagou os antigos. Soft-fail se a fase nao alcanca a tabela destino.'
         required: false
@@ -1471,6 +1489,322 @@ jobs:
               echo "::warning::IndexNow submit falhou — Bing vai descobrir via crawl normal"
           else
             echo "INDEXNOW_KEY nao setada — skip IndexNow notify"
+          fi
+
+      # ── Toggle licitacoes sitemap (enable/disable/keep) ──
+      # Controla SITEMAP_INCLUDE_LICITACOES via drop-in systemd em
+      # cruza-web.service.d/sitemap-licitacoes.conf. Drop-in preservado
+      # entre deploys (deploy.yml so substitui o .service file).
+      #
+      # "enable" exige cache populado (>= 100 LICITACAO_PERFIL rows). Faz:
+      #   1. Sanity-check cache + LICITACOES_QUALIFICADAS_COUNT
+      #   2. Coverage gate >= 80%
+      #   3. Escreve drop-in
+      #   4. systemctl daemon-reload + restart cruza-web
+      #   5. Verifica /sitemap.xml inclui >=1 shard de licitacoes
+      #   6. E2E smoke test: 5 paths aleatorios → HTTP 200
+      #   7. IndexNow re-submit
+      # Falha em 5-6 dispara rollback automatico (rm drop-in).
+      #
+      # "disable" sempre roda (mesmo sem warm). Remove drop-in + restart.
+      # "keep" (default) nada faz.
+      - name: Disable licitacoes sitemap (rm drop-in)
+        if: inputs.expose_licitacoes_sitemap == 'disable'
+        run: |
+          set -euo pipefail
+          DROPIN=/etc/systemd/system/cruza-web.service.d/sitemap-licitacoes.conf
+          if [ -f "$DROPIN" ]; then
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web
+            echo "Drop-in licitacoes removido. /licitacao/ saiu do sitemap.xml. Cache preservado."
+          else
+            echo "Drop-in nao existia (sitemap ja estava sem /licitacao/). No-op."
+          fi
+
+      - name: Enable licitacoes sitemap (drop-in + verify + IndexNow)
+        if: |
+          inputs.expose_licitacoes_sitemap == 'enable' &&
+          steps.warm-cache.outcome != 'failure'
+        run: |
+          set -euo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          source .env 2>/dev/null || true
+          PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
+
+          # 1. Coverage check: cache cobre >= 80% das licitacoes qualificadas.
+          # Usa o mesmo SQL que o sitemap-index (LICITACOES_QUALIFICADAS_COUNT)
+          # pra evitar drift entre coverage check e o que vai pro sitemap.
+          QUALIFYING=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT COUNT(*) FROM (
+                SELECT DISTINCT l.municipio, l.ano_licitacao, l.codigo_ug,
+                                l.modalidade, l.numero_licitacao
+                FROM tce_pb_licitacao l
+                WHERE l.ano_licitacao IS NOT NULL
+                  AND l.numero_licitacao IS NOT NULL
+                  AND l.modalidade IS NOT NULL
+                  AND l.codigo_ug IS NOT NULL
+                  AND l.municipio IS NOT NULL
+                  AND EXISTS (
+                      SELECT 1
+                      FROM tce_pb_licitacao l2
+                      LEFT JOIN estabelecimento est
+                          ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
+                         AND est.cnpj_ordem = '0001'
+                      WHERE l2.municipio = l.municipio
+                        AND l2.ano_licitacao = l.ano_licitacao
+                        AND l2.codigo_ug = l.codigo_ug
+                        AND l2.modalidade = l.modalidade
+                        AND l2.numero_licitacao = l.numero_licitacao
+                        AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
+                        AND est.cnpj_basico IS NOT NULL
+                  )
+            ) q
+          ")
+          CACHED=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c \
+            "SELECT COUNT(*) FROM web_cache WHERE query_id = 'LICITACAO_PERFIL';")
+          if [ "$QUALIFYING" -le 0 ]; then
+            echo "::error::Sem licitacoes qualificadas (rode etl_phase=sql ou =all primeiro)"
+            exit 1
+          fi
+          COVERAGE_PCT=$((CACHED * 100 / QUALIFYING))
+          echo "Coverage licitacoes: $CACHED/$QUALIFYING = ${COVERAGE_PCT}%"
+          if [ "$COVERAGE_PCT" -lt 80 ]; then
+            echo "::error::Cobertura ${COVERAGE_PCT}% < 80%. Rode warm_cache=true antes."
+            exit 1
+          fi
+
+          # 2. Escreve drop-in
+          DROPIN_DIR=/etc/systemd/system/cruza-web.service.d
+          DROPIN="$DROPIN_DIR/sitemap-licitacoes.conf"
+          sudo mkdir -p "$DROPIN_DIR"
+          {
+            echo '# Auto-gerado por deploy.yml com expose_licitacoes_sitemap=enable.'
+            echo '# Removido por expose_licitacoes_sitemap=disable.'
+            echo '[Service]'
+            echo 'Environment="SITEMAP_INCLUDE_LICITACOES=1"'
+          } | sudo tee "$DROPIN" >/dev/null
+          echo "Drop-in licitacoes escrito em $DROPIN"
+
+          # 3. Reload + restart com rollback
+          sudo systemctl daemon-reload
+          if ! sudo systemctl restart cruza-web; then
+            echo "::error::cruza-web restart falhou. Rollback automatico."
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web || true
+            exit 1
+          fi
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -sf --max-time 3 -o /dev/null \
+              -H "Host: transparenciapb.org" \
+              http://127.0.0.1:8000/static/manifest.webmanifest; then
+              echo "cruza-web ready (tentativa $i)"
+              break
+            fi
+            sleep 2
+          done
+
+          # 4. Sitemap-index lista shards de licitacoes
+          INDEX_HAS_LIC=$(curl -s --max-time 60 \
+            -H "Host: transparenciapb.org" \
+            http://127.0.0.1:8000/sitemap.xml | grep -c '/sitemap-licitacoes-' || true)
+          echo "sitemap.xml-index lista $INDEX_HAS_LIC shards de licitacoes"
+          if [ "$INDEX_HAS_LIC" -lt 1 ]; then
+            echo "::error::sitemap-index nao lista shard de licitacoes. Rollback."
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web
+            exit 1
+          fi
+
+          # 5. E2E smoke: 5 paths aleatorios das licitacoes em cache → HTTP 200
+          PATHS=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT municipio FROM web_cache
+            WHERE query_id = 'LICITACAO_PERFIL'
+            ORDER BY random() LIMIT 5;
+          ")
+          FAIL=0
+          OK=0
+          for cache_key in $PATHS; do
+            # cache_key formato: <mun-slug>:<ano>:<ug-slug>:<modnum-slug>
+            # Converte pros segmentos do path.
+            mun_slug=$(echo "$cache_key" | cut -d: -f1)
+            ano=$(echo "$cache_key" | cut -d: -f2)
+            ug_slug=$(echo "$cache_key" | cut -d: -f3)
+            mod_num=$(echo "$cache_key" | cut -d: -f4-)
+            URL="/licitacao/${mun_slug}/${ano}/${ug_slug}/${mod_num}"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time 10 \
+              -H "Host: transparenciapb.org" \
+              "http://127.0.0.1:8000${URL}")
+            if [ "$STATUS" = "200" ]; then
+              echo "  ${URL} -> 200 OK"
+              OK=$((OK + 1))
+            else
+              echo "  ${URL} -> $STATUS (FAIL)"
+              FAIL=$((FAIL + 1))
+            fi
+          done
+          echo "E2E smoke: $OK/5 OK, $FAIL/5 FAIL"
+          if [ "$OK" -lt 4 ]; then
+            echo "::error::E2E smoke FAIL — so $OK/5 paths respondem 200. Rollback."
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web
+            exit 1
+          fi
+
+          # 6. IndexNow re-submit
+          source venv/bin/activate
+          set -a
+          source .env 2>/dev/null || true
+          set +a
+          if [ -n "${INDEXNOW_KEY:-}" ]; then
+            echo "=== IndexNow re-submit (licitacoes) ==="
+            SITEMAP_INCLUDE_LICITACOES=1 python -m web.indexnow_submit 2>&1 || \
+              echo "::warning::IndexNow submit falhou — descobrirao via crawl normal"
+          else
+            echo "INDEXNOW_KEY nao setada — skip IndexNow"
+          fi
+
+      # ── Toggle cidade-resumo mensal sitemap ──
+      # Mesma logica do empresa/licitacoes mas pra /cidade/<slug>/<yyyy-mm>.
+      # Volume menor (~14k URLs em 1 sitemap unico, sem sharding).
+      - name: Disable cidade-resumo sitemap (rm drop-in)
+        if: inputs.expose_cidade_resumo_sitemap == 'disable'
+        run: |
+          set -euo pipefail
+          DROPIN=/etc/systemd/system/cruza-web.service.d/sitemap-cidade-resumo.conf
+          if [ -f "$DROPIN" ]; then
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web
+            echo "Drop-in cidade-resumo removido. URLs /cidade/<slug>/<yyyymm> saem do sitemap."
+          else
+            echo "Drop-in nao existia. No-op."
+          fi
+
+      - name: Enable cidade-resumo sitemap (drop-in + verify + IndexNow)
+        if: |
+          inputs.expose_cidade_resumo_sitemap == 'enable' &&
+          steps.warm-cache.outcome != 'failure'
+        run: |
+          set -euo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          source .env 2>/dev/null || true
+          PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
+
+          # 1. Coverage check: cache cobre >= 80% dos (mun, ano, mes) com dados.
+          QUALIFYING=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT COUNT(*) FROM (
+                SELECT 1 FROM tce_pb_despesa
+                WHERE municipio IS NOT NULL
+                  AND data_empenho IS NOT NULL
+                  AND valor_pago > 0
+                GROUP BY municipio, EXTRACT(YEAR FROM data_empenho), EXTRACT(MONTH FROM data_empenho)
+                HAVING COUNT(*) > 0
+            ) q
+          ")
+          CACHED=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c \
+            "SELECT COUNT(*) FROM web_cache WHERE query_id = 'CIDADE_RESUMO_MENSAL';")
+          if [ "$QUALIFYING" -le 0 ]; then
+            echo "::error::Sem (mun, ano, mes) qualificados"
+            exit 1
+          fi
+          COVERAGE_PCT=$((CACHED * 100 / QUALIFYING))
+          echo "Coverage cidade-resumo: $CACHED/$QUALIFYING = ${COVERAGE_PCT}%"
+          if [ "$COVERAGE_PCT" -lt 80 ]; then
+            echo "::error::Cobertura ${COVERAGE_PCT}% < 80%. Rode warm_cache=true antes."
+            exit 1
+          fi
+
+          # 2. Drop-in
+          DROPIN_DIR=/etc/systemd/system/cruza-web.service.d
+          DROPIN="$DROPIN_DIR/sitemap-cidade-resumo.conf"
+          sudo mkdir -p "$DROPIN_DIR"
+          {
+            echo '# Auto-gerado por deploy.yml com expose_cidade_resumo_sitemap=enable.'
+            echo '[Service]'
+            echo 'Environment="SITEMAP_INCLUDE_CIDADE_RESUMO=1"'
+          } | sudo tee "$DROPIN" >/dev/null
+          echo "Drop-in cidade-resumo escrito"
+
+          sudo systemctl daemon-reload
+          if ! sudo systemctl restart cruza-web; then
+            echo "::error::cruza-web restart falhou. Rollback."
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web || true
+            exit 1
+          fi
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -sf --max-time 3 -o /dev/null \
+              -H "Host: transparenciapb.org" \
+              http://127.0.0.1:8000/static/manifest.webmanifest; then
+              echo "cruza-web ready (tentativa $i)"
+              break
+            fi
+            sleep 2
+          done
+
+          # 3. Sitemap-index inclui /sitemap-cidade-resumo.xml
+          INDEX_HAS_RESUMO=$(curl -s --max-time 60 \
+            -H "Host: transparenciapb.org" \
+            http://127.0.0.1:8000/sitemap.xml | grep -c '/sitemap-cidade-resumo.xml' || true)
+          if [ "$INDEX_HAS_RESUMO" -lt 1 ]; then
+            echo "::error::sitemap-index nao lista cidade-resumo. Rollback."
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web
+            exit 1
+          fi
+
+          # 4. E2E smoke: 5 (mun, yyyy-mm) aleatorios → HTTP 200
+          KEYS=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -At -c "
+            SELECT municipio FROM web_cache
+            WHERE query_id = 'CIDADE_RESUMO_MENSAL'
+            ORDER BY random() LIMIT 5;
+          ")
+          FAIL=0
+          OK=0
+          for cache_key in $KEYS; do
+            # cache_key formato: <mun-slug>:<yyyy>-<mm>
+            mun_slug=$(echo "$cache_key" | cut -d: -f1)
+            yyyymm=$(echo "$cache_key" | cut -d: -f2)
+            URL="/cidade/${mun_slug}/${yyyymm}"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time 10 \
+              -H "Host: transparenciapb.org" \
+              "http://127.0.0.1:8000${URL}")
+            if [ "$STATUS" = "200" ]; then
+              echo "  ${URL} -> 200 OK"
+              OK=$((OK + 1))
+            else
+              echo "  ${URL} -> $STATUS (FAIL)"
+              FAIL=$((FAIL + 1))
+            fi
+          done
+          echo "E2E smoke cidade-resumo: $OK/5 OK, $FAIL/5 FAIL"
+          if [ "$OK" -lt 4 ]; then
+            echo "::error::E2E smoke FAIL. Rollback."
+            sudo rm -f "$DROPIN"
+            sudo systemctl daemon-reload
+            sudo systemctl restart cruza-web
+            exit 1
+          fi
+
+          # 5. IndexNow re-submit
+          source venv/bin/activate
+          set -a
+          source .env 2>/dev/null || true
+          set +a
+          if [ -n "${INDEXNOW_KEY:-}" ]; then
+            echo "=== IndexNow re-submit (cidade-resumo) ==="
+            SITEMAP_INCLUDE_CIDADE_RESUMO=1 python -m web.indexnow_submit 2>&1 || \
+              echo "::warning::IndexNow submit falhou — descobrirao via crawl normal"
+          else
+            echo "INDEXNOW_KEY nao setada — skip IndexNow"
           fi
 
       # ── Verify ──

--- a/web/main.py
+++ b/web/main.py
@@ -13,6 +13,7 @@ from fastapi.templating import Jinja2Templates
 from web import db
 from web.routes.cidade import router as cidade_router
 from web.routes.empresa import router as empresa_router
+from web.routes.licitacao import router as licitacao_router
 from web.routes.mapa import router as mapa_router
 from web.routes.og_image import router as og_router
 from web.routes.contato import build_router as build_contato_router
@@ -597,6 +598,7 @@ templates.env.filters["municipio_slug"] = _municipio_slug
 
 app.include_router(cidade_router)
 app.include_router(empresa_router)
+app.include_router(licitacao_router)
 app.include_router(mapa_router)
 app.include_router(og_router)
 app.include_router(build_contato_router(templates))

--- a/web/queries/cidade_resumo.py
+++ b/web/queries/cidade_resumo.py
@@ -1,0 +1,218 @@
+"""SQL parametrizado para /cidade/<slug>/<yyyy>-<mm> — resumo mensal.
+
+Design:
+- Agregacoes mensais sobre tce_pb_despesa e tce_pb_licitacao por
+  (municipio, ano, mes) — sem exposicao individual de PF.
+- Top empenhos lista ITEM-A-ITEM no template precisa filter PJ inline,
+  similar ao licitacao.py (LENGTH digits = 14 + JOIN estabelecimento).
+- Mes derivado de EXTRACT(YEAR/MONTH FROM data_empenho) (ano contabil
+  real, NAO ano_arquivo). Documentado no template.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Agregacoes principais do mes
+# ─────────────────────────────────────────────────────────────────────────
+
+# KPIs hero: totais agregados pro (municipio, ano, mes). Tudo agregado,
+# zero PF.
+RESUMO_AGGS_MES = """
+    SELECT
+        COUNT(*) AS qtd_empenhos,
+        COUNT(DISTINCT cpf_cnpj) AS qtd_fornecedores_unicos,
+        COALESCE(SUM(valor_empenhado), 0) AS total_empenhado,
+        COALESCE(SUM(valor_liquidado), 0) AS total_liquidado,
+        COALESCE(SUM(valor_pago), 0) AS total_pago,
+        COUNT(*) FILTER (
+            WHERE numero_licitacao IS NULL
+               OR numero_licitacao = ''
+               OR numero_licitacao = '000000000'
+               OR modalidade_licitacao ILIKE '%sem licit%'
+        ) AS qtd_sem_licitacao,
+        COALESCE(SUM(valor_pago) FILTER (
+            WHERE numero_licitacao IS NULL
+               OR numero_licitacao = ''
+               OR numero_licitacao = '000000000'
+               OR modalidade_licitacao ILIKE '%sem licit%'
+        ), 0) AS total_sem_licitacao
+    FROM tce_pb_despesa
+    WHERE municipio = %(municipio)s
+      AND EXTRACT(YEAR FROM data_empenho) = %(ano)s
+      AND EXTRACT(MONTH FROM data_empenho) = %(mes)s
+      AND valor_pago > 0
+"""
+
+# Top 20 fornecedores do mes. Apenas PJ (LENGTH digits = 14). JOIN
+# estabelecimento pra trazer cnpj_completo + razao_social canonica e ja
+# descartar credores sem cadastro (Layer 2).
+RESUMO_TOP_FORNECEDORES = """
+    SELECT
+        REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g') AS cnpj_clean,
+        COALESCE(NULLIF(e.razao_social, ''), d.nome_credor) AS razao_social,
+        SUM(d.valor_pago) AS total_pago,
+        COUNT(*) AS qtd_empenhos,
+        est.cnpj_completo
+    FROM tce_pb_despesa d
+    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                                  AND est.cnpj_ordem = '0001'
+    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+    WHERE d.municipio = %(municipio)s
+      AND EXTRACT(YEAR FROM d.data_empenho) = %(ano)s
+      AND EXTRACT(MONTH FROM d.data_empenho) = %(mes)s
+      AND d.valor_pago > 0
+      AND LENGTH(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g')) = 14
+      AND est.cnpj_basico IS NOT NULL
+    GROUP BY REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'),
+             COALESCE(NULLIF(e.razao_social, ''), d.nome_credor),
+             est.cnpj_completo
+    ORDER BY SUM(d.valor_pago) DESC NULLS LAST
+    LIMIT 20
+"""
+
+# Top elementos de despesa (agregado, sem PF). Categoria do gasto: ex.
+# "Material de Consumo", "Servicos de Terceiros Pessoa Juridica".
+RESUMO_TOP_ELEMENTOS = """
+    SELECT
+        elemento_despesa,
+        SUM(valor_pago) AS total_pago,
+        COUNT(*) AS qtd_empenhos
+    FROM tce_pb_despesa
+    WHERE municipio = %(municipio)s
+      AND EXTRACT(YEAR FROM data_empenho) = %(ano)s
+      AND EXTRACT(MONTH FROM data_empenho) = %(mes)s
+      AND valor_pago > 0
+      AND elemento_despesa IS NOT NULL
+      AND elemento_despesa != ''
+    GROUP BY elemento_despesa
+    ORDER BY SUM(valor_pago) DESC NULLS LAST
+    LIMIT 20
+"""
+
+# Distribuicao por modalidade de licitacao (chart). Agregado.
+RESUMO_MODALIDADES = """
+    SELECT
+        COALESCE(NULLIF(modalidade_licitacao, ''), 'Sem licitacao') AS modalidade,
+        SUM(valor_pago) AS total_pago,
+        COUNT(*) AS qtd_empenhos
+    FROM tce_pb_despesa
+    WHERE municipio = %(municipio)s
+      AND EXTRACT(YEAR FROM data_empenho) = %(ano)s
+      AND EXTRACT(MONTH FROM data_empenho) = %(mes)s
+      AND valor_pago > 0
+    GROUP BY COALESCE(NULLIF(modalidade_licitacao, ''), 'Sem licitacao')
+    ORDER BY SUM(valor_pago) DESC NULLS LAST
+"""
+
+# Top 20 empenhos do mes (item-por-item). Apenas PJ credor. NAO expoe PF.
+# Inclui link pra /empresa/<cnpj_completo>.
+RESUMO_TOP_EMPENHOS = """
+    SELECT
+        d.id,
+        d.numero_empenho,
+        d.data_empenho,
+        d.elemento_despesa,
+        d.valor_empenhado,
+        d.valor_pago,
+        d.modalidade_licitacao,
+        d.numero_licitacao,
+        REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g') AS cnpj_clean,
+        COALESCE(NULLIF(e.razao_social, ''), d.nome_credor) AS razao_social,
+        est.cnpj_completo
+    FROM tce_pb_despesa d
+    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                                  AND est.cnpj_ordem = '0001'
+    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+    WHERE d.municipio = %(municipio)s
+      AND EXTRACT(YEAR FROM d.data_empenho) = %(ano)s
+      AND EXTRACT(MONTH FROM d.data_empenho) = %(mes)s
+      AND d.valor_pago > 0
+      AND LENGTH(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g')) = 14
+      AND est.cnpj_basico IS NOT NULL
+    ORDER BY d.valor_pago DESC NULLS LAST
+    LIMIT 20
+"""
+
+# Top 10 licitacoes homologadas no mes (cross-link pra /licitacao). Filter
+# PJ vencedor via JOIN com proponentes (mesma logica).
+# Agrega por 5-tupla canonica pro path.
+RESUMO_TOP_LICITACOES = """
+    WITH lic_unique AS (
+        SELECT DISTINCT
+            l.municipio,
+            l.ano_licitacao,
+            l.codigo_ug,
+            l.descricao_ug,
+            l.modalidade,
+            l.numero_licitacao,
+            l.objeto_licitacao,
+            l.data_homologacao
+        FROM tce_pb_licitacao l
+        WHERE l.municipio = %(municipio)s
+          AND EXTRACT(YEAR FROM l.data_homologacao) = %(ano)s
+          AND EXTRACT(MONTH FROM l.data_homologacao) = %(mes)s
+          AND EXISTS (
+              SELECT 1
+              FROM tce_pb_licitacao l2
+              LEFT JOIN estabelecimento est
+                  ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
+                 AND est.cnpj_ordem = '0001'
+              WHERE l2.municipio = l.municipio
+                AND l2.ano_licitacao = l.ano_licitacao
+                AND l2.codigo_ug = l.codigo_ug
+                AND l2.modalidade = l.modalidade
+                AND l2.numero_licitacao = l.numero_licitacao
+                AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
+                AND est.cnpj_basico IS NOT NULL
+          )
+    )
+    SELECT lu.*, COALESCE(SUM(l.valor_ofertado), 0) AS valor_total
+    FROM lic_unique lu
+    LEFT JOIN tce_pb_licitacao l ON l.municipio = lu.municipio
+                                AND l.ano_licitacao = lu.ano_licitacao
+                                AND l.codigo_ug = lu.codigo_ug
+                                AND l.modalidade = lu.modalidade
+                                AND l.numero_licitacao = lu.numero_licitacao
+    GROUP BY lu.municipio, lu.ano_licitacao, lu.codigo_ug, lu.descricao_ug,
+             lu.modalidade, lu.numero_licitacao, lu.objeto_licitacao,
+             lu.data_homologacao
+    ORDER BY COALESCE(SUM(l.valor_ofertado), 0) DESC NULLS LAST
+    LIMIT 10
+"""
+
+# Comparativo: total pago no mes anterior + mesmo mes do ano anterior.
+# Usado pra calcular delta % no hero.
+RESUMO_COMPARATIVO = """
+    SELECT
+        SUM(CASE WHEN EXTRACT(YEAR FROM data_empenho) = %(ano_prev_mes)s
+                  AND EXTRACT(MONTH FROM data_empenho) = %(mes_prev_mes)s
+                 THEN valor_pago ELSE 0 END) AS total_mes_anterior,
+        SUM(CASE WHEN EXTRACT(YEAR FROM data_empenho) = %(ano_prev_yr)s
+                  AND EXTRACT(MONTH FROM data_empenho) = %(mes_prev_yr)s
+                 THEN valor_pago ELSE 0 END) AS total_mesmo_mes_ano_anterior
+    FROM tce_pb_despesa
+    WHERE municipio = %(municipio)s
+      AND valor_pago > 0
+      AND data_empenho >= MAKE_DATE(%(ano_prev_yr)s::int, %(mes_prev_yr)s::int, 1)
+      AND data_empenho < (MAKE_DATE(%(ano_prev_mes)s::int, %(mes_prev_mes)s::int, 1) + INTERVAL '1 month')
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sitemap qualifying — todos os (municipio, ano, mes) com >=1 empenho PJ
+# ─────────────────────────────────────────────────────────────────────────
+
+# Lista pra sitemap. Filter qtd_empenhos > 0 evita meses vazios entrarem
+# no sitemap (servem com noindex mas nao desperdicam crawl budget).
+# ORDER BY estavel pra paginacao bater entre warmer e sitemap.
+CIDADE_RESUMO_QUALIFICADOS_LIST = """
+    SELECT
+        municipio,
+        EXTRACT(YEAR FROM data_empenho)::int AS ano,
+        EXTRACT(MONTH FROM data_empenho)::int AS mes,
+        COUNT(*) AS qtd_empenhos
+    FROM tce_pb_despesa
+    WHERE municipio IS NOT NULL
+      AND data_empenho IS NOT NULL
+      AND valor_pago > 0
+    GROUP BY municipio, EXTRACT(YEAR FROM data_empenho), EXTRACT(MONTH FROM data_empenho)
+    HAVING COUNT(*) > 0
+    ORDER BY municipio, ano DESC, mes DESC
+"""

--- a/web/queries/cidade_resumo.py
+++ b/web/queries/cidade_resumo.py
@@ -52,15 +52,20 @@ RESUMO_TOP_FORNECEDORES = """
         COUNT(*) AS qtd_empenhos,
         est.cnpj_completo
     FROM tce_pb_despesa d
-    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
-                                  AND est.cnpj_ordem = '0001'
-    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+    JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                            AND est.cnpj_ordem = '0001'
+    JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                  -- Layer 2 + MEI/EI exclusion (P1-6 Opus PR #108).
+                  AND e.natureza_juridica IS DISTINCT FROM '2135'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM simples s
+                      WHERE s.cnpj_basico = e.cnpj_basico AND s.opcao_mei = 'S'
+                  )
     WHERE d.municipio = %(municipio)s
       AND EXTRACT(YEAR FROM d.data_empenho) = %(ano)s
       AND EXTRACT(MONTH FROM d.data_empenho) = %(mes)s
       AND d.valor_pago > 0
       AND LENGTH(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g')) = 14
-      AND est.cnpj_basico IS NOT NULL
     GROUP BY REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'),
              COALESCE(NULLIF(e.razao_social, ''), d.nome_credor),
              est.cnpj_completo
@@ -118,15 +123,20 @@ RESUMO_TOP_EMPENHOS = """
         COALESCE(NULLIF(e.razao_social, ''), d.nome_credor) AS razao_social,
         est.cnpj_completo
     FROM tce_pb_despesa d
-    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
-                                  AND est.cnpj_ordem = '0001'
-    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+    JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                            AND est.cnpj_ordem = '0001'
+    JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                  -- Layer 2 + MEI/EI exclusion (P1-6 Opus PR #108).
+                  AND e.natureza_juridica IS DISTINCT FROM '2135'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM simples s
+                      WHERE s.cnpj_basico = e.cnpj_basico AND s.opcao_mei = 'S'
+                  )
     WHERE d.municipio = %(municipio)s
       AND EXTRACT(YEAR FROM d.data_empenho) = %(ano)s
       AND EXTRACT(MONTH FROM d.data_empenho) = %(mes)s
       AND d.valor_pago > 0
       AND LENGTH(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g')) = 14
-      AND est.cnpj_basico IS NOT NULL
     ORDER BY d.valor_pago DESC NULLS LAST
     LIMIT 20
 """
@@ -152,16 +162,21 @@ RESUMO_TOP_LICITACOES = """
           AND EXISTS (
               SELECT 1
               FROM tce_pb_licitacao l2
-              LEFT JOIN estabelecimento est
+              JOIN estabelecimento est
                   ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
                  AND est.cnpj_ordem = '0001'
+              JOIN empresa e2 ON e2.cnpj_basico = est.cnpj_basico
+                             AND e2.natureza_juridica IS DISTINCT FROM '2135'
+                             AND NOT EXISTS (
+                                 SELECT 1 FROM simples s2
+                                 WHERE s2.cnpj_basico = e2.cnpj_basico AND s2.opcao_mei = 'S'
+                             )
               WHERE l2.municipio = l.municipio
                 AND l2.ano_licitacao = l.ano_licitacao
                 AND l2.codigo_ug = l.codigo_ug
                 AND l2.modalidade = l.modalidade
                 AND l2.numero_licitacao = l.numero_licitacao
                 AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
-                AND est.cnpj_basico IS NOT NULL
           )
     )
     SELECT lu.*, COALESCE(SUM(l.valor_ofertado), 0) AS valor_total

--- a/web/queries/licitacao.py
+++ b/web/queries/licitacao.py
@@ -1,0 +1,220 @@
+"""SQL parametrizado para /licitacao/<mun>/<ano>/<ug>/<mod-num> e
+sitemap-licitacoes.
+
+Design:
+- Filter PJ-only via inline regex sobre cpf_cnpj_proponente. Sem dependencia
+  de cpf_cnpj_norm normalizado (que nao existe em tce_pb_licitacao). O filter
+  conta digitos apos REGEXP_REPLACE pra evitar falso-positivo de mascaras
+  com 14 chars (ex: '123.456.789-01' = 14 chars mas 11 digitos = CPF PF).
+- Layer 2 de defense in depth no template: JOIN com `estabelecimento` —
+  proponente sem cadastro RFB e omitido.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Detalhes principais — metadata, proponentes, despesas vinculadas, outras
+# ─────────────────────────────────────────────────────────────────────────
+
+# Metadata da licitacao. Filtra por (municipio, ano, codigo_ug, modalidade,
+# numero_licitacao). 5-tupla garante unicidade (validado no spike).
+# Multiple rows existem (1 por proponente); pegamos DISTINCT no metadata
+# e agregamos proponentes na query separada.
+LICITACAO_DETAIL = """
+    SELECT DISTINCT
+        l.numero_licitacao,
+        l.ano_licitacao,
+        l.modalidade,
+        l.objeto_licitacao,
+        l.data_homologacao,
+        l.descricao_ug,
+        l.codigo_ug,
+        l.municipio
+    FROM tce_pb_licitacao l
+    WHERE l.municipio = %(municipio)s
+      AND l.ano_licitacao = %(ano)s
+      AND l.codigo_ug = %(codigo_ug)s
+      AND l.modalidade = %(modalidade)s
+      AND l.numero_licitacao = %(numero_licitacao)s
+    LIMIT 1
+"""
+
+# Proponentes da licitacao. Apenas PJ (14 digitos limpos). JOIN com
+# estabelecimento pra trazer razao_social canonica e descartar proponentes
+# sem cadastro RFB (layer 2 da defesa).
+#
+# Agrega valor_ofertado por (nome, cpf) pra evitar duplicacao em casos onde
+# o TCE tem rows diferentes pro mesmo proponente.
+LICITACAO_PROPONENTES = """
+    WITH proponentes_pj AS (
+        SELECT
+            l.cpf_cnpj_proponente,
+            l.nome_proponente,
+            l.valor_ofertado,
+            l.situacao_proposta,
+            REGEXP_REPLACE(l.cpf_cnpj_proponente, '\\D', '', 'g') AS cnpj_clean
+        FROM tce_pb_licitacao l
+        WHERE l.municipio = %(municipio)s
+          AND l.ano_licitacao = %(ano)s
+          AND l.codigo_ug = %(codigo_ug)s
+          AND l.modalidade = %(modalidade)s
+          AND l.numero_licitacao = %(numero_licitacao)s
+          AND LENGTH(REGEXP_REPLACE(l.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
+    )
+    SELECT
+        p.cnpj_clean AS cpf_cnpj,
+        COALESCE(NULLIF(e.razao_social, ''), p.nome_proponente) AS razao_social,
+        SUM(p.valor_ofertado) AS valor_ofertado,
+        MAX(p.situacao_proposta) AS situacao_proposta,
+        MAX(est.cnpj_completo) AS cnpj_completo
+    FROM proponentes_pj p
+    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(p.cnpj_clean, 8)
+                                  AND est.cnpj_ordem = '0001'
+    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(p.cnpj_clean, 8)
+    WHERE est.cnpj_basico IS NOT NULL  -- Layer 2 guard: PJ deve ter cadastro RFB
+    GROUP BY p.cnpj_clean, p.nome_proponente, e.razao_social
+    ORDER BY SUM(p.valor_ofertado) DESC NULLS LAST
+"""
+
+# Despesas (empenhos) vinculadas a essa licitacao. Apenas PJ credores via
+# mesmo filter. Top 50 ordenado por valor_pago. Page links pra /empresa.
+LICITACAO_EMPENHOS_VINCULADOS = """
+    SELECT
+        d.id,
+        d.numero_empenho,
+        d.data_empenho,
+        d.elemento_despesa,
+        d.valor_empenhado,
+        d.valor_pago,
+        REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g') AS cnpj_clean,
+        COALESCE(NULLIF(e.razao_social, ''), d.nome_credor) AS razao_social,
+        est.cnpj_completo
+    FROM tce_pb_despesa d
+    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                                  AND est.cnpj_ordem = '0001'
+    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+    WHERE d.municipio = %(municipio)s
+      AND d.numero_licitacao = %(numero_licitacao)s
+      AND d.valor_pago > 0
+      AND LENGTH(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g')) = 14
+      AND est.cnpj_basico IS NOT NULL
+    ORDER BY d.valor_pago DESC NULLS LAST
+    LIMIT 50
+"""
+
+# Outras licitacoes do mesmo orgao no mesmo ano (sidebar/related).
+# Filtra pra excluir a licitacao atual.
+LICITACAO_OUTRAS_MESMO_ORGAO = """
+    SELECT DISTINCT
+        l.numero_licitacao,
+        l.ano_licitacao,
+        l.modalidade,
+        l.codigo_ug,
+        l.objeto_licitacao,
+        l.data_homologacao
+    FROM tce_pb_licitacao l
+    WHERE l.municipio = %(municipio)s
+      AND l.ano_licitacao = %(ano)s
+      AND l.codigo_ug = %(codigo_ug)s
+      AND NOT (
+           l.modalidade = %(modalidade)s
+       AND l.numero_licitacao = %(numero_licitacao)s
+      )
+    ORDER BY l.data_homologacao DESC NULLS LAST
+    LIMIT 5
+"""
+
+# Outras licitacoes da mesma modalidade no municipio (cross-orgao). Mais
+# long-tail signal (busca "pregao presencial joao pessoa").
+LICITACAO_OUTRAS_MESMA_MODALIDADE = """
+    SELECT DISTINCT
+        l.numero_licitacao,
+        l.ano_licitacao,
+        l.modalidade,
+        l.codigo_ug,
+        l.descricao_ug,
+        l.objeto_licitacao,
+        l.data_homologacao
+    FROM tce_pb_licitacao l
+    WHERE l.municipio = %(municipio)s
+      AND l.modalidade = %(modalidade)s
+      AND NOT (
+           l.ano_licitacao = %(ano)s
+       AND l.codigo_ug = %(codigo_ug)s
+       AND l.numero_licitacao = %(numero_licitacao)s
+      )
+    ORDER BY l.data_homologacao DESC NULLS LAST
+    LIMIT 5
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sitemap qualifying — todas as licitacoes com >=1 proponente PJ qualificado
+# ─────────────────────────────────────────────────────────────────────────
+
+# Lista paginada pro warmer/sitemap. Retorna a 5-tupla canonica que vai
+# montar o URL. ORDER BY estavel pra paginacao bater entre warmer e shard.
+LICITACOES_QUALIFICADAS_PAGINATED = """
+    WITH lic_unique AS (
+        SELECT DISTINCT
+            l.municipio,
+            l.ano_licitacao,
+            l.codigo_ug,
+            l.descricao_ug,
+            l.modalidade,
+            l.numero_licitacao
+        FROM tce_pb_licitacao l
+        WHERE l.ano_licitacao IS NOT NULL
+          AND l.numero_licitacao IS NOT NULL
+          AND l.modalidade IS NOT NULL
+          AND l.codigo_ug IS NOT NULL
+          AND l.municipio IS NOT NULL
+          AND EXISTS (
+              SELECT 1
+              FROM tce_pb_licitacao l2
+              LEFT JOIN estabelecimento est
+                  ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
+                 AND est.cnpj_ordem = '0001'
+              WHERE l2.municipio = l.municipio
+                AND l2.ano_licitacao = l.ano_licitacao
+                AND l2.codigo_ug = l.codigo_ug
+                AND l2.modalidade = l.modalidade
+                AND l2.numero_licitacao = l.numero_licitacao
+                AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
+                AND est.cnpj_basico IS NOT NULL
+          )
+    )
+    SELECT municipio, ano_licitacao, codigo_ug, descricao_ug, modalidade, numero_licitacao
+    FROM lic_unique
+    ORDER BY municipio, ano_licitacao DESC, codigo_ug, modalidade, numero_licitacao
+    LIMIT %(limit)s OFFSET %(offset)s
+"""
+
+# Count total pra calcular num_shards no sitemap-index.
+LICITACOES_QUALIFICADAS_COUNT = """
+    SELECT COUNT(*) FROM (
+        SELECT DISTINCT
+            l.municipio,
+            l.ano_licitacao,
+            l.codigo_ug,
+            l.modalidade,
+            l.numero_licitacao
+        FROM tce_pb_licitacao l
+        WHERE l.ano_licitacao IS NOT NULL
+          AND l.numero_licitacao IS NOT NULL
+          AND l.modalidade IS NOT NULL
+          AND l.codigo_ug IS NOT NULL
+          AND l.municipio IS NOT NULL
+          AND EXISTS (
+              SELECT 1
+              FROM tce_pb_licitacao l2
+              LEFT JOIN estabelecimento est
+                  ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
+                 AND est.cnpj_ordem = '0001'
+              WHERE l2.municipio = l.municipio
+                AND l2.ano_licitacao = l.ano_licitacao
+                AND l2.codigo_ug = l.codigo_ug
+                AND l2.modalidade = l.modalidade
+                AND l2.numero_licitacao = l.numero_licitacao
+                AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
+                AND est.cnpj_basico IS NOT NULL
+          )
+    ) qualificadas
+"""

--- a/web/queries/licitacao.py
+++ b/web/queries/licitacao.py
@@ -66,12 +66,26 @@ LICITACAO_PROPONENTES = """
         MAX(p.situacao_proposta) AS situacao_proposta,
         MAX(est.cnpj_completo) AS cnpj_completo
     FROM proponentes_pj p
-    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(p.cnpj_clean, 8)
-                                  AND est.cnpj_ordem = '0001'
-    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(p.cnpj_clean, 8)
-    WHERE est.cnpj_basico IS NOT NULL  -- Layer 2 guard: PJ deve ter cadastro RFB
+    JOIN estabelecimento est ON est.cnpj_basico = LEFT(p.cnpj_clean, 8)
+                            AND est.cnpj_ordem = '0001'
+    JOIN empresa e ON e.cnpj_basico = LEFT(p.cnpj_clean, 8)
+                  -- Layer 2 guard: PJ deve ter cadastro RFB completo.
+                  -- Exclui Empresario Individual (natureza_juridica='2135') e MEI
+                  -- (simples.opcao_mei='S') pra evitar exposicao de PF disfarcada
+                  -- de PJ (razao_social = "NOME CIVIL CPF" eh convencao RFB).
+                  -- P1-6 review Opus 4.7 PR #108.
+                  AND e.natureza_juridica IS DISTINCT FROM '2135'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM simples s
+                      WHERE s.cnpj_basico = e.cnpj_basico AND s.opcao_mei = 'S'
+                  )
     GROUP BY p.cnpj_clean, p.nome_proponente, e.razao_social
-    ORDER BY SUM(p.valor_ofertado) DESC NULLS LAST
+    ORDER BY
+        -- Vencedor primeiro: situacao_proposta com "vencedor"/"homologad"/"adjudicad".
+        -- Sem isso, ORDER BY valor escolhe maior valor como "vencedor" — errado
+        -- em pregao menor preco (P2 GPT 5.5 review PR #108).
+        CASE WHEN MAX(LOWER(p.situacao_proposta)) ~ '(vencedor|homolog|adjudic)' THEN 0 ELSE 1 END,
+        SUM(p.valor_ofertado) DESC NULLS LAST
 """
 
 # Despesas (empenhos) vinculadas a essa licitacao. Apenas PJ credores via
@@ -88,14 +102,24 @@ LICITACAO_EMPENHOS_VINCULADOS = """
         COALESCE(NULLIF(e.razao_social, ''), d.nome_credor) AS razao_social,
         est.cnpj_completo
     FROM tce_pb_despesa d
-    LEFT JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
-                                  AND est.cnpj_ordem = '0001'
-    LEFT JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+    JOIN estabelecimento est ON est.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                            AND est.cnpj_ordem = '0001'
+    JOIN empresa e ON e.cnpj_basico = LEFT(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g'), 8)
+                  -- Layer 2 + MEI/EI guard (P1-6 Opus PR #108)
+                  AND e.natureza_juridica IS DISTINCT FROM '2135'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM simples s
+                      WHERE s.cnpj_basico = e.cnpj_basico AND s.opcao_mei = 'S'
+                  )
     WHERE d.municipio = %(municipio)s
       AND d.numero_licitacao = %(numero_licitacao)s
+      -- Filter pela 5-tupla canonica pra evitar colisoes entre orgaos/anos
+      -- com mesmo numero_licitacao. (P1 GPT 5.5 review PR #108.)
+      AND d.codigo_ug = %(codigo_ug)s
+      AND d.modalidade_licitacao = %(modalidade)s
+      AND EXTRACT(YEAR FROM d.data_empenho) BETWEEN %(ano)s - 1 AND %(ano)s + 5
       AND d.valor_pago > 0
       AND LENGTH(REGEXP_REPLACE(d.cpf_cnpj, '\\D', '', 'g')) = 14
-      AND est.cnpj_basico IS NOT NULL
     ORDER BY d.valor_pago DESC NULLS LAST
     LIMIT 50
 """
@@ -108,6 +132,7 @@ LICITACAO_OUTRAS_MESMO_ORGAO = """
         l.ano_licitacao,
         l.modalidade,
         l.codigo_ug,
+        l.descricao_ug,
         l.objeto_licitacao,
         l.data_homologacao
     FROM tce_pb_licitacao l
@@ -117,6 +142,27 @@ LICITACAO_OUTRAS_MESMO_ORGAO = """
       AND NOT (
            l.modalidade = %(modalidade)s
        AND l.numero_licitacao = %(numero_licitacao)s
+      )
+      -- Mesmo filter de PJ qualificada do sitemap qualifying — evita
+      -- gerar links de sidebar que retornam 503 (P2 Opus PR #108).
+      AND EXISTS (
+          SELECT 1
+          FROM tce_pb_licitacao l2
+          JOIN estabelecimento est
+              ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
+             AND est.cnpj_ordem = '0001'
+          JOIN empresa e2 ON e2.cnpj_basico = est.cnpj_basico
+                         AND e2.natureza_juridica IS DISTINCT FROM '2135'
+                         AND NOT EXISTS (
+                             SELECT 1 FROM simples s2
+                             WHERE s2.cnpj_basico = e2.cnpj_basico AND s2.opcao_mei = 'S'
+                         )
+          WHERE l2.municipio = l.municipio
+            AND l2.ano_licitacao = l.ano_licitacao
+            AND l2.codigo_ug = l.codigo_ug
+            AND l2.modalidade = l.modalidade
+            AND l2.numero_licitacao = l.numero_licitacao
+            AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
       )
     ORDER BY l.data_homologacao DESC NULLS LAST
     LIMIT 5
@@ -140,6 +186,25 @@ LICITACAO_OUTRAS_MESMA_MODALIDADE = """
            l.ano_licitacao = %(ano)s
        AND l.codigo_ug = %(codigo_ug)s
        AND l.numero_licitacao = %(numero_licitacao)s
+      )
+      AND EXISTS (
+          SELECT 1
+          FROM tce_pb_licitacao l2
+          JOIN estabelecimento est
+              ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
+             AND est.cnpj_ordem = '0001'
+          JOIN empresa e2 ON e2.cnpj_basico = est.cnpj_basico
+                         AND e2.natureza_juridica IS DISTINCT FROM '2135'
+                         AND NOT EXISTS (
+                             SELECT 1 FROM simples s2
+                             WHERE s2.cnpj_basico = e2.cnpj_basico AND s2.opcao_mei = 'S'
+                         )
+          WHERE l2.municipio = l.municipio
+            AND l2.ano_licitacao = l.ano_licitacao
+            AND l2.codigo_ug = l.codigo_ug
+            AND l2.modalidade = l.modalidade
+            AND l2.numero_licitacao = l.numero_licitacao
+            AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
       )
     ORDER BY l.data_homologacao DESC NULLS LAST
     LIMIT 5
@@ -169,16 +234,21 @@ LICITACOES_QUALIFICADAS_PAGINATED = """
           AND EXISTS (
               SELECT 1
               FROM tce_pb_licitacao l2
-              LEFT JOIN estabelecimento est
+              JOIN estabelecimento est
                   ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
                  AND est.cnpj_ordem = '0001'
+              JOIN empresa e2 ON e2.cnpj_basico = est.cnpj_basico
+                             AND e2.natureza_juridica IS DISTINCT FROM '2135'
+                             AND NOT EXISTS (
+                                 SELECT 1 FROM simples s2
+                                 WHERE s2.cnpj_basico = e2.cnpj_basico AND s2.opcao_mei = 'S'
+                             )
               WHERE l2.municipio = l.municipio
                 AND l2.ano_licitacao = l.ano_licitacao
                 AND l2.codigo_ug = l.codigo_ug
                 AND l2.modalidade = l.modalidade
                 AND l2.numero_licitacao = l.numero_licitacao
                 AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
-                AND est.cnpj_basico IS NOT NULL
           )
     )
     SELECT municipio, ano_licitacao, codigo_ug, descricao_ug, modalidade, numero_licitacao
@@ -205,16 +275,21 @@ LICITACOES_QUALIFICADAS_COUNT = """
           AND EXISTS (
               SELECT 1
               FROM tce_pb_licitacao l2
-              LEFT JOIN estabelecimento est
+              JOIN estabelecimento est
                   ON est.cnpj_basico = LEFT(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g'), 8)
                  AND est.cnpj_ordem = '0001'
+              JOIN empresa e2 ON e2.cnpj_basico = est.cnpj_basico
+                             AND e2.natureza_juridica IS DISTINCT FROM '2135'
+                             AND NOT EXISTS (
+                                 SELECT 1 FROM simples s2
+                                 WHERE s2.cnpj_basico = e2.cnpj_basico AND s2.opcao_mei = 'S'
+                             )
               WHERE l2.municipio = l.municipio
                 AND l2.ano_licitacao = l.ano_licitacao
                 AND l2.codigo_ug = l.codigo_ug
                 AND l2.modalidade = l.modalidade
                 AND l2.numero_licitacao = l.numero_licitacao
                 AND LENGTH(REGEXP_REPLACE(l2.cpf_cnpj_proponente, '\\D', '', 'g')) = 14
-                AND est.cnpj_basico IS NOT NULL
           )
     ) qualificadas
 """

--- a/web/queries/licitacao.py
+++ b/web/queries/licitacao.py
@@ -81,10 +81,13 @@ LICITACAO_PROPONENTES = """
                   )
     GROUP BY p.cnpj_clean, p.nome_proponente, e.razao_social
     ORDER BY
-        -- Vencedor primeiro: situacao_proposta com "vencedor"/"homologad"/"adjudicad".
-        -- Sem isso, ORDER BY valor escolhe maior valor como "vencedor" — errado
-        -- em pregao menor preco (P2 GPT 5.5 review PR #108).
-        CASE WHEN MAX(LOWER(p.situacao_proposta)) ~ '(vencedor|homolog|adjudic)' THEN 0 ELSE 1 END,
+        -- Vencedor primeiro: qualquer row do proponente com situacao
+        -- "vencedor"/"homologad"/"adjudicad". Usa bool_or() (nao MAX()) pra
+        -- nao perder vencedor quando o mesmo CNPJ tem rows heterogeneas
+        -- (multiplos itens em pregao por item). MAX retornaria max
+        -- lexicografico — "inabilitado" > "homologado" alfabeticamente,
+        -- mascarando rows vencedoras (P2 Opus/GPT round 2 PR #108).
+        CASE WHEN bool_or(LOWER(p.situacao_proposta) ~ '(vencedor|homolog|adjudic)') THEN 0 ELSE 1 END,
         SUM(p.valor_ofertado) DESC NULLS LAST
 """
 

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -684,6 +684,93 @@ async def cidade_by_slug(request: Request, slug: str):
     return await _render_cidade(request, municipio)
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# /cidade/<slug>/<yyyy>-<mm> — resumo mensal (cache-only)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+CACHE_QUERY_ID_RESUMO = "CIDADE_RESUMO_MENSAL"
+
+
+def _build_resumo_cache_key(mun_slug: str, yyyy: int, mm: int) -> str:
+    """Cache key canonica pra resumo mensal."""
+    return f"{mun_slug}:{yyyy:04d}-{mm:02d}"
+
+
+@router.get("/cidade/{slug}/{yyyymm}")
+async def cidade_resumo_mensal(request: Request, slug: str, yyyymm: str):
+    """Resumo mensal /cidade/<slug>/<yyyy>-<mm>. Cache-only.
+
+    Validacao em ordem:
+    1. Parse yyyymm (regex + bounds 2018-2099 + 01-12). Falha → 404.
+    2. Resolve slug → nome canonico via slug_to_municipio.
+    3. Canonicaliza slug (case/acentos) → 301 se diferente.
+    4. Lookup web_cache(CIDADE_RESUMO_MENSAL, "<slug>:<yyyy>-<mm>"). Hit → render.
+       Miss → 503 (Retry-After 1h).
+    """
+    from web.main import templates
+    from web.utils.slug import (
+        SlugLookupError,
+        municipio_slug,
+        parse_yyyymm,
+        slug_to_municipio,
+    )
+
+    parsed = parse_yyyymm(yyyymm)
+    if parsed is None:
+        return templates.TemplateResponse(
+            request, "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+    yyyy, mm = parsed
+
+    try:
+        municipio = slug_to_municipio(slug)
+    except SlugLookupError:
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "60"},
+            content="Cache de slugs indisponivel. Tente novamente.",
+            media_type="text/plain; charset=utf-8",
+        )
+    if not municipio:
+        return templates.TemplateResponse(
+            request, "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+
+    canonical_slug = municipio_slug(municipio)
+    if canonical_slug and slug != canonical_slug:
+        return RedirectResponse(
+            url=f"/cidade/{canonical_slug}/{yyyy:04d}-{mm:02d}",
+            status_code=301,
+        )
+
+    cache_key = _build_resumo_cache_key(canonical_slug, yyyy, mm)
+    cached = read_web_cache(CACHE_QUERY_ID_RESUMO, cache_key)
+    if cached is not None:
+        cols, rows = cached
+        if rows and rows[0]:
+            data = rows[0][0]
+            if isinstance(data, dict) and data:
+                return templates.TemplateResponse(
+                    request, "results/cidade_resumo.html", data
+                )
+
+    logging.info("cache miss /cidade/%s/%s — returning 503", canonical_slug, yyyymm)
+    return Response(
+        status_code=503,
+        headers={"Retry-After": "3600"},
+        content=(
+            "Resumo mensal em construcao — esta pagina ainda nao foi pre-processada. "
+            "Tente novamente mais tarde."
+        ),
+        media_type="text/plain; charset=utf-8",
+    )
+
+
 @router.get("/search/cidade")
 async def search_cidade(request: Request, q: str = Query(..., min_length=2)):
     """URL legada (busca por texto livre). Quando consegue resolver o termo

--- a/web/routes/cidade_resumo_compute.py
+++ b/web/routes/cidade_resumo_compute.py
@@ -1,0 +1,227 @@
+"""Pipeline de computacao do resumo mensal /cidade/<slug>/<yyyy>-<mm>.
+
+Chamado APENAS pelo warmer (web/warm_cache.py). Nao chamar da rota
+(cache-only invariant).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any
+
+from web.config import TIMEOUT_PROFILE
+from web.db import get_conn
+from web.queries.cidade_resumo import (
+    RESUMO_AGGS_MES,
+    RESUMO_COMPARATIVO,
+    RESUMO_MODALIDADES,
+    RESUMO_TOP_ELEMENTOS,
+    RESUMO_TOP_EMPENHOS,
+    RESUMO_TOP_FORNECEDORES,
+    RESUMO_TOP_LICITACOES,
+)
+from web.utils.slug import format_yyyymm, municipio_slug, numero_slug
+
+_log = logging.getLogger("transparencia.cidade_resumo")
+
+
+class CidadeResumoEmpty(Exception):
+    """Mes sem empenhos pagos > 0 para esse municipio."""
+
+
+_MESES_PT = [
+    "", "janeiro", "fevereiro", "marco", "abril", "maio", "junho",
+    "julho", "agosto", "setembro", "outubro", "novembro", "dezembro",
+]
+
+
+def _row_to_dict(cols, row):
+    return dict(zip(cols, row))
+
+
+def _convert(value):
+    if hasattr(value, "as_tuple"):
+        return float(value)
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return value
+
+
+def _convert_row(d: dict) -> dict:
+    return {k: _convert(v) for k, v in d.items()}
+
+
+def _prev_month(yyyy: int, mm: int) -> tuple[int, int]:
+    if mm == 1:
+        return yyyy - 1, 12
+    return yyyy, mm - 1
+
+
+def _build_meta_description(
+    municipio: str, yyyy: int, mm: int,
+    aggs: dict, top_forn: list,
+) -> str:
+    """Meta description rica + factual."""
+    mes_nome = _MESES_PT[mm].capitalize()
+    parts = [
+        f"Gastos publicos de {municipio}/PB em {mes_nome} de {yyyy}."
+    ]
+    total_pago = float(aggs.get("total_pago") or 0)
+    qtd_emp = int(aggs.get("qtd_empenhos") or 0)
+    if total_pago > 0:
+        parts.append(f"Total pago: R$ {total_pago:,.0f}".replace(",", "."))
+    if qtd_emp > 0:
+        parts.append(f"{qtd_emp} empenhos.")
+    if top_forn:
+        top1 = top_forn[0]
+        parts.append(f"Maior fornecedor: {top1.get('razao_social', '')}.")
+    return " ".join(parts)[:300]
+
+
+def compute_cidade_resumo_dict(
+    municipio: str,
+    yyyy: int,
+    mm: int,
+    timeout_sec: int = TIMEOUT_PROFILE,
+) -> dict[str, Any]:
+    """Executa as queries do resumo mensal e monta dict pro template/cache.
+
+    Raises:
+        CidadeResumoEmpty: se nao ha empenhos pagos > 0 no mes. Caller
+            decide entre nao-cachear ou cachear com flag noindex.
+    """
+    if not municipio:
+        raise CidadeResumoEmpty(f"municipio vazio para {yyyy}-{mm}")
+    if not (1 <= mm <= 12):
+        raise CidadeResumoEmpty(f"mes invalido: {mm}")
+    if not (2018 <= yyyy <= 2099):
+        raise CidadeResumoEmpty(f"ano invalido: {yyyy}")
+
+    params = {"municipio": municipio, "ano": yyyy, "mes": mm}
+
+    # Comparativos
+    prev_yr_y, prev_yr_m = yyyy - 1, mm
+    prev_mes_y, prev_mes_m = _prev_month(yyyy, mm)
+    comp_params = {
+        "municipio": municipio,
+        "ano_prev_mes": prev_mes_y, "mes_prev_mes": prev_mes_m,
+        "ano_prev_yr": prev_yr_y, "mes_prev_yr": prev_yr_m,
+    }
+
+    with get_conn() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(f"SET statement_timeout = '{timeout_sec * 1000}'")
+            try:
+                # 1. KPIs hero
+                cur.execute(RESUMO_AGGS_MES, params)
+                a_cols = [d[0] for d in cur.description]
+                a_row = cur.fetchone()
+                aggs = _convert_row(_row_to_dict(a_cols, a_row)) if a_row else {}
+
+                qtd_emp = int(aggs.get("qtd_empenhos") or 0)
+                if qtd_emp == 0:
+                    raise CidadeResumoEmpty(
+                        f"sem empenhos: {municipio} em {yyyy}-{mm:02d}"
+                    )
+
+                # 2. Top fornecedores
+                cur.execute(RESUMO_TOP_FORNECEDORES, params)
+                tf_cols = [d[0] for d in cur.description]
+                top_fornecedores = [
+                    _convert_row(_row_to_dict(tf_cols, r)) for r in cur.fetchall()
+                ]
+
+                # 3. Top elementos
+                cur.execute(RESUMO_TOP_ELEMENTOS, params)
+                te_cols = [d[0] for d in cur.description]
+                top_elementos = [
+                    _convert_row(_row_to_dict(te_cols, r)) for r in cur.fetchall()
+                ]
+
+                # 4. Modalidades
+                cur.execute(RESUMO_MODALIDADES, params)
+                mo_cols = [d[0] for d in cur.description]
+                modalidades = [
+                    _convert_row(_row_to_dict(mo_cols, r)) for r in cur.fetchall()
+                ]
+
+                # 5. Top empenhos (PJ-only)
+                cur.execute(RESUMO_TOP_EMPENHOS, params)
+                em_cols = [d[0] for d in cur.description]
+                top_empenhos = [
+                    _convert_row(_row_to_dict(em_cols, r)) for r in cur.fetchall()
+                ]
+
+                # 6. Top licitacoes
+                cur.execute(RESUMO_TOP_LICITACOES, params)
+                tl_cols = [d[0] for d in cur.description]
+                top_licitacoes = [
+                    _convert_row(_row_to_dict(tl_cols, r)) for r in cur.fetchall()
+                ]
+                # Adicionar slugs canonicos pra link
+                for lic in top_licitacoes:
+                    mod = lic.get("modalidade") or ""
+                    num = lic.get("numero_licitacao") or ""
+                    ug = lic.get("descricao_ug") or ""
+                    lic["mod_num_slug"] = f"{numero_slug(mod) or 'lic'}-{numero_slug(num) or '0'}"
+                    lic["ug_slug"] = numero_slug(ug) or "prefeitura"
+
+                # 7. Comparativo
+                cur.execute(RESUMO_COMPARATIVO, comp_params)
+                cp_cols = [d[0] for d in cur.description]
+                cp_row = cur.fetchone()
+                comparativo = _convert_row(_row_to_dict(cp_cols, cp_row)) if cp_row else {}
+            finally:
+                try:
+                    cur.execute("RESET statement_timeout")
+                except Exception:
+                    _log.warning("RESET statement_timeout falhou")
+
+    mun_slug_canonical = municipio_slug(municipio)
+    yyyymm = format_yyyymm(yyyy, mm)
+
+    # Deltas %
+    total_atual = float(aggs.get("total_pago") or 0)
+    total_mes_ant = float(comparativo.get("total_mes_anterior") or 0)
+    total_ano_ant = float(comparativo.get("total_mesmo_mes_ano_anterior") or 0)
+    delta_mes_ant_pct = None
+    if total_mes_ant > 0:
+        delta_mes_ant_pct = ((total_atual - total_mes_ant) / total_mes_ant) * 100.0
+    delta_ano_ant_pct = None
+    if total_ano_ant > 0:
+        delta_ano_ant_pct = ((total_atual - total_ano_ant) / total_ano_ant) * 100.0
+
+    meta_description = _build_meta_description(
+        municipio, yyyy, mm, aggs, top_fornecedores
+    )
+
+    return {
+        # Identificacao
+        "municipio": municipio,
+        "municipio_slug": mun_slug_canonical,
+        "ano": yyyy,
+        "mes": mm,
+        "yyyymm": yyyymm,
+        "mes_nome": _MESES_PT[mm],
+        "mes_nome_cap": _MESES_PT[mm].capitalize(),
+        "ano_anterior": prev_yr_y,
+        "mes_anterior_y": prev_mes_y,
+        "mes_anterior_m": prev_mes_m,
+        "mes_anterior_yyyymm": format_yyyymm(prev_mes_y, prev_mes_m),
+        # KPIs agregados
+        "aggs": aggs,
+        "comparativo": comparativo,
+        "delta_mes_ant_pct": delta_mes_ant_pct,
+        "delta_ano_ant_pct": delta_ano_ant_pct,
+        # Listas
+        "top_fornecedores": top_fornecedores,
+        "top_elementos": top_elementos,
+        "modalidades": modalidades,
+        "top_empenhos": top_empenhos,
+        "top_licitacoes": top_licitacoes,
+        # SEO
+        "meta_description": meta_description,
+        "scope": "cidade_resumo",
+    }

--- a/web/routes/cidade_resumo_compute.py
+++ b/web/routes/cidade_resumo_compute.py
@@ -21,6 +21,7 @@ from web.queries.cidade_resumo import (
     RESUMO_TOP_FORNECEDORES,
     RESUMO_TOP_LICITACOES,
 )
+from web.utils.pii_scrub import scrub_pii
 from web.utils.slug import format_yyyymm, municipio_slug, numero_slug
 
 _log = logging.getLogger("transparencia.cidade_resumo")
@@ -160,13 +161,16 @@ def compute_cidade_resumo_dict(
                 top_licitacoes = [
                     _convert_row(_row_to_dict(tl_cols, r)) for r in cur.fetchall()
                 ]
-                # Adicionar slugs canonicos pra link
+                # Adicionar slugs canonicos pra link + scrub objeto_licitacao
+                # (P1 GPT 5.5 — texto livre pode ter PII embedded).
                 for lic in top_licitacoes:
                     mod = lic.get("modalidade") or ""
                     num = lic.get("numero_licitacao") or ""
                     ug = lic.get("descricao_ug") or ""
                     lic["mod_num_slug"] = f"{numero_slug(mod) or 'lic'}-{numero_slug(num) or '0'}"
                     lic["ug_slug"] = numero_slug(ug) or "prefeitura"
+                    if lic.get("objeto_licitacao"):
+                        lic["objeto_licitacao"] = scrub_pii(lic["objeto_licitacao"])
 
                 # 7. Comparativo
                 cur.execute(RESUMO_COMPARATIVO, comp_params)

--- a/web/routes/licitacao.py
+++ b/web/routes/licitacao.py
@@ -1,0 +1,347 @@
+"""Rota publica /licitacao/<mun-slug>/<ano>/<ug-slug>/<modalidade-num-slug>
+— perfil SEO de licitacao publica TCE-PB.
+
+ARQUITETURA cache-only (mirror de /empresa, mesma motivacao do PR #57):
+- Rota le de web_cache (chave LICITACAO_PERFIL:<canonical-path>) e renderiza.
+- Cache miss = 503 com Retry-After (NAO faz live query — sob trafego de
+  crawler agressivo, pool exauria). Cache-miss-only e seguro porque
+  licitacoes so entram no sitemap depois de warmed.
+- A funcao `compute_licitacao_dict` executa as queries e monta o dict.
+  Eh chamada APENAS pelo warmer (web/warm_cache.py), nunca inline.
+
+URL canonica: 5 segmentos garantem unicidade absoluta:
+  /licitacao/<mun-slug>/<ano>/<ug-slug>/<modalidade-num-slug>
+
+  Onde:
+    - mun-slug: municipio_slug(nome canonico do municipio)
+    - ano: 4 digitos (2018-2099)
+    - ug-slug: slug do descricao_ug ("secretaria-municipal-de-saude")
+    - modalidade-num-slug: f"{numero_slug(modalidade)}-{numero_slug(numero)}"
+
+Cache key idem: "{mun_slug}:{ano}:{ug_slug}:{modalidade_num_slug}".
+
+LGPD: filtragem PJ-only via REGEXP no warm SQL. Layer 2 no template:
+proponente sem JOIN em estabelecimento e omitido.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse, Response
+
+from web.config import TIMEOUT_PROFILE, TIMEOUT_PROFILE_WARM
+from web.db import execute_query, get_conn, read_web_cache
+from web.queries.licitacao import (
+    LICITACAO_DETAIL,
+    LICITACAO_EMPENHOS_VINCULADOS,
+    LICITACAO_OUTRAS_MESMA_MODALIDADE,
+    LICITACAO_OUTRAS_MESMO_ORGAO,
+    LICITACAO_PROPONENTES,
+)
+from web.utils.slug import (
+    SlugLookupError,
+    all_municipios_slugged,
+    municipio_slug,
+    numero_slug,
+    slug_to_municipio,
+)
+
+router = APIRouter()
+_log = logging.getLogger("transparencia.licitacao")
+
+# Chave canonica usada em web_cache. Warmer e rota DEVEM usar exatamente
+# esta string. Mudancas exigem invalidar o cache existente.
+CACHE_QUERY_ID = "LICITACAO_PERFIL"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_ANO_RE = re.compile(r"^(20[1-9][0-9])$")  # 2010-2099
+
+
+def _row_to_dict(cols, row):
+    return dict(zip(cols, row))
+
+
+def _convert(value):
+    if hasattr(value, "as_tuple"):  # Decimal
+        return float(value)
+    if hasattr(value, "isoformat"):  # date/datetime
+        return value.isoformat()
+    return value
+
+
+def _convert_row(d: dict) -> dict:
+    return {k: _convert(v) for k, v in d.items()}
+
+
+def _build_cache_key(mun_slug: str, ano: int, ug_slug: str, mod_num_slug: str) -> str:
+    """Constroi a cache key canonica. Mesma string usada pelo warmer."""
+    return f"{mun_slug}:{ano}:{ug_slug}:{mod_num_slug}"
+
+
+def _build_mod_num_slug(modalidade: str, numero_licitacao: str) -> str:
+    """Junta modalidade-slug + numero-slug no formato canonico."""
+    mod = numero_slug(modalidade) or "lic"
+    num = numero_slug(numero_licitacao) or "0"
+    return f"{mod}-{num}"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Compute pipeline (chamado APENAS pelo warmer)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class LicitacaoNotFoundError(Exception):
+    """Licitacao nao existe na 5-tupla canonica OU nao tem proponente PJ qualificado."""
+
+
+def _build_meta_description(detail: dict, proponentes: list, empenhos: list) -> str:
+    """Meta description rica + factual."""
+    mun = detail.get("municipio", "")
+    modalidade = detail.get("modalidade", "")
+    num = detail.get("numero_licitacao", "")
+    ano = detail.get("ano_licitacao", "")
+    objeto = (detail.get("objeto_licitacao") or "").strip()
+    if len(objeto) > 100:
+        objeto = objeto[:97].rstrip() + "..."
+    parts = [f"Licitacao {modalidade} {num}/{ano} em {mun}/PB."]
+    if objeto:
+        parts.append(f"Objeto: {objeto}")
+    if proponentes:
+        parts.append(f"{len(proponentes)} proponente(s).")
+    total_pago = sum(float(e.get("valor_pago") or 0) for e in empenhos)
+    if total_pago > 0:
+        parts.append(f"R$ {total_pago:,.0f} pagos".replace(",", "."))
+    return " ".join(parts)[:300]
+
+
+def compute_licitacao_dict(
+    municipio: str,
+    ano: int,
+    codigo_ug: str,
+    modalidade: str,
+    numero_licitacao: str,
+    timeout_sec: int = TIMEOUT_PROFILE,
+) -> dict[str, Any]:
+    """Executa queries e monta dict pra template + cache.
+
+    Args:
+        municipio: nome canonico do municipio (NAO slug).
+        ano: ano_licitacao SMALLINT.
+        codigo_ug: codigo_ug VARCHAR exato.
+        modalidade: modalidade TEXT exato.
+        numero_licitacao: numero_licitacao VARCHAR exato.
+        timeout_sec: statement_timeout. Default TIMEOUT_PROFILE (3s) pro
+            route inline (nao chamado); warmer usa TIMEOUT_PROFILE_WARM (600s).
+
+    Raises:
+        LicitacaoNotFoundError: se nao casa nenhuma row OR sem proponente PJ.
+    """
+    params = {
+        "municipio": municipio,
+        "ano": ano,
+        "codigo_ug": codigo_ug,
+        "modalidade": modalidade,
+        "numero_licitacao": numero_licitacao,
+    }
+
+    with get_conn() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(f"SET statement_timeout = '{timeout_sec * 1000}'")
+            try:
+                # 1. Metadata
+                cur.execute(LICITACAO_DETAIL, params)
+                det_cols = [d[0] for d in cur.description]
+                det_row = cur.fetchone()
+                if not det_row:
+                    raise LicitacaoNotFoundError(
+                        f"Licitacao nao encontrada: {municipio}/{ano}/{codigo_ug}/{modalidade}/{numero_licitacao}"
+                    )
+                detail = _convert_row(_row_to_dict(det_cols, det_row))
+
+                # 2. Proponentes (apenas PJ via inline regex + JOIN estabelecimento)
+                cur.execute(LICITACAO_PROPONENTES, params)
+                prop_cols = [d[0] for d in cur.description]
+                proponentes = [
+                    _convert_row(_row_to_dict(prop_cols, r)) for r in cur.fetchall()
+                ]
+
+                if not proponentes:
+                    # Sem proponente PJ qualificado — nao deve estar no sitemap
+                    raise LicitacaoNotFoundError(
+                        f"Licitacao sem proponente PJ qualificado: {numero_licitacao}/{ano}"
+                    )
+
+                # 3. Empenhos vinculados (top 50, PJ only)
+                cur.execute(LICITACAO_EMPENHOS_VINCULADOS, params)
+                emp_cols = [d[0] for d in cur.description]
+                empenhos = [
+                    _convert_row(_row_to_dict(emp_cols, r)) for r in cur.fetchall()
+                ]
+
+                # 4. Outras licitacoes do mesmo orgao (sidebar)
+                cur.execute(LICITACAO_OUTRAS_MESMO_ORGAO, params)
+                or_cols = [d[0] for d in cur.description]
+                outras_orgao = [
+                    _convert_row(_row_to_dict(or_cols, r)) for r in cur.fetchall()
+                ]
+                for o in outras_orgao:
+                    o["mod_num_slug"] = _build_mod_num_slug(
+                        o.get("modalidade") or "", o.get("numero_licitacao") or ""
+                    )
+
+                # 5. Outras licitacoes da mesma modalidade no municipio
+                cur.execute(LICITACAO_OUTRAS_MESMA_MODALIDADE, params)
+                om_cols = [d[0] for d in cur.description]
+                outras_modalidade = [
+                    _convert_row(_row_to_dict(om_cols, r)) for r in cur.fetchall()
+                ]
+                for o in outras_modalidade:
+                    o["mod_num_slug"] = _build_mod_num_slug(
+                        o.get("modalidade") or "", o.get("numero_licitacao") or ""
+                    )
+                    o["ug_slug"] = numero_slug(o.get("descricao_ug") or "") or "prefeitura"
+            finally:
+                try:
+                    cur.execute("RESET statement_timeout")
+                except Exception:
+                    _log.warning("RESET statement_timeout falhou")
+
+    # Total contratado (do vencedor): proponente com maior valor_ofertado.
+    vencedor = proponentes[0] if proponentes else None
+    valor_contratado = float(vencedor.get("valor_ofertado") or 0) if vencedor else 0.0
+    valor_pago_total = sum(float(e.get("valor_pago") or 0) for e in empenhos)
+    valor_empenhado_total = sum(float(e.get("valor_empenhado") or 0) for e in empenhos)
+
+    mun_slug = municipio_slug(municipio)
+    ug_slug_canonical = numero_slug(detail.get("descricao_ug") or "") or "prefeitura"
+    mod_num_slug = _build_mod_num_slug(modalidade, numero_licitacao)
+
+    meta_description = _build_meta_description(detail, proponentes, empenhos)
+
+    return {
+        # Identificacao canonica
+        "municipio": municipio,
+        "municipio_slug": mun_slug,
+        "ano": ano,
+        "codigo_ug": codigo_ug,
+        "ug_slug": ug_slug_canonical,
+        "modalidade": modalidade,
+        "numero_licitacao": numero_licitacao,
+        "mod_num_slug": mod_num_slug,
+        # Dados principais
+        "detail": detail,
+        "proponentes": proponentes,
+        "empenhos": empenhos,
+        "outras_orgao": outras_orgao,
+        "outras_modalidade": outras_modalidade,
+        # KPIs derivados
+        "vencedor": vencedor,
+        "valor_contratado": valor_contratado,
+        "valor_pago_total": valor_pago_total,
+        "valor_empenhado_total": valor_empenhado_total,
+        # SEO
+        "meta_description": meta_description,
+        "scope": "licitacao",
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Rota — cache-only
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/licitacao/{mun_slug}/{ano}/{ug_slug}/{mod_num_slug}")
+async def licitacao_perfil(
+    request: Request,
+    mun_slug: str,
+    ano: str,
+    ug_slug: str,
+    mod_num_slug: str,
+):
+    """Renderiza pagina de licitacao. Cache-only. Miss = 503."""
+    from web.main import templates
+
+    # Validacao ano
+    if not _ANO_RE.fullmatch(ano):
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+
+    # Resolve mun_slug → nome canonico
+    try:
+        municipio_nome = slug_to_municipio(mun_slug)
+    except SlugLookupError:
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "60"},
+            content="Cache de slugs indisponivel. Tente novamente.",
+            media_type="text/plain; charset=utf-8",
+        )
+    if not municipio_nome:
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+
+    # Slug nao canonico → 301
+    canonical_mun_slug = municipio_slug(municipio_nome)
+    if canonical_mun_slug and canonical_mun_slug != mun_slug:
+        return RedirectResponse(
+            url=f"/licitacao/{canonical_mun_slug}/{ano}/{ug_slug}/{mod_num_slug}",
+            status_code=301,
+        )
+
+    # Validacao basica de slug segments (rejeita injection cedo)
+    if not re.fullmatch(r"[a-z0-9-]+", ug_slug):
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+    if not re.fullmatch(r"[a-z0-9-]+", mod_num_slug):
+        return templates.TemplateResponse(
+            request,
+            "errors/404.html",
+            {"path": str(request.url.path)},
+            status_code=404,
+        )
+
+    # Lookup no web_cache
+    cache_key = _build_cache_key(canonical_mun_slug, int(ano), ug_slug, mod_num_slug)
+    cached = read_web_cache(CACHE_QUERY_ID, cache_key)
+    if cached is not None:
+        cols, rows = cached
+        if rows and rows[0]:
+            data = rows[0][0]
+            if isinstance(data, dict) and data:
+                return templates.TemplateResponse(
+                    request, "results/licitacao.html", data
+                )
+
+    # Cache miss
+    _log.info("cache miss /licitacao/%s — returning 503", cache_key)
+    return Response(
+        status_code=503,
+        headers={"Retry-After": "3600"},
+        content=(
+            "Licitacao em construcao — esta pagina ainda nao foi pre-processada. "
+            "Tente novamente mais tarde."
+        ),
+        media_type="text/plain; charset=utf-8",
+    )

--- a/web/routes/licitacao.py
+++ b/web/routes/licitacao.py
@@ -42,6 +42,7 @@ from web.queries.licitacao import (
     LICITACAO_OUTRAS_MESMO_ORGAO,
     LICITACAO_PROPONENTES,
 )
+from web.utils.pii_scrub import scrub_pii
 from web.utils.slug import (
     SlugLookupError,
     all_municipios_slugged,
@@ -167,6 +168,12 @@ def compute_licitacao_dict(
                         f"Licitacao nao encontrada: {municipio}/{ano}/{codigo_ug}/{modalidade}/{numero_licitacao}"
                     )
                 detail = _convert_row(_row_to_dict(det_cols, det_row))
+                # Scrub PII de texto livre antes de cachear (P1 GPT 5.5).
+                # objeto_licitacao eh TEXT digitado por servidor TCE — pode
+                # conter CPF/RG/email/tel embedded mesmo quando a licitacao
+                # eh PJ. Aplicado AQUI pra cache ficar limpo.
+                if detail.get("objeto_licitacao"):
+                    detail["objeto_licitacao"] = scrub_pii(detail["objeto_licitacao"])
 
                 # 2. Proponentes (apenas PJ via inline regex + JOIN estabelecimento)
                 cur.execute(LICITACAO_PROPONENTES, params)
@@ -198,6 +205,13 @@ def compute_licitacao_dict(
                     o["mod_num_slug"] = _build_mod_num_slug(
                         o.get("modalidade") or "", o.get("numero_licitacao") or ""
                     )
+                    # ug_slug per row (P2 Opus PR #108) — antes herdava
+                    # ug_slug da pagina pai, gerando 503 quando descricao_ug
+                    # textual variava entre rows do mesmo codigo_ug.
+                    o["ug_slug"] = numero_slug(o.get("descricao_ug") or "") or "prefeitura"
+                    # Scrub objeto_licitacao (texto livre).
+                    if o.get("objeto_licitacao"):
+                        o["objeto_licitacao"] = scrub_pii(o["objeto_licitacao"])
 
                 # 5. Outras licitacoes da mesma modalidade no municipio
                 cur.execute(LICITACAO_OUTRAS_MESMA_MODALIDADE, params)
@@ -210,6 +224,8 @@ def compute_licitacao_dict(
                         o.get("modalidade") or "", o.get("numero_licitacao") or ""
                     )
                     o["ug_slug"] = numero_slug(o.get("descricao_ug") or "") or "prefeitura"
+                    if o.get("objeto_licitacao"):
+                        o["objeto_licitacao"] = scrub_pii(o["objeto_licitacao"])
             finally:
                 try:
                     cur.execute("RESET statement_timeout")

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -480,16 +480,29 @@ async def sitemap_xml(request: Request) -> Response:
         )
 
     xml = _build_sitemap_index(origin)
-    flag_on = os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1"
-    has_empresa_shards = "/sitemap-empresas-" in xml
-    is_complete = (not flag_on) or has_empresa_shards
+    # Anti-cache parcial: nao cachear sitemap-index quando uma flag
+    # de tipo esta ligada mas o tipo NAO esta listado no XML (signal de
+    # que cache de licitacoes/empresas/resumo ainda nao foi populado).
+    # Sem isso, primeiro hit pos-deploy com flag=1 + warm em curso
+    # cacheia sitemap vazio por 24h → Google nao descobre paginas.
+    # (P2 GPT 5.5 round 2 PR #108.)
+    flag_emp = os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1"
+    flag_lic = os.environ.get("SITEMAP_INCLUDE_LICITACOES", "0") == "1"
+    flag_res = os.environ.get("SITEMAP_INCLUDE_CIDADE_RESUMO", "0") == "1"
+    has_empresa = "/sitemap-empresas-" in xml
+    has_lic = "/sitemap-licitacoes-" in xml
+    has_res = "/sitemap-cidade-resumo.xml" in xml
+    is_complete = (
+        (not flag_emp or has_empresa)
+        and (not flag_lic or has_lic)
+        and (not flag_res or has_res)
+    )
     if is_complete:
         _SITEMAP_CACHE["index"] = {"ts": now, "xml": xml}
     else:
         _log.warning(
-            "Sitemap-index parcial (flag_empresas=%s mas sem shards) — "
-            "nao cacheando",
-            flag_on,
+            "Sitemap-index parcial (flags emp=%s lic=%s res=%s; has emp=%s lic=%s res=%s) — nao cacheando",
+            flag_emp, flag_lic, flag_res, has_empresa, has_lic, has_res,
         )
     return Response(
         content=xml,
@@ -628,6 +641,9 @@ def _licitacoes_qualificadas_count() -> int:
     Antes contava de LICITACOES_QUALIFICADAS_COUNT direto da fonte; agora
     le de web_cache pra que num_shards bata com o que _licitacoes_paginated
     retorna. (P1 GPT 5.5 PR #108.)
+
+    Anti-cache parcial: nao cachear count=0 quando flag esta ligada — pode
+    ser cache miss transitorio durante warm (P2 GPT 5.5 round 2).
     """
     cached = _SITEMAP_CACHE.get("licitacoes_count")
     now = time.time()
@@ -642,7 +658,15 @@ def _licitacoes_qualificadas_count() -> int:
                 )
                 row = cur.fetchone()
                 count = int(row[0]) if row else 0
-        _SITEMAP_CACHE["licitacoes_count"] = {"ts": now, "value": count}
+        # So cacheia count se != 0 OU se a flag esta desligada.
+        flag_on = os.environ.get("SITEMAP_INCLUDE_LICITACOES", "0") == "1"
+        if count > 0 or not flag_on:
+            _SITEMAP_CACHE["licitacoes_count"] = {"ts": now, "value": count}
+        else:
+            _log.warning(
+                "_licitacoes_qualificadas_count = 0 com flag ligada — nao cacheando "
+                "(provavelmente warm em curso)"
+            )
         return count
     except Exception:
         _log.exception("Falha ao contar licitacoes em web_cache")
@@ -750,6 +774,8 @@ def _cidade_resumo_qualificados() -> list[tuple[str, int, int]]:
     sitemap tem cache populado. (P1 GPT 5.5 PR #108.)
     Cache key formato: "<mun_slug>:<yyyy>-<mm>". Retornamos mun_slug
     diretamente (nao precisa de slug_to_municipio).
+
+    Anti-cache parcial: nao cachear lista vazia quando flag esta ligada.
     """
     cached = _SITEMAP_CACHE.get("cidade_resumo_list")
     now = time.time()
@@ -778,7 +804,13 @@ def _cidade_resumo_qualificados() -> list[tuple[str, int, int]]:
                     except ValueError:
                         continue
                     out.append((mun_slug, yyyy, mm))
-        _SITEMAP_CACHE["cidade_resumo_list"] = {"ts": now, "value": out}
+        flag_on = os.environ.get("SITEMAP_INCLUDE_CIDADE_RESUMO", "0") == "1"
+        if out or not flag_on:
+            _SITEMAP_CACHE["cidade_resumo_list"] = {"ts": now, "value": out}
+        else:
+            _log.warning(
+                "_cidade_resumo_qualificados vazio com flag ligada — nao cacheando"
+            )
         return out
     except Exception:
         _log.exception("Falha ao listar cidade-resumo em web_cache")

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -623,33 +623,42 @@ async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: int) 
 
 
 def _licitacoes_qualificadas_count() -> int:
-    """Conta licitacoes qualificadas (com >=1 proponente PJ). Cache 24h."""
+    """Conta licitacoes em web_cache (sitemap reflete o que esta cacheado).
+
+    Antes contava de LICITACOES_QUALIFICADAS_COUNT direto da fonte; agora
+    le de web_cache pra que num_shards bata com o que _licitacoes_paginated
+    retorna. (P1 GPT 5.5 PR #108.)
+    """
     cached = _SITEMAP_CACHE.get("licitacoes_count")
     now = time.time()
     if cached and (now - cached["ts"] < _SITEMAP_TTL):
         return int(cached["value"])
-    from web.queries.licitacao import LICITACOES_QUALIFICADAS_COUNT
     try:
         with db.get_conn() as conn:
             conn.autocommit = True
             with conn.cursor() as cur:
-                cur.execute(LICITACOES_QUALIFICADAS_COUNT)
+                cur.execute(
+                    "SELECT COUNT(*) FROM web_cache WHERE query_id = 'LICITACAO_PERFIL'"
+                )
                 row = cur.fetchone()
                 count = int(row[0]) if row else 0
         _SITEMAP_CACHE["licitacoes_count"] = {"ts": now, "value": count}
         return count
     except Exception:
-        _log.exception("Falha ao contar licitacoes pro sitemap")
+        _log.exception("Falha ao contar licitacoes em web_cache")
         return 0
 
 
 def _licitacoes_paginated(shard_n: int, shard_size: int) -> list[tuple[str, int, str, str, str, str]]:
-    """Retorna 6-tupla pro shard N: (mun_slug, ano, ug_slug, mod_num_slug,
-    municipio_canon, descricao_ug). Aplica slugs aqui pra evitar SQL fancy.
-    """
-    from web.queries.licitacao import LICITACOES_QUALIFICADAS_PAGINATED
-    from web.utils.slug import municipio_slug as _mun_slug, numero_slug as _num_slug
+    """Retorna 6-tupla pro shard N a partir do que esta cacheado em web_cache.
 
+    LE DE web_cache (NAO do qualifying set) — garante que cada URL do sitemap
+    tem cache populado, evitando 503 mass-publish. Coverage gate eh sanity
+    check no deploy, mas o sitemap eh estritamente o que existe na cache.
+    (P1 GPT 5.5 review PR #108.)
+
+    Cache key formato: "<mun_slug>:<ano>:<ug_slug>:<mod_num_slug>".
+    """
     if shard_n < 1:
         return []
     offset = (shard_n - 1) * shard_size
@@ -658,32 +667,31 @@ def _licitacoes_paginated(shard_n: int, shard_size: int) -> list[tuple[str, int,
             conn.autocommit = True
             with conn.cursor() as cur:
                 cur.execute(
-                    LICITACOES_QUALIFICADAS_PAGINATED,
-                    {"limit": shard_size, "offset": offset},
+                    """
+                    SELECT municipio
+                    FROM web_cache
+                    WHERE query_id = 'LICITACAO_PERFIL'
+                    ORDER BY municipio
+                    LIMIT %s OFFSET %s
+                    """,
+                    (shard_size, offset),
                 )
                 out: list[tuple[str, int, str, str, str, str]] = []
-                seen: set[tuple[str, int, str, str]] = set()
-                for municipio, ano, codigo_ug, descricao_ug, modalidade, numero in cur.fetchall():
-                    if not municipio or not ano or not modalidade or not numero or not codigo_ug:
+                for (cache_key,) in cur.fetchall():
+                    if not cache_key:
                         continue
-                    mun_slug = _mun_slug(str(municipio))
-                    if not mun_slug:
+                    parts = str(cache_key).split(":", 3)
+                    if len(parts) != 4:
                         continue
-                    ug_slug = _num_slug(str(descricao_ug or "")) or "prefeitura"
-                    mod_slug = _num_slug(str(modalidade))
-                    num_slug = _num_slug(str(numero))
-                    if not mod_slug or not num_slug:
+                    mun_slug, ano_s, ug_slug, mod_num_slug = parts
+                    try:
+                        ano_int = int(ano_s)
+                    except ValueError:
                         continue
-                    mod_num_slug = f"{mod_slug}-{num_slug}"
-                    key = (mun_slug, int(ano), ug_slug, mod_num_slug)
-                    if key in seen:
-                        continue
-                    seen.add(key)
-                    out.append((mun_slug, int(ano), ug_slug, mod_num_slug,
-                                str(municipio), str(descricao_ug or "")))
+                    out.append((mun_slug, ano_int, ug_slug, mod_num_slug, "", ""))
                 return out
     except Exception:
-        _log.exception("Falha ao carregar shard %d de licitacoes", shard_n)
+        _log.exception("Falha ao carregar shard %d de licitacoes do web_cache", shard_n)
         return []
 
 
@@ -736,38 +744,53 @@ async def sitemap_licitacoes_shard_xml(request: Request, shard_n: int) -> Respon
 
 
 def _cidade_resumo_qualificados() -> list[tuple[str, int, int]]:
-    """Retorna (municipio_canon, ano, mes) pra cada cidade-mes com qtd_empenhos > 0.
-    Cache 24h."""
+    """Retorna (mun_slug, ano, mes) pra cada entrada em web_cache.
+
+    LE DE web_cache (NAO do qualifying SQL) — garante que cada URL no
+    sitemap tem cache populado. (P1 GPT 5.5 PR #108.)
+    Cache key formato: "<mun_slug>:<yyyy>-<mm>". Retornamos mun_slug
+    diretamente (nao precisa de slug_to_municipio).
+    """
     cached = _SITEMAP_CACHE.get("cidade_resumo_list")
     now = time.time()
     if cached and (now - cached["ts"] < _SITEMAP_TTL):
         return list(cached["value"])
-    from web.queries.cidade_resumo import CIDADE_RESUMO_QUALIFICADOS_LIST
     try:
         with db.get_conn() as conn:
             conn.autocommit = True
             with conn.cursor() as cur:
-                cur.execute(CIDADE_RESUMO_QUALIFICADOS_LIST)
+                cur.execute(
+                    "SELECT municipio FROM web_cache WHERE query_id = 'CIDADE_RESUMO_MENSAL'"
+                )
                 out: list[tuple[str, int, int]] = []
-                for municipio, ano, mes, _qtd in cur.fetchall():
-                    if not municipio or not ano or not mes:
+                for (cache_key,) in cur.fetchall():
+                    if not cache_key:
                         continue
-                    out.append((str(municipio), int(ano), int(mes)))
+                    parts = str(cache_key).split(":", 1)
+                    if len(parts) != 2:
+                        continue
+                    mun_slug, yyyymm = parts
+                    if len(yyyymm) != 7 or yyyymm[4] != "-":
+                        continue
+                    try:
+                        yyyy = int(yyyymm[:4])
+                        mm = int(yyyymm[5:7])
+                    except ValueError:
+                        continue
+                    out.append((mun_slug, yyyy, mm))
         _SITEMAP_CACHE["cidade_resumo_list"] = {"ts": now, "value": out}
         return out
     except Exception:
-        _log.exception("Falha ao listar cidade-resumo qualificados pro sitemap")
+        _log.exception("Falha ao listar cidade-resumo em web_cache")
         return []
 
 
 def _build_cidade_resumo_sitemap(origin: str) -> str:
-    """urlset com /cidade/<slug>/<yyyy>-<mm> pra cada cidade-mes com dados."""
-    from web.utils.slug import municipio_slug as _mun_slug
+    """urlset com /cidade/<mun_slug>/<yyyy>-<mm> pra cada entry em cache."""
     lastmod = _lastmod_iso()
     parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>',
                         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
-    for municipio, ano, mes in _cidade_resumo_qualificados():
-        mun_slug = _mun_slug(municipio)
+    for mun_slug, ano, mes in _cidade_resumo_qualificados():
         if not mun_slug:
             continue
         loc = f"{origin}/cidade/{mun_slug}/{ano:04d}-{mes:02d}"

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -55,11 +55,16 @@ _SITEMAP_CACHE: dict[str, Any] = {
     "cidades": {"ts": 0.0, "xml": ""},
     "empresas": {},  # {shard_n: {"ts": ..., "xml": ...}}
     "empresas_municipios": {},  # {shard_n: {"ts": ..., "xml": ...}}
+    "licitacoes": {},  # {shard_n: {"ts": ..., "xml": ...}}
+    "cidade_resumo": {"ts": 0.0, "xml": ""},
 }
 
 # Tamanho de cada shard de empresas. Limite do protocolo eh 50K URLs por
 # arquivo; 49K deixa folga pra evitar overflow se o filtro mudar.
 EMPRESA_SHARD_SIZE = 49000
+
+# Tamanho de shard de licitacoes (mesmo limite do empresa).
+LICITACAO_SHARD_SIZE = 49000
 
 
 def _site_origin(request: Request) -> str:
@@ -428,6 +433,25 @@ def _build_sitemap_index(origin: str) -> str:
                 parts.append(f"    <lastmod>{lastmod}</lastmod>")
                 parts.append("  </sitemap>")
 
+    # Sub-sitemaps de licitacoes (gated por env flag separado).
+    if os.environ.get("SITEMAP_INCLUDE_LICITACOES", "0") == "1":
+        total_lic = _licitacoes_qualificadas_count()
+        if total_lic > 0:
+            num_shards_lic = math.ceil(total_lic / LICITACAO_SHARD_SIZE)
+            for n in range(1, num_shards_lic + 1):
+                parts.append("  <sitemap>")
+                parts.append(f"    <loc>{xml_escape(origin)}/sitemap-licitacoes-{n}.xml</loc>")
+                parts.append(f"    <lastmod>{lastmod}</lastmod>")
+                parts.append("  </sitemap>")
+
+    # Sub-sitemap unico de cidade-resumo mensal (gated por env flag separado).
+    # Sem sharding: ~14k URLs cabem em 1 urlset (limite protocolo: 50k).
+    if os.environ.get("SITEMAP_INCLUDE_CIDADE_RESUMO", "0") == "1":
+        parts.append("  <sitemap>")
+        parts.append(f"    <loc>{xml_escape(origin)}/sitemap-cidade-resumo.xml</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
+        parts.append("  </sitemap>")
+
     parts.append("</sitemapindex>")
     return "\n".join(parts)
 
@@ -586,6 +610,192 @@ async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: int) 
                 "Sitemap-empresas-municipios shard 1 vazio — nao cacheando "
                 "(DB pode ter falhado)"
             )
+    return Response(
+        content=xml,
+        media_type="application/xml",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Licitacoes — /sitemap-licitacoes-<n>.xml + helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _licitacoes_qualificadas_count() -> int:
+    """Conta licitacoes qualificadas (com >=1 proponente PJ). Cache 24h."""
+    cached = _SITEMAP_CACHE.get("licitacoes_count")
+    now = time.time()
+    if cached and (now - cached["ts"] < _SITEMAP_TTL):
+        return int(cached["value"])
+    from web.queries.licitacao import LICITACOES_QUALIFICADAS_COUNT
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(LICITACOES_QUALIFICADAS_COUNT)
+                row = cur.fetchone()
+                count = int(row[0]) if row else 0
+        _SITEMAP_CACHE["licitacoes_count"] = {"ts": now, "value": count}
+        return count
+    except Exception:
+        _log.exception("Falha ao contar licitacoes pro sitemap")
+        return 0
+
+
+def _licitacoes_paginated(shard_n: int, shard_size: int) -> list[tuple[str, int, str, str, str, str]]:
+    """Retorna 6-tupla pro shard N: (mun_slug, ano, ug_slug, mod_num_slug,
+    municipio_canon, descricao_ug). Aplica slugs aqui pra evitar SQL fancy.
+    """
+    from web.queries.licitacao import LICITACOES_QUALIFICADAS_PAGINATED
+    from web.utils.slug import municipio_slug as _mun_slug, numero_slug as _num_slug
+
+    if shard_n < 1:
+        return []
+    offset = (shard_n - 1) * shard_size
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    LICITACOES_QUALIFICADAS_PAGINATED,
+                    {"limit": shard_size, "offset": offset},
+                )
+                out: list[tuple[str, int, str, str, str, str]] = []
+                seen: set[tuple[str, int, str, str]] = set()
+                for municipio, ano, codigo_ug, descricao_ug, modalidade, numero in cur.fetchall():
+                    if not municipio or not ano or not modalidade or not numero or not codigo_ug:
+                        continue
+                    mun_slug = _mun_slug(str(municipio))
+                    if not mun_slug:
+                        continue
+                    ug_slug = _num_slug(str(descricao_ug or "")) or "prefeitura"
+                    mod_slug = _num_slug(str(modalidade))
+                    num_slug = _num_slug(str(numero))
+                    if not mod_slug or not num_slug:
+                        continue
+                    mod_num_slug = f"{mod_slug}-{num_slug}"
+                    key = (mun_slug, int(ano), ug_slug, mod_num_slug)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    out.append((mun_slug, int(ano), ug_slug, mod_num_slug,
+                                str(municipio), str(descricao_ug or "")))
+                return out
+    except Exception:
+        _log.exception("Falha ao carregar shard %d de licitacoes", shard_n)
+        return []
+
+
+def _build_licitacoes_shard_sitemap(origin: str, shard_n: int) -> str:
+    """urlset com /licitacao/<mun>/<ano>/<ug>/<modnum> pro shard N."""
+    lastmod = _lastmod_iso()
+    parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>',
+                        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+    lics = _licitacoes_paginated(shard_n, LICITACAO_SHARD_SIZE)
+    for mun_slug, ano, ug_slug, mod_num_slug, _mun_nome, _ug_nome in lics:
+        loc = f"{origin}/licitacao/{mun_slug}/{ano}/{ug_slug}/{mod_num_slug}"
+        parts.append("  <url>")
+        parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
+        parts.append("    <changefreq>monthly</changefreq>")
+        parts.append("    <priority>0.5</priority>")
+        parts.append("  </url>")
+    parts.append("</urlset>")
+    return "\n".join(parts)
+
+
+@router.get("/sitemap-licitacoes-{shard_n:int}.xml")
+async def sitemap_licitacoes_shard_xml(request: Request, shard_n: int) -> Response:
+    """Sub-sitemap shard de licitacoes. 1-indexed. Past-end retorna urlset
+    vazio (mesmo padrao /sitemap-empresas-N.xml)."""
+    if shard_n < 1 or shard_n > 9999:
+        raise HTTPException(status_code=404)
+    origin = _site_origin(request)
+    now = time.time()
+    shard_cache = _SITEMAP_CACHE["licitacoes"].get(shard_n)
+    if shard_cache and shard_cache.get("xml") and (now - shard_cache["ts"] < _SITEMAP_TTL):
+        xml = shard_cache["xml"]
+    else:
+        xml = _build_licitacoes_shard_sitemap(origin, shard_n)
+        urls_n = xml.count("/licitacao/")
+        if urls_n > 0:
+            _SITEMAP_CACHE["licitacoes"][shard_n] = {"ts": now, "xml": xml}
+        elif shard_n == 1:
+            _log.warning("Sitemap-licitacoes shard 1 vazio — nao cacheando")
+    return Response(
+        content=xml,
+        media_type="application/xml",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cidade resumo mensal — /sitemap-cidade-resumo.xml (urlset unico, ~14k URLs)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _cidade_resumo_qualificados() -> list[tuple[str, int, int]]:
+    """Retorna (municipio_canon, ano, mes) pra cada cidade-mes com qtd_empenhos > 0.
+    Cache 24h."""
+    cached = _SITEMAP_CACHE.get("cidade_resumo_list")
+    now = time.time()
+    if cached and (now - cached["ts"] < _SITEMAP_TTL):
+        return list(cached["value"])
+    from web.queries.cidade_resumo import CIDADE_RESUMO_QUALIFICADOS_LIST
+    try:
+        with db.get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(CIDADE_RESUMO_QUALIFICADOS_LIST)
+                out: list[tuple[str, int, int]] = []
+                for municipio, ano, mes, _qtd in cur.fetchall():
+                    if not municipio or not ano or not mes:
+                        continue
+                    out.append((str(municipio), int(ano), int(mes)))
+        _SITEMAP_CACHE["cidade_resumo_list"] = {"ts": now, "value": out}
+        return out
+    except Exception:
+        _log.exception("Falha ao listar cidade-resumo qualificados pro sitemap")
+        return []
+
+
+def _build_cidade_resumo_sitemap(origin: str) -> str:
+    """urlset com /cidade/<slug>/<yyyy>-<mm> pra cada cidade-mes com dados."""
+    from web.utils.slug import municipio_slug as _mun_slug
+    lastmod = _lastmod_iso()
+    parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>',
+                        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">']
+    for municipio, ano, mes in _cidade_resumo_qualificados():
+        mun_slug = _mun_slug(municipio)
+        if not mun_slug:
+            continue
+        loc = f"{origin}/cidade/{mun_slug}/{ano:04d}-{mes:02d}"
+        parts.append("  <url>")
+        parts.append(f"    <loc>{xml_escape(loc)}</loc>")
+        parts.append(f"    <lastmod>{lastmod}</lastmod>")
+        parts.append("    <changefreq>monthly</changefreq>")
+        parts.append("    <priority>0.6</priority>")
+        parts.append("  </url>")
+    parts.append("</urlset>")
+    return "\n".join(parts)
+
+
+@router.get("/sitemap-cidade-resumo.xml")
+async def sitemap_cidade_resumo_xml(request: Request) -> Response:
+    """Sub-sitemap unico com todas as cidade-mes paginas (~14k URLs)."""
+    origin = _site_origin(request)
+    now = time.time()
+    cached = _SITEMAP_CACHE["cidade_resumo"]
+    if cached["xml"] and (now - cached["ts"] < _SITEMAP_TTL):
+        xml = cached["xml"]
+    else:
+        xml = _build_cidade_resumo_sitemap(origin)
+        urls_n = xml.count("/cidade/")
+        if urls_n > 0:
+            _SITEMAP_CACHE["cidade_resumo"] = {"ts": now, "xml": xml}
+        else:
+            _log.warning("Sitemap-cidade-resumo vazio — nao cacheando")
     return Response(
         content=xml,
         media_type="application/xml",

--- a/web/static/js/components/heatmap-dialog.js
+++ b/web/static/js/components/heatmap-dialog.js
@@ -68,6 +68,21 @@ async function openHeatmapMonthDialog(municipio, ano, mes, options = {}) {
     const empenhos = data.empenhos || [];
     let html = _historyNote('Historico completo do mes selecionado — este detalhamento nao muda com o filtro de periodo da pagina.');
 
+    // Link pra pagina dedicada do mes (indexavel, com mais conteudo).
+    // Hide quando ja estamos numa pagina /cidade/<slug>/<yyyy>-<mm>
+    // (auto-detect via URL pra evitar self-link).
+    if (municipio && ano && mes) {
+        const mesPad = String(mes).padStart(2, '0');
+        const yyyymm = `${ano}-${mesPad}`;
+        const munSlug = (typeof _municipio_slug_of === 'function')
+            ? _municipio_slug_of(municipio)
+            : encodeURIComponent(municipio.toLowerCase().replace(/\s+/g, '-'));
+        const isOnPage = location.pathname === `/cidade/${munSlug}/${yyyymm}`;
+        if (!isOnPage) {
+            html += `<p class="text-sm" style="margin:.5rem 0"><a href="/cidade/${munSlug}/${yyyymm}" class="ext-link-inline" title="Ver pagina dedicada deste mes (mais detalhes e SEO)">Ver pagina completa de ${yyyymm} &#8599;</a></p>`;
+        }
+    }
+
     html += '<div class="dialog-section"><h4>Resumo do mes</h4>';
     html += '<div class="stats-grid">';
     html += `<div class="stat"><div class="stat-label">${dualLabel('Reservado','Total empenhado')}</div><div class="stat-value">${_shortBrl(Number(resumo.total_empenhado || 0))}</div></div>`;

--- a/web/static/js/components/licitacao-dialog.js
+++ b/web/static/js/components/licitacao-dialog.js
@@ -55,6 +55,25 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
     }
 
     let html = _historyNote('Historico completo da licitacao — este detalhamento nao muda com o filtro de periodo da pagina.');
+
+    // Link pra pagina dedicada da licitacao (indexavel, mais conteudo).
+    // Hide quando ja na pagina /licitacao/X (auto-detect via URL).
+    if (data.licitacao && data.licitacao.descricao_ug && anoLicitacao && numeroLicitacao && municipio && modalidade) {
+        const _txtSlug = (s) => String(s || '').toLowerCase()
+            .normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+            .replace(/[^a-z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+        const munSlug = _txtSlug(municipio);
+        const ugSlug = _txtSlug(data.licitacao.descricao_ug) || 'prefeitura';
+        const modSlug = _txtSlug(modalidade) || 'lic';
+        const numSlug = _txtSlug(numeroLicitacao) || '0';
+        const modNumSlug = `${modSlug}-${numSlug}`;
+        const pagePath = `/licitacao/${munSlug}/${anoLicitacao}/${ugSlug}/${modNumSlug}`;
+        const isOnPage = location.pathname === pagePath;
+        if (!isOnPage) {
+            html += `<p class="text-sm" style="margin:.5rem 0"><a href="${pagePath}" class="ext-link-inline" title="Ver pagina dedicada desta licitacao (mais detalhes e SEO)">Ver pagina completa da licitacao &#8599;</a></p>`;
+        }
+    }
+
     html += `<div class="dialog-section"><h4>${dualLabel('Dados desta licitacao','Dados da licitacao')}</h4>`;
     if (data.licitacao) {
         const lic = data.licitacao;

--- a/web/templates/partials/seo/_faq_cidade_resumo.html
+++ b/web/templates/partials/seo/_faq_cidade_resumo.html
@@ -1,0 +1,59 @@
+{# FAQs dinamicas pra /cidade/<slug>/<yyyy>-<mm>.
+
+   Caller passa: municipio, ano, mes, mes_nome_cap, mes_nome,
+   aggs, top_fornecedores, delta_mes_ant_pct, delta_ano_ant_pct,
+   ano_anterior, mes_anterior_yyyymm.
+#}
+{% from "partials/seo/_faq.html" import faq_section %}
+{% set _total = aggs.total_pago|float if aggs else 0 %}
+{% set _qtd_emp = aggs.qtd_empenhos|int if aggs else 0 %}
+{% set _qtd_forn = aggs.qtd_fornecedores_unicos|int if aggs else 0 %}
+{% set _sem_lic_pct = ((aggs.total_sem_licitacao|float / _total) * 100) if (aggs and _total > 0) else 0 %}
+{% set _top1 = top_fornecedores[0] if top_fornecedores else None %}
+
+{% set _faqs = [
+    {
+        'q': 'Quanto a prefeitura de ' ~ municipio ~ ' gastou em ' ~ mes_nome ~ ' de ' ~ ano|string ~ '?',
+        'a': 'Em ' ~ mes_nome_cap ~ '/' ~ ano|string ~ ', a administracao publica municipal de ' ~ municipio ~ '/PB pagou um total de R$ ' ~ ("{:,.2f}".format(_total)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ' distribuidos em ' ~ _qtd_emp|string ~ ' empenhos a ' ~ _qtd_forn|string ~ ' fornecedores distintos. Esses valores vem dos relatorios do TCE-PB e cobrem pagamentos efetivos (nao incluem empenhos ainda nao pagos).',
+        'links': [
+            {'label': 'Top fornecedores', 'href': '#top-fornecedores'},
+            {'label': 'Categorias de gasto', 'href': '#top-elementos'},
+        ],
+    },
+    {
+        'q': 'Quem foi o maior fornecedor de ' ~ municipio ~ ' em ' ~ mes_nome ~ '/' ~ ano|string ~ '?',
+        'a': ('O maior fornecedor do mes foi ' ~ _top1.razao_social ~ ', com R$ ' ~ ("{:,.2f}".format(_top1.total_pago|float)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ' recebidos em ' ~ _top1.qtd_empenhos|string ~ ' empenhos. Veja a pagina da empresa para detalhes do CNPJ, presenca em outros municipios e cruzamento com sancoes/PGFN.') if _top1 else ('Nao localizamos fornecedores pessoa juridica nos pagamentos do mes. Pode haver pagamentos de pessoa fisica (folha, beneficios sociais) que nao listamos individualmente nesta pagina.'),
+        'links': ([
+            {'label': 'Pagina da empresa', 'href': '/empresa/' ~ _top1.cnpj_completo}
+        ] if _top1 and _top1.cnpj_completo else [
+            {'label': 'Top fornecedores', 'href': '#top-fornecedores'},
+        ]),
+    },
+    {
+        'q': 'Houve pagamentos sem licitacao em ' ~ municipio ~ ' em ' ~ mes_nome ~ '?',
+        'a': ('Sim. Cerca de ' ~ ("%0.0f"|format(_sem_lic_pct)) ~ '% do total pago (R$ ' ~ ("{:,.2f}".format(aggs.total_sem_licitacao|float)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ') saiu via dispensa ou inexigibilidade de licitacao no mes. Pagamentos sem licitacao sao legalmente permitidos em casos previstos na Lei 14.133/2021 mas merecem analise — verifique a secao "Pagamentos por modalidade" para detalhamento.') if (aggs and aggs.qtd_sem_licitacao and aggs.qtd_sem_licitacao > 0) else 'Os pagamentos do mes seguiram processos licitatorios formais. Detalhamento por modalidade (pregao, concorrencia, dispensa) na secao especifica.',
+        'links': [
+            {'label': 'Pagamentos por modalidade', 'href': '#modalidades'},
+            {'label': 'Licitacoes homologadas', 'href': '#top-licitacoes'},
+        ],
+    },
+    {
+        'q': 'Como os gastos de ' ~ mes_nome ~ '/' ~ ano|string ~ ' se comparam ao mes anterior?',
+        'a': ('Em comparacao ao mes anterior, os pagamentos variaram em ' ~ ("%+.1f"|format(delta_mes_ant_pct)) ~ '%' ~ (' (aumento)' if delta_mes_ant_pct > 0 else ' (reducao)') ~ '. Em comparacao ao mesmo mes de ' ~ ano_anterior|string ~ ', a variacao foi de ' ~ ("%+.1f"|format(delta_ano_ant_pct)) ~ '%.') if (delta_mes_ant_pct is not none and delta_ano_ant_pct is not none) else 'Comparacao com periodos anteriores nao disponivel (mes anterior ou ano-1 sem dados na base atual).',
+        'links': [
+            {'label': 'Mes anterior: ' ~ mes_anterior_yyyymm, 'href': '/cidade/' ~ municipio_slug ~ '/' ~ mes_anterior_yyyymm},
+            {'label': 'Mesmo mes ' ~ ano_anterior|string, 'href': '/cidade/' ~ municipio_slug ~ '/' ~ ano_anterior|string ~ '-' ~ ("%02d"|format(mes))},
+        ],
+    },
+    {
+        'q': 'Onde encontrar dados oficiais sobre o orcamento municipal de ' ~ municipio ~ '?',
+        'a': 'Os dados desta pagina vem do TCE-PB (Tribunal de Contas do Estado da Paraiba) — dados-abertos.tce.pb.gov.br/dados-consolidados. Para o portal da transparencia municipal, consulte o site da prefeitura de ' ~ municipio ~ '. A Lei 12.527/2011 (Lei de Acesso a Informacao) garante o direito de qualquer cidadao consultar despesas publicas.',
+        'links': [
+            {'label': 'Perfil completo de ' ~ municipio, 'href': '/cidade/' ~ municipio_slug},
+            {'label': 'Site do TCE-PB', 'href': 'https://tce.pb.gov.br', 'external': true},
+            {'label': 'Reportar correcao', 'href': '/contato'},
+        ],
+    },
+] %}
+
+{{ faq_section(_faqs, title='Perguntas frequentes', anchor='faq-cidade-resumo') }}

--- a/web/templates/partials/seo/_faq_licitacao.html
+++ b/web/templates/partials/seo/_faq_licitacao.html
@@ -1,0 +1,58 @@
+{# FAQs dinamicas pra /licitacao/<mun>/<ano>/<ug>/<mod-num>.
+
+   Caller passa o contexto da pagina (modalidade, numero, ano, municipio,
+   detail, proponentes, empenhos, vencedor, valor_contratado).
+#}
+{% from "partials/seo/_faq.html" import faq_section %}
+{% set _lic = modalidade ~ ' ' ~ numero_licitacao ~ '/' ~ ano %}
+{% set _orgao = detail.descricao_ug or 'Prefeitura' %}
+{% set _objeto = (detail.objeto_licitacao or '')|replace('\n',' ')|truncate(160) %}
+{% set _venc_nome = (vencedor.razao_social if vencedor else '') %}
+{% set _venc_valor = (vencedor.valor_ofertado if vencedor else 0) %}
+
+{% set _faqs = [
+    {
+        'q': 'O que foi a licitacao ' ~ _lic ~ ' em ' ~ municipio ~ '?',
+        'a': ('Foi um processo licitatorio publico realizado pelo ' ~ _orgao ~ ' em ' ~ municipio ~ '/PB no ano de ' ~ ano|string ~ '. Objeto: ' ~ (_objeto or 'descricao nao informada pelo TCE-PB') ~ '. Veja na pagina os proponentes, valor contratado e os empenhos efetivamente pagos.') if _objeto else ('Processo licitatorio do ' ~ _orgao ~ ' em ' ~ municipio ~ '/PB. Veja na pagina os proponentes, valor contratado e os empenhos.'),
+        'links': [
+            {'label': 'Objeto detalhado', 'href': '#objeto'},
+            {'label': 'Proponentes', 'href': '#proponentes'},
+            {'label': 'Empenhos vinculados', 'href': '#empenhos'},
+        ],
+    },
+    {
+        'q': 'Quem venceu a licitacao ' ~ _lic ~ ' em ' ~ municipio ~ '?',
+        'a': ('Vencedor: ' ~ _venc_nome ~ '. Valor ofertado: R$ ' ~ ("{:,.2f}".format(_venc_valor|float)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ '. Veja a pagina da empresa pra detalhes do CNPJ, outros empenhos e cruzamento com sancoes CEIS/CNEP.') if _venc_nome else ('A pagina nao identificou um vencedor unico para esta licitacao. Consulte a secao de Proponentes para ver as propostas registradas no TCE-PB.'),
+        'links': ([
+            {'label': 'Empresa vencedora', 'href': '/empresa/' ~ vencedor.cnpj_completo}
+        ] if vencedor and vencedor.cnpj_completo else [
+            {'label': 'Proponentes', 'href': '#proponentes'},
+        ]),
+    },
+    {
+        'q': 'Quanto foi pago em empenhos vinculados a esta licitacao?',
+        'a': ('Foram pagos R$ ' ~ ("{:,.2f}".format(valor_pago_total|float)|replace(',', '#')|replace('.', ',')|replace('#', '.')) ~ ' em ' ~ empenhos|length|string ~ ' empenhos vinculados a ' ~ _lic ~ ' (consulta agregada do TCE-PB). Veja a secao de Empenhos para a lista detalhada com datas, elementos de despesa e valores individuais.') if valor_pago_total > 0 else ('Nao localizamos empenhos pagos vinculados diretamente a ' ~ _lic ~ ' nos dados atuais do TCE-PB. Isso pode indicar contrato ainda em curso, pagamento via outra licitacao, ou divergencia nos snapshots disponiveis.'),
+        'links': [
+            {'label': 'Lista de empenhos', 'href': '#empenhos'},
+        ],
+    },
+    {
+        'q': 'O que significa a modalidade ' ~ modalidade ~ '?',
+        'a': 'A modalidade ' ~ modalidade ~ ' eh um dos tipos de processo licitatorio previstos na Lei 14.133/2021 (Nova Lei de Licitacoes) ou na Lei 8.666/1993. Cada modalidade tem regras especificas sobre publicidade, prazo, criterio de julgamento e limite de valor. Consulte tambem as outras licitacoes da mesma modalidade neste municipio para comparacao.',
+        'links': [
+            {'label': 'Outras licitacoes desta modalidade em ' ~ municipio, 'href': '#outras-modalidade'},
+            {'label': 'Glossario', 'href': '/glossario'},
+        ],
+    },
+    {
+        'q': 'Onde encontrar dados oficiais sobre esta licitacao?',
+        'a': 'Os dados publicados nesta pagina vem do TCE-PB (Tribunal de Contas do Estado da Paraiba) — dados-abertos.tce.pb.gov.br/dados-consolidados. Para o edital original e atos do processo, consulte o portal de transparencia do proprio ' ~ _orgao ~ ' (' ~ municipio ~ '). Erros ou divergencias podem ser reportados pelo nosso canal.',
+        'links': [
+            {'label': 'Site do TCE-PB', 'href': 'https://tce.pb.gov.br', 'external': true},
+            {'label': 'Metodologia', 'href': '/sobre'},
+            {'label': 'Reportar correcao', 'href': '/contato'},
+        ],
+    },
+] %}
+
+{{ faq_section(_faqs, title='Perguntas frequentes', anchor='faq-licitacao') }}

--- a/web/templates/results/cidade_resumo.html
+++ b/web/templates/results/cidade_resumo.html
@@ -1,0 +1,267 @@
+{% extends "base.html" %}
+{% block title %}Gastos de {{ municipio|clean_text }} em {{ mes_nome_cap }}/{{ ano }}{% endblock %}
+{% block meta_description %}{{ meta_description }}{% endblock %}
+{% block og_title %}Gastos publicos de {{ municipio|clean_text }}/PB em {{ mes_nome_cap }} {{ ano }} | TransparenciaPB{% endblock %}
+{% block og_description %}{{ meta_description }}{% endblock %}
+{% block og_type %}article{% endblock %}
+{% block json_ld_extra %}
+{% set origin = request_origin(request) if request else '' %}
+{% set page_url = origin + '/cidade/' + municipio_slug + '/' + yyyymm %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": {{ (municipio|clean_text) | tojson }}, "item": "{{ origin }}/cidade/{{ municipio_slug }}"},
+        {"@type": "ListItem", "position": 3, "name": {{ (mes_nome_cap ~ "/" ~ ano) | tojson }}, "item": {{ page_url | tojson }} }
+      ]
+    },
+    {
+      "@type": "Article",
+      "headline": {{ ("Gastos publicos de " ~ municipio ~ "/PB em " ~ mes_nome_cap ~ " de " ~ ano) | clean_text | tojson }},
+      "description": {{ meta_description | tojson }},
+      "url": {{ page_url | tojson }},
+      "inLanguage": "pt-BR",
+      "isAccessibleForFree": true,
+      "about": {
+        "@type": "AdministrativeArea",
+        "name": {{ (municipio ~ "/PB") | clean_text | tojson }}
+      },
+      "publisher": {
+        "@type": "Organization",
+        "@id": "{{ origin }}/#organization",
+        "name": "TransparenciaPB",
+        "url": "{{ origin }}/"
+      }
+    }
+  ]
+}
+</script>
+{% endblock %}
+
+{% block content %}
+<article class="cidade-resumo-page empresa-page">
+    <header class="empresa-section empresa-hero">
+        <p class="text-sm text-muted">
+            <a href="/cidade/{{ municipio_slug }}">{{ municipio|clean_text }}/PB</a>
+            &middot; Resumo mensal
+        </p>
+        <h1>Gastos publicos de {{ municipio|clean_text }} em {{ mes_nome_cap }} de {{ ano }}</h1>
+        <p class="text-base">
+            Pagamentos, fornecedores, modalidades de licitacao e empenhos consolidados do mes,
+            com dados oficiais do TCE-PB.
+        </p>
+        <div class="stats-grid" style="margin-top:1rem">
+            <div class="stat-cell">
+                <span class="stat-value">R$ {{ "%0.0f"|format(aggs.total_pago or 0)|replace(",", ".") }}</span>
+                <span class="stat-label">Total pago no mes</span>
+            </div>
+            <div class="stat-cell">
+                <span class="stat-value">{{ aggs.qtd_empenhos or 0 }}</span>
+                <span class="stat-label">Empenhos</span>
+            </div>
+            <div class="stat-cell">
+                <span class="stat-value">{{ aggs.qtd_fornecedores_unicos or 0 }}</span>
+                <span class="stat-label">Fornecedores unicos</span>
+            </div>
+            <div class="stat-cell">
+                <span class="stat-value">{{ top_licitacoes|length }}</span>
+                <span class="stat-label">Licitacoes homologadas</span>
+            </div>
+        </div>
+
+        {% if delta_mes_ant_pct is not none or delta_ano_ant_pct is not none %}
+        <div class="text-sm" style="margin-top:1rem">
+            <strong>Comparativos:</strong>
+            {% if delta_mes_ant_pct is not none %}
+                vs mes anterior:
+                <span class="{% if delta_mes_ant_pct > 0 %}text-red{% else %}text-green{% endif %}">{{ "%+.1f"|format(delta_mes_ant_pct) }}%</span>
+            {% endif %}
+            {% if delta_ano_ant_pct is not none %}
+                {% if delta_mes_ant_pct is not none %} &middot; {% endif %}
+                vs mesmo mes de {{ ano_anterior }}:
+                <span class="{% if delta_ano_ant_pct > 0 %}text-red{% else %}text-green{% endif %}">{{ "%+.1f"|format(delta_ano_ant_pct) }}%</span>
+            {% endif %}
+        </div>
+        {% endif %}
+
+        {% if aggs.qtd_sem_licitacao and aggs.qtd_sem_licitacao > 0 %}
+        <p class="text-sm" style="margin-top:.5rem">
+            <span class="badge badge-yellow">Atencao</span>
+            {{ aggs.qtd_sem_licitacao }} empenhos sem licitacao
+            ({{ "%0.0f"|format((aggs.total_sem_licitacao / (aggs.total_pago or 1)) * 100) }}% do total pago).
+        </p>
+        {% endif %}
+    </header>
+
+    {% if top_fornecedores %}
+    <section class="empresa-section" id="top-fornecedores">
+        <h2>Top fornecedores do mes</h2>
+        <div class="tbl-wrap">
+            <table class="dialog-table stack-mobile">
+                <thead>
+                    <tr>
+                        <th>Empresa</th>
+                        <th class="text-right">Total pago</th>
+                        <th class="text-right">Empenhos</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for f in top_fornecedores %}
+                    <tr>
+                        <td data-label="Empresa" class="stack-title">
+                            {% if f.cnpj_completo %}
+                                <a href="/empresa/{{ f.cnpj_completo }}">{{ f.razao_social|clean_text }}</a>
+                            {% else %}
+                                {{ f.razao_social|clean_text }}
+                            {% endif %}
+                        </td>
+                        <td data-label="Total pago" class="text-right num">R$ {{ "%0.2f"|format(f.total_pago or 0)|replace(".", "@")|replace(",", ".")|replace("@", ",") }}</td>
+                        <td data-label="Empenhos" class="text-right num">{{ f.qtd_empenhos or 0 }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
+    {% if top_elementos %}
+    <section class="empresa-section" id="top-elementos">
+        <h2>Categorias de gasto</h2>
+        <div class="tbl-wrap">
+            <table class="dialog-table stack-mobile">
+                <thead>
+                    <tr>
+                        <th>Elemento</th>
+                        <th class="text-right">Total pago</th>
+                        <th class="text-right">Empenhos</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for e in top_elementos %}
+                    <tr>
+                        <td data-label="Elemento" class="stack-title">{{ e.elemento_despesa|clean_text }}</td>
+                        <td data-label="Total pago" class="text-right num">R$ {{ "%0.2f"|format(e.total_pago or 0)|replace(".", "@")|replace(",", ".")|replace("@", ",") }}</td>
+                        <td data-label="Empenhos" class="text-right num">{{ e.qtd_empenhos or 0 }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
+    {% if modalidades %}
+    <section class="empresa-section" id="modalidades">
+        <h2>Pagamentos por modalidade de licitacao</h2>
+        <div class="tbl-wrap">
+            <table class="dialog-table stack-mobile">
+                <thead>
+                    <tr>
+                        <th>Modalidade</th>
+                        <th class="text-right">Total pago</th>
+                        <th class="text-right">Empenhos</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for m in modalidades %}
+                    <tr>
+                        <td data-label="Modalidade" class="stack-title">{{ m.modalidade|clean_text }}</td>
+                        <td data-label="Total pago" class="text-right num">R$ {{ "%0.2f"|format(m.total_pago or 0)|replace(".", "@")|replace(",", ".")|replace("@", ",") }}</td>
+                        <td data-label="Empenhos" class="text-right num">{{ m.qtd_empenhos or 0 }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
+    {% if top_empenhos %}
+    <section class="empresa-section" id="top-empenhos">
+        <h2>Maiores empenhos do mes</h2>
+        <p class="text-sm text-muted">Apenas pagamentos a pessoas juridicas (empresas).</p>
+        <div class="tbl-wrap">
+            <table class="dialog-table stack-mobile">
+                <thead>
+                    <tr>
+                        <th>Data</th>
+                        <th>Empenho</th>
+                        <th>Empresa</th>
+                        <th>Elemento</th>
+                        <th class="text-right">Pago</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for e in top_empenhos %}
+                    <tr>
+                        <td data-label="Data" class="stack-meta">{% if e.data_empenho %}{{ e.data_empenho[8:10] }}/{{ e.data_empenho[5:7] }}{% else %}-{% endif %}</td>
+                        <td data-label="Empenho" class="stack-meta"><code>{{ e.numero_empenho|clean_text or "-" }}</code></td>
+                        <td data-label="Empresa" class="stack-title">
+                            {% if e.cnpj_completo %}
+                                <a href="/empresa/{{ e.cnpj_completo }}">{{ e.razao_social|clean_text }}</a>
+                            {% else %}
+                                {{ e.razao_social|clean_text }}
+                            {% endif %}
+                        </td>
+                        <td data-label="Elemento" class="stack-meta">{{ e.elemento_despesa|clean_text or "-" }}</td>
+                        <td data-label="Pago" class="text-right num">R$ {{ "%0.2f"|format(e.valor_pago or 0)|replace(".", "@")|replace(",", ".")|replace("@", ",") }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
+    {% if top_licitacoes %}
+    <section class="empresa-section" id="top-licitacoes">
+        <h2>Licitacoes homologadas no mes</h2>
+        <ul>
+            {% for lic in top_licitacoes %}
+            <li>
+                <a href="/licitacao/{{ municipio_slug }}/{{ lic.ano_licitacao }}/{{ lic.ug_slug }}/{{ lic.mod_num_slug }}">
+                    <strong>{{ lic.modalidade|clean_text }} {{ lic.numero_licitacao|clean_text }}</strong>
+                    &mdash; {{ (lic.objeto_licitacao or '')|clean_text|truncate(120) }}
+                </a>
+                <div class="text-sm text-muted">
+                    {{ lic.descricao_ug|clean_text or "Prefeitura" }}
+                    {% if lic.data_homologacao %} &middot; Homologada em {{ lic.data_homologacao[8:10] }}/{{ lic.data_homologacao[5:7] }}/{{ lic.data_homologacao[0:4] }}{% endif %}
+                    {% if lic.valor_total and lic.valor_total > 0 %} &middot; Valor: R$ {{ "%0.2f"|format(lic.valor_total)|replace(".", "@")|replace(",", ".")|replace("@", ",") }}{% endif %}
+                </div>
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+
+    <nav class="empresa-section" id="navegacao">
+        <h2>Navegacao temporal</h2>
+        <ul style="display:flex;flex-wrap:wrap;gap:1rem;list-style:none;padding:0">
+            <li><a href="/cidade/{{ municipio_slug }}/{{ mes_anterior_yyyymm }}">&larr; {{ mes_anterior_m }}/{{ mes_anterior_y }} (mes anterior)</a></li>
+            <li><a href="/cidade/{{ municipio_slug }}/{{ ano_anterior }}-{{ "%02d"|format(mes) }}">Mesmo mes em {{ ano_anterior }}</a></li>
+            <li><a href="/cidade/{{ municipio_slug }}">Perfil completo de {{ municipio|clean_text }}</a></li>
+        </ul>
+    </nav>
+
+    <section class="empresa-section empresa-fontes">
+        <h2>Fontes oficiais</h2>
+        <p class="text-sm text-muted">
+            Dados oficiais do TCE-PB (Tribunal de Contas do Estado da Paraiba). Cadastros de
+            empresas (CNPJ) da Receita Federal. As prefeituras municipais reportam empenhos,
+            liquidacoes e pagamentos conforme a Lei de Acesso a Informacao (Lei 12.527/2011)
+            e a LRF (LC 101/2000). Mes contabil deriva da data do empenho.
+        </p>
+        <p class="text-sm">
+            <a href="/sobre">Metodologia e fontes</a> &middot;
+            <a href="/contato">Reportar correcao</a>
+        </p>
+    </section>
+
+    {% include "partials/seo/_faq_cidade_resumo.html" %}
+</article>
+{% endblock %}

--- a/web/templates/results/licitacao.html
+++ b/web/templates/results/licitacao.html
@@ -1,0 +1,214 @@
+{% extends "base.html" %}
+{% block title %}Licitacao {{ modalidade }} {{ numero_licitacao }}/{{ ano }} - {{ municipio|clean_text }}{% endblock %}
+{% block meta_description %}{{ meta_description }}{% endblock %}
+{% block og_title %}Licitacao {{ modalidade }} {{ numero_licitacao }}/{{ ano }} - {{ municipio|clean_text }}/PB | TransparenciaPB{% endblock %}
+{% block og_description %}{{ meta_description }}{% endblock %}
+{% block og_type %}article{% endblock %}
+{% block json_ld_extra %}
+{% set origin = request_origin(request) if request else '' %}
+{% set page_url = origin + '/licitacao/' + municipio_slug + '/' + (ano|string) + '/' + ug_slug + '/' + mod_num_slug %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "{{ origin }}/"},
+        {"@type": "ListItem", "position": 2, "name": {{ (municipio|clean_text) | tojson }}, "item": "{{ origin }}/cidade/{{ municipio_slug }}"},
+        {"@type": "ListItem", "position": 3, "name": "Licitacoes", "item": "{{ origin }}/cidade/{{ municipio_slug }}#licitacoes"},
+        {"@type": "ListItem", "position": 4, "name": {{ ("Licitacao " ~ modalidade ~ " " ~ numero_licitacao ~ "/" ~ ano) | clean_text | tojson }}, "item": {{ page_url | tojson }} }
+      ]
+    },
+    {
+      "@type": "Article",
+      "headline": {{ ("Licitacao " ~ modalidade ~ " " ~ numero_licitacao ~ "/" ~ ano ~ " - " ~ (detail.descricao_ug or "Prefeitura") ~ " - " ~ municipio) | clean_text | tojson }},
+      "description": {{ meta_description | tojson }},
+      "url": {{ page_url | tojson }},
+      "inLanguage": "pt-BR",
+      "isAccessibleForFree": true,
+      "about": {
+        "@type": "GovernmentOrganization",
+        "name": {{ (detail.descricao_ug or ("Prefeitura de " ~ municipio)) | clean_text | tojson }},
+        "areaServed": {
+          "@type": "AdministrativeArea",
+          "name": {{ (municipio ~ "/PB") | clean_text | tojson }}
+        }
+      },
+      "publisher": {
+        "@type": "Organization",
+        "@id": "{{ origin }}/#organization",
+        "name": "TransparenciaPB",
+        "url": "{{ origin }}/"
+      }
+    }
+  ]
+}
+</script>
+{% endblock %}
+
+{% block content %}
+<article class="licitacao-page empresa-page">
+    <header class="empresa-section empresa-hero">
+        <p class="text-sm text-muted">
+            <a href="/cidade/{{ municipio_slug }}">{{ municipio|clean_text }}/PB</a>
+            &middot; <a href="/cidade/{{ municipio_slug }}/{{ ano }}-{% if detail.data_homologacao %}{{ detail.data_homologacao[5:7] }}{% else %}01{% endif %}">{{ ano }}</a>
+            &middot; Licitacao publica
+        </p>
+        <h1>Licitacao {{ modalidade|clean_text }} {{ numero_licitacao|clean_text }}/{{ ano }}</h1>
+        <p class="text-base">
+            <strong>{{ detail.descricao_ug|clean_text or "Prefeitura" }}</strong>
+            &middot; {{ municipio|clean_text }}/PB
+            {% if detail.data_homologacao %} &middot; Homologada em {{ detail.data_homologacao[8:10] }}/{{ detail.data_homologacao[5:7] }}/{{ detail.data_homologacao[0:4] }}{% endif %}
+        </p>
+        <div class="stats-grid" style="margin-top:1rem">
+            <div class="stat-cell">
+                <span class="stat-value">{{ proponentes|length }}</span>
+                <span class="stat-label">Proponentes</span>
+            </div>
+            {% if valor_contratado > 0 %}
+            <div class="stat-cell">
+                <span class="stat-value">R$ {{ "%0.0f"|format(valor_contratado)|replace(",", ".") }}</span>
+                <span class="stat-label">Valor contratado</span>
+            </div>
+            {% endif %}
+            {% if valor_pago_total > 0 %}
+            <div class="stat-cell">
+                <span class="stat-value">R$ {{ "%0.0f"|format(valor_pago_total)|replace(",", ".") }}</span>
+                <span class="stat-label">Total pago aos vencedores</span>
+            </div>
+            {% endif %}
+            <div class="stat-cell">
+                <span class="stat-value">{{ empenhos|length }}</span>
+                <span class="stat-label">Empenhos vinculados</span>
+            </div>
+        </div>
+    </header>
+
+    {% if detail.objeto_licitacao %}
+    <section class="empresa-section" id="objeto">
+        <h2>Objeto da licitacao</h2>
+        <p style="line-height:1.6">{{ detail.objeto_licitacao|clean_text }}</p>
+    </section>
+    {% endif %}
+
+    {% if proponentes %}
+    <section class="empresa-section" id="proponentes">
+        <h2>Proponentes</h2>
+        <p class="text-sm text-muted">Empresas que apresentaram proposta nesta licitacao. Vencedor destacado.</p>
+        <div class="tbl-wrap">
+            <table class="dialog-table stack-mobile">
+                <thead>
+                    <tr>
+                        <th>Empresa</th>
+                        <th class="text-right">Valor ofertado</th>
+                        <th>Situacao</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for p in proponentes %}
+                    <tr {% if loop.first %}class="row-vencedor"{% endif %}>
+                        <td data-label="Empresa" class="stack-title">
+                            {% if p.cnpj_completo %}
+                                <a href="/empresa/{{ p.cnpj_completo }}">{{ p.razao_social|clean_text }}</a>
+                            {% else %}
+                                {{ p.razao_social|clean_text }}
+                            {% endif %}
+                            {% if loop.first %}<span class="badge badge-green">Vencedor</span>{% endif %}
+                        </td>
+                        <td data-label="Valor" class="text-right num">R$ {{ "%0.2f"|format(p.valor_ofertado or 0)|replace(".", "@")|replace(",", ".")|replace("@", ",") }}</td>
+                        <td data-label="Situacao" class="stack-meta">{{ p.situacao_proposta|clean_text or "-" }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
+    {% if empenhos %}
+    <section class="empresa-section" id="empenhos">
+        <h2>Empenhos vinculados ({{ empenhos|length }})</h2>
+        <p class="text-sm text-muted">Pagamentos efetuados pelo orgao referentes a esta licitacao. Top 50 por valor pago.</p>
+        <div class="tbl-wrap">
+            <table class="dialog-table stack-mobile">
+                <thead>
+                    <tr>
+                        <th>Data</th>
+                        <th>Empenho</th>
+                        <th>Credor</th>
+                        <th>Elemento</th>
+                        <th class="text-right">Pago</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for e in empenhos %}
+                    <tr>
+                        <td data-label="Data" class="stack-meta">{% if e.data_empenho %}{{ e.data_empenho[8:10] }}/{{ e.data_empenho[5:7] }}/{{ e.data_empenho[0:4] }}{% else %}-{% endif %}</td>
+                        <td data-label="Empenho" class="stack-meta"><code>{{ e.numero_empenho|clean_text or "-" }}</code></td>
+                        <td data-label="Credor" class="stack-title">
+                            {% if e.cnpj_completo %}
+                                <a href="/empresa/{{ e.cnpj_completo }}">{{ e.razao_social|clean_text }}</a>
+                            {% else %}
+                                {{ e.razao_social|clean_text }}
+                            {% endif %}
+                        </td>
+                        <td data-label="Elemento" class="stack-meta">{{ e.elemento_despesa|clean_text or "-" }}</td>
+                        <td data-label="Pago" class="text-right num">R$ {{ "%0.2f"|format(e.valor_pago or 0)|replace(".", "@")|replace(",", ".")|replace("@", ",") }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
+    {% if outras_orgao %}
+    <section class="empresa-section" id="outras-orgao">
+        <h2>Outras licitacoes do mesmo orgao em {{ ano }}</h2>
+        <ul>
+            {% for o in outras_orgao %}
+            <li>
+                <a href="/licitacao/{{ municipio_slug }}/{{ o.ano_licitacao }}/{{ ug_slug }}/{{ o.mod_num_slug }}">
+                    {{ o.modalidade|clean_text }} {{ o.numero_licitacao|clean_text }} &mdash; {{ (o.objeto_licitacao or '')|clean_text|truncate(100) }}
+                </a>
+                {% if o.data_homologacao %}<span class="text-sm text-muted">({{ o.data_homologacao[8:10] }}/{{ o.data_homologacao[5:7] }}/{{ o.data_homologacao[0:4] }})</span>{% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+
+    {% if outras_modalidade %}
+    <section class="empresa-section" id="outras-modalidade">
+        <h2>Outras {{ modalidade|clean_text|lower }} em {{ municipio|clean_text }}</h2>
+        <ul>
+            {% for o in outras_modalidade %}
+            <li>
+                <a href="/licitacao/{{ municipio_slug }}/{{ o.ano_licitacao }}/{{ o.ug_slug }}/{{ o.mod_num_slug }}">
+                    {{ o.descricao_ug|clean_text or "Prefeitura" }} &middot; {{ o.numero_licitacao|clean_text }} &mdash; {{ (o.objeto_licitacao or '')|clean_text|truncate(80) }}
+                </a>
+                {% if o.data_homologacao %}<span class="text-sm text-muted">({{ o.data_homologacao[8:10] }}/{{ o.data_homologacao[5:7] }}/{{ o.data_homologacao[0:4] }})</span>{% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+
+    <section class="empresa-section empresa-fontes">
+        <h2>Fontes oficiais</h2>
+        <p class="text-sm text-muted">
+            Dados desta licitacao publica vem do TCE-PB (Tribunal de Contas do Estado da Paraiba).
+            Cadastros de empresas (CNPJ) vem da Receita Federal. Empenhos e pagamentos da prefeitura
+            municipal sao reportados ao TCE conforme a Lei de Acesso a Informacao (Lei 12.527/2011)
+            e a LRF (LC 101/2000).
+        </p>
+        <p class="text-sm">
+            <a href="/sobre">Metodologia e fontes</a> &middot;
+            <a href="/contato">Reportar correcao</a>
+        </p>
+    </section>
+
+    {% include "partials/seo/_faq_licitacao.html" %}
+</article>
+{% endblock %}

--- a/web/templates/results/licitacao.html
+++ b/web/templates/results/licitacao.html
@@ -169,7 +169,7 @@
         <ul>
             {% for o in outras_orgao %}
             <li>
-                <a href="/licitacao/{{ municipio_slug }}/{{ o.ano_licitacao }}/{{ ug_slug }}/{{ o.mod_num_slug }}">
+                <a href="/licitacao/{{ municipio_slug }}/{{ o.ano_licitacao }}/{{ o.ug_slug }}/{{ o.mod_num_slug }}">
                     {{ o.modalidade|clean_text }} {{ o.numero_licitacao|clean_text }} &mdash; {{ (o.objeto_licitacao or '')|clean_text|truncate(100) }}
                 </a>
                 {% if o.data_homologacao %}<span class="text-sm text-muted">({{ o.data_homologacao[8:10] }}/{{ o.data_homologacao[5:7] }}/{{ o.data_homologacao[0:4] }})</span>{% endif %}

--- a/web/utils/pii_scrub.py
+++ b/web/utils/pii_scrub.py
@@ -1,0 +1,82 @@
+"""Redaction de PII em texto livre antes de cachear pra paginas indexaveis.
+
+Usado pra `objeto_licitacao`, `historico` de empenho, e qualquer outro
+campo TEXT que pode ter sido digitado por servidor com CPF/RG/email/telefone
+embedded (ex: "Pagamento a Joao Silva CPF 123.456.789-01" ou "Contratacao
+de servico para paciente Maria CNH 12345678").
+
+Conservador deliberadamente: false-positives sao OK (perdemos um pouco de
+texto legitimo); false-negatives expoem PII indexada. Por isso o regex
+de CPF eh agressivo (qualquer 11 digitos consecutivos).
+
+Aplicado no warm/compute ANTES de salvar na cache. Cache fica limpo.
+P1 GPT 5.5 review PR #108.
+"""
+from __future__ import annotations
+
+import re
+
+# CPF: 11 digitos com ou sem mascara. Casa "123.456.789-01", "12345678901",
+# "***.456.789-**". Captura tambem "CPF: 123.456.789-01" e similares.
+# Inclui sequencias de 11 digitos puros (mesmo sem rotulo) — agressivo.
+_CPF_RE = re.compile(
+    r"\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b"
+    r"|"
+    r"\*{3}\.?\d{3}\.?\d{3}-?\*{2}",
+)
+
+# RG (varia muito por estado, mas formato comum: 7-10 digitos +/- DV).
+# Pegamos "RG: <numeros>" ou "RG <numeros>".
+_RG_RE = re.compile(r"\bRG\s*:?\s*[\d.\-X]{7,12}\b", re.IGNORECASE)
+
+# Email
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+# Telefone brasileiro: (83) 9 9999-9999, (83)99999-9999, 83 99999 9999, etc.
+# Pega 10-11 digitos com separadores opcionais (parenteses, espaco, hifen).
+_PHONE_RE = re.compile(
+    r"\(?\d{2}\)?\s*9?\s*\d{4}[-\s]?\d{4}\b"
+    r"|"
+    r"\b\d{2}\s*9?\d{4}[-\s]?\d{4}\b",
+)
+
+
+def scrub_pii(text: str | None) -> str | None:
+    """Substitui CPF/RG/email/telefone embedded em texto livre por placeholders.
+
+    Returns None se input eh None. String vazia se input eh vazia.
+
+    >>> scrub_pii("Pagamento a Maria CPF 123.456.789-01")
+    'Pagamento a Maria [CPF removido]'
+    >>> scrub_pii("Contato joao@exemplo.com tel (83) 99999-9999")
+    'Contato [email removido] tel [telefone removido]'
+    >>> scrub_pii("RG: 1234567-X documento de identidade")
+    '[RG removido] documento de identidade'
+    >>> scrub_pii(None)
+    >>> scrub_pii("")
+    ''
+    """
+    if text is None:
+        return None
+    if not text:
+        return text
+    s = str(text)
+    s = _CPF_RE.sub("[CPF removido]", s)
+    s = _RG_RE.sub("[RG removido]", s)
+    s = _EMAIL_RE.sub("[email removido]", s)
+    s = _PHONE_RE.sub("[telefone removido]", s)
+    return s
+
+
+def scrub_pii_dict(d: dict, keys: list[str]) -> dict:
+    """Aplica scrub_pii nas chaves especificadas do dict (in-place + return).
+
+    Caller passa explicitamente as chaves de texto livre — evita scrub
+    overzealous em campos estruturados que coincidentemente tem digitos.
+    """
+    if not d:
+        return d
+    for k in keys:
+        if k in d and d[k]:
+            d[k] = scrub_pii(d[k])
+    return d

--- a/web/utils/slug.py
+++ b/web/utils/slug.py
@@ -177,3 +177,73 @@ def all_municipios_slugged() -> dict[str, str]:
     Levanta SlugLookupError no cold start sem fallback.
     """
     return dict(_ensure_cache())
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helpers pra paginas de transacao publica (/licitacao, /cidade/<slug>/<yyyy-mm>)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_YYYY_MM_RE = re.compile(r"^(?P<yyyy>\d{4})-(?P<mm>\d{2})$")
+
+
+def numero_slug(numero: str) -> str:
+    """Slug pra numero_licitacao / numero_empenho: lowercase, dedup hifens.
+
+    TCE-PB tem formatos variados: '001/2025', '2025NE000282', '00028-2025',
+    'PP 001/2024'. Normalizamos canonicamente pra string URL-safe.
+
+    >>> numero_slug('001/2025')
+    '001-2025'
+    >>> numero_slug('PP 001/2024')
+    'pp-001-2024'
+    >>> numero_slug('2025NE000282')
+    '2025ne000282'
+    """
+    if not numero:
+        return ""
+    s = str(numero).lower().strip()
+    # Remove acentos (raro mas defensive)
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("ascii")
+    # Tudo nao-alfanumerico vira hifen
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    # Dedupe hifens
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-")
+
+
+def parse_yyyymm(s: str) -> tuple[int, int] | None:
+    """Parse '<yyyy>-<mm>' com bounds 2018-2099 / 01-12.
+
+    Retorna (yyyy, mm) int ou None se invalido. Usado pela rota
+    /cidade/<slug>/<yyyy>-<mm> e pela parsing de mes em sitemap.
+
+    >>> parse_yyyymm('2024-03')
+    (2024, 3)
+    >>> parse_yyyymm('2030-12')
+    (2030, 12)
+    >>> parse_yyyymm('2024-13')
+    >>> parse_yyyymm('99-03')
+    >>> parse_yyyymm('2024-3')
+    """
+    if not s:
+        return None
+    m = _YYYY_MM_RE.fullmatch(str(s).strip())
+    if not m:
+        return None
+    yyyy = int(m.group("yyyy"))
+    mm = int(m.group("mm"))
+    if not (2018 <= yyyy <= 2099):
+        return None
+    if not (1 <= mm <= 12):
+        return None
+    return yyyy, mm
+
+
+def format_yyyymm(yyyy: int, mm: int) -> str:
+    """Format inverso pro path canonico.
+
+    >>> format_yyyymm(2024, 3)
+    '2024-03'
+    """
+    return f"{yyyy:04d}-{mm:02d}"

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -1212,9 +1212,13 @@ def main():
         ok_p, fail_p = warm_cycle_pb(municipios_pb)
         ok_e = fail_e = skip_e = 0
         ok_em = fail_em = skip_em = 0
+        ok_l = fail_l = skip_l = 0
+        ok_r = fail_r = skip_r = 0
         if not skip_empresas_flag:
             ok_e, fail_e, skip_e = _warm_empresas_phase()
             ok_em, fail_em, skip_em = _warm_empresas_municipios_phase()
+            ok_l, fail_l, skip_l = _warm_licitacoes_phase()
+            ok_r, fail_r, skip_r = _warm_cidade_resumo_phase()
         # Shadow swap: apos TODO trabalho do ciclo terminar, fazemos os
         # swaps atomicos (UMA transacao cobrindo todos os qids elegiveis)
         # das qids que estavam em shadow E completaram sem falhas.
@@ -1222,13 +1226,17 @@ def main():
         # rows" step no proximo deploy descarta o shadow stale antes de
         # reprocessar.
         # Importante: swap acontece UMA VEZ por ciclo, depois das fases
-        # PB + empresas + empresas_municipios. Garante que KPI_SUMMARY
-        # (derived) ja foi computado contra o shadow de PERFIL antes do
-        # swap dos deps.
+        # PB + empresas + empresas_municipios + licitacoes + cidade_resumo.
+        # Garante que KPI_SUMMARY (derived) ja foi computado contra o
+        # shadow de PERFIL antes do swap dos deps.
         _swap_all_pending_shadows(verbose=True)
         # Reset tracking pra eventual proximo ciclo (mode --loop).
         _shadow_results.clear()
-        return ok_p + ok_e + ok_em, fail_p + fail_e + fail_em, skip_e + skip_em
+        return (
+            ok_p + ok_e + ok_em + ok_l + ok_r,
+            fail_p + fail_e + fail_em + fail_l + fail_r,
+            skip_e + skip_em + skip_l + skip_r,
+        )
 
     if args.daemon:
         print(f"Daemon mode: {len(municipios_pb)} PB municipios.")
@@ -1589,6 +1597,302 @@ def _warm_empresas_municipios_phase() -> tuple[int, int, int]:
             pass
 
     return ok, fail, skipped_resume + skip_nf
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Licitacoes — warm /licitacao/<mun>/<ano>/<ug>/<mod-num>
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _warm_licitacoes_phase() -> tuple[int, int, int]:
+    """Fase de warming de licitacoes. Cada licitacao qualificada (>=1
+    proponente PJ) vira uma pagina.
+
+    Returns: (ok, fail, skipped). skipped = ja cacheados (resume) +
+    licitacoes que nao retornaram dados (skip_nf).
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from web.queries.licitacao import LICITACOES_QUALIFICADAS_PAGINATED
+    from web.routes.licitacao import (
+        CACHE_QUERY_ID as LIC_CACHE_QID,
+        LicitacaoNotFoundError,
+        _build_cache_key,
+        _build_mod_num_slug,
+        compute_licitacao_dict,
+    )
+    from web.utils.slug import municipio_slug as _mun_slug, numero_slug as _num_slug
+
+    print("--- Licitacoes: enumerando qualificadas ---")
+    boot = psycopg2.connect(DSN)
+    boot.autocommit = True
+    all_lics: list[tuple[str, int, str, str, str, str]] = []
+    try:
+        with boot.cursor() as cur:
+            # Sem paginacao aqui — pegamos todas. Em prod, ajustar pra streaming
+            # se ultrapassar memoria (improvavel com ~80k linhas + 5 strings cada).
+            cur.execute(
+                LICITACOES_QUALIFICADAS_PAGINATED,
+                {"limit": 1000000, "offset": 0},
+            )
+            for municipio, ano, codigo_ug, descricao_ug, modalidade, numero in cur.fetchall():
+                if not (municipio and ano and codigo_ug and modalidade and numero):
+                    continue
+                all_lics.append((
+                    str(municipio), int(ano), str(codigo_ug),
+                    str(descricao_ug or ""), str(modalidade), str(numero),
+                ))
+    finally:
+        boot.close()
+
+    if not all_lics:
+        print("[licitacoes] Nenhuma qualificada. Skipping.")
+        return 0, 0, 0
+
+    # Constroi keys canonicas (com slugs) pra checar cache
+    lic_by_key: dict[str, tuple] = {}
+    keys: list[str] = []
+    for municipio, ano, codigo_ug, descricao_ug, modalidade, numero in all_lics:
+        mun_slug = _mun_slug(municipio)
+        if not mun_slug:
+            continue
+        ug_slug = _num_slug(descricao_ug) or "prefeitura"
+        mod_num_slug = _build_mod_num_slug(modalidade, numero)
+        if not mod_num_slug:
+            continue
+        key = _build_cache_key(mun_slug, ano, ug_slug, mod_num_slug)
+        lic_by_key[key] = (municipio, ano, codigo_ug, modalidade, numero)
+        keys.append(key)
+
+    if not keys:
+        return 0, 0, 0
+
+    remaining_keys, skipped_resume = _filter_cached_munis(LIC_CACHE_QID, keys)
+    if skipped_resume > 0:
+        print(
+            f"[licitacoes] {_skip_mode_label()}: {skipped_resume} ja cacheadas, "
+            f"processando {len(remaining_keys)} restantes."
+        )
+
+    if not remaining_keys:
+        return 0, 0, skipped_resume
+
+    from web import db as web_db
+    web_db.init_pool()
+
+    def _warm_one(key: str) -> tuple[bool, str | None]:
+        try:
+            municipio, ano, codigo_ug, modalidade, numero = lic_by_key[key]
+            data = compute_licitacao_dict(
+                municipio, ano, codigo_ug, modalidade, numero,
+                timeout_sec=TIMEOUT_PROFILE_WARM,
+            )
+            conn = _thread_conn()
+            with conn.cursor() as cur:
+                _upsert(
+                    cur,
+                    _effective_qid(LIC_CACHE_QID),
+                    key,
+                    ["payload"],
+                    [[data]],
+                )
+            conn.commit()
+            return True, None
+        except LicitacaoNotFoundError as e:
+            return False, f"not_found:{e}"
+        except Exception as e:
+            try:
+                _thread_conn().rollback()
+            except Exception:
+                pass
+            return False, f"compute_failed:{str(e).splitlines()[0]}"
+
+    total = len(remaining_keys)
+    print(
+        f"[licitacoes] Warming {total} licitacoes em {PARALLEL_WORKERS} workers...",
+        flush=True,
+    )
+    ok = fail = skipped_nf = 0
+    t0 = time.time()
+    try:
+        with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as ex:
+            futures = {ex.submit(_warm_one, k): k for k in remaining_keys}
+            done = 0
+            for fut in as_completed(futures):
+                done += 1
+                try:
+                    success, msg = fut.result()
+                except Exception as e:
+                    success, msg = False, f"future_exception:{e}"
+                if success:
+                    ok += 1
+                elif msg and msg.startswith("not_found:"):
+                    skipped_nf += 1
+                else:
+                    fail += 1
+                if done % 200 == 0:
+                    elapsed = time.time() - t0
+                    rate = done / elapsed if elapsed > 0 else 0
+                    eta = (total - done) / rate if rate > 0 else 0
+                    print(
+                        f"[licitacoes] {done}/{total} "
+                        f"({ok} ok, {fail} fail, {skipped_nf} not_found) — "
+                        f"{rate:.1f}/s, eta {eta/60:.1f}min",
+                        flush=True,
+                    )
+    finally:
+        try:
+            web_db.close_pool()
+        except Exception:
+            pass
+
+    elapsed = time.time() - t0
+    print(
+        f"[licitacoes] Completo: {ok} ok, {fail} fail, {skipped_nf} not_found "
+        f"({elapsed/60:.1f}min)",
+        flush=True,
+    )
+    _record_shadow_result(LIC_CACHE_QID, ok, fail)
+    return ok, fail, skipped_resume + skipped_nf
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cidade Resumo Mensal — warm /cidade/<slug>/<yyyy>-<mm>
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _warm_cidade_resumo_phase() -> tuple[int, int, int]:
+    """Fase de warming de resumo mensal de cidade. ~14k paginas
+    (237 munis × ~60 meses).
+
+    Returns: (ok, fail, skipped).
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from web.queries.cidade_resumo import CIDADE_RESUMO_QUALIFICADOS_LIST
+    from web.routes.cidade import CACHE_QUERY_ID_RESUMO, _build_resumo_cache_key
+    from web.routes.cidade_resumo_compute import (
+        CidadeResumoEmpty,
+        compute_cidade_resumo_dict,
+    )
+    from web.utils.slug import municipio_slug as _mun_slug
+
+    print("--- Cidade-resumo: enumerando (mun, ano, mes) qualificados ---")
+    boot = psycopg2.connect(DSN)
+    boot.autocommit = True
+    all_triples: list[tuple[str, int, int]] = []
+    try:
+        with boot.cursor() as cur:
+            cur.execute(CIDADE_RESUMO_QUALIFICADOS_LIST)
+            for municipio, ano, mes, _qtd in cur.fetchall():
+                if not municipio or not ano or not mes:
+                    continue
+                all_triples.append((str(municipio), int(ano), int(mes)))
+    finally:
+        boot.close()
+
+    if not all_triples:
+        print("[cidade-resumo] Nenhum (mun, ano, mes) qualificado. Skipping.")
+        return 0, 0, 0
+
+    triple_by_key: dict[str, tuple[str, int, int]] = {}
+    keys: list[str] = []
+    for municipio, ano, mes in all_triples:
+        mun_slug = _mun_slug(municipio)
+        if not mun_slug:
+            continue
+        key = _build_resumo_cache_key(mun_slug, ano, mes)
+        triple_by_key[key] = (municipio, ano, mes)
+        keys.append(key)
+
+    if not keys:
+        return 0, 0, 0
+
+    remaining_keys, skipped_resume = _filter_cached_munis(CACHE_QUERY_ID_RESUMO, keys)
+    if skipped_resume > 0:
+        print(
+            f"[cidade-resumo] {_skip_mode_label()}: {skipped_resume} ja "
+            f"cacheados, processando {len(remaining_keys)} restantes."
+        )
+
+    if not remaining_keys:
+        return 0, 0, skipped_resume
+
+    from web import db as web_db
+    web_db.init_pool()
+
+    def _warm_one(key: str) -> tuple[bool, str | None]:
+        try:
+            municipio, ano, mes = triple_by_key[key]
+            data = compute_cidade_resumo_dict(
+                municipio, ano, mes,
+                timeout_sec=TIMEOUT_PROFILE_WARM,
+            )
+            conn = _thread_conn()
+            with conn.cursor() as cur:
+                _upsert(
+                    cur,
+                    _effective_qid(CACHE_QUERY_ID_RESUMO),
+                    key,
+                    ["payload"],
+                    [[data]],
+                )
+            conn.commit()
+            return True, None
+        except CidadeResumoEmpty as e:
+            return False, f"empty:{e}"
+        except Exception as e:
+            try:
+                _thread_conn().rollback()
+            except Exception:
+                pass
+            return False, f"compute_failed:{str(e).splitlines()[0]}"
+
+    total = len(remaining_keys)
+    print(
+        f"[cidade-resumo] Warming {total} (mun, ano, mes) em {PARALLEL_WORKERS} workers...",
+        flush=True,
+    )
+    ok = fail = skipped_empty = 0
+    t0 = time.time()
+    try:
+        with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as ex:
+            futures = {ex.submit(_warm_one, k): k for k in remaining_keys}
+            done = 0
+            for fut in as_completed(futures):
+                done += 1
+                try:
+                    success, msg = fut.result()
+                except Exception as e:
+                    success, msg = False, f"future_exception:{e}"
+                if success:
+                    ok += 1
+                elif msg and msg.startswith("empty:"):
+                    skipped_empty += 1
+                else:
+                    fail += 1
+                if done % 200 == 0:
+                    elapsed = time.time() - t0
+                    rate = done / elapsed if elapsed > 0 else 0
+                    eta = (total - done) / rate if rate > 0 else 0
+                    print(
+                        f"[cidade-resumo] {done}/{total} "
+                        f"({ok} ok, {fail} fail, {skipped_empty} empty) — "
+                        f"{rate:.1f}/s, eta {eta/60:.1f}min",
+                        flush=True,
+                    )
+    finally:
+        try:
+            web_db.close_pool()
+        except Exception:
+            pass
+
+    elapsed = time.time() - t0
+    print(
+        f"[cidade-resumo] Completo: {ok} ok, {fail} fail, {skipped_empty} empty "
+        f"({elapsed/60:.1f}min)",
+        flush=True,
+    )
+    _record_shadow_result(CACHE_QUERY_ID_RESUMO, ok, fail)
+    return ok, fail, skipped_resume + skipped_empty
 
 
 if __name__ == "__main__":

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -1623,16 +1623,15 @@ def _warm_licitacoes_phase() -> tuple[int, int, int]:
     from web.utils.slug import municipio_slug as _mun_slug, numero_slug as _num_slug
 
     print("--- Licitacoes: enumerando qualificadas ---")
+    _WARM_LIC_LIMIT = 1000000  # Limite defensivo de fetch in-memory.
     boot = psycopg2.connect(DSN)
     boot.autocommit = True
     all_lics: list[tuple[str, int, str, str, str, str]] = []
     try:
         with boot.cursor() as cur:
-            # Sem paginacao aqui — pegamos todas. Em prod, ajustar pra streaming
-            # se ultrapassar memoria (improvavel com ~80k linhas + 5 strings cada).
             cur.execute(
                 LICITACOES_QUALIFICADAS_PAGINATED,
-                {"limit": 1000000, "offset": 0},
+                {"limit": _WARM_LIC_LIMIT, "offset": 0},
             )
             for municipio, ano, codigo_ug, descricao_ug, modalidade, numero in cur.fetchall():
                 if not (municipio and ano and codigo_ug and modalidade and numero):
@@ -1643,6 +1642,16 @@ def _warm_licitacoes_phase() -> tuple[int, int, int]:
                 ))
     finally:
         boot.close()
+
+    # Detecta truncamento silencioso (S Opus PR #108) — se a base crescer
+    # alem do LIMIT, warmer perderia linhas sem aviso. Loga error e prossegue
+    # com o subset (melhor warm parcial do que crash).
+    if len(all_lics) >= _WARM_LIC_LIMIT:
+        print(
+            f"::error::[licitacoes] Fetch truncado em {_WARM_LIC_LIMIT}. "
+            f"Base de licitacoes cresceu — adapte pra streaming/paginar.",
+            flush=True,
+        )
 
     if not all_lics:
         print("[licitacoes] Nenhuma qualificada. Skipping.")


### PR DESCRIPTION
## Resumo

2 tipos de pagina indexavel novas com long-tail SEO transacional, mirror do padrao /empresa + reuso da infra do PR #105:

1. **`/licitacao/<mun-slug>/<ano>/<ug-slug>/<modalidade-num-slug>`**  perfil de licitacao publica PB. ~50-100k pages estimadas.
2. **`/cidade/<slug>/<yyyy>-<mm>`**  resumo mensal agregado. ~14k pages (237 munis x 60 meses).

## Contexto

Esse PR e o resultado de 3 iteracoes de planejamento com plan review de GPT 5.5 + Opus 4.7:

1. Plan inicial /servidor  **rejeitado por LGPD** (cpf6 + nome + cidade re-identificavel; agregacao + amplificacao via indexacao; anonimato do portal vira agravante).
2. Pivot /empenho + /licitacao + /cidade/resumo  **reject por LGPD** (empenho expoe folha de pagamento PF; numero_empenho natural key tem 10 colunas, nao 4).
3. Escopo final /licitacao + /cidade/resumo: aceitavel, todos os P0/P1 do review aplicados antes de codar.

## URL design (rationale)

### Licitacao: 5 segmentos garantem unicidade absoluta
- `/licitacao/joao-pessoa/2024/secretaria-municipal-de-saude/pregao-presencial-001`
- Tupla `(municipio, ano, codigo_ug, modalidade, numero_licitacao)` eh a unique key real em `tce_pb_licitacao` (verificada empiricamente  multiple UGs/modalidades reusam numeros). 5-tupla evita colisoes que apareceram no spike SQL.
- Cada segmento eh keyword long-tail (orgao, modalidade, numero).

### Resumo cidade: 2 segmentos extras
- `/cidade/joao-pessoa/2024-03`
- Reutiliza namespace `/cidade/<slug>` existente (decisao do user  sem `/resumo/` verb intermediario).

## Conteudo das paginas

**Minimo parity com respectivo dialog + extras long-tail:**

### Licitacao
- Hero: H1 com modalidade + numero + ano + orgao, KPIs (proponentes, valor contratado, total pago, # empenhos)
- Objeto rich text (TEXT completo da licitacao = principal sinal SEO)
- Proponentes com badge "Vencedor" + link `/empresa/<cnpj>`
- Empenhos vinculados (top 50) com link `/empresa`
- Outras licitacoes do mesmo orgao + da mesma modalidade (sidebars)
- FAQ dinamica (5 Qs com links contextuais)
- JSON-LD: BreadcrumbList + Article (about GovernmentOrganization)

### Resumo mensal
- Hero: KPIs com comparativos vs mes anterior + mesmo mes ano-1
- Top 20 fornecedores PJ com link `/empresa`
- Top 20 elementos despesa
- Distribuicao por modalidade
- % pagamentos sem licitacao (badge atencao)
- Top 20 empenhos PJ-only (sem PF nominal)
- Top 10 licitacoes homologadas com link `/licitacao`
- Navegacao temporal (mes anterior, mesmo mes ano-1)
- FAQ dinamica
- JSON-LD: BreadcrumbList + Article (about AdministrativeArea)

## LGPD safeguards

Cache-only com filter PJ por construcao. Salvaguardas em camadas independentes (atendendo P1-7 do Opus review):

**Layer 1 (warm SQL):** inline regex `LENGTH(REGEXP_REPLACE(cpf_cnpj, ''\D'', '''', ''g'')) = 14`
- Conta DIGITOS apos remover mascara, nao chars da string crua.
- Resolve P0-1 do Opus (cpf_cnpj_norm nao existe em tce_pb_*).

**Layer 2 (template via JOIN):** `LEFT JOIN estabelecimento ON LEFT(cpf_clean, 8)`  proponente/credor sem cadastro RFB descartado.

**Layer 3 (route):** cache-only  sem dado nao tem pagina.

## Sitemap

3 env flags gated, mirror empresa:
- `SITEMAP_INCLUDE_LICITACOES` (sharded 49k/shard)
- `SITEMAP_INCLUDE_CIDADE_RESUMO` (urlset unico, ~14k caem em 1 arquivo)

Endpoints novos: `/sitemap-licitacoes-<n>.xml`, `/sitemap-cidade-resumo.xml`.

## Warm cache

2 phases novas integradas no ciclo:
- `_warm_licitacoes_phase`
- `_warm_cidade_resumo_phase`

Shadow rewarm automatico via match exato `LICITACAO_PERFIL` / `CIDADE_RESUMO_MENSAL` (reuso PR #105). Volume estimado: 4-8h adicional em B4 4 workers.

## Dialog links

- `heatmap-dialog.js`: link "Ver pagina completa de <yyyy-mm>" no topo
- `licitacao-dialog.js`: link "Ver pagina completa da licitacao" no topo

Ambos hide quando user ja esta na pagina respectiva (auto-detect via `location.pathname`).

## Deploy.yml

3 toggle inputs novos espelhando empresa:
- `expose_licitacoes_sitemap=keep/enable/disable`
- `expose_cidade_resumo_sitemap=keep/enable/disable`

Steps "Enable X sitemap" completos:
1. Coverage gate >=80% (cache cobrindo qualifying set)
2. Drop-in systemd + restart cruza-web
3. Sitemap-index verification
4. E2E smoke test (5 amostras  HTTP 200, tolera 1 falha)
5. IndexNow re-submit
6. Rollback automatico em qualquer falha

## Decisoes vs plano original

- **DROP `/empenho`**: thin content massivo + MEI/PF exposure via nome_credor + natural key tem 10 colunas em `tce_pb_despesa` (impossivel URL canonica simples). Reviewers explicitamente recomendaram dropar.
- **5-tupla URL licitacao**: spike SQL antes confirmaria, mas adotado por design defensivo (P1-5 do Opus).
- **ano via EXTRACT em resumo**: ano contabil real, nao ano_arquivo (P0-3 do Opus).
- **JSON-LD conservador**: Article+BreadcrumbList apenas. Sem Dataset/MonetaryAmount (P1-11 do Opus  abuso de schema).
- **noindex pra mes vazio**: filter em warm phase pra evitar entrada no cache (P1-10).

## Validacao

- `python -m compileall web etl` 
- `python -c "yaml.safe_load(open(deploy.yml))"` 
- Jinja parse smoke (licitacao.html + cidade_resumo.html + FAQs) 
- Edge cases bash do warm_skip_hours:  (PR #105 herdado)

## Reviewers  angulos pra analisar

**Como nas PRs anteriores, 2 angulos obrigatorios + bugs:**

1. **Complexidade**: 2 tipos simultaneos eh certo? Mirror /empresa demais? Algum lugar onde simplificar?
2. **SEO long-tail effectiveness**: queries listadas captam intencao real? Thin content risk nas paginas mais simples (mes vazio, licitacao com 1 proponente)? Internal linking suficiente? FAQ rephrasing pode gerar near-duplicate?
3. **Privacy edge case**: salvaguardas PJ-only suficientes? `nome_proponente` pode conter info PF mesmo com cpf_cnpj 14 digits (MEI/sole-prop com nome civil)? `objeto_licitacao` text livre pode mencionar CPF/RG/dados sensiveis?
4. **Edge cases tecnicos**:
   - numero_slug round-trip preserva canonical form?
   - Cache key colision entre munis com slugs proximos?
   - Resumo mensal com `data_empenho` NULL? `ano_arquivo` discrepancy?
   - Comparativo SQL params: usa `MAKE_DATE`  testado pra dezembrojaneiro wrap?
5. **Performance**: SQL do RESUMO_TOP_LICITACOES tem CTE + 2 JOINs duplicados (qualifying + valor sum). Custo aceitavel ou refator?
6. **Operacional**: warm 4-8h adicional. web_cache ~500MB extra. PG tolera?