### PR TITLE
fix(web): escape % literal em RESUMO_AGGS_MES (warm cidade-resumo)

### DIFF
--- a/web/queries/cidade_resumo.py
+++ b/web/queries/cidade_resumo.py
@@ -26,13 +26,13 @@ RESUMO_AGGS_MES = """
             WHERE numero_licitacao IS NULL
                OR numero_licitacao = ''
                OR numero_licitacao = '000000000'
-               OR modalidade_licitacao ILIKE '%sem licit%'
+               OR modalidade_licitacao ILIKE '%%sem licit%%'
         ) AS qtd_sem_licitacao,
         COALESCE(SUM(valor_pago) FILTER (
             WHERE numero_licitacao IS NULL
                OR numero_licitacao = ''
                OR numero_licitacao = '000000000'
-               OR modalidade_licitacao ILIKE '%sem licit%'
+               OR modalidade_licitacao ILIKE '%%sem licit%%'
         ), 0) AS total_sem_licitacao
     FROM tce_pb_despesa
     WHERE municipio = %(municipio)s


### PR DESCRIPTION
Bug pre-existente desde commit inicial do PR #108: `ILIKE '%sem licit%'` com placeholders `%(named)s` no mesmo SQL faz psycopg2 falhar com `TypeError: dict is not a sequence`. Estava mascarado pelos timeouts que #109 corrigiu  agora o warm da phase cidade-resumo chega a executar RESUMO_AGGS_MES e bate no escape ausente. Fix: `%sem licit%` -> `%%sem licit%%`. Validado em prod (Patos/Cabedelo/Campina Grande).