### PR TITLE
feat(web): link pra pagina /licitacao no empenho-dialog + robustez licitacao-dialog

### DIFF
--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -2032,16 +2032,28 @@ async def get_empenho_detalhes(payload: dict = Body(...)):
             conn.autocommit = True
             with conn.cursor() as cur:
                 cur.execute("""
-                    SELECT numero_empenho, data_empenho, nome_credor, cpf_cnpj,
-                           valor_empenhado, valor_liquidado, valor_pago,
-                           elemento_despesa, modalidade_licitacao, numero_licitacao,
-                           historico, funcao, subfuncao, programa, acao,
-                           descricao_ug, descricao_unidade_orcamentaria,
-                           descricao_fonte_recurso, categoria_economica,
-                           grupo_natureza_despesa, modalidade_aplicacao,
-                           municipio
-                    FROM tce_pb_despesa
-                    WHERE id = %s
+                    SELECT d.numero_empenho, d.data_empenho, d.nome_credor, d.cpf_cnpj,
+                           d.valor_empenhado, d.valor_liquidado, d.valor_pago,
+                           d.elemento_despesa, d.modalidade_licitacao, d.numero_licitacao,
+                           d.historico, d.funcao, d.subfuncao, d.programa, d.acao,
+                           d.descricao_ug, d.descricao_unidade_orcamentaria,
+                           d.descricao_fonte_recurso, d.categoria_economica,
+                           d.grupo_natureza_despesa, d.modalidade_aplicacao,
+                           d.municipio, d.codigo_ug,
+                           -- ano_licitacao autoritativo via tce_pb_licitacao (5-tupla canonica).
+                           -- LIMIT 1 porque mesma licitacao tem multiplas rows (1 por proponente).
+                           -- Fallback EXTRACT(YEAR FROM data_empenho) quando licitacao nao bate.
+                           COALESCE(
+                               (SELECT l.ano_licitacao FROM tce_pb_licitacao l
+                                WHERE l.municipio = d.municipio
+                                  AND l.codigo_ug = d.codigo_ug
+                                  AND l.modalidade = d.modalidade_licitacao
+                                  AND l.numero_licitacao = d.numero_licitacao
+                                LIMIT 1),
+                               EXTRACT(YEAR FROM d.data_empenho)::int
+                           ) AS ano_licitacao
+                    FROM tce_pb_despesa d
+                    WHERE d.id = %s
                 """, (empenho_id,))
                 cols = [d[0] for d in cur.description]
                 row = cur.fetchone()

--- a/web/static/js/components/empenho-dialog.js
+++ b/web/static/js/components/empenho-dialog.js
@@ -41,6 +41,44 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     title.textContent = `Empenho ${data.numero_empenho}`;
     let html = _historyNote('Historico completo do empenho — este detalhamento nao muda com o filtro de periodo da pagina.');
 
+    // Licitacao vinculada — primeiro bloco logo apos o historico, pra dar
+    // contexto imediato do empenho (qual processo originou o pagamento).
+    // Renderiza como link direto pra /licitacao/<mun>/<ano>/<ug>/<modnum>
+    // quando temos os 5 campos canonicos (mais SEO/conteudo que o dialog).
+    // Fallback: dialog-link abre o dialog quando codigo_ug ausente.
+    {
+        const mod = data.modalidade_licitacao || '';
+        const numLic = data.numero_licitacao || '';
+        const semLic = !numLic || numLic === '000000000' || mod.toLowerCase().includes('sem licit');
+        const empMun = data.municipio || '';
+        if (!semLic) {
+            const _txtSlug = (s) => String(s || '').toLowerCase()
+                .normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+                .replace(/[^a-z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+            const ano = parseInt(data.ano_licitacao) || 0;
+            const cod_ug = data.codigo_ug || data.descricao_ug || '';
+            if (ano && cod_ug && empMun) {
+                const munSlug = _txtSlug(empMun);
+                const ugSlug = _txtSlug(data.descricao_ug) || 'prefeitura';
+                const modSlug = _txtSlug(mod) || 'lic';
+                const numSlug = _txtSlug(numLic) || '0';
+                const pagePath = `/licitacao/${munSlug}/${ano}/${ugSlug}/${modSlug}-${numSlug}`;
+                html += `<div class="dialog-section"><h4>${dualLabel('Origem do gasto (licitacao)','Licitacao vinculada')}</h4>`;
+                html += `<p class="text-sm"><a href="${pagePath}" class="ext-link-inline" title="Ver pagina dedicada desta licitacao (mais detalhes e SEO)">${_esc(mod)} (${_esc(numLic)}) &#8599;</a></p>`;
+                html += '</div>';
+            } else {
+                // Sem ano/ug — fallback pra dialog que ja existe.
+                html += `<div class="dialog-section"><h4>${dualLabel('Origem do gasto (licitacao)','Licitacao vinculada')}</h4>`;
+                html += `<p class="text-sm"><a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="${ano || 0}" data-lic-mun="${_esc(empMun)}">${_esc(mod)} (${_esc(numLic)})</a></p>`;
+                html += '</div>';
+            }
+        } else {
+            html += `<div class="dialog-section"><h4>${dualLabel('Origem do gasto (licitacao)','Licitacao vinculada')}</h4>`;
+            html += '<p class="text-sm"><span class="badge badge-yellow">Sem licitacao</span></p>';
+            html += '</div>';
+        }
+    }
+
     // Historico (descricao detalhada)
     if (data.historico) {
         html += '<div class="dialog-section"><h4>Descricao</h4>';
@@ -109,22 +147,6 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     if (data.descricao_fonte_recurso) html += `<span><strong>${dualLabel('Origem do recurso:','Fonte:')}</strong> ${_esc(data.descricao_fonte_recurso)}</span>`;
     if (data.municipio) html += `<span><strong>Municipio:</strong> ${_esc(data.municipio)}</span>`;
     html += '</div></div>';
-
-    // Licitacao vinculada. Inclui data-mun do proprio empenho — sem ele,
-    // dialog-links.js cai em _currentMunicipio global. Em /empresa/<cnpj>
-    // (global) esse global eh '' e a API devolve vazio. Repassar o
-    // municipio do empenho corrige cross-dialog navigation no perfil
-    // global; nas demais paginas (cidade, empresa-municipio) eh
-    // equivalente ao comportamento atual.
-    const mod = data.modalidade_licitacao || '';
-    const numLic = data.numero_licitacao || '';
-    const semLic = !numLic || numLic === '000000000' || mod.toLowerCase().includes('sem licit');
-    const empMun = data.municipio || '';
-    if (!semLic) {
-        html += `<p class="text-sm mt-2"><strong>Licitacao:</strong> <a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="0" data-lic-mun="${_esc(empMun)}">${_esc(mod)} (${_esc(numLic)})</a></p>`;
-    } else {
-        html += '<p class="text-sm mt-2"><strong>Licitacao:</strong> <span class="badge badge-yellow">Sem licitacao</span></p>';
-    }
     html += '</div>';
 
     body.innerHTML = html;

--- a/web/static/js/components/licitacao-dialog.js
+++ b/web/static/js/components/licitacao-dialog.js
@@ -58,12 +58,14 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
 
     // Link pra pagina dedicada da licitacao (indexavel, mais conteudo).
     // Hide quando ja na pagina /licitacao/X (auto-detect via URL).
-    if (data.licitacao && data.licitacao.descricao_ug && anoLicitacao && numeroLicitacao && municipio && modalidade) {
+    // Mostrar sempre que tiver os 4 campos essenciais; descricao_ug e
+    // opcional (fallback 'prefeitura' no slug).
+    if (anoLicitacao && numeroLicitacao && municipio && modalidade) {
         const _txtSlug = (s) => String(s || '').toLowerCase()
             .normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
             .replace(/[^a-z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
         const munSlug = _txtSlug(municipio);
-        const ugSlug = _txtSlug(data.licitacao.descricao_ug) || 'prefeitura';
+        const ugSlug = _txtSlug(data.licitacao && data.licitacao.descricao_ug) || 'prefeitura';
         const modSlug = _txtSlug(modalidade) || 'lic';
         const numSlug = _txtSlug(numeroLicitacao) || '0';
         const modNumSlug = `${modSlug}-${numSlug}`;


### PR DESCRIPTION
Empenho-dialog: move bloco Licitacao pra topo + renderiza como link real pra `/licitacao/<mun>/<ano>/<ug>/<modnum>` quando tem 5 campos canonicos. Adiciona `codigo_ug`+`ano_licitacao` na API /api/empenho/detalhes (subquery em tce_pb_licitacao).`r`n`r`nLicitacao-dialog: remove dep em `descricao_ug` pra mostrar link 'Ver pagina completa' - basta ter ano+num+mun+modalidade. UG fallback 'prefeitura' no slug.