### PR TITLE
fix(web): canonical match modalidade+numero_licitacao no empenho/licitacao dialog (hotfix PR #111)

### DIFF
--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -2031,6 +2031,20 @@ async def get_empenho_detalhes(payload: dict = Body(...)):
         with get_conn() as conn:
             conn.autocommit = True
             with conn.cursor() as cur:
+                # LATERAL canonico pra resolver licitacao real (tce_pb_licitacao)
+                # a partir do empenho. Necessario porque tce_pb_despesa e
+                # tce_pb_licitacao usam formatos diferentes pros mesmos dados:
+                #   numero_licitacao: '00003/2025' (lic) vs '000032025' (des)
+                #   modalidade:       'Pregao (Lei No 14.133/2021)' (lic)
+                #                  vs 'Pregao (Lei 14.133/21)'      (des)
+                # Igualdade direta em (modalidade, numero_licitacao) NUNCA bate.
+                # Match canonico:
+                #   - numero: digit-only normalization
+                #   - modalidade: lowercase + unaccent + strip " (...)" suffix
+                # Retorna lic_modalidade/lic_numero_licitacao/lic_descricao_ug
+                # *do registro real da licitacao* — usados pelo JS pra montar
+                # URLs de /licitacao/<mun>/<ano>/<ug>/<modnum> que batem com
+                # o cache key canonico do warmer.
                 cur.execute("""
                     SELECT d.numero_empenho, d.data_empenho, d.nome_credor, d.cpf_cnpj,
                            d.valor_empenhado, d.valor_liquidado, d.valor_pago,
@@ -2040,19 +2054,28 @@ async def get_empenho_detalhes(payload: dict = Body(...)):
                            d.descricao_fonte_recurso, d.categoria_economica,
                            d.grupo_natureza_despesa, d.modalidade_aplicacao,
                            d.municipio, d.codigo_ug,
-                           -- ano_licitacao autoritativo via tce_pb_licitacao (5-tupla canonica).
-                           -- LIMIT 1 porque mesma licitacao tem multiplas rows (1 por proponente).
-                           -- Fallback EXTRACT(YEAR FROM data_empenho) quando licitacao nao bate.
-                           COALESCE(
-                               (SELECT l.ano_licitacao FROM tce_pb_licitacao l
-                                WHERE l.municipio = d.municipio
-                                  AND l.codigo_ug = d.codigo_ug
-                                  AND l.modalidade = d.modalidade_licitacao
-                                  AND l.numero_licitacao = d.numero_licitacao
-                                LIMIT 1),
-                               EXTRACT(YEAR FROM d.data_empenho)::int
-                           ) AS ano_licitacao
+                           lic.modalidade        AS lic_modalidade,
+                           lic.numero_licitacao  AS lic_numero_licitacao,
+                           lic.descricao_ug      AS lic_descricao_ug,
+                           COALESCE(lic.ano_licitacao,
+                                    EXTRACT(YEAR FROM d.data_empenho)::int) AS ano_licitacao
                     FROM tce_pb_despesa d
+                    LEFT JOIN LATERAL (
+                        SELECT l.ano_licitacao, l.modalidade,
+                               l.numero_licitacao, l.descricao_ug
+                        FROM tce_pb_licitacao l
+                        WHERE l.municipio = d.municipio
+                          AND l.codigo_ug = d.codigo_ug
+                          AND LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                                l.modalidade,
+                                '\\s*-?\\s*\\([^)]*\\).*$', ''))))
+                            = LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                                d.modalidade_licitacao,
+                                '\\s*-?\\s*\\([^)]*\\).*$', ''))))
+                          AND REGEXP_REPLACE(l.numero_licitacao, '\\D', '', 'g')
+                            = REGEXP_REPLACE(d.numero_licitacao, '\\D', '', 'g')
+                        LIMIT 1
+                    ) lic ON true
                     WHERE d.id = %s
                 """, (empenho_id,))
                 cols = [d[0] for d in cur.description]
@@ -2249,6 +2272,15 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
             numero = f"{num_part}/{year_part}"
             if not ano:
                 ano = int(year_part)
+    # Match canonico de modalidade — formatos divergem entre tce_pb_licitacao
+    # ('Pregao (Lei No 14.133/2021)') e tce_pb_despesa ('Pregao (Lei 14.133/21)').
+    # Normalizacao: strip " (...)" suffix + lower + unaccent.
+    # Quando modalidade vem do empenho-dialog, esta no formato despesa; aqui
+    # comparamos via canonical pra encontrar a row certa em ambas tabelas.
+    _CANON_MOD = (
+        "LOWER(unaccent(BTRIM(REGEXP_REPLACE("
+        "  {col}, '\\s*-?\\s*\\([^)]*\\).*$', ''))))"
+    )
     try:
         from web.db import get_conn
 
@@ -2264,14 +2296,18 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
         with get_conn() as conn:
             conn.autocommit = True
             with conn.cursor() as cur:
-                # Metadata da licitacao
-                cur.execute("""
+                # Metadata da licitacao. Inclui numero_licitacao+modalidade
+                # canonicos (do tce_pb_licitacao) — frontend usa esses
+                # valores pra montar URL canonica de /licitacao/<...>.
+                cur.execute(f"""
                     SELECT DISTINCT objeto_licitacao, modalidade,
+                           numero_licitacao,
                            data_homologacao, descricao_ug
                     FROM tce_pb_licitacao
                     WHERE numero_licitacao = %s AND municipio = %s
                       AND (%s = 0 OR ano_licitacao = %s)
-                      AND (%s = '' OR modalidade = %s)
+                      AND (%s = '' OR {_CANON_MOD.format(col='modalidade')}
+                                    = {_CANON_MOD.format(col='%s')})
                     LIMIT 1
                 """, (numero, municipio, ano, ano, modalidade, modalidade))
                 cols = [d[0] for d in cur.description]
@@ -2280,7 +2316,7 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
                     result["licitacao"] = _convert(_row_to_dict(cols, rows[0]))
 
                 # Proponentes
-                cur.execute("""
+                cur.execute(f"""
                     SELECT l.nome_proponente, l.cpf_cnpj_proponente,
                            SUM(l.valor_ofertado) AS valor_ofertado,
                            MAX(l.situacao_proposta) AS situacao_proposta,
@@ -2289,7 +2325,8 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
                     LEFT JOIN empresa e ON e.cnpj_basico = l.cnpj_basico_proponente
                     WHERE l.numero_licitacao = %s AND l.municipio = %s
                       AND (%s = 0 OR l.ano_licitacao = %s)
-                      AND (%s = '' OR l.modalidade = %s)
+                      AND (%s = '' OR {_CANON_MOD.format(col='l.modalidade')}
+                                    = {_CANON_MOD.format(col='%s')})
                     GROUP BY l.nome_proponente, l.cpf_cnpj_proponente
                     ORDER BY SUM(l.valor_ofertado) DESC
                 """, (numero, municipio, ano, ano, modalidade, modalidade))
@@ -2297,16 +2334,22 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
                 rows = cur.fetchall()
                 result["proponentes"] = [_convert(_row_to_dict(cols, r)) for r in rows]
 
-                # Despesas vinculadas
-                cur.execute("""
+                # Despesas vinculadas. Filtra por modalidade canonical pra
+                # nao misturar empenhos de licitacoes diferentes que
+                # compartilham numero_licitacao no mesmo municipio (ex: Cruz
+                # do Espirito Santo tem 7 licitacoes distintas com '00003/2025',
+                # uma por modalidade x UG).
+                cur.execute(f"""
                     SELECT id, nome_credor, cpf_cnpj, data_empenho,
                            elemento_despesa, valor_empenhado, valor_pago
                     FROM tce_pb_despesa
                     WHERE numero_licitacao = %s AND municipio = %s
                       AND valor_pago > 0
+                      AND (%s = '' OR {_CANON_MOD.format(col='modalidade_licitacao')}
+                                    = {_CANON_MOD.format(col='%s')})
                     ORDER BY data_empenho DESC
                     LIMIT 50
-                """, (numero_despesa, municipio))
+                """, (numero_despesa, municipio, modalidade, modalidade))
                 cols = [d[0] for d in cur.description]
                 rows = cur.fetchall()
                 result["despesas"] = [_convert(_row_to_dict(cols, r)) for r in rows]

--- a/web/static/js/components/dialog-links.js
+++ b/web/static/js/components/dialog-links.js
@@ -8,7 +8,12 @@ function _reattachDialogLinks(body) {
             // resolver a licitacao com o municipio do proprio empenho.
             const linkMun = link.dataset.licMun || '';
             const mun = linkMun || _currentMunicipio;
-            openLicitacaoDialog(link.dataset.licNum, link.dataset.licAno || '0', mun, link.textContent);
+            // Forwarding licMod (vem do empenho-dialog em formato despesa)
+            // pra API resolver via canonical match — sem isso, o dialog cai
+            // em LIMIT 1 e pode escolher uma das N licitacoes que compartilham
+            // numero_licitacao no mesmo municipio.
+            openLicitacaoDialog(link.dataset.licNum, link.dataset.licAno || '0',
+                                mun, link.textContent, link.dataset.licMod || '');
         });
     });
     body.querySelectorAll('.dialog-link[data-forn-cnpj]').forEach(link => {

--- a/web/static/js/components/empenho-dialog.js
+++ b/web/static/js/components/empenho-dialog.js
@@ -44,32 +44,44 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     // Licitacao vinculada — primeiro bloco logo apos o historico, pra dar
     // contexto imediato do empenho (qual processo originou o pagamento).
     // Renderiza como link direto pra /licitacao/<mun>/<ano>/<ug>/<modnum>
-    // quando temos os 5 campos canonicos (mais SEO/conteudo que o dialog).
-    // Fallback: dialog-link abre o dialog quando codigo_ug ausente.
+    // quando temos os campos canonicos vindos de tce_pb_licitacao via
+    // LATERAL JOIN no /api/empenho/detalhes (lic_modalidade, lic_numero_licitacao,
+    // lic_descricao_ug, ano_licitacao). Esses sao OBRIGATORIOS pro slug bater
+    // com o cache key do warmer; usar campos do empenho direto (data.modalidade_licitacao,
+    // data.numero_licitacao) gera URLs broken porque os formatos divergem entre
+    // tce_pb_despesa e tce_pb_licitacao (ex: "Pregao (Lei 14.133/21)" vs
+    // "Pregao (Lei No 14.133/2021)", "000032025" vs "00003/2025"). Fallback
+    // dialog-link quando lic_* nao vem da API (licitacao nao encontrada na
+    // canonical match).
     {
         const mod = data.modalidade_licitacao || '';
         const numLic = data.numero_licitacao || '';
         const semLic = !numLic || numLic === '000000000' || mod.toLowerCase().includes('sem licit');
         const empMun = data.municipio || '';
+        const labelDisplay = `${_esc(mod || data.lic_modalidade || 'Licitacao')} (${_esc(numLic || data.lic_numero_licitacao || '')})`;
         if (!semLic) {
             const _txtSlug = (s) => String(s || '').toLowerCase()
                 .normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
                 .replace(/[^a-z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
             const ano = parseInt(data.ano_licitacao) || 0;
-            const cod_ug = data.codigo_ug || data.descricao_ug || '';
-            if (ano && cod_ug && empMun) {
+            const licMod = data.lic_modalidade || '';
+            const licNum = data.lic_numero_licitacao || '';
+            const licUg = data.lic_descricao_ug || data.descricao_ug || '';
+            if (ano && empMun && licMod && licNum) {
                 const munSlug = _txtSlug(empMun);
-                const ugSlug = _txtSlug(data.descricao_ug) || 'prefeitura';
-                const modSlug = _txtSlug(mod) || 'lic';
-                const numSlug = _txtSlug(numLic) || '0';
+                const ugSlug = _txtSlug(licUg) || 'prefeitura';
+                const modSlug = _txtSlug(licMod) || 'lic';
+                const numSlug = _txtSlug(licNum) || '0';
                 const pagePath = `/licitacao/${munSlug}/${ano}/${ugSlug}/${modSlug}-${numSlug}`;
                 html += `<div class="dialog-section"><h4>${dualLabel('Origem do gasto (licitacao)','Licitacao vinculada')}</h4>`;
-                html += `<p class="text-sm"><a href="${pagePath}" class="ext-link-inline" title="Ver pagina dedicada desta licitacao (mais detalhes e SEO)">${_esc(mod)} (${_esc(numLic)}) &#8599;</a></p>`;
+                html += `<p class="text-sm"><a href="${pagePath}" class="ext-link-inline" title="Ver pagina dedicada desta licitacao (mais detalhes e SEO)">${labelDisplay} &#8599;</a></p>`;
                 html += '</div>';
             } else {
-                // Sem ano/ug — fallback pra dialog que ja existe.
+                // Sem campos canonicos da licitacao (LATERAL match falhou).
+                // Cai no dialog-link, que abre o licitacao-dialog e tenta
+                // resolver via /api/licitacao/detalhes (canonical match server-side).
                 html += `<div class="dialog-section"><h4>${dualLabel('Origem do gasto (licitacao)','Licitacao vinculada')}</h4>`;
-                html += `<p class="text-sm"><a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="${ano || 0}" data-lic-mun="${_esc(empMun)}">${_esc(mod)} (${_esc(numLic)})</a></p>`;
+                html += `<p class="text-sm"><a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="${ano || 0}" data-lic-mun="${_esc(empMun)}" data-lic-mod="${_esc(mod)}">${labelDisplay}</a></p>`;
                 html += '</div>';
             }
         } else {

--- a/web/static/js/components/licitacao-dialog.js
+++ b/web/static/js/components/licitacao-dialog.js
@@ -58,16 +58,23 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
 
     // Link pra pagina dedicada da licitacao (indexavel, mais conteudo).
     // Hide quando ja na pagina /licitacao/X (auto-detect via URL).
-    // Mostrar sempre que tiver os 4 campos essenciais; descricao_ug e
-    // opcional (fallback 'prefeitura' no slug).
-    if (anoLicitacao && numeroLicitacao && municipio && modalidade) {
+    // PREFERE campos canonicos vindos da API (data.licitacao.modalidade /
+    // data.licitacao.numero_licitacao) — esses sao do tce_pb_licitacao e
+    // batem com o slug usado pelo warmer/SSR. Quando o dialog e aberto a
+    // partir do empenho-dialog, os argumentos `modalidade` e `numeroLicitacao`
+    // vem em formato de tce_pb_despesa (ex: "Pregao (Lei 14.133/21)" /
+    // "000032025") que NAO bate com o slug do warmer ("Pregao (Lei No
+    // 14.133/2021)" / "00003/2025") — gera 503 cache miss. So renderiza o
+    // link quando data.licitacao foi resolvida (canonical match server-side).
+    if (data.licitacao && data.licitacao.modalidade && data.licitacao.numero_licitacao
+        && anoLicitacao && municipio) {
         const _txtSlug = (s) => String(s || '').toLowerCase()
             .normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
             .replace(/[^a-z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
         const munSlug = _txtSlug(municipio);
-        const ugSlug = _txtSlug(data.licitacao && data.licitacao.descricao_ug) || 'prefeitura';
-        const modSlug = _txtSlug(modalidade) || 'lic';
-        const numSlug = _txtSlug(numeroLicitacao) || '0';
+        const ugSlug = _txtSlug(data.licitacao.descricao_ug) || 'prefeitura';
+        const modSlug = _txtSlug(data.licitacao.modalidade) || 'lic';
+        const numSlug = _txtSlug(data.licitacao.numero_licitacao) || '0';
         const modNumSlug = `${modSlug}-${numSlug}`;
         const pagePath = `/licitacao/${munSlug}/${anoLicitacao}/${ugSlug}/${modNumSlug}`;
         const isOnPage = location.pathname === pagePath;


### PR DESCRIPTION
## Problema

PR #111 introduziu link direto pra `/licitacao/<mun>/<ano>/<ug>/<modnum>` no empenho-dialog, mas a URL gerada **nunca casa** com o cache key do warmer porque os formatos divergem entre as tabelas TCE-PB:

| Campo | `tce_pb_licitacao` | `tce_pb_despesa` |
|---|---|---|
| `numero_licitacao` | `00003/2025` | `000032025` |
| `modalidade` | `Pregao (Lei N 14.133/2021)` | `Pregao (Lei 14.133/21)` |

### Bug 1 - subquery do `ano_licitacao` sempre retorna NULL

A subquery em `/api/empenho/detalhes` filtrava com igualdade exata:

`WHERE l.modalidade = d.modalidade_licitacao AND l.numero_licitacao = d.numero_licitacao`

Validei contra o banco: zero matches. Resultado: `ano_licitacao` cai sempre no fallback `EXTRACT(YEAR FROM data_empenho)` (ano do empenho, não da licitação). Empenhos pagos em 2026 de licitações 2025  URL `/licitacao/.../2026/...`  404.

### Bug 2 - slugs JS em formato errado

O JS slugifica os campos `data.modalidade_licitacao` e `data.numero_licitacao` (formato despesa), gerando:

`/licitacao/cruz-do-espirito-santo/2026/.../pregao-lei-14-133-21-000032025`

Mas o cache do warmer foi feito com formato licitacao:

`/licitacao/cruz-do-espirito-santo/2025/.../pregao-lei-no-14-133-2021-00003-2025`

 503 cache miss em **todo** request com licitação pos-Lei 14.133/2021.

### Bug bonus - dialog mistura empenhos de licitações diferentes

Em municípios PB existem múltiplas licitações com mesmo `numero_licitacao` (uma por modalidade  UG). Cruz do Espírito Santo tem **7 licitações distintas** com `00003/2025`. A query de despesas em `/api/licitacao/detalhes` não filtrava por modalidade  mostrava 43 empenhos misturados (alimentos + obras + software + jurídico).

## Solução

Match canônico em SQL: `LOWER(unaccent(BTRIM(REGEXP_REPLACE(modalidade, '\s*-?\s*\([^)]*\).*\$', ''))))` (strip suffix ` (...)` + lowercase + unaccent) + `REGEXP_REPLACE(numero, '\D', '', 'g')` (digit-only). Validado contra todas as 30+ modalidades do banco.

### Backend

- **`/api/empenho/detalhes`**: substitui subquery por `LEFT JOIN LATERAL` com canonical match. Adiciona `lic_modalidade`, `lic_numero_licitacao`, `lic_descricao_ug` ao payload (campos vindos de `tce_pb_licitacao`, formato canônico).
- **`/api/licitacao/detalhes`**: filtra modalidade via canonical match nas 3 queries (metadata, proponentes, despesas). Adiciona `numero_licitacao` ao SELECT do metadata.

### Frontend

- **`empenho-dialog.js`**: usa `data.lic_modalidade`, `data.lic_numero_licitacao`, `data.lic_descricao_ug` pra montar URL. Fallback dialog-link quando LATERAL não resolve (e.g., `Sem Licitação`).
- **`licitacao-dialog.js`**: usa `data.licitacao.modalidade` e `data.licitacao.numero_licitacao` pra slug (fonte canônica), ao invés de argumentos do caller.
- **`dialog-links.js`**: forwarding `data-lic-mod` do empenho-dialog pra API resolver corretamente.

## Validação

Testado contra Cruz do Espírito Santo / `00003/2025`:

| Cenário | Antes | Depois |
|---|---|---|
| Dialog `/api/licitacao/detalhes` | 43 empenhos misturados | **8 empenhos** só do Pregão alimentos  |
| URL `Ver pagina completa` | `/licitacao/.../2026/.../pregao-lei-14-133-21-000032025` (503) | `/licitacao/.../2025/.../pregao-lei-no-14-133-2021-00003-2025` (200)  |
| Empenho `Sem Licitação` | URL broken | Fallback graceful pra dialog  |

5 amostras testadas via psycopg2 (Pregão Prefeitura, Inex Câmara, Dispensa Câmara, Pregão repetido, Sem Licitação)  todas resolveram corretamente.

## Não incluído neste hotfix

- Filtro por `codigo_ug` em `/api/licitacao/detalhes` (ainda mistura quando 2 UGs distintas têm mesmo `numero_licitacao + modalidade canônica` no mesmo município  caso raro, apenas Câmara  Prefeitura).
- Fix do `LICITACAO_EMPENHOS_VINCULADOS` da página SSR (provavelmente mostra 0 empenhos hoje pelo mesmo motivo de format mismatch).

Esses ficam pra um PR separado mais amplo.