### PR TITLE
feat(web): propaga codigo_ug + canonical match no SSR licitacao (4-tupla)

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -208,6 +208,7 @@ COLUMN_META: dict[str, dict[str, Any]] = {
     "numero_empenho":       {"auditor": "Numero Empenho",      "auditor_only": True},
     "numero_licitacao":     {"auditor": "Numero Licitacao",    "auditor_only": True},
     "numero_contrato":      {"auditor": "Numero Contrato",     "auditor_only": True},
+    "codigo_ug":            {"auditor": "Codigo UG",           "auditor_only": True},
     "ano_mes":              {"auditor": "Ano-Mes",             "auditor_only": True},
     "cnpjs_socio":          {"auditor": "CNPJs Socio",         "auditor_only": True},
     "cnpjs_vinculo":        {"auditor": "CNPJs Vinculo",       "auditor_only": True},

--- a/web/queries/licitacao.py
+++ b/web/queries/licitacao.py
@@ -94,6 +94,13 @@ LICITACAO_PROPONENTES = """
 # Despesas (empenhos) vinculadas a essa licitacao. Usa d.cnpj_basico
 # pre-computado em tce_pb_despesa (varchar(8)), cast pra bpchar(8) no JOIN
 # pra forcar uso de empresa_pkey/estabelecimento_pkey.
+#
+# IMPORTANTE: o warmer recebe a 5-tupla canonica do tce_pb_licitacao
+# (numero_licitacao='00003/2025', modalidade='Pregao (Lei No 14.133/2021)')
+# mas tce_pb_despesa usa formatos diferentes ('000032025', 'Pregao (Lei
+# 14.133/21)'). Igualdade direta NUNCA bate. Match canonico:
+#   - numero: digit-only normalization (REGEXP_REPLACE \D)
+#   - modalidade: lowercase + unaccent + strip suffix " (...)"
 LICITACAO_EMPENHOS_VINCULADOS = """
     WITH despesas_pj AS MATERIALIZED (
         SELECT
@@ -102,11 +109,22 @@ LICITACAO_EMPENHOS_VINCULADOS = """
             d.cnpj_basico::bpchar(8) AS cnpj_basico
         FROM tce_pb_despesa d
         WHERE d.municipio = %(municipio)s
-          AND d.numero_licitacao = %(numero_licitacao)s
+          -- Match canonico: tce_pb_despesa.numero_licitacao usa formato
+          -- compacto ('000032025'), tce_pb_licitacao usa '00003/2025'.
+          AND REGEXP_REPLACE(d.numero_licitacao, '\\D', '', 'g')
+            = REGEXP_REPLACE(%(numero_licitacao)s, '\\D', '', 'g')
           -- Filter pela 5-tupla canonica pra evitar colisoes entre orgaos/anos
           -- com mesmo numero_licitacao. (P1 GPT 5.5 review PR #108.)
           AND d.codigo_ug = %(codigo_ug)s
-          AND d.modalidade_licitacao = %(modalidade)s
+          -- Match canonico: tce_pb_despesa.modalidade_licitacao usa formato
+          -- compacto ('Pregao (Lei 14.133/21)'), tce_pb_licitacao usa
+          -- 'Pregao (Lei No 14.133/2021)'.
+          AND LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                d.modalidade_licitacao,
+                '\\s*-?\\s*\\([^)]*\\).*$', ''))))
+            = LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                %(modalidade)s,
+                '\\s*-?\\s*\\([^)]*\\).*$', ''))))
           AND EXTRACT(YEAR FROM d.data_empenho) BETWEEN %(ano)s - 1 AND %(ano)s + 5
           AND d.valor_pago > 0
           AND d.cnpj_basico IS NOT NULL

--- a/web/queries/registry.py
+++ b/web/queries/registry.py
@@ -557,7 +557,7 @@ _skip("Q68", "Licitacao com proponente unico",
      "Licitacao e Concorrencia",
      """
 SELECT l.municipio, l.numero_licitacao, l.ano_licitacao,
-       l.modalidade, l.objeto_licitacao,
+       l.modalidade, l.codigo_ug, l.objeto_licitacao,
        l.nome_proponente, l.cpf_cnpj_proponente,
        l.valor_ofertado, l.situacao_proposta
 FROM tce_pb_licitacao l
@@ -576,7 +576,7 @@ ORDER BY l.valor_ofertado DESC
 LIMIT 500
 """, timeout=30, sql_dated="""
 SELECT l.municipio, l.numero_licitacao, l.ano_licitacao,
-       l.modalidade, l.objeto_licitacao,
+       l.modalidade, l.codigo_ug, l.objeto_licitacao,
        l.nome_proponente, l.cpf_cnpj_proponente,
        l.valor_ofertado, l.situacao_proposta
 FROM tce_pb_licitacao l
@@ -601,7 +601,7 @@ _reg("Q69", "Todas as licitacoes do municipio",
      "Licitacao e Concorrencia",
      """
 SELECT l.numero_licitacao, l.ano_licitacao,
-       l.modalidade,
+       l.modalidade, l.codigo_ug,
        MAX(l.objeto_licitacao) AS objeto_licitacao,
        COUNT(DISTINCT l.cpf_cnpj_proponente) AS qtd_vencedores,
        MAX(l.valor_ofertado) AS maior_valor,
@@ -609,12 +609,12 @@ SELECT l.numero_licitacao, l.ano_licitacao,
 FROM tce_pb_licitacao l
 WHERE l.ano_licitacao >= 2022
   AND l.municipio = %(municipio)s
-GROUP BY l.numero_licitacao, l.ano_licitacao, l.modalidade
+GROUP BY l.numero_licitacao, l.ano_licitacao, l.modalidade, l.codigo_ug
 ORDER BY l.ano_licitacao DESC, MAX(l.valor_ofertado) DESC
 LIMIT 500
 """, timeout=30, sql_dated="""
 SELECT l.numero_licitacao, l.ano_licitacao,
-       l.modalidade,
+       l.modalidade, l.codigo_ug,
        MAX(l.objeto_licitacao) AS objeto_licitacao,
        COUNT(DISTINCT l.cpf_cnpj_proponente) AS qtd_vencedores,
        MAX(l.valor_ofertado) AS maior_valor,
@@ -622,7 +622,7 @@ SELECT l.numero_licitacao, l.ano_licitacao,
 FROM tce_pb_licitacao l
 WHERE l.ano_licitacao >= %(ano_inicio)s AND l.ano_licitacao <= %(ano_fim)s
   AND l.municipio = %(municipio)s
-GROUP BY l.numero_licitacao, l.ano_licitacao, l.modalidade
+GROUP BY l.numero_licitacao, l.ano_licitacao, l.modalidade, l.codigo_ug
 ORDER BY l.ano_licitacao DESC, MAX(l.valor_ofertado) DESC
 LIMIT 500
 """)

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -2260,6 +2260,11 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
     ano = payload.get("ano_licitacao", 0)
     municipio = payload.get("municipio", "")
     modalidade = payload.get("modalidade", "")
+    # codigo_ug opcional. Quando presente, narrow para a 4-tupla canonica
+    # (municipio + codigo_ug + modalidade-canonical + numero) — desambigua
+    # casos onde a mesma modalidade aparece em UGs diferentes do municipio
+    # (ex: Camara 101065 e Prefeitura 201065 ambas com Dispensa 00003/2025).
+    codigo_ug = str(payload.get("codigo_ug", "") or "")
     if not numero or not municipio:
         return JSONResponse({})
 
@@ -2301,15 +2306,18 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
                 # valores pra montar URL canonica de /licitacao/<...>.
                 cur.execute(f"""
                     SELECT DISTINCT objeto_licitacao, modalidade,
-                           numero_licitacao,
+                           numero_licitacao, codigo_ug,
                            data_homologacao, descricao_ug
                     FROM tce_pb_licitacao
                     WHERE numero_licitacao = %s AND municipio = %s
                       AND (%s = 0 OR ano_licitacao = %s)
+                      AND (%s = '' OR codigo_ug = %s)
                       AND (%s = '' OR {_CANON_MOD.format(col='modalidade')}
                                     = {_CANON_MOD.format(col='%s')})
                     LIMIT 1
-                """, (numero, municipio, ano, ano, modalidade, modalidade))
+                """, (numero, municipio, ano, ano,
+                      codigo_ug, codigo_ug,
+                      modalidade, modalidade))
                 cols = [d[0] for d in cur.description]
                 rows = cur.fetchall()
                 if rows:
@@ -2325,17 +2333,20 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
                     LEFT JOIN empresa e ON e.cnpj_basico = l.cnpj_basico_proponente
                     WHERE l.numero_licitacao = %s AND l.municipio = %s
                       AND (%s = 0 OR l.ano_licitacao = %s)
+                      AND (%s = '' OR l.codigo_ug = %s)
                       AND (%s = '' OR {_CANON_MOD.format(col='l.modalidade')}
                                     = {_CANON_MOD.format(col='%s')})
                     GROUP BY l.nome_proponente, l.cpf_cnpj_proponente
                     ORDER BY SUM(l.valor_ofertado) DESC
-                """, (numero, municipio, ano, ano, modalidade, modalidade))
+                """, (numero, municipio, ano, ano,
+                      codigo_ug, codigo_ug,
+                      modalidade, modalidade))
                 cols = [d[0] for d in cur.description]
                 rows = cur.fetchall()
                 result["proponentes"] = [_convert(_row_to_dict(cols, r)) for r in rows]
 
-                # Despesas vinculadas. Filtra por modalidade canonical pra
-                # nao misturar empenhos de licitacoes diferentes que
+                # Despesas vinculadas. Filtra por modalidade canonical + codigo_ug
+                # pra nao misturar empenhos de licitacoes diferentes que
                 # compartilham numero_licitacao no mesmo municipio (ex: Cruz
                 # do Espirito Santo tem 7 licitacoes distintas com '00003/2025',
                 # uma por modalidade x UG).
@@ -2345,11 +2356,14 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
                     FROM tce_pb_despesa
                     WHERE numero_licitacao = %s AND municipio = %s
                       AND valor_pago > 0
+                      AND (%s = '' OR codigo_ug = %s)
                       AND (%s = '' OR {_CANON_MOD.format(col='modalidade_licitacao')}
                                     = {_CANON_MOD.format(col='%s')})
                     ORDER BY data_empenho DESC
                     LIMIT 50
-                """, (numero_despesa, municipio, modalidade, modalidade))
+                """, (numero_despesa, municipio,
+                      codigo_ug, codigo_ug,
+                      modalidade, modalidade))
                 cols = [d[0] for d in cur.description]
                 rows = cur.fetchall()
                 result["despesas"] = [_convert(_row_to_dict(cols, r)) for r in rows]

--- a/web/static/js/components/clickable-rows.js
+++ b/web/static/js/components/clickable-rows.js
@@ -46,7 +46,9 @@ function initClickableRows(root = document) {
             if (licNum) {
                 const licAno = row.dataset.licitacaoAno || '0';
                 const licMod = row.dataset.licitacaoMod || '';
-                openLicitacaoDialog(licNum, licAno, _currentMunicipio, `Licitacao ${licNum}`, licMod);
+                const licUg = row.dataset.licitacaoUg || '';
+                openLicitacaoDialog(licNum, licAno, _currentMunicipio,
+                                    `Licitacao ${licNum}`, licMod, licUg);
             }
         };
         row.addEventListener('click', (event) => activate(event));

--- a/web/static/js/components/dialog-links.js
+++ b/web/static/js/components/dialog-links.js
@@ -8,12 +8,14 @@ function _reattachDialogLinks(body) {
             // resolver a licitacao com o municipio do proprio empenho.
             const linkMun = link.dataset.licMun || '';
             const mun = linkMun || _currentMunicipio;
-            // Forwarding licMod (vem do empenho-dialog em formato despesa)
-            // pra API resolver via canonical match — sem isso, o dialog cai
-            // em LIMIT 1 e pode escolher uma das N licitacoes que compartilham
-            // numero_licitacao no mesmo municipio.
+            // Forwarding licMod (formato despesa) + licUg (codigo_ug) pra API
+            // narrow ao 4-tuple canonico (mun + codigo_ug + canonical-mod + num).
+            // Sem ambos, dialog cai em LIMIT 1 e pode escolher errado entre
+            // licitacoes que compartilham numero_licitacao no mesmo municipio.
             openLicitacaoDialog(link.dataset.licNum, link.dataset.licAno || '0',
-                                mun, link.textContent, link.dataset.licMod || '');
+                                mun, link.textContent,
+                                link.dataset.licMod || '',
+                                link.dataset.licUg || '');
         });
     });
     body.querySelectorAll('.dialog-link[data-forn-cnpj]').forEach(link => {

--- a/web/static/js/components/dialog-url-state.js
+++ b/web/static/js/components/dialog-url-state.js
@@ -167,7 +167,10 @@ async function _restoreDialogFromUrl() {
                 if (!state.num) throw new Error('num ausente');
                 const mun = state.mun || _currentMunicipio || '';
                 if (typeof openLicitacaoDialog === 'function') {
-                    await openLicitacaoDialog(state.num, state.ano || '0', mun, `Licitacao ${state.num}`, state.mod || '', { fromUrl: true });
+                    await openLicitacaoDialog(state.num, state.ano || '0', mun,
+                                              `Licitacao ${state.num}`,
+                                              state.mod || '', state.ug || '',
+                                              { fromUrl: true });
                 }
                 return true;
             }

--- a/web/static/js/components/empenho-dialog.js
+++ b/web/static/js/components/empenho-dialog.js
@@ -80,8 +80,10 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
                 // Sem campos canonicos da licitacao (LATERAL match falhou).
                 // Cai no dialog-link, que abre o licitacao-dialog e tenta
                 // resolver via /api/licitacao/detalhes (canonical match server-side).
+                // Repassa codigo_ug do empenho (data.codigo_ug) pra API narrow
+                // ao 4-tuple canonico.
                 html += `<div class="dialog-section"><h4>${dualLabel('Origem do gasto (licitacao)','Licitacao vinculada')}</h4>`;
-                html += `<p class="text-sm"><a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="${ano || 0}" data-lic-mun="${_esc(empMun)}" data-lic-mod="${_esc(mod)}">${labelDisplay}</a></p>`;
+                html += `<p class="text-sm"><a href="#" class="dialog-link" data-lic-num="${_esc(numLic)}" data-lic-ano="${ano || 0}" data-lic-mun="${_esc(empMun)}" data-lic-mod="${_esc(mod)}" data-lic-ug="${_esc(data.codigo_ug || '')}">${labelDisplay}</a></p>`;
                 html += '</div>';
             }
         } else {

--- a/web/static/js/components/licitacao-dialog.js
+++ b/web/static/js/components/licitacao-dialog.js
@@ -1,10 +1,23 @@
 // === components/licitacao-dialog.js ===
-function _fetchLicitacaoDetails(numeroLicitacao, anoLicitacao, municipio, modalidade) {
-    return _cachedPost('/api/licitacao/detalhes', `lic:${numeroLicitacao}:${anoLicitacao}:${municipio}:${modalidade}`,
-        { numero_licitacao: numeroLicitacao, ano_licitacao: parseInt(anoLicitacao) || 0, municipio, modalidade: modalidade || '' });
+function _fetchLicitacaoDetails(numeroLicitacao, anoLicitacao, municipio, modalidade, codigoUg) {
+    // codigo_ug entra na cache key pra evitar colisao quando 2 UGs distintas
+    // (ex: Camara 101065 + Prefeitura 201065) compartilham numero_licitacao
+    // + modalidade no mesmo municipio.
+    return _cachedPost('/api/licitacao/detalhes',
+        `lic:${numeroLicitacao}:${anoLicitacao}:${municipio}:${modalidade}:${codigoUg || ''}`,
+        { numero_licitacao: numeroLicitacao, ano_licitacao: parseInt(anoLicitacao) || 0,
+          municipio, modalidade: modalidade || '', codigo_ug: codigoUg || '' });
 }
 
-async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, label, modalidade, options = {}) {
+async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, label, modalidade, codigoUg, options = {}) {
+    // Suporte chamada legacy onde codigoUg vinha como `options` (5 args + obj):
+    // openLicitacaoDialog(num, ano, mun, label, mod, {fromUrl: true})
+    if (codigoUg && typeof codigoUg === 'object' && !options) {
+        options = codigoUg;
+        codigoUg = '';
+    }
+    options = options || {};
+    codigoUg = codigoUg || '';
     const dialog = document.getElementById('empresa-dialog');
     if (!dialog) return;
     const fromUrl = !!options.fromUrl;
@@ -19,6 +32,7 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
             ano: String(anoLicitacao || ''),
             mod: modalidade || '',
             mun: municipio || '',
+            ug: codigoUg || '',
         }, fromUrl, isInitialOpen);
     }
     const seq = (typeof _dialogNextSeq === 'function') ? _dialogNextSeq() : null;
@@ -34,6 +48,7 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
         ano: String(anoLicitacao || ''),
         modalidade: modalidade || '',
         municipio: municipio || _currentMunicipio || '',
+        codigo_ug: codigoUg || '',
     });
     else if (drilledFrom) trackEvent && trackEvent('dialog-aberto', {
         tipo: 'licitacao',
@@ -41,10 +56,11 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
         ano: String(anoLicitacao || ''),
         modalidade: modalidade || '',
         municipio: municipio || _currentMunicipio || '',
+        codigo_ug: codigoUg || '',
         drilled_from: drilledFrom,
     });
 
-    const data = await _fetchLicitacaoDetails(numeroLicitacao, anoLicitacao, municipio, modalidade);
+    const data = await _fetchLicitacaoDetails(numeroLicitacao, anoLicitacao, municipio, modalidade, codigoUg);
     if (seq !== null && typeof _dialogSeqValid === 'function' && !_dialogSeqValid(seq)) return;
 
     // Metadata — always render header

--- a/web/static/js/components/result-table.js
+++ b/web/static/js/components/result-table.js
@@ -21,6 +21,7 @@ function buildResultTable(queryId, columns, rows, municipio) {
     const iLicNum = columns.indexOf('numero_licitacao');
     const iLicAno = columns.indexOf('ano_licitacao');
     const iLicMod = columns.indexOf('modalidade');
+    const iLicUg = columns.indexOf('codigo_ug');
     const iNomeCredorExact = columns.indexOf('nome_credor');
     const hasFornecedor = iCnpjBasico >= 0 || iCpfCnpj >= 0 || iCnpjCompleto >= 0;
     const hasServidor = iCpf6 >= 0 && (iNomeUpper >= 0 || iNomeServidor >= 0);
@@ -113,8 +114,9 @@ function buildResultTable(queryId, columns, rows, municipio) {
             const licNum = String(row[iLicNum] || '');
             const licAno = iLicAno >= 0 ? String(row[iLicAno] || '0') : '0';
             const licMod = iLicMod >= 0 ? String(row[iLicMod] || '') : '';
+            const licUg = iLicUg >= 0 ? String(row[iLicUg] || '') : '';
             if (licNum && licNum !== '000000000') {
-                return `<tr class="clickable-row${rowHighlight}" data-licitacao-num="${_esc(licNum)}" data-licitacao-ano="${_esc(licAno)}" data-licitacao-mod="${_esc(licMod)}">${cells}</tr>`;
+                return `<tr class="clickable-row${rowHighlight}" data-licitacao-num="${_esc(licNum)}" data-licitacao-ano="${_esc(licAno)}" data-licitacao-mod="${_esc(licMod)}" data-licitacao-ug="${_esc(licUg)}">${cells}</tr>`;
             }
         }
         // Fornecedor row detection

--- a/web/templates/partials/result_table.html
+++ b/web/templates/partials/result_table.html
@@ -74,6 +74,7 @@
                     {% set lic_num_val = row.get('numero_licitacao', '') or '' %}
                     {% set lic_ano_val = row.get('ano_licitacao', '0') or '0' %}
                     {% set lic_mod_val = row.get('modalidade', '') or '' %}
+                    {% set lic_ug_val = row.get('codigo_ug', '') or '' %}
                     {% set abr_val = row.get('abrangencia', '') or '' %}
                     {% set cat_val = row.get('categoria_sancao', '') or '' %}
                     {% set row_hl = '' %}
@@ -87,7 +88,7 @@
                     {% if cpf6_val and nome_upper_val %}
                     <tr class="clickable-row{{ row_hl }}" data-cpf6="{{ cpf6_val }}" data-nome-upper="{{ nome_upper_val }}" data-nome="{{ nome_upper_val }}" data-cnpjs="[]">
                     {% elif lic_num_val and lic_num_val != '000000000' %}
-                    <tr class="clickable-row{{ row_hl }}" data-licitacao-num="{{ lic_num_val }}" data-licitacao-ano="{{ lic_ano_val }}" data-licitacao-mod="{{ lic_mod_val }}">
+                    <tr class="clickable-row{{ row_hl }}" data-licitacao-num="{{ lic_num_val }}" data-licitacao-ano="{{ lic_ano_val }}" data-licitacao-mod="{{ lic_mod_val }}" data-licitacao-ug="{{ lic_ug_val }}">
                     {% elif cnpj_basico_val|length == 8 and cnpj_basico_val.isdigit() and cpf_cnpj_digits|length == 14 %}
                     {% set nome_credor_val = row.get('nome_credor', '') or '' %}
                     <tr class="clickable-row{{ row_hl }}" data-fornecedor-cnpj="{{ cnpj_basico_val }}" data-fornecedor-cpf-cnpj="{{ cpf_cnpj_digits }}" data-fornecedor-nome="{{ nome_val|clean_text }}" data-fornecedor-nome-credor="{{ nome_credor_val|clean_text }}">


### PR DESCRIPTION
Complementa o hotfix PR #112 propagando `codigo_ug` por todo o fluxo de licitacao e corrigindo a SSR query `LICITACAO_EMPENHOS_VINCULADOS` que retornava **0 empenhos em producao** por causa do format mismatch entre as duas tabelas TCE.

## Problemas resolvidos

### Bug 1  SSR licitacao mostra 0 empenhos vinculados

A query `LICITACAO_EMPENHOS_VINCULADOS` filtrava com igualdade exata:
`WHERE d.modalidade_licitacao = %(modalidade)s AND d.numero_licitacao = %(numero_licitacao)s`

Mas os formatos divergem:
| Campo | `tce_pb_licitacao` (warmer envia) | `tce_pb_despesa` (compara) |
|---|---|---|
| `numero_licitacao` | `00003/2025` | `000032025` |
| `modalidade` | `Pregao (Lei No 14.133/2021)` | `Pregao (Lei 14.133/21)` |

Nenhum empenho casa  todas as paginas `/licitacao/<...>` indexadas mostravam zero empenhos vinculados. Fix: canonical match (digit-only + lowercase+unaccent+strip suffix).

### Bug 2 — Dialog mistura UGs com mesmo modalidade

Pos PR #112, o dialog filtra modalidade canonical. Mas quando 2 UGs distintas tem mesmo canonical+numero+ano (caso Camara x Prefeitura no mesmo municipio), ainda mistura. Exemplo Cruz do ES 00003/2025 Inexigibilidade:

| UG | Credor | Valor | Objeto |
|---|---|---|---|
| 101065 (Camara) | PUBLICSOFT | R | sistema contabil |
| 201065 (Prefeitura) | QUALITY CONSUTORIA | R | assessoria juridica |

Fix: `/api/licitacao/detalhes` aceita `codigo_ug` opcional, aplica 4-tupla canonica (municipio + codigo_ug + canonical-mod + numero) nas 3 queries.

### Bug 3  Q69 agrega cross-UG silenciosamente

`Q69 - Todas as licitacoes do municipio` agrupava por `(numero_licitacao, ano_licitacao, modalidade)` sem `codigo_ug`. Em municipios com Camara + Prefeitura, licitacoes com mesmo num/ano/modalidade nas 2 UGs colapsavam numa linha so com totais agregados. Fix: GROUP BY inclui codigo_ug.

## Mudancas

### Backend

- `web/queries/licitacao.py` LICITACAO_EMPENHOS_VINCULADOS  canonical match em modalidade + numero.
- `web/routes/cidade.py` `/api/licitacao/detalhes`  aceita `codigo_ug`, aplica em metadata/proponentes/despesas.
- `web/queries/registry.py` Q68/Q69  SELECT inclui `l.codigo_ug`; Q69 GROUP BY tb.
- `web/main.py` COLUMN_META  `codigo_ug` marcado `auditor_only` (some em modo cidadao).

### Frontend

- `licitacao-dialog.js`  `openLicitacaoDialog(num, ano, mun, label, mod, codigoUg, options)`. `codigoUg` entra na cache key + payload da API + URL state. Suporte legacy quando arg 6 e `options` object.
- `empenho-dialog.js`  `data-lic-ug` no fallback dialog-link (`data.codigo_ug` ja vinha do API desde PR #111).
- `dialog-links.js`  extrai `data-lic-ug`, repassa.
- `clickable-rows.js`  extrai `data-licitacao-ug`, repassa.
- `dialog-url-state.js`  restaura `state.ug` quando reabre dialog via URL.
- `result-table.js` (render JS) + `result_table.html` (Jinja)  emitem `data-licitacao-ug` do `row.codigo_ug`.

## Validacao

Validado contra DB local com 4 cenarios de licitacao Cruz ES 00003/2025:

| Caso | Empenhos retornados | Credor | Total |
|---|---|---|---|
| Pregao Prefeitura (alimentos) | 8 | ADEMIR LOURENCO | R |
| Concorrencia Prefeitura (UBS) | 4 | JGM CONSTRUTORA | R |
| Inexigibilidade Camara (sistema) | 12 | PUBLICSOFT | R |
| Inexigibilidade Prefeitura (juridico) | 8 | QUALITY | R |

Cada um isolado, sem mistura, com modalidade/numero canonical correto e URL slug bate com o cache key do warmer.

## Cache invalidation

A query SSR `LICITACAO_EMPENHOS_VINCULADOS` mudou  cache `LICITACAO_PERFIL` atual nao reflete os empenhos vinculados (era 0, agora N). Deploy recomendado:

`etl_phase=web + rewarm_cache_keys=LICITACAO_PERFIL`

Shadow rewarm zero-downtime preenche o cache atomico antes de servir.

## Nao incluido neste PR

Cache key do dialog inclui `codigoUg` agora  entradas antigas (sem ug) ficam orfas no browser local. Auto-expiram naturalmente, sem impacto.