### PR TITLE
fix(web): tornar LICITACAO_EMPENHOS_VINCULADOS sargable (use idx_tce_desp_licitacao)

### DIFF
--- a/web/queries/licitacao.py
+++ b/web/queries/licitacao.py
@@ -98,9 +98,13 @@ LICITACAO_PROPONENTES = """
 # IMPORTANTE: o warmer recebe a 5-tupla canonica do tce_pb_licitacao
 # (numero_licitacao='00003/2025', modalidade='Pregao (Lei No 14.133/2021)')
 # mas tce_pb_despesa usa formatos diferentes ('000032025', 'Pregao (Lei
-# 14.133/21)'). Igualdade direta NUNCA bate. Match canonico:
-#   - numero: digit-only normalization (REGEXP_REPLACE \D)
-#   - modalidade: lowercase + unaccent + strip suffix " (...)"
+# 14.133/21)'). Estrategia:
+#   - numero: tce_pb_despesa ja armazena digit-only. Normaliza so o INPUT
+#     pra preservar uso do idx_tce_desp_licitacao (sargable lookup).
+#   - modalidade: ambos os lados precisam canonicalizar (lowercase+unaccent+
+#     strip suffix). Aplicado como filter residual depois dos selecionadores
+#     indexados (municipio + codigo_ug + numero_licitacao) terem reduzido
+#     o conjunto pra <100 rows tipico.
 LICITACAO_EMPENHOS_VINCULADOS = """
     WITH despesas_pj AS MATERIALIZED (
         SELECT
@@ -109,16 +113,13 @@ LICITACAO_EMPENHOS_VINCULADOS = """
             d.cnpj_basico::bpchar(8) AS cnpj_basico
         FROM tce_pb_despesa d
         WHERE d.municipio = %(municipio)s
-          -- Match canonico: tce_pb_despesa.numero_licitacao usa formato
-          -- compacto ('000032025'), tce_pb_licitacao usa '00003/2025'.
-          AND REGEXP_REPLACE(d.numero_licitacao, '\\D', '', 'g')
-            = REGEXP_REPLACE(%(numero_licitacao)s, '\\D', '', 'g')
-          -- Filter pela 5-tupla canonica pra evitar colisoes entre orgaos/anos
-          -- com mesmo numero_licitacao. (P1 GPT 5.5 review PR #108.)
           AND d.codigo_ug = %(codigo_ug)s
-          -- Match canonico: tce_pb_despesa.modalidade_licitacao usa formato
-          -- compacto ('Pregao (Lei 14.133/21)'), tce_pb_licitacao usa
-          -- 'Pregao (Lei No 14.133/2021)'.
+          -- Sargable: tce_pb_despesa.numero_licitacao ja vem em formato
+          -- compacto digit-only ('000032025'). Normaliza apenas o input
+          -- (do tce_pb_licitacao em '00003/2025') pra preservar index hit.
+          AND d.numero_licitacao = REGEXP_REPLACE(%(numero_licitacao)s, '\\D', '', 'g')
+          -- Residual canonical match pra modalidade (formato divergente).
+          -- Roda apenas sobre o subset filtrado pelos selecionadores acima.
           AND LOWER(unaccent(BTRIM(REGEXP_REPLACE(
                 d.modalidade_licitacao,
                 '\\s*-?\\s*\\([^)]*\\).*$', ''))))


### PR DESCRIPTION
## Problema

PR #113 fez 100% das licitacoes falharem no warm cache de producao (cache `LICITACAO_PERFIL` ficou vazio  SSR `/licitacao/<...>` retorna 503 cache miss).

A causa foi a forma usada pra reconciliar os formatos divergentes de `numero_licitacao` entre `tce_pb_licitacao` (`'00003/2025'`) e `tce_pb_despesa` (`'000032025'`):

`sql
AND REGEXP_REPLACE(d.numero_licitacao, '\D', '', 'g')
  = REGEXP_REPLACE(%(numero_licitacao)s, '\D', '', 'g')
`

Aplicar `REGEXP_REPLACE` na **coluna** torna a comparacao nao-sargable  planner cai pra seq scan na particao filtrada por municipio. Em municipios grandes (Joao Pessoa, Campina Grande) com milhoes de despesas, cada query passa de subsegundo pra >30s  warm cumulativamente estoura `statement_timeout=600s` por shadow rewrite  shadow swap abortado  cache nunca preenchido em prod.

## Fix

`tce_pb_despesa.numero_licitacao` ja vem em formato compacto digit-only do TCE-PB. Normaliza apenas o **input** (vindo de `tce_pb_licitacao` em `'00003/2025'`) pra preservar a sargabilidade da coluna:

`sql
AND d.numero_licitacao = REGEXP_REPLACE(%(numero_licitacao)s, '\D', '', 'g')
`

A modalidade continua com canonical match em ambos os lados (formatos divergem nas duas tabelas mesmo: `'Pregao (Lei No 14.133/2021)'` vs `'Pregao (Lei 14.133/21)'`), mas como **residual filter** aplicado em ~100 linhas ja reduzidas pelos selecionadores indexados (municipio + codigo_ug + numero_licitacao).

## Validacao via EXPLAIN ANALYZE na VM de producao

Antes (com REGEXP_REPLACE na coluna): seq scan + filter, **1.3s** em municipio pequeno (Agua Branca), 30s+ em municipios grandes.

Depois (sargable):

`
Bitmap Heap Scan on tce_pb_despesa d  (cost=887.50..1011.38 rows=1) (actual time=6.255..6.391 rows=8 loops=1)
  Recheck Cond: numero_licitacao = '000032025' AND municipio = 'Cruz...' AND valor_pago > 0
  Filter: canonical-mod-match
  ->  BitmapAnd
        ->  Bitmap Index Scan on idx_tce_desp_licitacao (rows=26041)
        ->  Bitmap Index Scan on idx_tce_desp_mun_data (rows=77022)
Execution Time: 6.784 ms
`

**6.8ms** vs **1.3s antes** = ~190x speedup. BitmapAnd usa `idx_tce_desp_licitacao` + `idx_tce_desp_mun_data`, depois recheck + filter residual canonical-mod em ~45 linhas.

Validado contra 10 licitacoes via `compute_licitacao_dict`: todas concluem em <0.2s com upsert no shadow cache OK.

## Deploy plan

`
gh workflow run deploy.yml --ref main -f etl_phase=web \
  -f rewarm_cache_keys=LICITACAO_PERFIL
`

shadow rewarm zero-downtime  site continua servindo (mesmo que vazio hoje) ate o novo warm completar com sucesso, depois swap atomico promove.