### PR TITLE
fix(warm): import TIMEOUT_PROFILE_WARM em fases licitacoes + cidade-resumo (NameError em 100% dos items)

### DIFF
--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -1612,6 +1612,7 @@ def _warm_licitacoes_phase() -> tuple[int, int, int]:
     licitacoes que nao retornaram dados (skip_nf).
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
+    from web.config import TIMEOUT_PROFILE_WARM
     from web.queries.licitacao import LICITACOES_QUALIFICADAS_PAGINATED
     from web.routes.licitacao import (
         CACHE_QUERY_ID as LIC_CACHE_QID,
@@ -1776,6 +1777,7 @@ def _warm_cidade_resumo_phase() -> tuple[int, int, int]:
     Returns: (ok, fail, skipped).
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
+    from web.config import TIMEOUT_PROFILE_WARM
     from web.queries.cidade_resumo import CIDADE_RESUMO_QUALIFICADOS_LIST
     from web.routes.cidade import CACHE_QUERY_ID_RESUMO, _build_resumo_cache_key
     from web.routes.cidade_resumo_compute import (


### PR DESCRIPTION
## TL;DR

Bug introduzido em #108: as duas fases novas de warm (`_warm_licitacoes_phase`, `_warm_cidade_resumo_phase`) referenciam `TIMEOUT_PROFILE_WARM` sem importar. **NameError em 100% dos itens**  cache `LICITACAO_PERFIL` e `CIDADE_RESUMO_MENSAL` permanecem vazios em prod desde Out/Nov  todas as paginas `/licitacao/<...>` e `/cidade/<slug>/<yyyy-mm>` retornam **503**.

## Como descobri

Suspeitei do warmer porque deploys com `rewarm_cache_keys=LICITACAO_PERFIL` reportavam 100% fail (`163,990 fail` em 12 segundos  9000 fails/s, impossivel ser timeout). O log do warm so reporta count, nao a exception message.

Monkey-patchei `_warm_one` em prod pra adicionar `print(traceback.format_exc())` antes de `return False`. Re-rodei o warm e o journal mostrou:

\\\
NameError: name 'TIMEOUT_PROFILE_WARM' is not defined. Did you mean: 'TIMEOUT_PERFIL_LIVE'?
  File /home/govbr/govbr-project/web/warm_cache.py, line 1696, in _warm_one
    timeout_sec=TIMEOUT_PROFILE_WARM,
\\\

`git blame` confirma: linhas adicionadas em `a34078b` (PR #108).

## Fix

Adiciona `from web.config import TIMEOUT_PROFILE_WARM` nas duas fases (as outras duas fases ja tinham: linhas 1044 e 1393):

\\\python
def _warm_licitacoes_phase() -> tuple[int, int, int]:
    from concurrent.futures import ThreadPoolExecutor, as_completed
+   from web.config import TIMEOUT_PROFILE_WARM
    from web.queries.licitacao import LICITACOES_QUALIFICADAS_PAGINATED
\\\

E identico em `_warm_cidade_resumo_phase`.

## Impacto pos-merge

Depois do deploy + rewarm:
- `LICITACAO_PERFIL`: 163,990 paginas voltam a ser cacheadas. SSR /licitacao/... 200 OK.
- `CIDADE_RESUMO_MENSAL`: 22,508 paginas voltam a ser cacheadas. SSR /cidade/<slug>/<yyyy-mm> 200 OK.

## Deploy

\\\
gh workflow run deploy.yml --ref main -f etl_phase=web \
  -f rewarm_cache_keys=LICITACAO_PERFIL
\\\

Cidade-resumo nao precisa de rewarm explicito  ja roda na fase normal apos empresas (que skip cached). Como a live nao tem entradas, qualquer warm preenche.