### PR TITLE
docs(security): scrub VM/Azure metadata do repo publico

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,12 +6,15 @@ name: Deploy to Azure VM
 #   3. postflight (github-hosted, OIDC) — resize VM down se etl_phase != web
 #
 # Required secrets:
-#   DB_PASSWORD            - PostgreSQL password
-#   ENV_FILE               - Contents of .env file
-#   VM_HOST                - VM IP/hostname (used pelo preflight pra checar SSH)
-#   AZURE_CLIENT_ID        - OIDC: app registration clientId
-#   AZURE_TENANT_ID        - OIDC: tenant
-#   AZURE_SUBSCRIPTION_ID  - OIDC: subscription com a VM
+#   DB_PASSWORD               - PostgreSQL password
+#   ENV_FILE                  - Contents of .env file
+#   VM_HOST                   - VM IP/hostname (used pelo preflight pra checar SSH)
+#   AZURE_CLIENT_ID           - OIDC: app registration clientId
+#   AZURE_TENANT_ID           - OIDC: tenant
+#   AZURE_SUBSCRIPTION_ID     - OIDC: subscription com a VM
+#   AZURE_RESOURCE_GROUP      - resource group da VM (consumido em env.AZURE_RG)
+#   AZURE_VM_NAME             - nome da VM (consumido em env.AZURE_VM)
+#   AZURE_DATA_DISK_NAME      - nome do disco de dados (consumido em env.DATA_DISK)
 #
 # First-time setup:
 #   1. Create an Ubuntu VM (tested on Azure Standard_B4as_v2, 16GB RAM)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,13 +114,20 @@ permissions:
 # concorrentes podem fazer az vm deallocate/resize um sobre o outro e quebrar o
 # banco (que leva DIAS para reconstruir do zero).
 concurrency:
-  group: deploy-vm-govbr
+  # Lock global por VM. Nome generico porque so existe 1 ambiente prod.
+  # Recursos especificos (RG/VM/disco) vem de secrets — ver env: abaixo.
+  group: deploy-azure-vm
   cancel-in-progress: false
 
 env:
   PROJECT_DIR: /home/govbr/govbr-project
-  AZURE_RG: RG-GOVBR-NCUS
-  AZURE_VM: vm-govbr
+  # Nomes de recursos Azure ficam em GitHub Secrets para nao expor metadata
+  # de infra em repo publico. Configurar antes do primeiro deploy:
+  #   gh secret set AZURE_RESOURCE_GROUP   --body "<rg-name>"
+  #   gh secret set AZURE_VM_NAME          --body "<vm-name>"
+  #   gh secret set AZURE_DATA_DISK_NAME   --body "<disk-name>"
+  AZURE_RG: ${{ secrets.AZURE_RESOURCE_GROUP }}
+  AZURE_VM: ${{ secrets.AZURE_VM_NAME }}
   # B2as_v2: 2 vCPU, 8GB  ~$55/mes  — adequado para servir web
   # B4as_v2: 4 vCPU, 16GB ~$108/mes — necessario para ETL/views pesados
   VM_SIZE_WEB: Standard_B2as_v2
@@ -132,7 +139,7 @@ env:
   # Como o disco eh cobrado POR HORA, swappar StandardSSD<->Premium nas
   # transicoes de tamanho da VM custa ~$0.05/h extra durante operacoes
   # pesadas, em vez de $35/mes always-on.
-  DATA_DISK: disk-govbr-data
+  DATA_DISK: ${{ secrets.AZURE_DATA_DISK_NAME }}
   DISK_SKU_LIGHT: StandardSSD_LRS
   DISK_SKU_HEAVY: Premium_LRS
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ A VM e o disco mudam de SKU automaticamente conforme o trabalho. Custos sao pror
 | **Total tipico** | **~$104** | **~R$ 585** |
 
 > Cabe nos **$150/mes de credito Azure** (Visual Studio Enterprise) com folga de ~$45.
-> Regiao: **North Central US**. Resource group: `RG-GOVBR-NCUS`. VM: `vm-govbr`. Data disk: `disk-govbr-data`.
+> Regiao: **North Central US**. Nomes de resource group, VM e disco ficam em GitHub Secrets (`AZURE_RESOURCE_GROUP`, `AZURE_VM_NAME`, `AZURE_DATA_DISK_NAME`).
 
 ⚠️ **Limite Azure:** disco aceita no maximo 2 mudancas de SKU por 24h. Se rodar 2 deploys com etl/warm no mesmo dia, o segundo upgrade falha — fica em Standard SSD por algumas horas (warm sera mais lento, mas funciona). Workflow detecta e segue.
 

--- a/TODO.md
+++ b/TODO.md
@@ -420,11 +420,11 @@ Items #i0a-#i0d listados acima na seção "Framework reutilizavel".
 - VM e disco mudam de SKU juntos via deploy.yml (preflight upsize, postflight downsize)
 - Disco Premium so cobra durante operacoes pesadas (~$3/mes vs $35/mes always-on)
 - Limite Azure: 2 mudancas de SKU de disco por 24h — workflow detecta e prossegue se atingir
-- IP estatico: 52.162.207.186 (~$4/mes)
+- IP estatico dedicado (~$4/mes)
 - Budget: ~US$150/mes (creditos Visual Studio Enterprise)
 - **Custo tipico:** ~$104/mes (web + 1 ETL + 1 warm)
-- Resource group: `RG-GOVBR-NCUS`. VM: `vm-govbr`. Data disk: `disk-govbr-data`. Subscription: `90676d79-a73b-462d-bdd6-2b4c738237f5`
-- SSH: `ssh -i C:\Users\lucas\.ssh\azure_vm.txt govbr@52.162.207.186` (read-only debug)
+- Resource group, VM name, data disk e subscription ficam em GitHub Secrets (`AZURE_RESOURCE_GROUP`, `AZURE_VM_NAME`, `AZURE_DATA_DISK_NAME`, `AZURE_SUBSCRIPTION_ID`) e nao sao expostos no repo.
+- SSH read-only de debug: `ssh -i <chave-privada> govbr@<VM_HOST>` (host e chave ficam locais ao mantenedor)
 - Workflows: `deploy.yml` (preflight resize + disk SKU → ETL → postflight resize back), `setup-runner.yml` (runner 1x)
 - Secrets: `VM_HOST`, `VM_SSH_KEY`, `DB_PASSWORD`, `ENV_FILE`, `RUNNER_ADMIN_TOKEN`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
 

--- a/deploy/setup-letsencrypt.sh
+++ b/deploy/setup-letsencrypt.sh
@@ -12,7 +12,7 @@
 #
 # Pré-requisitos:
 #   - DNS A records de transparenciapb.org e www.transparenciapb.org
-#     apontando para o IP público desta VM (52.162.207.186).
+#     apontando para o IP público desta VM.
 #   - Portas TCP 80 e 443 abertas no NSG/firewall.
 #
 # Variáveis de ambiente opcionais:

--- a/relatorios/relatorio_empresas_relacionadas_concorrencia_nacional.md
+++ b/relatorios/relatorio_empresas_relacionadas_concorrencia_nacional.md
@@ -231,7 +231,7 @@ O caso `PRIME HOLDING`, detalhado no relatorio da Paraiba, tambem entra no mapa 
 - casos em `PB`, `GO` e `RS`
 - **10 subsidiarias** e **5 bases de CNPJ distintas** na estrutura do grupo
 
-Isso faz dele um bom elo entre a visao nacional e a investigacao estadual ja documentada em [relatorio_empresas_relacionadas_concorrencia_pb.md](C:\Users\lucas\govbr-cruza-dados\relatorios\relatorio_empresas_relacionadas_concorrencia_pb.md).
+Isso faz dele um bom elo entre a visao nacional e a investigacao estadual ja documentada em [relatorio_empresas_relacionadas_concorrencia_pb.md](./relatorio_empresas_relacionadas_concorrencia_pb.md).
 
 ---
 


### PR DESCRIPTION
## Resumo

Remove referencias hardcoded a metadata da VM Azure (IP, resource group, VM name, data disk name, subscription ID) do repo publico e migra os 3 identificadores Azure pra GitHub Secrets.

Findings P0 #3 da analise distribuida de 11 agentes (prepara-repo-contrib) — owner divulgou o projeto e detectou que `TODO.md` versionado vazava o target package completo da infra.

## Mudancas

| Arquivo | Antes | Depois |
|---|---|---|
| `TODO.md:423-427` | IP, RG, VM, disk, subscription, SSH com path local Windows | Placeholders + nota sobre secrets |
| `README.md:221` | RG, VM e disk em texto | Nota sobre GitHub Secrets |
| `deploy/setup-letsencrypt.sh:15` | IP no comentario de pre-requisitos | Sem IP |
| `.github/workflows/deploy.yml:117,122,123,135` | `concurrency.group` por nome especifico + env vars hardcoded | `deploy-azure-vm` + env vars de `${{ secrets.AZURE_RESOURCE_GROUP }}`, `${{ secrets.AZURE_VM_NAME }}`, `${{ secrets.AZURE_DATA_DISK_NAME }}` + bloco inline com `gh secret set` instructions |

Validei com `grep` que nao sobrou nenhum valor real dos 7 identificadores em nenhum arquivo do repo.

## Acao obrigatoria antes do merge

Criar os 3 secrets no repo:

```bash
gh secret set AZURE_RESOURCE_GROUP --body "rg-name-real"
gh secret set AZURE_VM_NAME        --body "vm-name-real"
gh secret set AZURE_DATA_DISK_NAME --body "disk-name-real"
```

Sem esses secrets, qualquer run do `deploy.yml` falha imediatamente no preflight (env vars vazias passadas pra `az vm show -g "" -n ""`).

## Recomendacoes pos-merge (fora do escopo deste PR)

- Rotacionar a SSH key cujo caminho/nome foi vazado (chave local do mantenedor referenciada no `TODO.md`).
- Avaliar `git filter-repo` pra limpar o historico (os identificadores antigos continuam em commits anteriores ao merge). Memoria do mantenedor diz "nao reescrever historia git" — decidir caso a caso. Workaround menos invasivo: rotacionar so a credencial (SSH key + opcionalmente recriar app registration Azure).

## Como testar

- `grep -rn "<ip-antigo>\|<subscription-id-antigo>\|<rg-antigo>\|<vm-name-antigo>\|<disk-antigo>\|<ssh-key-filename-antigo>" .` deve retornar zero (substitua placeholders pelos valores reais conhecidos pelo mantenedor — NAO listar valores literais aqui, este body e publico).
- Apos criar os secrets, disparar `deploy.yml` com `etl_phase=web` e verificar que `preflight` consegue ler `az vm show -g $AZURE_RG -n $AZURE_VM`.

---

🤖 Identificado pela analise distribuida documentada em `.copilot/session-state/.../files/SINTESE-CONSOLIDADA.md` (A4 security audit).
