### PR TITLE
fix(security): autenticar POST /api/cache/invalidate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,8 +67,11 @@ UMAMI_WEBSITE_ID=
 #
 # Gerar com:
 #   python -c "import secrets; print(secrets.token_urlsafe(32))"
-# Chamar com:
+# Chamar com (note o header Origin: o Origin/Referer guard global em
+# web/main.py:100-118 roda ANTES do handler e exige host conhecido —
+# defense in depth proposital, alem do X-Admin-Token):
 #   curl -X POST https://transparenciapb.org/api/cache/invalidate \
+#        -H "Origin: https://transparenciapb.org" \
 #        -H "X-Admin-Token: <token>" \
 #        -H "Content-Type: application/json" \
 #        -d '{"query_ids": ["Q65", "PERFIL"]}'

--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,18 @@ SITE_URL=https://transparenciapb.org
 UMAMI_SCRIPT_URL=/_traffic/analytics/script.js
 UMAMI_WEBSITE_ID=
 
+# ─── Cache invalidation admin token ───
+# Token compartilhado para autenticar chamadas a POST /api/cache/invalidate
+# (endpoint destrutivo: apaga linhas do web_cache, causando cache-miss de
+# 12-18h para queries afetadas). Sem esta var, o endpoint responde 503 e
+# nao apaga nada — operacoes de cache em prod devem ir pelo deploy.yml
+# (inputs invalidate_cache_keys / rewarm_cache_keys), que usam psql direto.
+#
+# Gerar com:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Chamar com:
+#   curl -X POST https://transparenciapb.org/api/cache/invalidate \
+#        -H "X-Admin-Token: <token>" \
+#        -H "Content-Type: application/json" \
+#        -d '{"query_ids": ["Q65", "PERFIL"]}'
+CACHE_INVALIDATE_TOKEN=

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import csv
+import hmac
 import io
 import logging
+import os
 import time
 from datetime import date, datetime, timedelta, timezone
 
-from fastapi import APIRouter, Body, Query, Request
+from fastapi import APIRouter, Body, Header, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel
 from psycopg2.errors import QueryCanceled, UndefinedTable, UndefinedColumn
@@ -1402,11 +1404,47 @@ async def get_heatmap_mes(municipio_path: str, ano: int, mes: int):
 
 
 @router.post("/api/cache/invalidate")
-async def invalidate_web_cache(payload: dict = Body(...)):
-    """Invalida entradas do web_cache por query_id(s)."""
+async def invalidate_web_cache(
+    request: Request,
+    payload: dict = Body(...),
+    x_admin_token: str | None = Header(default=None, alias="X-Admin-Token"),
+):
+    """Invalida entradas do web_cache por query_id(s).
+
+    Endpoint destrutivo (DELETE em web_cache) protegido por token compartilhado
+    no header `X-Admin-Token`. Fail-closed: sem `CACHE_INVALIDATE_TOKEN`
+    configurado no ambiente, responde 503 e nao apaga nada.
+
+    Para invalidacao operacional, prefira o workflow `deploy.yml` com inputs
+    `invalidate_cache_keys` (HARD) ou `rewarm_cache_keys` (SHADOW zero-downtime),
+    que executam o DELETE via psql direto na VM, sem expor o endpoint.
+    """
+    expected_token = os.environ.get("CACHE_INVALIDATE_TOKEN", "").strip()
+    remote = request.client.host if request.client else "?"
+
+    if not expected_token:
+        logging.warning("[cache-invalidate] CACHE_INVALIDATE_TOKEN nao configurado; rejeitando chamada de %s", remote)
+        return JSONResponse(
+            {"error": "endpoint desabilitado: CACHE_INVALIDATE_TOKEN nao configurado"},
+            status_code=503,
+        )
+
+    if not x_admin_token or not hmac.compare_digest(x_admin_token, expected_token):
+        logging.warning("[cache-invalidate] token invalido/ausente em chamada de %s", remote)
+        return JSONResponse({"error": "nao autorizado"}, status_code=401)
+
     query_ids = payload.get("query_ids", [])
+    if not isinstance(query_ids, list):
+        return JSONResponse({"error": "query_ids deve ser lista"}, status_code=400)
+    # Defesa em profundidade: cap em 100 ids/chamada (warm_cache tem ~30 hoje).
+    if len(query_ids) > 100:
+        return JSONResponse({"error": "query_ids: maximo 100 por chamada"}, status_code=400)
+    # Aceita so strings curtas (caracteres seguros pra query_id).
+    if not all(isinstance(q, str) and 1 <= len(q) <= 80 for q in query_ids):
+        return JSONResponse({"error": "query_ids deve ser lista de strings (1-80 chars)"}, status_code=400)
     if not query_ids:
         return JSONResponse({"deleted": 0})
+
     try:
         from web.db import get_conn
         with get_conn() as conn:
@@ -1415,8 +1453,10 @@ async def invalidate_web_cache(payload: dict = Body(...)):
                 ph = ",".join(["%s"] * len(query_ids))
                 cur.execute(f"DELETE FROM web_cache WHERE query_id IN ({ph})", query_ids)
                 deleted = cur.rowcount
+        logging.info("[cache-invalidate] %s ids, %s rows apagadas, origem=%s", len(query_ids), deleted, remote)
         return JSONResponse({"deleted": deleted})
     except Exception:
+        logging.exception("[cache-invalidate] falha ao invalidar (origem=%s)", remote)
         return JSONResponse({"error": "falha ao invalidar"}, status_code=500)
 
 

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1406,7 +1406,6 @@ async def get_heatmap_mes(municipio_path: str, ano: int, mes: int):
 @router.post("/api/cache/invalidate")
 async def invalidate_web_cache(
     request: Request,
-    payload: dict = Body(...),
     x_admin_token: str | None = Header(default=None, alias="X-Admin-Token"),
 ):
     """Invalida entradas do web_cache por query_id(s).
@@ -1414,6 +1413,10 @@ async def invalidate_web_cache(
     Endpoint destrutivo (DELETE em web_cache) protegido por token compartilhado
     no header `X-Admin-Token`. Fail-closed: sem `CACHE_INVALIDATE_TOKEN`
     configurado no ambiente, responde 503 e nao apaga nada.
+
+    O body so eh parseado DEPOIS da autenticacao bem-sucedida; caso contrario
+    `payload: dict = Body(...)` deixaria o FastAPI retornar 422 antes do 503/401
+    quando o body fosse mal-formado, vazando schema e quebrando fail-closed.
 
     Para invalidacao operacional, prefira o workflow `deploy.yml` com inputs
     `invalidate_cache_keys` (HARD) ou `rewarm_cache_keys` (SHADOW zero-downtime),
@@ -1432,6 +1435,15 @@ async def invalidate_web_cache(
     if not x_admin_token or not hmac.compare_digest(x_admin_token, expected_token):
         logging.warning("[cache-invalidate] token invalido/ausente em chamada de %s", remote)
         return JSONResponse({"error": "nao autorizado"}, status_code=401)
+
+    # Auth ok — agora parsea o body. Erros de body abaixo retornam 400 (nao 422),
+    # mantendo a mesma surface de erro independente do payload.
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse({"error": "body deve ser JSON"}, status_code=400)
+    if not isinstance(payload, dict):
+        return JSONResponse({"error": "body deve ser objeto JSON"}, status_code=400)
 
     query_ids = payload.get("query_ids", [])
     if not isinstance(query_ids, list):


### PR DESCRIPTION
## Resumo

Adiciona autenticacao no endpoint `POST /api/cache/invalidate` (web/routes/cidade.py:1404) que estava acessivel sem auth alem do Origin/Referer guard global — e o proprio comentario em `web/main.py:100-118` admite que o guard "nao e seguranca real".

Findings P0 #5 da analise distribuida de 11 agentes (prepara-repo-contrib) — owner divulgou o projeto, qualquer atacante com Origin forjado podia apagar o `web_cache` (DELETE), causando cache-miss de 12-18h ate o warm reconstruir.

## Mudancas

### `web/routes/cidade.py`
- Header `X-Admin-Token` obrigatorio, comparado a env var `CACHE_INVALIDATE_TOKEN` via `hmac.compare_digest` (resistente a timing attack).
- **Fail-closed**: sem `CACHE_INVALIDATE_TOKEN` setado, retorna `503` (`endpoint desabilitado`). Em prod nao precisa habilitar — invalidacao operacional vai pelo `deploy.yml` (inputs `invalidate_cache_keys` / `rewarm_cache_keys`), que executam `DELETE`/shadow swap via `psql` direto na VM.
- Validacao reforcada de payload:
  - `query_ids` deve ser **lista** (rejeita scalar/dict)
  - Cap de **100 ids** por chamada (warm tem ~30 hoje)
  - Cada id: string 1-80 chars
- Log estruturado: origem do IP, sucesso/falha de auth, num ids, rows apagadas. **Nao loga o token**.

### `.env.example`
- Nova secao "Cache invalidation admin token" com:
  - Comando pra gerar (`secrets.token_urlsafe(32)`)
  - Exemplo curl
  - Nota explicando que o canal operacional default e o workflow, nao o endpoint

## Comportamento

| Cenario | Antes | Depois |
|---|---|---|
| Sem `CACHE_INVALIDATE_TOKEN` env | DELETE ok com Origin OK | **503** + log warning |
| `CACHE_INVALIDATE_TOKEN` setado, sem header | DELETE ok com Origin OK | **401** + log warning |
| Header errado | DELETE ok com Origin OK | **401** + log warning |
| Header correto + payload valido | DELETE | DELETE + log info |
| Payload `query_ids` nao-lista | 200 `{deleted:0}` | **400** |
| Payload com 101 ids | 200 DELETE | **400** |

## Compatibilidade

Nenhum consumidor real do endpoint encontrado no repo:
- `web/warm_cache.py` faz DELETE direto em `web_cache` (nao chama API)
- `.github/workflows/deploy.yml` usa `psql` direto na VM
- Nada em `etl/`, `scripts/` ou frontend chama `/api/cache/invalidate`

Logo, fail-closed nao quebra fluxo existente. Owner pode optar por:
1. **Nao habilitar** (recomendado) — endpoint fica permanentemente 503, operacao 100% via workflow
2. **Habilitar** — setar `CACHE_INVALIDATE_TOKEN=<token>` no `.env` da VM, restart `cruza-web`

## Como testar

```bash
# 1. Sem env var → 503
unset CACHE_INVALIDATE_TOKEN
python -m uvicorn web.main:app --port 8000 &
curl -X POST http://localhost:8000/api/cache/invalidate \
     -H "Content-Type: application/json" \
     -d '{"query_ids": ["Q65"]}'
# Esperado: 503 {"error":"endpoint desabilitado: ..."}

# 2. Com env mas sem header → 401
export CACHE_INVALIDATE_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
# restart uvicorn
curl -X POST http://localhost:8000/api/cache/invalidate \
     -H "Content-Type: application/json" \
     -d '{"query_ids": ["Q65"]}'
# Esperado: 401 {"error":"nao autorizado"}

# 3. Com header correto → ok
curl -X POST http://localhost:8000/api/cache/invalidate \
     -H "X-Admin-Token: $CACHE_INVALIDATE_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"query_ids": ["Q65"]}'
# Esperado: 200 {"deleted":N}

# 4. Cap de 100
curl -X POST http://localhost:8000/api/cache/invalidate \
     -H "X-Admin-Token: $CACHE_INVALIDATE_TOKEN" \
     -H "Content-Type: application/json" \
     -d "$(python -c 'import json; print(json.dumps({"query_ids":["Q"+str(i) for i in range(101)]}))')"
# Esperado: 400
```

---

🤖 Identificado pela analise distribuida documentada em `.copilot/session-state/.../files/SINTESE-CONSOLIDADA.md` (A4 security audit + B2 web newcomer review).
