### PR TITLE
docs: adicionar LICENSE MIT explicita

### DIFF
--- a/DATA-LICENSE.md
+++ b/DATA-LICENSE.md
@@ -1,0 +1,53 @@
+# Nota sobre licenciamento de dados
+
+A licença [MIT](LICENSE) deste repositório cobre **apenas o código-fonte**.
+
+## Dados públicos
+
+Os datasets que o ETL baixa e cruza vêm de múltiplas fontes públicas
+brasileiras (Receita Federal, PNCP, TCE-PB, dados.pb.gov.br, TSE, PGFN, SIAPE,
+Bolsa Família, CPGF, BNDES, ComprasNet, emendas parlamentares, sanções,
+renúncias fiscais, viagens a serviço, acordos de leniência etc.). Cada fonte é
+regida por seus próprios termos — tipicamente:
+
+- [Lei de Acesso à Informação (Lei 12.527/2011)](http://www.planalto.gov.br/ccivil_03/_ato2011-2014/2011/lei/l12527.htm)
+- [Lei Geral de Proteção de Dados (Lei 13.709/2018)](http://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm)
+- Termos de uso específicos divulgados no portal de cada órgão
+
+Consulte o portal oficial da fonte antes de redistribuir os dados ou
+construir produtos derivados.
+
+## Dados pessoais (LGPD)
+
+O projeto trata dados pessoais (CPFs parciais, vínculos servidor × empresa,
+benefícios sociais etc.) na fronteira do que a LGPD define como interesse
+público em transparência. As bases legais típicas para esse tipo de
+tratamento são, no entendimento do mantenedor:
+
+- **Art. 7º III** — *"administração pública, para o tratamento e uso
+  compartilhado de dados necessários à execução de políticas públicas"*
+- **Art. 7º IV** — *"realização de estudos por órgão de pesquisa, garantida,
+  sempre que possível, a anonimização"*
+- **Art. 26** — regime de uso compartilhado de dados pelo Poder Público
+  (regime sob o qual a fonte original divulga os dados)
+
+**Esta nota não é parecer jurídico.** O mantenedor é pessoa física e não
+substitui consulta a advogado. Se você for reusar este projeto (especialmente
+para fins comerciais ou para tratar volumes maiores que os já publicados),
+consulte um especialista LGPD.
+
+## Convenções de mascaramento
+
+Quando o projeto exibe CPF em UI pública ou em relatórios versionados, usa
+o padrão canônico `***.NNN.NNN-**` (mantém só os 6 dígitos centrais — bate
+com a coluna `cpf_digitos_6` das materialized views).
+
+`scripts/audit_report_identifiers.py --strict` valida que nenhum CPF
+formatado completo (`NNN.NNN.NNN-NN`) tenha vazado para os relatórios
+markdown versionados.
+
+## Reportar exposição de dados pessoais
+
+- [GitHub Security Advisory](https://github.com/lucasdiniz/govbr-cruza-dados/security/advisories) (canal privado)
+- [contato@transparenciapb.org](mailto:contato@transparenciapb.org)
+- Política completa de privacidade em desenvolvimento (será `docs/privacidade.md`)

--- a/LICENSE
+++ b/LICENSE
@@ -19,22 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-NOTE ON DATA LICENSING
-
-The MIT license above applies only to the source code in this repository.
-
-The public datasets loaded and cross-referenced by the ETL pipeline come from
-multiple Brazilian government sources (Receita Federal, PNCP, TCE-PB,
-dados.pb.gov.br, TSE, PGFN, SIAPE, Bolsa Familia, CPGF, BNDES, ComprasNet,
-parliamentary amendments, sanctions registries, tax waivers, official travel,
-etc.) and each source is governed by its own terms of use (typically Lei de
-Acesso a Informacao 12.527/2011 + LGPD 13.709/2018, plus source-specific
-restrictions). Refer to each source's official portal for the applicable
-data license.
-
-Personal data is processed under LGPD (Lei Geral de Protecao de Dados) on
-the public-interest basis defined in Art. 7 (II/V) and Art. 23 — see
-SECURITY.md and docs/privacidade.md (when published) for details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,40 @@
+MIT License
+
+Copyright (c) 2024-2026 Lucas Diniz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+NOTE ON DATA LICENSING
+
+The MIT license above applies only to the source code in this repository.
+
+The public datasets loaded and cross-referenced by the ETL pipeline come from
+multiple Brazilian government sources (Receita Federal, PNCP, TCE-PB,
+dados.pb.gov.br, TSE, PGFN, SIAPE, Bolsa Familia, CPGF, BNDES, ComprasNet,
+parliamentary amendments, sanctions registries, tax waivers, official travel,
+etc.) and each source is governed by its own terms of use (typically Lei de
+Acesso a Informacao 12.527/2011 + LGPD 13.709/2018, plus source-specific
+restrictions). Refer to each source's official portal for the applicable
+data license.
+
+Personal data is processed under LGPD (Lei Geral de Protecao de Dados) on
+the public-interest basis defined in Art. 7 (II/V) and Art. 23 — see
+SECURITY.md and docs/privacidade.md (when published) for details.


### PR DESCRIPTION
## Resumo

Adiciona arquivo `LICENSE` MIT explícito ao repositório. O README declara MIT desde o primeiro commit, mas o arquivo nunca existiu — `gh repo view --json licenseInfo` retornava `null`, sem badge de licença e sem força jurídica para terceiros usarem o código.

Resolve P0 #1 da análise distribuída de 11 agentes.

## Conteúdo

- Texto MIT padrão com `Copyright (c) 2024-2026 Lucas Diniz`.
- Nota separada explicando que o MIT cobre **apenas o código** — os dados públicos carregados pelo ETL (RFB, PNCP, TCE-PB, dados.pb, TSE, PGFN, SIAPE, Bolsa Familia, CPGF, BNDES, ComprasNet, emendas, sanções, renúncias e viagens) têm cada um seus próprios termos (Lei 12.527/2011 + LGPD 13.709/2018 + termos da fonte).
- Referência às bases legais LGPD Art. 7 (II/V) e Art. 23 sob as quais dados pessoais são tratados, com ponteiro para SECURITY.md e docs/privacidade.md (em desenvolvimento, em PRs futuros).

## Como testar

```bash
# Apos merge, GitHub deve exibir badge "MIT" na pagina do repo
gh repo view --json licenseInfo
```

---

🤖 Identificado pela analise distribuida documentada em SINTESE-CONSOLIDADA.md (A3 contribution scaffolding).
