### PR TITLE
fix(privacy): mascarar 2 CPFs vazados + audit --strict

### DIFF
--- a/relatorios/relatorio_inidoneidade_ilegal_pb.md
+++ b/relatorios/relatorio_inidoneidade_ilegal_pb.md
@@ -472,7 +472,7 @@
 | 25 | Masterfer Comércio de Ferragens | 11.175.931/0001-47 | Governo da Bahia (Estadual) | 21.766,00 | Campina Grande, Mãe d'Água |
 | 26 | Mapa Mix Comércio | 22.552.766/0001-11 | Pref. Garanhuns-PE (Municipal) | 14.698,09 | Gurinhém |
 | 27 | BH Soluções Integradas | 37.610.183/0001-77 | Governo da Bahia (Estadual) | 8.888,00 | Campina Grande |
-| 28 | Maria José Nunes de Oliveira | 542.092.696-20 (CPF) | CGU (Federal) | 4.481,10 | Barra de Santana |
+| 28 | Maria José Nunes de Oliveira | ***.092.696-** (CPF) | CGU (Federal) | 4.481,10 | Barra de Santana |
 | 29 | EFL Silva Manutenção | 24.798.024/0001-04 | CRM-SP (Federal) | 3.825,00 | João Pessoa |
 | 30 | Soserv Comércio e Serviços | 12.085.495/0001-88 | TRT 13ª Região-PB (Federal) | 3.750,00 | Cuité |
 | 31 | Associação Grupo de Mães Bem Viver | 00.000.113/0001-97 | SME (Municipal) | 1.700,00 | Caiçara, Santa Luzia |

--- a/relatorios/relatorio_rede_empresarial_familia_hugo_motta.md
+++ b/relatorios/relatorio_rede_empresarial_familia_hugo_motta.md
@@ -48,7 +48,7 @@
 
 | # | Nome completo | Relação com Hugo Motta | CPF (se conhecido) | Empresas vinculadas (RFB) | Atividade pública / notas |
 |---|---------------|------------------------|---------------------|---------------------------|---------------------------|
-| 1 | Hugo Motta Wanderley da Nóbrega | Próprio | 047.962.494-19 | Hugo M W.N. Ltda (33722496), MWN Consultoria (45951194) | Presidente da Câmara dos Deputados (Republicanos-PB); 4º mandato consecutivo |
+| 1 | Hugo Motta Wanderley da Nóbrega | Próprio | ***.962.494-** | Hugo M W.N. Ltda (33722496), MWN Consultoria (45951194) | Presidente da Câmara dos Deputados (Republicanos-PB); 4º mandato consecutivo |
 | 2 | Luana Medeiros Motta | Esposa | — | Medeiros & Medeiros Ltda (32830711), Fronteira Ind. e Com. de Minerais (08181087) | Assessora do conselho da Codevasf desde 2019 |
 | 3 | Hugo Motta W.N. Filho | Filho | — | Medeiros & Medeiros Ltda (32830711) | — |
 | 4 | Paola Medeiros Motta Wanderley | Filha | — | Medeiros & Medeiros Ltda (32830711) | — |

--- a/scripts/audit_report_identifiers.py
+++ b/scripts/audit_report_identifiers.py
@@ -3,15 +3,19 @@
 Uso:
     python scripts/audit_report_identifiers.py
     python scripts/audit_report_identifiers.py --report relatorios/relatorio_x.md
+    python scripts/audit_report_identifiers.py --strict          # apenas checa CPFs nao-mascarados, offline (sem DB)
 
 Saída:
-    TSV em stdout com status por citação.
+    TSV em stdout com status por citação (modo padrao).
+    Modo --strict: imprime CPFs nao-mascarados encontrados e retorna exit code
+    1 se houver qualquer violacao (uso em CI / pre-commit).
 
 Observações:
     - A validação de CNPJ usa a base local RFB (`empresa` + `estabelecimento`).
     - A validação de CPF só é tentada quando o CPF completo aparece no texto e quando
       existe uma tabela com pessoa física identificável na base local. Como a maior
       parte dos relatórios usa CPF mascarado, o status tende a ser `cpf_nao_validado`.
+    - Modo --strict NAO conecta ao banco: faz apenas analise de texto, util em CI.
 """
 
 from __future__ import annotations
@@ -73,6 +77,9 @@ NAME_CNPJ_PATTERNS = [
 
 CNPJ_PATTERN = re.compile(r"\b\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2}\b|\b\d{14}\b")
 CPF_PATTERN = re.compile(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b|\b\d{11}\b")
+# CPF formatado completo — pega so CPFs nao-mascarados, sem falsos positivos
+# de codigos numericos de 11 digitos. Usado em --strict.
+CPF_FORMATTED_PATTERN = re.compile(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b")
 
 
 @dataclass
@@ -108,6 +115,27 @@ def find_named_cnpjs(text: str) -> dict[str, str]:
             if len(cnpj) == 14 and name and cnpj not in found:
                 found[cnpj] = name
     return found
+
+
+def find_unmasked_cpfs(text: str) -> list[tuple[int, str, str]]:
+    """Retorna lista de (linha, cpf, contexto) com CPFs formatados nao-mascarados.
+
+    Considera nao-mascarado qualquer CPF no padrao `NNN.NNN.NNN-NN` sem `*` na
+    string. O padrao canonico do projeto para CPF parcialmente exposto e
+    `***.NNN.NNN-**` (mantem so os 6 digitos centrais).
+    """
+    violations: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for match in CPF_FORMATTED_PATTERN.finditer(line):
+            # Ja-mascarado tem '*' na mesma string. CPF_FORMATTED_PATTERN nao
+            # casa string com '*', entao todo match aqui e' nao-mascarado.
+            cpf = match.group(0)
+            start, end = match.span()
+            ctx_start = max(0, start - 30)
+            ctx_end = min(len(line), end + 30)
+            context = line[ctx_start:ctx_end].strip()
+            violations.append((lineno, cpf, context))
+    return violations
 
 
 def list_reports(single_report: str | None) -> list[pathlib.Path]:
@@ -212,7 +240,15 @@ def audit_report(path: pathlib.Path) -> list[AuditRow]:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--report", help="Caminho de um relatório específico")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="So checa CPFs nao-mascarados (offline, sem DB). Exit 1 se houver violacoes.",
+    )
     args = parser.parse_args()
+
+    if args.strict:
+        return run_strict(args.report)
 
     print("report\tkind\tidentifier\tcited_name\tofficial_name\tstatus\tnote")
     for report in list_reports(args.report):
@@ -227,6 +263,28 @@ def main() -> int:
                 row.note,
             ]
             print("\t".join(v.replace("\t", " ").replace("\n", " ") for v in values))
+    return 0
+
+
+def run_strict(single_report: str | None) -> int:
+    """Modo strict — so analise de texto, sem DB. Exit 1 se algum CPF nao-mascarado."""
+    total_violations = 0
+    for report in list_reports(single_report):
+        text = report.read_text(encoding="utf-8", errors="ignore")
+        violations = find_unmasked_cpfs(text)
+        if violations:
+            for lineno, cpf, context in violations:
+                print(f"{report}:{lineno}: CPF nao-mascarado encontrado: {cpf} | contexto: {context}", file=sys.stderr)
+            total_violations += len(violations)
+
+    if total_violations > 0:
+        print(
+            f"\n[strict] {total_violations} CPF(s) nao-mascarado(s) encontrado(s). "
+            "Mascarar com padrao ***.NNN.NNN-** (mantem so 6 digitos centrais).",
+            file=sys.stderr,
+        )
+        return 1
+    print("[strict] OK — nenhum CPF nao-mascarado encontrado.")
     return 0
 
 

--- a/scripts/audit_report_identifiers.py
+++ b/scripts/audit_report_identifiers.py
@@ -27,7 +27,8 @@ import sys
 import unicodedata
 from dataclasses import dataclass
 
-from etl.db import get_conn
+# Import lazy: get_conn nao deve ser importado em modo --strict (que roda offline).
+# A funcao audit_report() faz o import dentro do corpo quando precisa do banco.
 
 
 STOPWORDS = {
@@ -138,10 +139,16 @@ def find_unmasked_cpfs(text: str) -> list[tuple[int, str, str]]:
     return violations
 
 
+# Raiz do repo, derivada do caminho fisico deste script. Garante que --strict
+# rode da mesma forma independente do cwd (pre-commit hook, CI, chamada manual).
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_RELATORIOS_DIR = _REPO_ROOT / "relatorios"
+
+
 def list_reports(single_report: str | None) -> list[pathlib.Path]:
     if single_report:
         return [pathlib.Path(single_report)]
-    return sorted(pathlib.Path("relatorios").glob("*.md"))
+    return sorted(_RELATORIOS_DIR.glob("*.md"))
 
 
 def audit_report(path: pathlib.Path) -> list[AuditRow]:
@@ -151,6 +158,9 @@ def audit_report(path: pathlib.Path) -> list[AuditRow]:
     raw_cpfs = {re.sub(r"\D", "", m) for m in CPF_PATTERN.findall(text)}
 
     rows: list[AuditRow] = []
+    # Import lazy: so quem nao usa --strict abre conexao Postgres. Permite que
+    # --strict rode em ambientes sem psycopg2/python-dotenv instalados.
+    from etl.db import get_conn   # noqa: WPS433 — import dentro de funcao por design
     conn = get_conn()
     cur = conn.cursor()
 
@@ -267,9 +277,25 @@ def main() -> int:
 
 
 def run_strict(single_report: str | None) -> int:
-    """Modo strict — so analise de texto, sem DB. Exit 1 se algum CPF nao-mascarado."""
+    """Modo strict — so analise de texto, sem DB. Exit 1 se algum CPF nao-mascarado.
+
+    Anchored em `_RELATORIOS_DIR` (derivado de `__file__`), nao do cwd, para evitar
+    falsos negativos silenciosos quando rodado de outro diretorio.
+    """
+    reports = list_reports(single_report)
+    if not reports:
+        print(
+            "[strict] ERRO: nenhum relatorio encontrado. "
+            f"Esperava .md em {_RELATORIOS_DIR} ou --report apontando para arquivo valido.",
+            file=sys.stderr,
+        )
+        return 2
+
     total_violations = 0
-    for report in list_reports(single_report):
+    for report in reports:
+        if not report.exists():
+            print(f"[strict] ERRO: {report} nao existe.", file=sys.stderr)
+            return 2
         text = report.read_text(encoding="utf-8", errors="ignore")
         violations = find_unmasked_cpfs(text)
         if violations:
@@ -284,7 +310,7 @@ def run_strict(single_report: str | None) -> int:
             file=sys.stderr,
         )
         return 1
-    print("[strict] OK — nenhum CPF nao-mascarado encontrado.")
+    print(f"[strict] OK — {len(reports)} relatorio(s) auditado(s), nenhum CPF nao-mascarado encontrado.")
     return 0
 
 


### PR DESCRIPTION
## Resumo

Mascara 2 CPFs completos que estavam vazados em relatórios versionados publicamente, e estende `scripts/audit_report_identifiers.py` com um modo `--strict` offline que pode ser chamado em CI ou pre-commit pra impedir vazamentos futuros.

Resolve P0 #2 da análise distribuída de 11 agentes.

## Contexto

A análise da equipe Opus 4.7 (agente A4 — security & secrets audit) encontrou 2 CPFs em texto aberto em relatórios `.md` versionados:

| Arquivo | Linha | Pessoa |
|---|---|---|
| `relatorios/relatorio_inidoneidade_ilegal_pb.md` | 475 | Maria José Nunes de Oliveira |
| `relatorios/relatorio_rede_empresarial_familia_hugo_motta.md` | 51 | Hugo Motta Wanderley da Nóbrega (Presidente da Câmara) |

Risco LGPD: CPF é dado pessoal sob LGPD independentemente da exposição pública do titular (STF/ANPD vêm orientando que figura pública não tem imunidade automática nessa categoria). Repo público + CPF completo = tratamento sem base legal documentada, exposto a takedown ANPD.

## Mudanças

### Mascaramento dos CPFs

Padrão canônico do projeto: `***.NNN.NNN-**` (mantém só os 6 dígitos centrais — bate com a coluna `cpf_digitos_6` usada nas MVs).

```diff
-| 28 | Maria José Nunes de Oliveira | 542.092.696-20 (CPF) | ...
+| 28 | Maria José Nunes de Oliveira | ***.092.696-** (CPF) | ...

-| 1 | Hugo Motta Wanderley da Nóbrega | Próprio | 047.962.494-19 | ...
+| 1 | Hugo Motta Wanderley da Nóbrega | Próprio | ***.962.494-** | ...
```

### Extensão do audit script

`scripts/audit_report_identifiers.py` ganhou flag `--strict`:

- Roda 100% **offline** (não conecta ao Postgres) — pode rodar em CI/pre-commit sem precisar dos 58GB de RFB.
- Novo regex `CPF_FORMATTED_PATTERN` casa só `\d{3}\.\d{3}\.\d{3}-\d{2}` (CPF formatado completo); evita falsos positivos de códigos numéricos de 11 dígitos.
- Imprime `arquivo:linha`, CPF e contexto de cada violação em **stderr**.
- Retorna **exit 1** se qualquer violação for encontrada (compatível com CI).
- Modo padrão (sem `--strict`) inalterado — validação via base RFB local segue funcionando.

## Como testar

```bash
python scripts/audit_report_identifiers.py --strict
# Esperado: [strict] OK — nenhum CPF nao-mascarado encontrado. (exit 0)

# Smoke negativo: introduzir um CPF intencionalmente
echo "test CPF 123.456.789-09" > /tmp/test.md
python scripts/audit_report_identifiers.py --strict --report /tmp/test.md
# Esperado: stderr com violacao + exit 1
```

## Follow-up sugerido

- Quando o CI for criado (P0 #8), adicionar step que roda `--strict` em PRs que tocam em `relatorios/`.
- Pre-commit hook que roda `--strict` só nos arquivos modificados (já que o script aceita `--report`).

---

🤖 Identificado pela analise distribuida documentada em SINTESE-CONSOLIDADA.md (A4 security & secrets audit).
