### PR TITLE
fix(seo): IndexNow itera shards de licitacoes + cidade-resumo

### DIFF
--- a/web/indexnow_submit.py
+++ b/web/indexnow_submit.py
@@ -138,6 +138,10 @@ def main() -> int:
     #   1. /sitemap-cidades.xml  (static + cidades, ~228 URLs)
     #   2. /sitemap-empresas-{n}.xml  (N shards de ate 49K cada, so se
     #                                  SITEMAP_INCLUDE_EMPRESAS=1)
+    #   3. /sitemap-empresas-municipios-{n}.xml  (so se SITEMAP_INCLUDE_EMPRESAS=1)
+    #   4. /sitemap-licitacoes-{n}.xml  (so se SITEMAP_INCLUDE_LICITACOES=1)
+    #   5. /sitemap-cidade-resumo.xml  (urlset unico, so se
+    #                                   SITEMAP_INCLUDE_CIDADE_RESUMO=1)
     # Junta URLs de todos os sub-sitemaps e submete em batches de 500.
     #
     # NAO chamamos _build_sitemap_index — esse retorna apenas links pros
@@ -145,17 +149,23 @@ def main() -> int:
     from web import db as web_db
     from web.routes.seo import (
         EMPRESA_SHARD_SIZE,
+        LICITACAO_SHARD_SIZE,
+        _build_cidade_resumo_sitemap,
         _build_cidades_sitemap,
         _build_empresas_municipios_shard_sitemap,
         _build_empresas_shard_sitemap,
+        _build_licitacoes_shard_sitemap,
         _empresas_municipios_qualificadas_count,
         _empresas_qualificadas_count,
+        _licitacoes_qualificadas_count,
     )
     import math as _math
 
     pool_inited = False
     urls: list[str] = []
     flag_empresas = os.environ.get("SITEMAP_INCLUDE_EMPRESAS", "0") == "1"
+    flag_licitacoes = os.environ.get("SITEMAP_INCLUDE_LICITACOES", "0") == "1"
+    flag_cidade_resumo = os.environ.get("SITEMAP_INCLUDE_CIDADE_RESUMO", "0") == "1"
     try:
         try:
             web_db.init_pool()
@@ -226,8 +236,48 @@ def main() -> int:
                 )
         else:
             log.info(
-                "SITEMAP_INCLUDE_EMPRESAS != '1' — submetendo so cidades+estaticas"
+                "SITEMAP_INCLUDE_EMPRESAS != '1' — pulando empresas/empresas-municipios"
             )
+
+        # Sub-sitemaps de licitacoes (so quando flag=1). Cada shard
+        # ate ~49K URLs (LICITACAO_SHARD_SIZE). /licitacao/<mun>/<ano>/<ug>/<modnum>
+        if flag_licitacoes:
+            try:
+                total_lic = _licitacoes_qualificadas_count()
+                num_shards_lic = (
+                    _math.ceil(total_lic / LICITACAO_SHARD_SIZE) if total_lic > 0 else 0
+                )
+                log.info(
+                    "licitacoes qualificadas=%d, shards=%d (size=%d)",
+                    total_lic, num_shards_lic, LICITACAO_SHARD_SIZE,
+                )
+                for n in range(1, num_shards_lic + 1):
+                    try:
+                        shard_xml = _build_licitacoes_shard_sitemap(site_url, n)
+                        shard_urls = _extract_urls_from_sitemap(shard_xml)
+                        urls.extend(shard_urls)
+                        log.info(
+                            "sitemap-licitacoes-%d: %d URLs", n, len(shard_urls),
+                        )
+                    except Exception:
+                        log.exception("Falha ao gerar sitemap-licitacoes shard %d", n)
+            except Exception:
+                log.exception("Falha ao contar licitacoes pro sitemap")
+        else:
+            log.info("SITEMAP_INCLUDE_LICITACOES != '1' — pulando licitacoes")
+
+        # Sub-sitemap unico de cidade-resumo mensal (urlset, sem sharding —
+        # ~22K URLs cabem em 1 sitemap, limite protocolo eh 50K).
+        if flag_cidade_resumo:
+            try:
+                cr_xml = _build_cidade_resumo_sitemap(site_url)
+                cr_urls = _extract_urls_from_sitemap(cr_xml)
+                urls.extend(cr_urls)
+                log.info("sitemap-cidade-resumo: %d URLs", len(cr_urls))
+            except Exception:
+                log.exception("Falha ao gerar sitemap-cidade-resumo")
+        else:
+            log.info("SITEMAP_INCLUDE_CIDADE_RESUMO != '1' — pulando cidade-resumo")
     finally:
         if pool_inited:
             try:


### PR DESCRIPTION
## Problema

Deploy 25918043439 (ativou flags `SITEMAP_INCLUDE_LICITACOES=1` + `SITEMAP_INCLUDE_CIDADE_RESUMO=1`) submeteu **apenas 229 URLs** ao IndexNow em vez das ~186k novas. Os steps `Enable licitacoes sitemap` e `Enable cidade-resumo sitemap` no deploy.yml chamam `python -m web.indexnow_submit`, mas o script não foi atualizado pra iterar os novos sub-sitemaps.

Logs do deploy:
\\\
[INFO] Submetendo 229 URL(s) ao IndexNow (host=transparenciapb.org)
[INFO] IndexNow response: HTTP 200 (229 URLs)
\\\
Repetido 3x (uma por step)  sempre as mesmas 229 URLs das cidades estáticas.

## Causa

`web/indexnow_submit.py` main() só iterava 2 dos 5 sub-sitemaps:
-  `sitemap-cidades.xml` (sempre)
-  `sitemap-empresas-{n}.xml` (gated por `SITEMAP_INCLUDE_EMPRESAS`)
-  `sitemap-empresas-municipios-{n}.xml` (gated junto)
-  **`sitemap-licitacoes-{n}.xml`**  código ausente
-  **`sitemap-cidade-resumo.xml`**  código ausente

## Fix

Adiciona iteração dos 2 sub-sitemaps que faltavam, gated pelos respectivos flags de env (`SITEMAP_INCLUDE_LICITACOES`, `SITEMAP_INCLUDE_CIDADE_RESUMO`). Reusa as funções já existentes em `web/routes/seo.py`:

- `_licitacoes_qualificadas_count()` + `_build_licitacoes_shard_sitemap()`  lê de `web_cache` (LICITACAO_PERFIL), itera shards de 49k até cobrir todas as 163,990 URLs.
- `_build_cidade_resumo_sitemap()`  urlset único (~22,513 URLs), lê de `web_cache` (CIDADE_RESUMO_MENSAL).

Coverage = sitemap público (mesma fonte). Batch logic existente (chunks de 500 com 0.5s sleep) cobre o volume sem alterações  ~373 batches totais, ~3 min total.

## Validação

\\\ash
python -m compileall web/indexnow_submit.py -q  # OK
\\\

Em prod, próximo deploy com `expose_licitacoes_sitemap=enable` ou via `--dry-run` deve mostrar:

\\\
sitemap-cidades: 229 URLs
licitacoes qualificadas=163990, shards=4 (size=49000)
sitemap-licitacoes-1: 49000 URLs
...
sitemap-licitacoes-4: 16990 URLs
sitemap-cidade-resumo: 22513 URLs
Submetendo 186732 URL(s) ao IndexNow (host=transparenciapb.org)
\\\

## Deploy

**Não disparar deploy junto com merge** (per user request, evita interromper warm/tráfego live agora). Próximo deploy de código que rodar IndexNow vai pegar o fix automaticamente.

Quando for hora de re-submeter: trigger manual `deploy.yml` com `etl_phase=web` e flags já estão ativos em produção. Script vai re-submeter as ~186k URLs.

## Out of scope

- Não muda comportamento quando flags estão off (back-compat 100%).
- Não muda rate limiting / batch size (existing 500 URLs/batch + 0.5s sleep funciona).
- `HEAD` request preflight pros sitemaps (validar que servidor retorna 200 antes de submeter): considerei, mas se servidor não retorna 200, o sitemap.xml index também não vai listar  então essa proteção já existe no nível do generator.