### PR TITLE
docs: postgres direto eh o padrao, docker eh alternativa

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,14 +69,21 @@ npm ci
 cp .env.example .env
 # Edite com credenciais do PostgreSQL e DATA_DIR
 
-# 5. Postgres 16 — instale local (Homebrew/apt) ou rode via Docker:
-docker run --name govbr-pg -e POSTGRES_PASSWORD=govbr_dev -e POSTGRES_USER=govbr \
-           -e POSTGRES_DB=govbr -p 5432:5432 -d postgres:16
+# 5. Postgres 16 — instalação direta é o padrão do projeto (a VM de produção
+#    também roda Postgres direto, sem Docker). Em desenvolvimento, instale via
+#    apt / Homebrew / instalador Windows e crie o banco:
+sudo -u postgres psql -c "CREATE USER govbr WITH PASSWORD 'govbr_dev';"
+sudo -u postgres psql -c "CREATE DATABASE govbr OWNER govbr;"
 
-# Extensoes obrigatorias — habilitar uma vez por banco:
-docker exec -i govbr-pg psql -U govbr -d govbr -c \
+# Extensões obrigatórias — habilitar uma vez por banco:
+sudo -u postgres psql -d govbr -c \
     "CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS unaccent;"
-# (os .so vem na imagem postgres:16 oficial; CREATE EXTENSION ativa por banco)
+
+# Alternativa via Docker (se preferir não instalar Postgres direto):
+#   docker run --name govbr-pg -e POSTGRES_PASSWORD=govbr_dev -e POSTGRES_USER=govbr \
+#              -e POSTGRES_DB=govbr -p 5432:5432 -d postgres:16
+#   docker exec -i govbr-pg psql -U govbr -d govbr -c \
+#       "CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS unaccent;"
 
 # 6. Smoke (não roda o ETL, só compila):
 python -m compileall etl web scripts -q

--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Fontes integradas: Receita Federal, PNCP, TCE-PB, dados.pb.gov.br, TSE, PGFN, SI
 pip install -e .[web,dev]
 npm ci
 cp .env.example .env                      # editar com creds locais
-docker run --name govbr-pg -e POSTGRES_PASSWORD=govbr_dev -e POSTGRES_USER=govbr \
-           -e POSTGRES_DB=govbr -p 5432:5432 -d postgres:16
+
+# Postgres 16 — instale local (apt / Homebrew / instalador Windows). Depois crie o banco:
+sudo -u postgres psql -c "CREATE USER govbr WITH PASSWORD 'govbr_dev';"
+sudo -u postgres psql -c "CREATE DATABASE govbr OWNER govbr;"
+sudo -u postgres psql -d govbr -c "CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS unaccent;"
+# (Alternativa via Docker, se preferir: ver CONTRIBUTING.md)
 
 # Smoke
 python -m compileall etl web scripts -q


### PR DESCRIPTION
## Motivacao

O projeto roda Postgres 16 direto em producao (VM Azure, sem Docker) e na maquina local de desenvolvimento tambem. O Quickstart do README sugeria docker run postgres:16 como passo default, o que:

1. **Confunde novos contribuidores**: quem segue o README literalmente acaba com setup diferente do real fluxo do projeto.
2. **Divergia do CONTRIBUTING.md** (que ja menciona Postgres local como opcao primaria, mas usava docker no exemplo).
3. **Diverge da producao**: a VM nao usa Docker; o tuning de shared_buffers/work_mem que o deploy faz assume Postgres direto.

## Mudancas

### README.md (Quickstart)
- Trocado docker run postgres:16 por passos sudo -u postgres psql (CREATE USER / DATABASE / EXTENSION).
- Docker mencionado como alternativa, com link para CONTRIBUTING.md.

### CONTRIBUTING.md (Setup local, passo 5)
- Passo 5 invertido na mesma logica: instalacao direta como padrao + nota explicita de que producao tambem roda assim.
- Comando docker comentado como alternativa, sem perder a referencia.

## Antes / Depois

**Antes (README):**
```bash
docker run --name govbr-pg -e POSTGRES_PASSWORD=govbr_dev -e POSTGRES_USER=govbr \
           -e POSTGRES_DB=govbr -p 5432:5432 -d postgres:16
```

**Depois (README):**
```bash
# Postgres 16 - instale local (apt / Homebrew / instalador Windows). Depois crie o banco:
sudo -u postgres psql -c "CREATE USER govbr WITH PASSWORD 'govbr_dev';"
sudo -u postgres psql -c "CREATE DATABASE govbr OWNER govbr;"
sudo -u postgres psql -d govbr -c "CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS unaccent;"
# (Alternativa via Docker, se preferir: ver CONTRIBUTING.md)
```

## Testes

Mudanca so de documentacao - nao tem build/test associado. python -m compileall passa (sem mudanca de codigo).
