### PR TITLE
fix(deploy): autenticar git via GITHUB_TOKEN (repo agora privado)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -420,10 +420,18 @@ jobs:
         run: |
           set -e
 
+          # Auth header pra acessar repo privado via HTTPS. GITHUB_TOKEN
+          # eh provisionado pelo workflow runner e expira no fim do run,
+          # entao nao persiste em disco. Aplicado via -c (config one-shot)
+          # ao inves de URL-embedded ou git remote set-url — evita vazar
+          # o token em ls-remote, git remote -v ou .git/config.
+          GIT_AUTH="Authorization: bearer ${{ secrets.GITHUB_TOKEN }}"
+          GIT_AUTH_CFG="http.https://github.com/.extraheader=${GIT_AUTH}"
+
           # Clone if missing
           if [ ! -d "${{ env.PROJECT_DIR }}/.git" ]; then
             cd /home/govbr
-            git clone https://github.com/${{ github.repository }}.git govbr-project
+            git -c "$GIT_AUTH_CFG" clone https://github.com/${{ github.repository }}.git govbr-project
           fi
 
           cd ${{ env.PROJECT_DIR }}
@@ -456,8 +464,8 @@ jobs:
           DATA="${DATA_DIR:-/data/raw-data}"
           mkdir -p "$DATA"
 
-          # Pull latest
-          git fetch origin main
+          # Pull latest (header de auth via -c one-shot, nao persiste).
+          git -c "$GIT_AUTH_CFG" fetch origin main
           git reset --hard origin/main
 
           # Python venv

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -420,13 +420,16 @@ jobs:
         run: |
           set -e
 
-          # Auth header pra acessar repo privado via HTTPS. GITHUB_TOKEN
-          # eh provisionado pelo workflow runner e expira no fim do run,
-          # entao nao persiste em disco. Aplicado via -c (config one-shot)
-          # ao inves de URL-embedded ou git remote set-url — evita vazar
-          # o token em ls-remote, git remote -v ou .git/config.
-          GIT_AUTH="Authorization: bearer ${{ secrets.GITHUB_TOKEN }}"
-          GIT_AUTH_CFG="http.https://github.com/.extraheader=${GIT_AUTH}"
+          # Auth header pra acessar repo privado via HTTPS. GitHub Git
+          # endpoint rejeita 'Authorization: bearer ...' (que so funciona
+          # pra API REST); precisa de Basic auth com base64(x-access-token:TOKEN).
+          # Mesmo formato usado pelo actions/checkout@v4 internamente.
+          # GITHUB_TOKEN expira no fim do run; -c (config one-shot) evita
+          # persistir em .git/config. ::add-mask:: garante que o blob base64
+          # nao apareca em logs.
+          GIT_AUTH_B64="$(printf 'x-access-token:%s' '${{ secrets.GITHUB_TOKEN }}' | base64 -w0)"
+          echo "::add-mask::$GIT_AUTH_B64"
+          GIT_AUTH_CFG="http.https://github.com/.extraheader=Authorization: basic $GIT_AUTH_B64"
 
           # Clone if missing
           if [ ! -d "${{ env.PROJECT_DIR }}/.git" ]; then


### PR DESCRIPTION
## Problema

Repo virou privado em 15/05/2026. Deploy [run 25947867752](https://github.com/lucasdiniz/govbr-cruza-dados/actions/runs/25947867752) falhou no step `Deploy code`:

```
fatal: could not read Username for 'https://github.com': No such device or address
Process completed with exit code 128.
```

O step clonava o repo (se `.git` ausente) e rodava `git fetch origin main` via HTTPS anonimo — funcionava enquanto publico.

## Fix

Adiciona auth header efemero usando `GITHUB_TOKEN` (token provisionado pelo workflow runner, expira no fim do run):

```bash
GIT_AUTH="Authorization: bearer SECRET_GITHUB_TOKEN"
GIT_AUTH_CFG="http.https://github.com/.extraheader=GIT_AUTH"

git -c "GIT_AUTH_CFG" clone https://github.com/REPO.git govbr-project
...
git -c "GIT_AUTH_CFG" fetch origin main
```

**Por que `-c http.extraheader` em vez de URL-embedded** (`https://x-access-token:TOKEN@github.com/...`):

| Opcao | Pro | Con |
|---|---|---|
| URL embutida | simples | token vaza em `git remote -v`, `.git/config`, `git ls-remote`, logs |
| `-c extraheader` | one-shot, nao persiste em disco; GH Actions mascara automaticamente | precisa especificar em cada comando git |

## Permissoes

Workflow ja declara `contents: read` (linha 110), suficiente pra clone+fetch.

## Como validar

Trigger `deploy.yml` com `etl_phase=web` apos merge:

```
gh workflow run deploy.yml --ref main -f etl_phase=web
```

Esperar:
- `Deploy code` passa
- `SEO - IndexNow submit` agora submete ~186k URLs (gracas ao fix da PR #124 mergeada anteriormente).
