### PR TITLE
fix(deploy): IndexNow submit le flags SITEMAP_INCLUDE_* dos drop-ins systemd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1228,6 +1228,24 @@ jobs:
             echo "INDEXNOW_KEY nao setada no .env — skipping IndexNow submit"
             exit 0
           fi
+          # Detecta flags SITEMAP_INCLUDE_* dos drop-ins systemd do cruza-web,
+          # que sao o state-of-truth de quais sub-sitemaps estao publicados.
+          # Sem isso, web.indexnow_submit so submete sitemap-cidades (~229 URLs)
+          # mesmo com /sitemap-licitacoes-*.xml e /sitemap-cidade-resumo.xml
+          # ativos em prod via drop-in.
+          DROPIN_DIR=/etc/systemd/system/cruza-web.service.d
+          if [ -d "$DROPIN_DIR" ]; then
+            for conf in "$DROPIN_DIR"/sitemap-*.conf; do
+              [ -f "$conf" ] || continue
+              while IFS= read -r line; do
+                # Match: Environment="KEY=VALUE" → export KEY=VALUE
+                if [[ "$line" =~ ^Environment=\"([A-Z_]+)=([^\"]+)\" ]]; then
+                  export "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
+                  echo "  detected flag from drop-in: ${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
+                fi
+              done < "$conf"
+            done
+          fi
           echo "=== IndexNow submit (host=${SITE_URL:-https://transparenciapb.org}) ==="
           # cruza-web ja foi restartado no step anterior; rota /<key>.txt
           # serve a chave nova caso ela tenha mudado.


### PR DESCRIPTION
## Problema

Deploy [25948398950](https://github.com/lucasdiniz/govbr-cruza-dados/actions/runs/25948398950) (PR #142 auth fix) passou no Deploy code, mas o step "SEO - IndexNow submit" submeteu apenas **229 URLs** (cidades estaticas), nao as ~186k cobertas pelo sitemap.

Logs:
```
[INFO] sitemap-cidades: 229 URLs
[INFO] SITEMAP_INCLUDE_EMPRESAS != '1' — pulando empresas/empresas-municipios
[INFO] SITEMAP_INCLUDE_LICITACOES != '1' — pulando licitacoes
[INFO] SITEMAP_INCLUDE_CIDADE_RESUMO != '1' — pulando cidade-resumo
[INFO] Submetendo 229 URL(s) ao IndexNow
[INFO] IndexNow response: HTTP 200 (229 URLs)
```

## Causa

Os flags `SITEMAP_INCLUDE_*` em prod ficam em **drop-ins systemd** do servico `cruza-web`:
```
/etc/systemd/system/cruza-web.service.d/sitemap-cidade-resumo.conf
/etc/systemd/system/cruza-web.service.d/sitemap-empresas.conf
/etc/systemd/system/cruza-web.service.d/sitemap-licitacoes.conf
```

Cada um com `Environment="SITEMAP_INCLUDE_X=1"`. Esses drop-ins so afetam o processo `uvicorn` (cruza-web), nao o subshell do step "SEO - IndexNow submit" que roda `python -m web.indexnow_submit` standalone.

Os steps "Enable licitacoes/cidade-resumo sitemap" funcionam porque exportam inline (`SITEMAP_INCLUDE_LICITACOES=1 python -m web.indexnow_submit`), mas so rodam quando `expose_*_sitemap=enable` eh passado no workflow_dispatch — nao eh o caso de deploys rotineiros.

## Fix

Step "SEO - IndexNow submit" agora le os drop-ins systemd antes de chamar o python, exportando as flags pro subprocess. Loop bash parseia `Environment="KEY=VALUE"` e exporta. State-of-truth = filesystem (drop-ins), nao parametro de workflow.

```bash
DROPIN_DIR=/etc/systemd/system/cruza-web.service.d
if [ -d "$DROPIN_DIR" ]; then
  for conf in "$DROPIN_DIR"/sitemap-*.conf; do
    [ -f "$conf" ] || continue
    while IFS= read -r line; do
      if [[ "$line" =~ ^Environment=\"([A-Z_]+)=([^\"]+)\" ]]; then
        export "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
        echo "  detected flag from drop-in: ${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
      fi
    done < "$conf"
  done
fi
```

## Validacao

Apos merge, proximo `etl_phase=web` deploy deve mostrar nos logs:
```
detected flag from drop-in: SITEMAP_INCLUDE_CIDADE_RESUMO=1
detected flag from drop-in: SITEMAP_INCLUDE_EMPRESAS=1
detected flag from drop-in: SITEMAP_INCLUDE_LICITACOES=1
...
sitemap-cidades: 229 URLs
sitemap-empresas-1: 49000 URLs (× 3 shards)
sitemap-empresas-municipios-1: 49000 URLs (× 16 shards)
sitemap-licitacoes-1: 49000 URLs (× 4 shards)
sitemap-cidade-resumo: 22513 URLs
Submetendo 1114440+ URL(s) ao IndexNow
```

(Total estimado: cidades + empresas + emp-mun + licitacoes + cidade-resumo ~ 1.1M URLs. IndexNow pode rate-limit, mas o batch logic existente em 500 URLs/req com 0.5s sleep handles isso.)

## Out of scope

- Nao toca o script `web/indexnow_submit.py` (ja correto, so precisa das env vars).
- Nao toca os steps "Enable */sitemap" que ja exportam inline.
- Nao adiciona novos arquivos.

## Observacao sobre volume

1.1M URLs × 500/batch × 0.5s = ~18.5 min adicional ao deploy. Aceitavel pra submit pos-deploy. Se quiser limitar, podemos:
- Adicionar `--limit 200000` (ja suportado no script)
- Skip empresas/empresas-municipios no IndexNow (só submeter conteudo novo)

Mas: como o script ja envia em chunks com sleep entre batches, e a fail-soft existe (`|| echo "::warning::..."`), o atual handles graciosamente caso de rate-limit. Mantemos full submit por simplicidade.
