### PR TITLE
fix(web): empenhos clicaveis em /cidade/<slug>/<yyyymm> e /licitacao/...

### DIFF
--- a/web/templates/results/cidade_resumo.html
+++ b/web/templates/results/cidade_resumo.html
@@ -198,7 +198,7 @@
                 </thead>
                 <tbody>
                     {% for e in top_empenhos %}
-                    <tr>
+                    <tr{% if e.id %} class="clickable-row" data-empenho-id="{{ e.id }}"{% endif %}>
                         <td data-label="Data" class="stack-meta">{% if e.data_empenho %}{{ e.data_empenho[8:10] }}/{{ e.data_empenho[5:7] }}{% else %}-{% endif %}</td>
                         <td data-label="Empenho" class="stack-meta"><code>{{ e.numero_empenho|clean_text or "-" }}</code></td>
                         <td data-label="Empresa" class="stack-title">

--- a/web/templates/results/licitacao.html
+++ b/web/templates/results/licitacao.html
@@ -143,7 +143,7 @@
                 </thead>
                 <tbody>
                     {% for e in empenhos %}
-                    <tr>
+                    <tr{% if e.id %} class="clickable-row" data-empenho-id="{{ e.id }}"{% endif %}>
                         <td data-label="Data" class="stack-meta">{% if e.data_empenho %}{{ e.data_empenho[8:10] }}/{{ e.data_empenho[5:7] }}/{{ e.data_empenho[0:4] }}{% else %}-{% endif %}</td>
                         <td data-label="Empenho" class="stack-meta"><code>{{ e.numero_empenho|clean_text or "-" }}</code></td>
                         <td data-label="Credor" class="stack-title">


### PR DESCRIPTION
Fix simples (2 templates, 2 linhas):

## Problema
Na pagina `/cidade/<slug>/<yyyy>-<mm>` (resumo mensal) e `/licitacao/...` os <tr> da tabela `Maiores empenhos do mes` / `Empenhos vinculados` nao tinham `class=\"clickable-row\"` nem `data-empenho-id`. User reportou: empenhos nao clicaveis.

## Fix
Adiciona `class+data-attr` quando `e.id` presente. Queries (`RESUMO_TOP_EMPENHOS` + `LICITACAO_EMPENHOS_VINCULADOS`) ja retornam `d.id`. Handler global `initClickableRows` (clickable-rows.js) ja faz delegacao e chama `openEmpenhoDialog(id)`.

## Sem re-warm necessario
As paginas sao cache-only mas o que e cacheado e o DICT de dados, nao o HTML. `TemplateResponse` renderiza com o template atual em cada request — o fix aparece no proximo deploy sem precisar refazer ~14k entradas de cache.