### PR TITLE
fix(web): mesclar Descricao e Origem em uma secao so no dialog de empenho

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -438,7 +438,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "112"
+templates.env.globals["ASSET_VERSION"] = "113"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/components/empenho-dialog.js
+++ b/web/static/js/components/empenho-dialog.js
@@ -93,12 +93,11 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
         }
     }
 
-    // Historico (descricao detalhada)
-    if (data.historico) {
-        html += '<div class="dialog-section"><h4>Descricao</h4>';
-        html += `<p class="text-sm" style="line-height:1.6">${_esc(data.historico)}</p>`;
-        html += '</div>';
-    }
+    // Historico do empenho movido pra dentro da secao Origem mesclada
+    // (logo abaixo). Antes era secao propria "Descricao" entre o bloco
+    // de licitacao e o de valores, mas vinha duplicada visualmente com
+    // o campo "Origem do recurso" — agruparmos os dois descreve melhor
+    // o "de onde veio + o que diz o empenho" como uma unica narrativa.
 
     // Valores
     html += '<div class="dialog-section"><h4>Valores</h4>';
@@ -152,8 +151,13 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     html += '</div></div>';
     html += '</div>';
 
-    // Origem / UG / fonte
-    html += `<div class="dialog-section"><h4>${dualLabel('De onde veio o dinheiro','Origem')}</h4>`;
+    // Origem do recurso + descricao do empenho — mescladas em uma secao so:
+    // o texto livre do historico de empenho complementa os campos de
+    // origem (UG, fonte, unidade) explicando o "porque" daquele gasto.
+    html += `<div class="dialog-section"><h4>${dualLabel('De onde veio e o que diz o empenho','Origem e descricao')}</h4>`;
+    if (data.historico) {
+        html += `<p class="text-sm empenho-historico" style="line-height:1.6;margin:0 0 var(--space-3) 0">${_esc(data.historico)}</p>`;
+    }
     html += '<div class="empresa-card"><div class="empresa-details">';
     html += `<span><strong>Data:</strong> ${_fmtDate(data.data_empenho)}</span>`;
     if (data.descricao_ug) html += `<span><strong>${dualLabel('Setor:','UG:')}</strong> ${_esc(data.descricao_ug)}</span>`;


### PR DESCRIPTION
## Motivacao

As secoes **"Descricao"** (texto livre do historico do empenho) e **"Origem"** (UG, unidade orcamentaria, fonte do recurso, data, municipio) estavam empilhadas verticalmente no `empenho-dialog`, mas conceitualmente respondem a mesma pergunta: **"de onde veio esse dinheiro e o que diz o empenho?"**.

O usuario tinha que ler as duas secoes pra montar a narrativa. Faz mais sentido tratar como uma so.

## Mudancas

### `web/static/js/components/empenho-dialog.js`

- Removida secao **Descricao** standalone (entre Licitacao e Valores).
- Texto do historico agora vai como `<p class="text-sm empenho-historico">` **dentro** da secao Origem renomeada, antes do bloco de campos chave-valor.
- Header da secao mesclada:
  - **Auditor mode**: "Origem e descricao"
  - **Cidadao mode**: "De onde veio e o que diz o empenho"

### `web/main.py`

- `ASSET_VERSION` 112 -> 113 (cache buster do bundle JS).

## Ordem final do dialog

```
1. Licitacao vinculada
2. Valores (Empenhado / Liquidado / Pago)
3. Quem recebeu / Credor
4. Em que foi gasto / Classificacao orcamentaria
5. De onde veio e o que diz o empenho / Origem e descricao   <-- MESCLADA
   - Paragrafo com data.historico (se existir)
   - Campos: Data, UG, Unidade, Fonte, Municipio
```

## Antes vs Depois

**Antes**:
``````
[Licitacao vinculada]
[Descricao]
  <texto livre longo>
[Valores]
[Credor]
[Classificacao]
[Origem]
  Data:..., UG:..., Unidade:..., Fonte:..., Municipio:...
``````

**Depois**:
``````
[Licitacao vinculada]
[Valores]
[Credor]
[Classificacao]
[Origem e descricao]
  <texto livre longo>
  Data:..., UG:..., Unidade:..., Fonte:..., Municipio:...
``````

## Testes

- Sintaxe JS validada (`new Function(s)`)
- `python -m compileall web -q` passa
- `npm run build` gera novo bundle `core.32e1eb42.min.js` sem erros

Sem mudanca de API (`/api/empenho/detalhes` nao alterado). Sem mudanca de dados.
