### PR TITLE
docs: documentacao tecnica completa (18 docs novos + 16 Mermaid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Use `cpf_cnpj` completo (14 dígitos) — não `cnpj_basico` (8 dígitos), que s
 A tabela `web_cache` armazena resultados pré-computados (FastAPI lê direto dela, sem rodar SQL pesado em request time). Três modos de atualização:
 
 - **drop_cache** — `TRUNCATE web_cache` (12-18h de cache miss; use só em mudança de schema).
-- **invalidate_cache_keys** — `DELETE` cirúrgico HARD por prefixo de qid (cache miss até warm).
+- **invalidate_cache_keys** — `DELETE` cirúrgico HARD por **substring** de qid (causa cache miss até warm). Cuidado: `PERFIL` casa também `EMPRESA_PERFIL`, `PERFIL_DATED`, etc.
 - **rewarm_cache_keys** — shadow rewarm **zero-downtime**: warm escreve em `<qid>__pending`, swap atômico promove `__pending` → live só se todas as queries da chave passaram (fail==0); caso contrário, aborta e mantém live antigo. **Default recomendado** para mudanças em `web/queries/registry.py`.
 
 Auto-expansão: shadow de `PERFIL`/`TOP_FORN`/`TOP_SERV` propaga para `KPI_SUMMARY` (mesmo prefixo).
@@ -309,7 +309,7 @@ O `preflight` faz resize VM/disco para cima quando o `etl_phase` exige; o `postf
 | `run_queries` | bool | roda `etl.run_queries` após ETL |
 | `incremental_only` | csv | limita incremental a specs específicas |
 | `drop_cache` | bool | TRUNCATE web_cache antes do warm |
-| `invalidate_cache_keys` | csv | DELETE cirúrgico HARD por prefixo de qid |
+| `invalidate_cache_keys` | csv | DELETE cirúrgico HARD por **substring** (`LIKE '%termo%'`); `PERFIL` casa também `EMPRESA_PERFIL` |
 | `rewarm_cache_keys` | csv | shadow rewarm zero-downtime (preferido) |
 | `warm_skip_hours` | int | controle de skip/rebuild do warm |
 | `expose_empresa_sitemap` / `_licitacoes_` / `_cidade_resumo_` | keep/enable/disable | toggle de URLs no sitemap |

--- a/README.md
+++ b/README.md
@@ -353,10 +353,43 @@ tests/incremental/ Suite atual — cobre o framework incremental
 
 ## Documentação adicional
 
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — convenções, setup local, como adicionar query/MV/fase
-- [`etl/incremental/README.md`](etl/incremental/README.md) — framework incremental detalhado
-- [`docs/dicionario_dados_pb.md`](docs/dicionario_dados_pb.md) — dicionário das tabelas TCE-PB e dados.pb.gov.br
-- [`docs/plano_novas_fontes.md`](docs/plano_novas_fontes.md) — roadmap de fontes adicionais
+Comece pela [arquitetura](docs/architecture.md), depois siga pro guia específico da sua área de contribuição.
+
+### Para todos os contributors
+
+- [`docs/architecture.md`](docs/architecture.md) — **landing page arquitetural** com 7 diagramas Mermaid (data flow ETL, entity resolution, ERD, MV layers, shadow rewarm sequence, deploy pipeline)
+- [`docs/glossario.md`](docs/glossario.md) — 60+ termos do domínio público brasileiro (empenho, UG, CEIS, LGPD, etc.)
+- [`docs/onboarding.md`](docs/onboarding.md) — walk-through clone → `uvicorn` em 3 caminhos
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — convenções de código, commits, PRs
+
+### Guias por área
+
+- [`docs/etl-guide.md`](docs/etl-guide.md) — como adicionar fase ETL clássica
+- [`docs/etl-incremental-guide.md`](docs/etl-incremental-guide.md) — como adicionar spec ao framework incremental (princípios P1-P6)
+- [`docs/web-guide.md`](docs/web-guide.md) — como adicionar query/rota/template/componente MD3
+- [`docs/queries-guide.md`](docs/queries-guide.md) — como adicionar Q## (header, EXPLAIN, índices)
+- [`docs/mv-guide.md`](docs/mv-guide.md) — como adicionar MV (camadas L1/L2/L3)
+- [`docs/cache.md`](docs/cache.md) — `web_cache` + shadow rewarm zero-downtime
+
+### Operações
+
+- [`docs/deploy.md`](docs/deploy.md) — 14 inputs do `deploy.yml` + cenários + OIDC setup
+- [`docs/ops.md`](docs/ops.md) — runbooks (rollback, restore, backup, runner repair, troubleshoot warm)
+
+### Privacidade e licenciamento
+
+- [`docs/privacidade.md`](docs/privacidade.md) — política LGPD pública
+- [`DATA-LICENSE.md`](DATA-LICENSE.md) — licenciamento de dados + disclaimer LGPD
+
+### Decisões arquiteturais (ADRs)
+
+- [`docs/adr/`](docs/adr/) — 5 ADRs: no-pandas, MV layered, shadow rewarm, framework incremental, no-ORM web
+
+### Referência
+
+- [`etl/incremental/README.md`](etl/incremental/README.md) — framework incremental detalhado (P1-P6, observabilidade, comandos)
+- [`docs/dicionario_dados_pb.md`](docs/dicionario_dados_pb.md) — catálogo de colunas TCE-PB e dados.pb.gov.br
+- [`docs/plano_novas_fontes.md`](docs/plano_novas_fontes.md) — roadmap histórico de fontes (legado)
 - [`relatorios/`](relatorios/) — 40+ investigações sobre casos reais (mascaradas conforme LGPD)
 
 ## Licença

--- a/docs/adr/0001-no-pandas.md
+++ b/docs/adr/0001-no-pandas.md
@@ -1,0 +1,95 @@
+# ADR-0001: No pandas — streaming + COPY FROM STDIN
+
+## Status
+
+Accepted
+
+## Date
+
+2024-06-15
+
+## Context
+
+O ETL precisa carregar aproximadamente **350 milhões de linhas** vindas de ~18
+fontes (RFB, TCE-PB, dados.pb, TSE, Bolsa Família, CEIS, CNEP, etc.) em uma VM
+Azure B4as_v2 com **16 GB de RAM**. Apenas a RFB sozinha são ~58 GB de CSV cru
+(latin-1).
+
+Caminhos considerados:
+
+1. **pandas DataFrame + `to_sql`** — abordagem padrão da comunidade Python. Carrega
+   o CSV inteiro em memória antes de qualquer escrita. Para a RFB ou TCE-PB,
+   estoura RAM antes mesmo do primeiro `INSERT`. `chunksize` ameniza mas continua
+   alocando objetos Python para cada célula.
+2. **`psycopg2.executemany`** com listas Python — cabe em RAM se a leitura for
+   streaming, mas o protocolo extended-query do Postgres envia cada `INSERT`
+   individualmente. Para 350M rows isso é ordens de magnitude mais lento que
+   `COPY` (testes locais: ~50x).
+3. **`COPY FROM STDIN`** com geradores Python — Postgres consome um fluxo de
+   bytes diretamente do socket. Memória usada = buffer do `COPY` (alguns MB) +
+   uma linha em flight no Python.
+
+## Decision
+
+**O projeto não usa pandas em código ETL.** Toda carga de dados segue o padrão:
+
+1. **Streaming line-by-line** com generators Python (`open(...)`, `csv.reader`,
+   ou helpers como `latin1_lines` em `etl/utils.py`).
+2. **`COPY FROM STDIN`** via helpers em `etl/db.py`:
+   - `copy_from_stream(conn, table, columns, iterator)` — recebe um generator
+     de tuples, escreve no `COPY`.
+   - `copy_csv_streaming(conn, table, csv_path, ...)` — caso comum CSV→tabela.
+   - `batch_insert(conn, table, rows, batch_size=...)` — fallback para casos
+     que precisam de `INSERT ... ON CONFLICT`.
+3. **Parsing BR-específico** centralizado em `etl/utils.py`:
+   `parse_date_br`, `parse_decimal_br`, `clean_cpf`, `clean_cnpj`,
+   `extract_cpf_masked`, `normalize_name`. Reuso obrigatório — os formatos de
+   data e decimal variam por fonte (e às vezes dentro da mesma fonte).
+
+JOINs e agregações ficam **em SQL**, não em Python. Materialized Views (ver
+[ADR-0002](0002-mv-layered.md)) materializam o resultado.
+
+## Consequences
+
+### Positive
+
+- **Cabe em <8 GB de RAM** mesmo para a RFB de 58 GB. O resto da RAM fica
+  disponível para o Postgres (`work_mem`, `shared_buffers`).
+- **ETL completo em ~10-20 h** na VM-alvo (B4as_v2, 4 vCPU). Estimativa com
+  pandas/executemany era de **dias**. A RFB (a maior fonte) carrega em ~30 min.
+- JOINs em SQL forçam o trabalho a acontecer onde o índice e o planner ajudam.
+- Sem dependência de NumPy/pandas (centenas de MB de wheels) na imagem do
+  runner.
+
+### Negative / Trade-offs
+
+- **Learning curve** para contributors vindos de Django/Flask + pandas. Não há
+  `df.merge`, `df.groupby`, `df.pivot_table` — tudo isso vira SQL.
+- Métricas, profiling e validação de qualidade exigem código manual (não dá
+  para `df.describe()` no meio do pipeline). Em geral fica como query
+  ad-hoc.
+- Sem o ecossistema de I/O do pandas (Parquet, Excel, Feather). O projeto lida
+  só com CSV/JSON, então isso não doeu, mas é uma porta fechada.
+- `COPY FROM STDIN` é menos amigável a erros: uma linha malformada aborta o
+  batch. Validação tem que acontecer antes de entrar no generator.
+
+### Mitigations
+
+- Helpers em `etl/db.py` reduzem boilerplate ao mínimo. O contributor escreve
+  apenas o generator de linhas; o `COPY` é uma chamada de função.
+- `CONTRIBUTING.md` documenta a convenção na seção "Convenções Python".
+- `docs/etl-guide.md` (a ser criado) traz exemplos completos do padrão
+  generator → `copy_from_stream`.
+- Para análise exploratória, contributors podem usar pandas em
+  Jupyter/notebooks **fora do código de produção** — basta não importar pandas
+  em `etl/**`.
+
+## Related
+
+- Code: [`etl/db.py`](../../etl/db.py) (`copy_from_stream`, `copy_csv_streaming`,
+  `batch_insert`), [`etl/utils.py`](../../etl/utils.py) (parsers BR).
+- Other ADRs: [ADR-0002](0002-mv-layered.md) (JOINs em SQL → MVs em camadas),
+  [ADR-0005](0005-no-orm-web.md) (mesma filosofia raw-SQL no web).
+- External:
+  - [PostgreSQL `COPY` docs](https://www.postgresql.org/docs/16/sql-copy.html)
+  - [psycopg2 `copy_expert`](https://www.psycopg.org/docs/cursor.html#cursor.copy_expert)

--- a/docs/adr/0001-no-pandas.md
+++ b/docs/adr/0001-no-pandas.md
@@ -78,7 +78,7 @@ JOINs e agregações ficam **em SQL**, não em Python. Materialized Views (ver
 - Helpers em `etl/db.py` reduzem boilerplate ao mínimo. O contributor escreve
   apenas o generator de linhas; o `COPY` é uma chamada de função.
 - `CONTRIBUTING.md` documenta a convenção na seção "Convenções Python".
-- `docs/etl-guide.md` (a ser criado) traz exemplos completos do padrão
+- [`docs/etl-guide.md`](../etl-guide.md) traz exemplos completos do padrão
   generator → `copy_from_stream`.
 - Para análise exploratória, contributors podem usar pandas em
   Jupyter/notebooks **fora do código de produção** — basta não importar pandas

--- a/docs/adr/0002-mv-layered.md
+++ b/docs/adr/0002-mv-layered.md
@@ -1,0 +1,127 @@
+# ADR-0002: Materialized Views em camadas L1 → L2 → views planas
+
+## Status
+
+Accepted
+
+## Date
+
+2024-09-10
+
+## Context
+
+O cálculo de **score de risco** (municipal, empresa, servidor) cruza de 5 a 10
+tabelas grandes: `tce_pb_*`, `empresa`, `estabelecimento`, `socio`, `ceis_sancao`,
+`cnep`, `bolsa_familia`, `servidor_pb`, entre outras. Algumas delas têm dezenas de
+milhões de linhas.
+
+Caminhos considerados:
+
+1. **Query live em request time** — joins em todas as tabelas a cada request.
+   Mesmo com índices, alguns scores levavam minutos; em produção dariam timeout.
+2. **Cache em `web_cache` (Postgres table)** — já existe (ver
+   [ADR-0003](0003-shadow-rewarm.md)). Funciona para o output final, mas precisa
+   de um **input estável e re-runnable** — a query bruta ainda é cara.
+3. **Materialized Views** — Postgres armazena o resultado fisicamente,
+   `REFRESH MATERIALIZED VIEW CONCURRENTLY` permite atualização sem bloquear
+   leitores. Drawback: refresh demora, e MVs com dependências entre si exigem
+   ordem.
+
+A primeira versão tinha um arquivo `sql/12_views.sql` com 30 MVs sem ordem
+explícita. Mudar a definição de uma quebrava cascata e ninguém entendia mais a
+ordem correta de `REFRESH`.
+
+## Decision
+
+MVs organizadas em **3 camadas** em [`sql/12_views.sql`](../../sql/12_views.sql),
+com regras estritas:
+
+### Camada L1 — independentes
+
+Agregam apenas **tabelas físicas**. Sem depender de outras MVs.
+
+- `mv_empresa_governo` — empresas com contrato governo (qualquer ente)
+- `mv_pessoa_pb` — universo de pessoas PB (CPF + nome)
+- `mv_municipio_pb_risco` — agregações por município PB
+- `mv_servidor_pb_base` — servidores PB consolidados
+- `mv_empresa_municipio_pagantes` — pares (empresa, município) com pagamento
+
+### Camada L2 — derivadas
+
+Dependem de **uma ou mais L1** (e possivelmente de tabelas físicas).
+
+- `mv_servidor_pb_risco` (← `mv_servidor_pb_base`)
+- `mv_empresa_pb` (← `mv_empresa_governo`, `mv_empresa_municipio_pagantes`)
+- `mv_rede_pb` (← múltiplas L1)
+- `mv_municipio_pb_kpi_score`, `mv_municipio_pb_mapa` (← `mv_municipio_pb_risco`)
+- `mv_q67_dated_pb`
+
+### Camada L3 — views planas (não materializadas)
+
+Views normais (sem armazenamento próprio) que apenas **renomeiam ou compõem L2**
+para consumo do web.
+
+- `v_risk_score_pb` (← `mv_municipio_pb_kpi_score`)
+- `v_risk_score_empresa` (← `mv_empresa_pb`)
+
+### Convenções obrigatórias em `sql/12_views.sql`
+
+1. **DROP em ordem reversa no topo do arquivo** (L3 → L2 → L1). Isso evita
+   `cannot drop because other objects depend on it`.
+2. **CREATE em ordem direta** (L1 → L2 → L3), seções comentadas separando
+   camadas.
+3. **`REFRESH CONCURRENTLY` exige `UNIQUE INDEX`** — toda MV criada precisa de
+   pelo menos um índice único declarado logo após o `CREATE MATERIALIZED VIEW`.
+4. **Rodapé do arquivo** lista os comandos `REFRESH MATERIALIZED VIEW
+   CONCURRENTLY` em ordem topológica, para uso operacional.
+5. **Cada MV tem comentário inline** com propósito + dependências explícitas
+   (`-- depends on: mv_xxx, tabela_yyy`).
+
+A fase 18 do ETL ([`etl/21_views.py`](../../etl/21_views.py)) reexecuta o arquivo
+inteiro após mudanças de dados.
+
+## Consequences
+
+### Positive
+
+- Queries da UI leem MV → **microssegundos vs minutos**.
+- Contributor adicionando query nova **reusa MV existente** em vez de duplicar
+  joins.
+- Refresh roda **offline** (cron noturno + `warm_cache` em sequência) sem
+  impacto em produção.
+- A camada explícita força o autor a decidir *onde* uma agregação pertence —
+  reduz duplicação acidental.
+
+### Negative / Trade-offs
+
+- **Refresh demora horas** para MVs grandes (5M+ rows com `CONCURRENTLY`).
+- **MV stale** se uma tabela física é atualizada sem refresh subsequente — não
+  há invalidação automática. O ETL principal sempre refaz, mas alterações
+  manuais não.
+- Mudança em **coluna de L1 quebra L2 em cascata**. Renomear `mv_pessoa_pb.cpf`
+  para `cpf_digitos` exige varrer todas as L2 e atualizar.
+- `web/queries/registry.py` referencia colunas de MVs por nome — drift entre
+  SQL e Python só aparece em runtime.
+
+### Mitigations
+
+- Cada MV é documentada inline com dependências; navegar `sql/12_views.sql`
+  topo-pra-baixo é suficiente para entender a árvore.
+- A fase 18 do ETL reexecuta todo o arquivo — refresh diário evita stale em
+  produção.
+- `docs/mv-guide.md` (a ser criado) detalha o passo-a-passo para adicionar uma
+  MV nova respeitando as 5 convenções.
+- CI futuro (issue [#135]) pode detectar drift entre MVs e referências em
+  `web/queries/registry.py`.
+
+## Related
+
+- Code: [`sql/12_views.sql`](../../sql/12_views.sql),
+  [`etl/21_views.py`](../../etl/21_views.py),
+  [`web/queries/registry.py`](../../web/queries/registry.py).
+- Other ADRs: [ADR-0001](0001-no-pandas.md) (JOINs em SQL, não em Python),
+  [ADR-0003](0003-shadow-rewarm.md) (cache de output usa MVs como input).
+- Docs: [`docs/architecture.md`](../architecture.md) seção "Materialized Views
+  em camadas".
+- External: [PostgreSQL `REFRESH MATERIALIZED VIEW
+  CONCURRENTLY`](https://www.postgresql.org/docs/16/sql-refreshmaterializedview.html).

--- a/docs/adr/0002-mv-layered.md
+++ b/docs/adr/0002-mv-layered.md
@@ -109,7 +109,7 @@ inteiro após mudanças de dados.
   topo-pra-baixo é suficiente para entender a árvore.
 - A fase 18 do ETL reexecuta todo o arquivo — refresh diário evita stale em
   produção.
-- `docs/mv-guide.md` (a ser criado) detalha o passo-a-passo para adicionar uma
+- [`docs/mv-guide.md`](../mv-guide.md) detalha o passo-a-passo para adicionar uma
   MV nova respeitando as 5 convenções.
 - CI futuro (issue [#135]) pode detectar drift entre MVs e referências em
   `web/queries/registry.py`.

--- a/docs/adr/0003-shadow-rewarm.md
+++ b/docs/adr/0003-shadow-rewarm.md
@@ -1,0 +1,116 @@
+# ADR-0003: Shadow rewarm com `__pending` swap atômico
+
+## Status
+
+Accepted
+
+## Date
+
+2025-01-20
+
+## Context
+
+A tabela `web_cache` armazena resultados pré-computados das queries em
+[`web/queries/registry.py`](../../web/queries/registry.py). Cada linha tem
+`(query_id, params_hash) → JSONB`. O warm leva **12–18 horas** para preencher
+todas as queries de todos os municípios PB.
+
+Mudanças em `registry.py` (ex.: correção de bug na Q65, nova versão da Q67 com
+filtro de data) **invalidam o cache existente** para essas queries. Workflow
+ingênuo:
+
+```
+DELETE FROM web_cache WHERE query_id = 'Q65';
+-- start warm
+```
+
+Durante todo o warm (horas) as rotas que dependem de Q65 retornam **cache miss
+→ query live (timeout) → 503**. Inaceitável.
+
+Caminhos considerados:
+
+1. **Aceitar downtime durante warm** — descartado, viola SLA do site público.
+2. **Warm em outra tabela `web_cache_v2`** e switch via config — exige restart
+   do app + manutenção de duas tabelas em paralelo + risco de drift de schema.
+3. **Shadow rewarm com sufixo no `query_id`** — manter live + pending na mesma
+   tabela, diferenciados por sufixo, swap atômico no fim. Sem restart. Sem
+   tabela duplicada.
+
+## Decision
+
+Pattern `rewarm_cache_keys` implementado em
+[`web/warm_cache.py`](../../web/warm_cache.py):
+
+### Fluxo
+
+1. Warm escreve em `<qid>__pending` — sufixo aplicado na coluna `query_id`
+   (`Q65` → `Q65__pending`).
+2. **Live rows continuam servindo** durante o warm (rotas leem `Q65`, ignoram
+   `Q65__pending`).
+3. Ao final do warm:
+   - **Se 100% sucesso (fail == 0)**: swap atômico em transação única:
+     ```sql
+     DELETE FROM web_cache WHERE query_id = 'Q65';
+     UPDATE web_cache SET query_id = 'Q65' WHERE query_id = 'Q65__pending';
+     ```
+   - **Se qualquer query falhou**: ABORT — descarta todo o `__pending`, mantém
+     live antigo intacto.
+
+### Auto-expansão de dependências
+
+Algumas chaves disparam expansão automática para evitar deploys parciais:
+
+- Shadow de prefixos `PERFIL`, `TOP_FORN`, `TOP_SERV` → inclui automaticamente
+  `KPI_SUMMARY` (que depende deles).
+
+### Match semantics — **exato de qid ou base**, não substring
+
+Para evitar matches espúrios em chaves compostas:
+
+- `PERFIL` casa: `PERFIL`, `ANO:PERFIL`, `ANO_MES:PERFIL`
+- `PERFIL` **NÃO** casa: `EMPRESA_PERFIL`, `PERFILADO`
+
+O matcher quebra o `query_id` em segmentos por `:` e compara o último segmento
+contra a chave fornecida (igualdade estrita).
+
+## Consequences
+
+### Positive
+
+- **Zero downtime** em rewarms operacionais.
+- **Abort preserva live** — warm parcial nunca corrompe produção.
+- **Auto-expansão** evita esquecer dependências (esquecer `KPI_SUMMARY` ao
+  reaquecer `PERFIL` daria UI inconsistente).
+- Swap é uma única transação curta → janela de inconsistência de milissegundos.
+
+### Negative / Trade-offs
+
+- Durante o warm, `web_cache` **dobra de tamanho** (~30–50 GB extras).
+- Complexidade em `warm_cache.py` (~1700 linhas) — matching, expansão, swap,
+  abort, retry, logging.
+- Política de abort é **estrita demais**: 1 query que falha aborta tudo,
+  mesmo quando 999 outras passaram. Pode atrasar deploys quando há flakiness
+  em uma única query.
+- Operacional: se o cron noturno falha em uma query intermitente, o live
+  fica antigo até o próximo run — não há recovery parcial.
+
+### Mitigations
+
+- **Storage Postgres é commodity** no setup atual (disco Azure managed
+  expansível); o pico durante o warm é aceitável.
+- Warm roda em **janela de baixo tráfego** (cron 03h BR).
+- Abort emite **log claro com a query culpada** + count de sucessos —
+  diagnosticar e re-rodar é direto.
+- O workflow `deploy.yml` aceita `rewarm_cache_keys` como input, permitindo
+  rewarm cirúrgico (só `Q65`, por exemplo) sem refazer as 12 h inteiras.
+
+## Related
+
+- Code: [`web/warm_cache.py`](../../web/warm_cache.py)
+  (`rewarm_cache_keys`, `_swap_pending_to_live`, `_expand_keys`).
+- Other ADRs: [ADR-0002](0002-mv-layered.md) (MVs alimentam o cache).
+- Workflow:
+  [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml) (input
+  `rewarm_cache_keys`).
+- Docs: `docs/cache.md` (a ser criado) detalha o ciclo de vida do
+  `web_cache` e operação do rewarm.

--- a/docs/adr/0003-shadow-rewarm.md
+++ b/docs/adr/0003-shadow-rewarm.md
@@ -12,7 +12,7 @@ Accepted
 
 A tabela `web_cache` armazena resultados pré-computados das queries em
 [`web/queries/registry.py`](../../web/queries/registry.py). Cada linha tem
-`(query_id, params_hash) → JSONB`. O warm leva **12–18 horas** para preencher
+`(query_id, municipio) → JSONB`. O warm leva **12–18 horas** para preencher
 todas as queries de todos os municípios PB.
 
 Mudanças em `registry.py` (ex.: correção de bug na Q65, nova versão da Q67 com
@@ -60,7 +60,7 @@ Pattern `rewarm_cache_keys` implementado em
 
 Algumas chaves disparam expansão automática para evitar deploys parciais:
 
-- Shadow de prefixos `PERFIL`, `TOP_FORN`, `TOP_SERV` → inclui automaticamente
+- Shadow de prefixos `PERFIL`, `TOP_FORNECEDORES`, `TOP_SERVIDORES` → inclui automaticamente
   `KPI_SUMMARY` (que depende deles).
 
 ### Match semantics — **exato de qid ou base**, não substring
@@ -112,5 +112,5 @@ contra a chave fornecida (igualdade estrita).
 - Workflow:
   [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml) (input
   `rewarm_cache_keys`).
-- Docs: `docs/cache.md` (a ser criado) detalha o ciclo de vida do
+- Docs: [`docs/cache.md`](../cache.md) detalha o ciclo de vida do
   `web_cache` e operação do rewarm.

--- a/docs/adr/0004-etl-incremental-framework.md
+++ b/docs/adr/0004-etl-incremental-framework.md
@@ -113,7 +113,7 @@ em [`etl/incremental/README.md`](../../etl/incremental/README.md):
 
 - [`etl/incremental/README.md`](../../etl/incremental/README.md) (8.3 KB)
   documenta P1–P6, fluxo end-to-end, comandos operacionais.
-- `docs/etl-incremental-guide.md` (a ser criado) destrincha os 8 passos para
+- [`docs/etl-incremental-guide.md`](../etl-incremental-guide.md) destrincha os 8 passos para
   adicionar uma nova spec, com checklist.
 - Tests em `tests/incremental/` verificam invariants — quebrar um princípio
   falha CI.
@@ -129,7 +129,7 @@ em [`etl/incremental/README.md`](../../etl/incremental/README.md):
     `sql/27_etl_admin_security_definer.sql`
   - [`tests/incremental/`](../../tests/incremental/)
 - Other ADRs: [ADR-0001](0001-no-pandas.md) (mesma filosofia streaming + COPY).
-- Docs: `docs/etl-incremental-guide.md` (a ser criado).
+- Docs: [`docs/etl-incremental-guide.md`](../etl-incremental-guide.md).
 - External:
   - [PostgreSQL `SECURITY DEFINER` best practices](https://www.postgresql.org/docs/16/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY)
   - RFC 4122 UUIDv5 (namespace-based determinism)

--- a/docs/adr/0004-etl-incremental-framework.md
+++ b/docs/adr/0004-etl-incremental-framework.md
@@ -1,0 +1,135 @@
+# ADR-0004: Framework ETL incremental dedicado
+
+## Status
+
+Accepted
+
+## Date
+
+2025-03-05
+
+## Context
+
+Duas fontes — **TCE-PB** e **dados.pb.gov.br** — publicam dados em **janelas
+mês/ano** e fazem **correções retroativas** (publicam um ajuste de 2023 em
+2025, por exemplo). O ETL clássico do projeto (`TRUNCATE + rebuild` por fase)
+tem dois problemas estruturais para estas fontes:
+
+1. **Re-download massivo**: TCE-PB completo são ~20 GB. Baixar tudo todo mês,
+   só para descobrir que 95% não mudou, é caro (banda, tempo, fair-use do
+   portal-fonte).
+2. **Histórico não preservado**: correção retroativa sobrescreve a versão
+   anterior sem rastro. Auditoria forense fica impossível ("o que essa fonte
+   reportava em janeiro?").
+
+Tentativa anterior (PR #87, descartado) foi **adaptar o ETL clássico para
+incremental no mesmo módulo**. Resultado:
+
+- PRs gigantescos misturando lógica de full-load e incremental.
+- Regressões em cargas full quando se mexia em incremental, e vice-versa.
+- Auditoria parcial — alguns sinks tinham log, outros não.
+- Sem garantia de não-corromper-dados (sem testes, sem role-segregation).
+
+## Decision
+
+**Subsistema dedicado em [`etl/incremental/`](../../etl/incremental/)** com
+contrato bem definido e **6 princípios não-negociáveis** (P1–P6), documentados
+em [`etl/incremental/README.md`](../../etl/incremental/README.md):
+
+### Princípios (precedência em caso de conflito: P1 > P2 > … > P6)
+
+1. **P1 — NÃO CORROMPER DADOS EXISTENTES.** Sobrepõe todos os outros. Se uma
+   operação tem qualquer risco de corromper o que já está lá, ela não roda.
+2. **P2 — NÃO-DESTRUTIVO.** Zero `TRUNCATE`/`DROP`/`DELETE` em tabelas
+   target. Inserts e updates idempotentes apenas.
+3. **P3 — AUDITÁVEL.** Rastro completo em `etl_run_log`, `etl_phase_log`,
+   `etl_download_log`, `etl_rejected_rows` (DLQ).
+4. **P4 — ERROR RESILIENT.** Recuperável de qualquer crash. Watermark
+   persistido + `bucket_token` UUIDv5 determinístico (mesma janela → mesmo
+   token → idempotência).
+5. **P5 — FAST.** Download condicional: `HEAD` probe + `If-None-Match` +
+   `If-Modified-Since`. Se o servidor diz 304, pula tudo.
+6. **P6 — ZERO TOLERANCE.** Watermark **nunca** avança em failure. DLQ
+   persiste mesmo em `ROLLBACK` da `main_conn` (escreve com conexão separada
+   e commit independente).
+
+### Role-segregation (defense-in-depth)
+
+- **`etl_incremental`** — LOGIN NOINHERIT, GRANT SELECT/INSERT/UPDATE apenas.
+  **Sem DELETE/TRUNCATE/DROP** no nível do banco. O loader corre como esse
+  role.
+- **`etl_admin`** — operações privilegiadas via `SECURITY DEFINER`
+  functions, com `search_path` lockado e fence de identidade
+  (`current_user`).
+- Triggers de proteção em tabelas críticas (impedem update destrutivo de
+  watermark).
+- **AST scan** em CI verifica que código de loader não usa `TRUNCATE`/`DROP`
+  literal.
+
+### Cobertura atual
+
+- **4 specs TCE-PB** + **16 specs dados-PB** = 20 specs em produção.
+- ~3.3 kLOC, 23 arquivos Python, 9 SQL migrations
+  (`sql/22_*.sql` a `sql/29_*.sql` + `32`, `34`, `35`).
+- Único subsistema do repositório com suite de testes
+  (`tests/incremental/`, 5 arquivos cobrindo invariants P1–P6 +
+  defesas SECDEF + role).
+
+## Consequences
+
+### Positive
+
+- **Dados históricos preservados** — toda versão de uma correção retroativa
+  fica registrada via `bucket_token` + timestamp.
+- **Recuperação automática** de crash: rerun pega de onde parou (watermark).
+- **Auditoria forense completa** — `etl_run_log`/`etl_phase_log`/
+  `etl_download_log`/`etl_rejected_rows` respondem "o que aconteceu, quando,
+  com qual resultado".
+- **Segurança em 4 camadas**: DB role + SECDEF function + triggers + AST
+  scan. Mesmo um bug no loader não consegue destruir target.
+- **Download eficiente** — em ciclos sem mudança, fonte é "pingada" e
+  pipeline volta em segundos.
+- **Único subsistema testado** — base para expandir testes ao resto do
+  projeto.
+
+### Negative / Trade-offs
+
+- **Complexidade alta** — ~3.3 kLOC, 9 migrations, 23 arquivos Python.
+  Curva de aprendizado real para contributors.
+- **Gerador DDL não-automatizado** — adicionar spec exige sincronizar 3
+  artefatos paralelos manualmente:
+  - `LoaderSpec` Python (colunas tipadas)
+  - DDL SQL da tabela target
+  - `UNIQUE INDEX` para idempotência
+  Drift entre eles é detectado apenas em runtime.
+- **Auto-discovery manual** — `runner.py:_load_all_specs()` exige
+  registro explícito (lista hardcoded). Esquecer = spec não roda.
+- Custos operacionais (Postgres roles, GRANTs) precisam ser replicados em
+  qualquer ambiente novo.
+- Dois sistemas paralelos (ETL clássico + incremental) — contributor precisa
+  saber em qual escrever.
+
+### Mitigations
+
+- [`etl/incremental/README.md`](../../etl/incremental/README.md) (8.3 KB)
+  documenta P1–P6, fluxo end-to-end, comandos operacionais.
+- `docs/etl-incremental-guide.md` (a ser criado) destrincha os 8 passos para
+  adicionar uma nova spec, com checklist.
+- Tests em `tests/incremental/` verificam invariants — quebrar um princípio
+  falha CI.
+- Roadmap inclui gerador DDL automático a partir de `LoaderSpec` (issue em
+  aberto).
+
+## Related
+
+- Code:
+  - [`etl/incremental/`](../../etl/incremental/) (loader, runner, specs)
+  - [`etl/incremental/README.md`](../../etl/incremental/README.md) (P1–P6)
+  - SQL: `sql/22_etl_watermark.sql` … `sql/29_etl_download_log.sql`,
+    `sql/27_etl_admin_security_definer.sql`
+  - [`tests/incremental/`](../../tests/incremental/)
+- Other ADRs: [ADR-0001](0001-no-pandas.md) (mesma filosofia streaming + COPY).
+- Docs: `docs/etl-incremental-guide.md` (a ser criado).
+- External:
+  - [PostgreSQL `SECURITY DEFINER` best practices](https://www.postgresql.org/docs/16/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY)
+  - RFC 4122 UUIDv5 (namespace-based determinism)

--- a/docs/adr/0005-no-orm-web.md
+++ b/docs/adr/0005-no-orm-web.md
@@ -44,11 +44,13 @@ Queries vivem em **`web/queries/registry.py`** como objetos `QueryDef`:
 
 ```python
 QueryDef(
-    qid="Q65",
+    id="Q65",
     title="Top fornecedores PB...",
+    description="Top empresas pagas por município PB...",
+    category="fornecedores-irregulares",
+    sql_count=COUNT_Q65,
     sql_full="""SELECT ... FROM mv_empresa_pb WHERE ...""",
     sql_full_dated="""SELECT ... WHERE data BETWEEN %(data_inicio)s AND %(data_fim)s""",
-    params=("municipio_id",),
     timeout_sec=30,
 )
 ```

--- a/docs/adr/0005-no-orm-web.md
+++ b/docs/adr/0005-no-orm-web.md
@@ -1,0 +1,114 @@
+# ADR-0005: Sem ORM no web — raw SQL via psycopg2
+
+## Status
+
+Accepted
+
+## Date
+
+2024-08-01
+
+## Context
+
+A camada web (FastAPI + Jinja2 em [`web/`](../../web/)) precisa servir queries
+analíticas pesadas: agregações por município, rankings de fornecedores,
+cruzamentos entre `mv_municipio_pb_risco` e `mv_empresa_pb`, queries Q01–Q310
+parametrizadas por intervalo de data.
+
+Caminhos considerados:
+
+1. **SQLAlchemy ORM** — padrão da comunidade Python web. Boa ergonomia para
+   CRUD. **Problemas no nosso caso**:
+   - Mapear MVs (ver [ADR-0002](0002-mv-layered.md)) e views planas exige
+     declarar modelos artificiais; mudanças em SQL exigem mudança em Python.
+   - JOINs analíticos complexos (5–10 tabelas, window functions, CTEs)
+     viram código ORM ilegível ou caem em `text()` — anulando o ORM.
+   - Geração de SQL do SQLAlchemy nem sempre usa o plano que escolheríamos;
+     ajustes finos exigem hints/raw fragments.
+2. **SQLAlchemy Core (sem ORM)** — query builder declarativo. Melhor que ORM
+   para analytics, mas ainda exige duplicar schema em metadata Python.
+3. **psycopg2 raw + `web/queries/registry.py`** — queries escritas em SQL
+   puro, parametrizadas com `%(named)s`, registradas em um `dict` por
+   `query_id`. Web app só executa.
+
+A filosofia de [ADR-0001](0001-no-pandas.md) (trabalho pesado em SQL, Python
+apenas como driver) e de [ADR-0002](0002-mv-layered.md) (MVs como contrato)
+favorecem a opção 3 fortemente.
+
+## Decision
+
+**Sem ORM e sem query builder.** A camada web usa **psycopg2 raw** com pool de
+conexões em [`web/db.py`](../../web/db.py).
+
+Queries vivem em **`web/queries/registry.py`** como objetos `QueryDef`:
+
+```python
+QueryDef(
+    qid="Q65",
+    title="Top fornecedores PB...",
+    sql_full="""SELECT ... FROM mv_empresa_pb WHERE ...""",
+    sql_full_dated="""SELECT ... WHERE data BETWEEN %(data_inicio)s AND %(data_fim)s""",
+    params=("municipio_id",),
+    timeout_sec=30,
+)
+```
+
+Convenções:
+
+- **Duas variantes** por query quando aplicável: `sql_full` (all-time) e
+  `sql_full_dated` (com placeholders `data_inicio`/`data_fim`,
+  `ano_inicio`/`ano_fim`, `ano_mes_inicio`/`ano_mes_fim`).
+- **Parâmetros sempre nomeados** (`%(nome)s`) — psycopg2 escapa, evita SQL
+  injection, ordem não importa.
+- **Timeout por query** (`QueryDef.timeout_sec`, default 30 s) aplicado via
+  `SET LOCAL statement_timeout`.
+- **Cache em `web_cache`** ([ADR-0003](0003-shadow-rewarm.md)) intermedia
+  produção — a query raw só roda em warm/miss.
+
+## Consequences
+
+### Positive
+
+- **SQL é o contrato** — DBA, analista e developer leem a mesma fonte
+  (`registry.py`), não precisam saber Python para entender o que sai do
+  banco.
+- Mudança em MV → ajuste pontual na query, sem migration de modelo Python.
+- **Plano de execução previsível** — o SQL que está no arquivo é o SQL que o
+  Postgres recebe (`EXPLAIN` direto, sem indireção do ORM).
+- Compatível com `pgbadger`/`pg_stat_statements` para profiling — query text
+  é o ID natural.
+- Coerente com [ADR-0001](0001-no-pandas.md): SQL no SQL, Python como driver.
+
+### Negative / Trade-offs
+
+- **Sem migrações automáticas de schema** — schema vive em `sql/*.sql`,
+  alterado à mão. Não há `alembic upgrade head`.
+- **Sem refactoring assistido** — renomear coluna exige `grep` em
+  `registry.py` + SQL files; IDE não ajuda.
+- **Risco de SQL injection** se contributor concatenar strings em vez de usar
+  `%(named)s`. Convenção + code review mitigam.
+- Sem mapeamento automático row → objeto — `cursor.fetchall()` retorna
+  tuples/dicts; conversão para template Jinja é manual.
+
+### Mitigations
+
+- `web/db.py` expõe helpers (`fetch_one`, `fetch_all`, `execute`) que
+  encapsulam pool + cursor + timeout — contributor raramente toca psycopg2
+  diretamente.
+- `registry.py` é a única porta de entrada — code review foca lá.
+- Schema vive versionado em `sql/*.sql` numerados; mudanças passam pelo
+  mesmo PR review.
+- Para o futuro: CI poderia rodar `EXPLAIN` em cada query do registry e
+  alertar regressões de plano.
+
+## Related
+
+- Code: [`web/db.py`](../../web/db.py),
+  [`web/queries/registry.py`](../../web/queries/registry.py),
+  [`web/main.py`](../../web/main.py).
+- Other ADRs: [ADR-0001](0001-no-pandas.md) (filosofia raw + streaming),
+  [ADR-0002](0002-mv-layered.md) (MVs são o "modelo" lido pelo web),
+  [ADR-0003](0003-shadow-rewarm.md) (cache em frente às queries raw).
+- External:
+  - [psycopg2 parameter passing](https://www.psycopg.org/docs/usage.html#passing-parameters-to-sql-queries)
+  - [PostgreSQL `statement_timeout`](https://www.postgresql.org/docs/16/runtime-config-client.html#GUC-STATEMENT-TIMEOUT)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,112 @@
+# Architecture Decision Records (ADRs)
+
+Este diretório registra as decisões arquiteturais relevantes do `govbr-cruza-dados`.
+
+## O que é um ADR?
+
+Um Architecture Decision Record documenta **uma decisão técnica importante**, o
+**contexto** em que ela foi tomada, e suas **consequências** (positivas, negativas e
+mitigações). ADRs não são tutoriais nem especificações — são a memória institucional
+do projeto.
+
+Os ADRs aqui foram, em sua maioria, escritos **retroativamente**: documentam decisões
+já tomadas e em produção. Isso é intencional — registrar a justificativa atrás de um
+"por que está assim?" é mais valioso do que não registrar nada.
+
+Para o panorama arquitetural geral (que referencia estes ADRs nos pontos críticos),
+veja [`docs/architecture.md`](../architecture.md).
+
+## Índice
+
+| ID       | Título                                                 | Status   | Data       |
+| -------- | ------------------------------------------------------ | -------- | ---------- |
+| ADR-0001 | [No pandas — streaming + COPY FROM STDIN](0001-no-pandas.md) | Accepted | 2024-06-15 |
+| ADR-0002 | [Materialized Views em camadas L1 → L2 → views planas](0002-mv-layered.md) | Accepted | 2024-09-10 |
+| ADR-0003 | [Shadow rewarm com `__pending` swap atômico](0003-shadow-rewarm.md) | Accepted | 2025-01-20 |
+| ADR-0004 | [Framework ETL incremental dedicado](0004-etl-incremental-framework.md) | Accepted | 2025-03-05 |
+| ADR-0005 | [Sem ORM no web — raw SQL via psycopg2](0005-no-orm-web.md) | Accepted | 2024-08-01 |
+
+## Convenções
+
+### Numeração
+
+ADRs são numerados sequencialmente com 4 dígitos zero-padded: `0001`, `0002`, ...
+O nome do arquivo segue o padrão `NNNN-titulo-curto-kebab-case.md`.
+
+### Imutabilidade
+
+**Uma vez `Accepted`, um ADR é imutável.** Correções tipográficas e links são OK.
+Mudança de decisão = **novo ADR** com:
+
+- `Status: Accepted`
+- Campo `Supersedes ADR-XXXX` no header
+- O ADR antigo atualizado para `Status: Superseded by ADR-YYYY`
+
+Isso preserva o histórico de raciocínio. Quem ler o repositório daqui a 2 anos vai
+querer entender *por que* a decisão mudou, não só que mudou.
+
+### Status
+
+- **Accepted** — em vigor, implementada
+- **Superseded by ADR-XXXX** — substituída por outra decisão
+- **Deprecated** — não está mais em uso, mas não foi formalmente substituída
+
+### Quando escrever um ADR?
+
+Escreva um ADR quando a decisão:
+
+- Afeta múltiplos módulos ou subsistemas
+- Tem trade-offs não-óbvios (alguém razoável poderia ter escolhido diferente)
+- Vai ser questionada depois ("por que não usamos X?")
+- Estabelece um padrão que outros contributors precisam seguir
+
+Decisões locais, idiomáticas ou facilmente reversíveis **não** precisam de ADR —
+um comentário no código basta.
+
+## Template
+
+```markdown
+# ADR-NNNN: <título curto>
+
+## Status
+
+[Accepted | Superseded by ADR-XXXX | Deprecated]
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+(O problema que motivou a decisão. Por que essa escolha precisou ser feita.
+ Quais alternativas existiam.)
+
+## Decision
+
+(A escolha feita, em linguagem direta.)
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative / Trade-offs
+
+- ...
+
+### Mitigations
+
+- ...
+
+## Related
+
+- Code: link para arquivos/funções
+- Other ADRs: ADR-XXXX
+- External: links para docs/posts/papers
+```
+
+## Referências externas
+
+- Michael Nygard, [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) (2011) — origem do formato
+- [adr.github.io](https://adr.github.io/) — coletânea de templates e exemplos

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,15 +41,43 @@ flowchart LR
 
 ```mermaid
 flowchart TB
-    subgraph SOURCES[18+ fontes públicas]
-        direction LR
-        S1[RFB CNPJ ~58GB]
-        S2[PNCP ~30GB]
-        S3[TCE-PB ~20GB]
-        S4[dados.pb ~10GB]
-        S5[TSE ~12GB]
-        S6[PGFN ~11GB]
-        S7[+ 12 outras]
+    subgraph SOURCES[18+ fontes públicas brasileiras]
+        direction TB
+
+        subgraph SRC_EMP[Cadastros de empresa]
+            S_RFB[RFB CNPJ<br/>~58GB]
+            S_BNDES[BNDES<br/>~1.1GB]
+            S_CN[ComprasNet<br/>~static]
+        end
+
+        subgraph SRC_COMPRA[Compras públicas]
+            S_PNCP1[PNCP contratações<br/>~5GB]
+            S_PNCP2[PNCP contratos<br/>~6GB]
+            S_PNCP3[PNCP itens<br/>~19GB]
+            S_EMENDAS[Emendas Parlamentares<br/>~1GB]
+        end
+
+        subgraph SRC_FOLHA[Folha / Beneficiários federais]
+            S_SIAPE[SIAPE servidores<br/>~1.3GB]
+            S_CPGF[CPGF cartão corp.<br/>~210MB]
+            S_VIAG[Viagens a serviço<br/>~6GB]
+            S_BF[Bolsa Família<br/>~2GB]
+        end
+
+        subgraph SRC_PB[Paraíba — estadual/municipal]
+            S_TCE[TCE-PB<br/>~20GB]
+            S_DPB[dados.pb.gov.br<br/>~4GB]
+        end
+
+        subgraph SRC_ELEIT[Eleitorais]
+            S_TSE[TSE candidatos +<br/>doadores + bens<br/>~12GB]
+        end
+
+        subgraph SRC_SAN[Sanções e fiscais]
+            S_SANC[Sanções<br/>CEIS/CNEP/CEAF/Acordos<br/>~240MB]
+            S_PGFN[PGFN dívida ativa<br/>~11GB]
+            S_REN[Renúncias fiscais<br/>~510MB]
+        end
     end
 
     SOURCES -->|HTTPS<br/>etl.00_download| RAW[(DATA_DIR<br/>CSV / JSON / ZIP)]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,384 @@
+# Arquitetura
+
+Visão geral arquitetural do `govbr-cruza-dados` — pensada como ponto único de entrada para contributors externos entenderem como as peças se encaixam. Este documento é a **landing page**; cada componente tem doc dedicado que aprofunda. Para vocabulário do domínio público brasileiro (empenho, UG, CEIS, etc.), veja [`glossario.md`](glossario.md).
+
+## TL;DR
+
+O projeto faz ETL de ~350M registros de ~18 fontes públicas brasileiras para PostgreSQL 16, normaliza identidades por CPF/CNPJ, materializa scores de risco em camadas, e serve o resultado via FastAPI no portal público [transparenciapb.org](https://transparenciapb.org). Tudo orquestrado por GitHub Actions sobre um self-hosted runner em Azure VM.
+
+```mermaid
+flowchart LR
+    SOURCES[18+ fontes<br/>públicas BR] --> ETL[ETL<br/>24 fases]
+    ETL --> DB[(PostgreSQL 16<br/>~248GB)]
+    DB --> MVS[(MVs<br/>L1 → L2 → views)]
+    MVS --> CACHE[(web_cache<br/>pré-computado)]
+    DB --> QUERIES[Queries Q##<br/>fraud detection]
+    CACHE --> WEB[FastAPI<br/>transparenciapb.org]
+    QUERIES --> REPORTS[40+ relatórios<br/>investigativos]
+
+    classDef src fill:#e8f5e9,stroke:#2e7d32
+    classDef store fill:#e3f2fd,stroke:#1565c0
+    classDef compute fill:#fff3e0,stroke:#e65100
+    class SOURCES src
+    class DB,MVS,CACHE store
+    class ETL,QUERIES,WEB compute
+```
+
+## Camadas
+
+1. **Ingestão de dados brutos** — 18 fontes públicas baixadas como CSVs/JSONs em `$DATA_DIR`. Owner: `etl/00_download.py`.
+2. **ETL clássico** — 24 fases (full reload, TRUNCATE+rebuild) carregando do raw para tabelas físicas. Owner: `etl/run_all.py`.
+3. **ETL incremental** — framework dedicado em `etl/incremental/` para fontes append-only (TCE-PB, dados.pb hoje). Princípios não-negociáveis P1-P6. Owner: [`etl/incremental/README.md`](../etl/incremental/README.md).
+4. **Schema** — DDL numerada em `sql/00_*.sql` a `sql/35d_*.sql`, executada pelo `etl.db.execute_sql_file`.
+5. **Materialized Views em camadas** — `sql/12_views.sql`. L1 (independentes) → L2 (derivadas) → views planas. Detalhes em [`mv-guide.md`](mv-guide.md).
+6. **Entity Resolution** — fase 17 (`etl/15_normalizar.py`) cria colunas `cpf_digitos` e `cpf_cnpj_norm` que permitem JOINs cross-source por igualdade direta.
+7. **Queries Q##** — `queries/*.sql` com 125+ queries de fraude, numeradas globalmente Q01-Q310. Executadas por `etl/run_queries.py`. Detalhes em [`queries-guide.md`](queries-guide.md).
+8. **Web frontend** — FastAPI + Jinja2 servindo cache pré-computado, com *shadow rewarm* zero-downtime. Detalhes em [`web-guide.md`](web-guide.md) e [`cache.md`](cache.md).
+9. **Deploy** — workflow GitHub Actions com auto-resize de VM Azure. Detalhes em [`deploy.md`](deploy.md).
+10. **Observabilidade** — Umami self-hosted + GoAccess + traffic-digest + pg-autotune. Detalhes em [`ops.md`](ops.md).
+
+## Data flow ETL
+
+```mermaid
+flowchart TB
+    subgraph SOURCES[18+ fontes públicas]
+        direction LR
+        S1[RFB CNPJ ~58GB]
+        S2[PNCP ~30GB]
+        S3[TCE-PB ~20GB]
+        S4[dados.pb ~10GB]
+        S5[TSE ~12GB]
+        S6[PGFN ~11GB]
+        S7[+ 12 outras]
+    end
+
+    SOURCES -->|HTTPS<br/>etl.00_download| RAW[(DATA_DIR<br/>CSV / JSON / ZIP)]
+
+    subgraph CLASSIC[ETL clássico — 24 fases — full reload]
+        direction TB
+        P1[1. Schema base<br/>etl.01_schema]
+        P2[2-14. Cargas<br/>RFB, PNCP, Emendas,<br/>CPGF, PGFN, BNDES]
+        P3[15-18. Sanções,<br/>Viagens, TSE,<br/>Bolsa Família]
+        P4[19-20. TCE-PB +<br/>dados.pb]
+        P5[17. Normalização<br/>CPF/CNPJ]
+        P6[18. MVs L1/L2/L3<br/>etl.21_views]
+        P7[19. MV sitemap<br/>etl.22_mv_sitemap]
+
+        P1 --> P2 --> P3 --> P4 --> P5 --> P6 --> P7
+    end
+
+    RAW --> CLASSIC
+
+    subgraph INCREMENTAL[ETL incremental — append-only]
+        direction TB
+        I1[etl.incremental.runner]
+        I2[Conditional GET<br/>HEAD probe + ETag]
+        I3[staging RAW<br/>staging typed]
+        I4[INSERT target<br/>ON CONFLICT DO NOTHING]
+        I5[DLQ: rows rejeitadas]
+
+        I1 --> I2 --> I3 --> I4
+        I3 -.->|NK NULL| I5
+    end
+
+    SOURCES -.->|TCE-PB +<br/>dados.pb| INCREMENTAL
+
+    CLASSIC --> DB[(PostgreSQL 16<br/>~248GB)]
+    INCREMENTAL --> DB
+
+    DB --> CONSUMERS[Queries Q## + web + relatórios]
+```
+
+ETL clássico e incremental coexistem para fontes diferentes — o incremental cobre TCE-PB e dados.pb (20 specs, ~40M rows); o clássico cobre todas as outras. Quando uma fonte clássica migra para incremental, ela sai da lista de `etl/run_all.py` e ganha `LoaderSpec` em `etl/incremental/specs/`.
+
+## Entity Resolution (CPF/CNPJ)
+
+CPFs aparecem mascarados em formatos diferentes por fonte. JOINs cross-source não funcionariam com `LIKE` / regex em 350M linhas. Solução: normalização na fase 17.
+
+```mermaid
+flowchart LR
+    subgraph FONTES[CPF em 7 formatos diferentes]
+        direction TB
+        F1["Bolsa Família / SIAPE / CPGF<br/><code>***.456.789-**</code><br/>6 dígitos centrais"]
+        F2["Sócio RFB<br/><code>***456789**</code><br/>sem pontuação"]
+        F3["PGFN<br/><code>XXX456.789XX</code><br/>formato próprio"]
+        F4["CEIS / CNEP<br/><code>12345678901</code><br/>completo (raro)"]
+        F5["TCE-PB servidor<br/><code>***.456.789-**</code>"]
+        F6["dados.pb pagamento<br/><code>00045678901</code><br/>completo!"]
+        F7["dados.pb empenho PF<br/><code>***456***</code><br/>3 dígitos centrais"]
+    end
+
+    FONTES -->|Phase 17<br/>etl.15_normalizar| NORM[Funções utilitárias<br/><code>clean_cpf, clean_cnpj,<br/>extract_cpf_masked</code>]
+
+    NORM --> COL1[("<b>cpf_digitos</b><br/>6 dígitos centrais<br/>indexed"]
+    NORM --> COL2[("<b>cpf_cnpj_norm</b><br/>11 ou 14 dígitos<br/>indexed")]
+
+    COL1 --> MATCH[JOIN por igualdade<br/>direta + nome normalizado]
+    COL2 --> MATCH
+```
+
+**Caveat importante**: ao identificar fornecedores em queries, use **`cpf_cnpj` completo (14 dígitos)** — não `cnpj_basico` (8 dígitos), que sofre colisão com CPFs cujos primeiros 8 dígitos coincidem com algum CNPJ. Filtre com `EXISTS (SELECT 1 FROM estabelecimento WHERE cpf_cnpj = ...)` para excluir falsos positivos. Detalhes em [`queries-guide.md`](queries-guide.md).
+
+## ERD principal
+
+Visão simplificada das entidades centrais. Tabelas auxiliares (`dom_*`, `etl_*` audit, `pb_extras_*`) omitidas para clareza.
+
+```mermaid
+erDiagram
+    empresa ||--o{ estabelecimento : "1 matriz : N filiais"
+    empresa ||--o{ socio : "1 empresa : N sócios"
+    empresa {
+        text cnpj_basico PK
+        text razao_social
+        text porte
+        text natureza_juridica
+        numeric capital_social
+    }
+    estabelecimento {
+        text cnpj_basico FK
+        text cpf_cnpj
+        text nome_fantasia
+        int situacao_cadastral
+        text municipio
+        text uf
+    }
+    socio {
+        text cnpj_basico FK
+        text nome_socio
+        text cpf_digitos
+    }
+    tce_pb_despesa }o--|| estabelecimento : "fornecedor via cpf_cnpj"
+    tce_pb_despesa {
+        text municipio
+        text nome_municipio
+        text cpf_cnpj
+        text modalidade_licitacao
+        text numero_licitacao
+        date data_empenho
+        numeric valor_empenhado
+        numeric valor_pago
+    }
+    pb_pagamento }o--|| estabelecimento : "credor via cpf_cnpj_norm"
+    pb_pagamento {
+        text exercicio
+        text ug
+        text empenho
+        text cpf_cnpj_norm
+        date data_pagamento
+        numeric valor
+    }
+    ceis_sancao }o--|| estabelecimento : "sancionado"
+    ceis_sancao {
+        text cpf_cnpj_sancionado
+        date data_inicio_sancao
+        date data_final_sancao
+        text tipo_sancao
+        text abrangencia
+    }
+    tce_pb_servidor }o--|| socio : "match por nome + cpf_digitos"
+    tce_pb_servidor {
+        text municipio
+        text cpf_digitos
+        text nome
+        text cargo
+        numeric salario
+    }
+    bolsa_familia }o--|| tce_pb_servidor : "match servidor → beneficiário"
+    bolsa_familia {
+        text municipio
+        text cpf_digitos
+        text nome
+        numeric valor
+        text competencia
+    }
+```
+
+Relacionamentos não-mostrados por simplicidade:
+
+- `pncp_*` (contratacao/contrato/item) → `estabelecimento` via `cpf_cnpj`
+- `pb_empenho`, `pb_contrato`, `pb_liquidacao_*` → `pb_pagamento` por `(exercicio, ug, empenho)`
+- `siape`, `cpgf`, `viagem` → `estabelecimento` / `socio` via `cpf_digitos` + nome
+- `tse_*` (candidato, doador, patrimônio) → `socio` via `cpf_digitos` + nome
+- `cnep_sancao`, `ceaf_expulsao`, `acordo_*` → similar a `ceis_sancao`
+
+Para o catálogo completo de colunas das tabelas TCE-PB e dados.pb, veja [`dicionario_dados_pb.md`](dicionario_dados_pb.md).
+
+## Materialized Views em camadas
+
+```mermaid
+flowchart TB
+    subgraph L0[Tabelas físicas]
+        T_TCE[tce_pb_*]
+        T_PB[pb_*]
+        T_EMP[empresa,<br/>estabelecimento,<br/>socio]
+        T_BF[bolsa_familia,<br/>siape, cpgf]
+        T_SAN[ceis_sancao,<br/>cnep_sancao,<br/>ceaf_expulsao]
+    end
+
+    subgraph L1[L1 - MVs independentes]
+        L1A[mv_empresa_governo]
+        L1B[mv_pessoa_pb]
+        L1C[mv_municipio_pb_risco]
+        L1D[mv_servidor_pb_base]
+        L1E[mv_empresa_municipio_pagantes]
+    end
+
+    subgraph L2[L2 - MVs derivadas]
+        L2A[mv_servidor_pb_risco]
+        L2B[mv_empresa_pb]
+        L2C[mv_rede_pb]
+        L2D[mv_municipio_pb_kpi_score]
+        L2E[mv_municipio_pb_mapa]
+        L2F[mv_q67_dated_pb]
+    end
+
+    subgraph L3[L3 - Views planas]
+        V1[v_risk_score_pb]
+        V2[v_risk_score_empresa]
+    end
+
+    L0 --> L1
+    L1A & L1B & L1C & L1D --> L2A
+    L1A & L1C --> L2B
+    L1A & L1B --> L2C
+    L2A & L1C --> L2D
+    L2D & L1C --> L2E
+    L1C --> L2F
+
+    L2A & L2B & L2C --> V1
+    L2B --> V2
+```
+
+Convenções estritas em `sql/12_views.sql`:
+
+1. **DROP no topo do arquivo, em ordem reversa** — views planas primeiro, L2 depois, L1 por último
+2. **Criação por camada** — L1 → L2 → views planas, na sequência
+3. **`REFRESH MATERIALIZED VIEW CONCURRENTLY`** exige UNIQUE INDEX na MV
+4. **Notas de refresh** no rodapé do arquivo documentam ordem em produção
+
+Detalhes operacionais em [`mv-guide.md`](mv-guide.md).
+
+## Web cache e shadow rewarm
+
+A tabela `web_cache` armazena resultados pré-computados de queries pesadas. FastAPI lê dela diretamente em request time. Três modos de atualização:
+
+```mermaid
+sequenceDiagram
+    participant Op as Owner / Workflow
+    participant Warm as warm_cache.py
+    participant Cache as web_cache (live)
+    participant Pending as web_cache (__pending)
+    participant Web as FastAPI
+
+    Note over Cache,Web: Estado: live serve todos os usuários
+
+    Op->>Warm: rewarm_cache_keys=Q65
+    Warm->>Pending: INSERT INTO Q65__pending<br/>(execução completa)
+
+    par Live continua servindo
+        Web->>Cache: SELECT Q65 (live)
+        Cache-->>Web: rows existentes
+    and Warm escreve em shadow
+        Warm->>Pending: queries calmas, 12-18h
+    end
+
+    alt Todas as queries Q65 succeeded (fail==0)
+        Warm->>Cache: SWAP ATÔMICO<br/>RENAME Q65__pending → Q65
+        Note over Cache: Nova versão visível
+    else Qualquer query Q65 falhou (fail>0)
+        Warm->>Pending: ABORT — descarta __pending
+        Note over Cache: Live mantido intacto
+    end
+```
+
+**Outros modos**:
+
+- **`drop_cache`** — TRUNCATE total. Causa 12-18h de cache miss em todas as queries. Só use em mudança de schema.
+- **`invalidate_cache_keys`** — DELETE cirúrgico por prefixo de qid. Causa cache miss até warm rebuildar. Use só quando dados live estão *broken*.
+- **`rewarm_cache_keys`** — shadow rewarm (acima). **Default recomendado**. Auto-expansão: `PERFIL` propaga para `KPI_SUMMARY` (mesmo prefixo).
+
+Detalhes em [`cache.md`](cache.md). Documentação dos inputs do `deploy.yml` em [`deploy.md`](deploy.md).
+
+## Deploy pipeline (resumo)
+
+```mermaid
+flowchart LR
+    DISPATCH[workflow_dispatch<br/>com 14 inputs]
+    DISPATCH --> PRE[Preflight<br/>github-hosted]
+    PRE -->|"resize VM B2→B4 +<br/>disk Standard→Premium"| AZ[Azure ARM]
+    PRE --> DEPLOY[Deploy<br/>self-hosted runner na VM]
+    DEPLOY -->|"ETL / SQL / web / incremental /<br/>warm cache / IndexNow"| POST[Postflight<br/>github-hosted]
+    POST -->|"resize VM B4→B2 +<br/>disk Premium→Standard"| AZ
+```
+
+3 jobs encadeados com `concurrency.group` único para evitar dois deploys simultâneos quebrarem o banco. Custo médio mensal ~$104 (web base + 1 ETL + 1 warm/mês), prorateado por hora. Detalhes em [`deploy.md`](deploy.md).
+
+## Componentes operacionais (transparenciapb.org)
+
+| Serviço | Systemd unit | Função |
+|---|---|---|
+| Frontend FastAPI | `cruza-web` | Uvicorn :8000 |
+| Warm cache | `cruza-warm-cache` | Type=oneshot, dispara via workflow |
+| Umami analytics | `cruza-umami` | `/_traffic/analytics/` (basic-auth + login) |
+| GoAccess | `cruza-goaccess` | Dashboard `/_traffic/goaccess/` |
+| Traffic tail | `cruza-traffic-tail` | últimas N linhas raw |
+| Traffic digest | `cruza-traffic-digest.{service,timer}` | cron diário |
+| PG auto-tune | `pg-autotune` | recalcula `shared_buffers` etc. por RAM da VM |
+
+Detalhes operacionais (runbooks de rollback, restore, troubleshoot warm, fail2ban) em [`ops.md`](ops.md).
+
+## SEO
+
+Camada de descobribilidade tratada como produto, com sitemap-index shardado, ~550k URLs cobertas, IndexNow, OG image dinâmica. README contém a seção dedicada `## SEO` com os detalhes técnicos.
+
+## Convenções não-negociáveis
+
+Cada uma com fundo arquitetural — quebrá-las introduz regressões silenciosas. Documentadas em [`../CONTRIBUTING.md`](../CONTRIBUTING.md):
+
+1. **PT-BR em todo o projeto** — identificadores, comentários, SQL, commits
+2. **Sem pandas** — RAM budget 16GB sobre 350M rows. Streaming line-by-line + `COPY FROM STDIN` (helpers em `etl/db.py`). ADR-001.
+3. **MVs em camadas L1→L2→views planas** — DROP reverso, REFRESH CONCURRENTLY. ADR-002.
+4. **Shadow rewarm** como padrão de atualização de cache. ADR-003.
+5. **Framework incremental dedicado** para fontes append-only, com role `etl_incremental` sem privilégios destrutivos. ADR-004.
+6. **Header `-- Q##:` obrigatório** em `queries/*.sql` — sem ele o parser custom de `etl/run_queries.py` não detecta a query.
+7. **`cpf_cnpj` (14 dígitos) para fornecedores**, não `cnpj_basico` (8) — colisão CPF/CNPJ.
+8. **RFB usa latin-1**, outras fontes utf-8 — usar `latin1_lines` para RFB.
+
+ADRs em [`adr/`](adr/) detalham o "porquê" de cada decisão arquitetural inegociável.
+
+## Hardest-to-onboard files
+
+Para contributor novo, os 5 arquivos com maior densidade conceitual:
+
+| Arquivo | Linhas | Por que difícil |
+|---|---|---|
+| `sql/12_views.sql` | 1500+ | MVs em 3 camadas, DROP reverso no topo, dependências implícitas |
+| `etl/run_all.py` | 800+ | 24 fases hardcoded, `_CSV_DIRS` vs `_SHARED_DIRS` cleanup automático |
+| `web/routes/cidade.py` | 2100+ | SSR + APIs + cache + dialogs em um arquivo |
+| `web/warm_cache.py` | 1700+ | Shadow rewarm, swap atômico, abort conditions, contextual rebuild |
+| `etl/run_queries.py:split_sql_statements` | ~60 | Parser custom de SQL (quotes + dollar-quoting), processa 125+ Q## |
+
+Os guias temáticos (`etl-guide.md`, `web-guide.md`, `mv-guide.md`, `queries-guide.md`, `cache.md`) destrincham cada um.
+
+## Documentação adicional
+
+| Doc | Para quem |
+|---|---|
+| [`../README.md`](../README.md) | Primeira leitura — quickstart + overview de features |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Convenções + 3 caminhos de contribuição + setup local |
+| [`glossario.md`](glossario.md) | Vocabulário do domínio (CEIS, empenho, UG, etc.) |
+| [`onboarding.md`](onboarding.md) | Walk-through 15min clone → `uvicorn` |
+| [`etl-guide.md`](etl-guide.md) | Adicionar fase ETL clássica |
+| [`etl-incremental-guide.md`](etl-incremental-guide.md) | Adicionar spec incremental (P1-P6) |
+| [`web-guide.md`](web-guide.md) | Adicionar query/rota/template/MD3 |
+| [`queries-guide.md`](queries-guide.md) | Adicionar Q## (header, EXPLAIN, índice) |
+| [`mv-guide.md`](mv-guide.md) | Adicionar MV (layered) |
+| [`cache.md`](cache.md) | `web_cache` + shadow rewarm |
+| [`deploy.md`](deploy.md) | 14 inputs `deploy.yml` + OIDC setup |
+| [`ops.md`](ops.md) | Runbooks operacionais |
+| [`privacidade.md`](privacidade.md) | Política LGPD pública |
+| [`dicionario_dados_pb.md`](dicionario_dados_pb.md) | Catálogo de colunas TCE-PB e dados.pb |
+| [`plano_novas_fontes.md`](plano_novas_fontes.md) | Roadmap de fontes (TSE histórico, etc.) |
+| [`adr/`](adr/) | Decision records arquiteturais |
+| [`../etl/incremental/README.md`](../etl/incremental/README.md) | Framework incremental detalhado |
+| [`../DATA-LICENSE.md`](../DATA-LICENSE.md) | Licenciamento de dados + LGPD |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,13 +56,13 @@ flowchart TB
 
     subgraph CLASSIC[ETL clássico — 24 fases — full reload]
         direction TB
-        P1[1. Schema base<br/>etl.01_schema]
-        P2[2-14. Cargas<br/>RFB, PNCP, Emendas,<br/>CPGF, PGFN, BNDES]
-        P3[15-18. Sanções,<br/>Viagens, TSE,<br/>Bolsa Família]
-        P4[19-20. TCE-PB +<br/>dados.pb]
-        P5[17. Normalização<br/>CPF/CNPJ]
-        P6[18. MVs L1/L2/L3<br/>etl.21_views]
-        P7[19. MV sitemap<br/>etl.22_mv_sitemap]
+        P1[Fase 0-1. Download + Schema base<br/>etl.00_download, etl.01_schema]
+        P2[Fase 2-8. RFB, PNCP, Emendas,<br/>CPGF, PGFN, BNDES, Renúncias,<br/>SIAPE]
+        P3[Fase 9-13. Sanções, Viagens,<br/>TSE Candidatos, Bolsa Família,<br/>TSE Prestação]
+        P4[Fase 14-16. TCE-PB + Dados PB +<br/>PNCP Itens]
+        P5[Fase 17. Normalização CPF/CNPJ<br/>etl.15_normalizar]
+        P6[Fase 18. MVs L1/L2/L3<br/>etl.21_views]
+        P7[Fase 19. MV sitemap<br/>etl.22_mv_sitemap]
 
         P1 --> P2 --> P3 --> P4 --> P5 --> P6 --> P7
     end
@@ -108,9 +108,9 @@ flowchart LR
         F7["dados.pb empenho PF<br/><code>***456***</code><br/>3 dígitos centrais"]
     end
 
-    FONTES -->|Phase 17<br/>etl.15_normalizar| NORM[Funções utilitárias<br/><code>clean_cpf, clean_cnpj,<br/>extract_cpf_masked</code>]
+    FONTES -->|Fase 17<br/>etl.15_normalizar| NORM[Funções utilitárias<br/><code>clean_cpf, clean_cnpj,<br/>extract_cpf_masked</code>]
 
-    NORM --> COL1[("<b>cpf_digitos</b><br/>6 dígitos centrais<br/>indexed"]
+    NORM --> COL1[("<b>cpf_digitos</b><br/>6 dígitos centrais<br/>indexed")]
     NORM --> COL2[("<b>cpf_cnpj_norm</b><br/>11 ou 14 dígitos<br/>indexed")]
 
     COL1 --> MATCH[JOIN por igualdade<br/>direta + nome normalizado]
@@ -294,7 +294,7 @@ sequenceDiagram
 **Outros modos**:
 
 - **`drop_cache`** — TRUNCATE total. Causa 12-18h de cache miss em todas as queries. Só use em mudança de schema.
-- **`invalidate_cache_keys`** — DELETE cirúrgico por prefixo de qid. Causa cache miss até warm rebuildar. Use só quando dados live estão *broken*.
+- **`invalidate_cache_keys`** — DELETE cirúrgico por **substring** de qid (`LIKE '%termo%'`, ver [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml)). Cuidado: passar `PERFIL` apaga `PERFIL`, `EMPRESA_PERFIL`, `PERFIL_DATED`, etc. Causa cache miss até warm rebuildar. Use só quando dados live estão *broken*.
 - **`rewarm_cache_keys`** — shadow rewarm (acima). **Default recomendado**. Auto-expansão: `PERFIL` propaga para `KPI_SUMMARY` (mesmo prefixo).
 
 Detalhes em [`cache.md`](cache.md). Documentação dos inputs do `deploy.yml` em [`deploy.md`](deploy.md).
@@ -353,7 +353,7 @@ Para contributor novo, os 5 arquivos com maior densidade conceitual:
 | Arquivo | Linhas | Por que difícil |
 |---|---|---|
 | `sql/12_views.sql` | 1500+ | MVs em 3 camadas, DROP reverso no topo, dependências implícitas |
-| `etl/run_all.py` | 800+ | 24 fases hardcoded, `_CSV_DIRS` vs `_SHARED_DIRS` cleanup automático |
+| `etl/run_all.py` | ~160 | 24 fases hardcoded na lista local `phases`, `_CSV_DIRS` vs `_SHARED_DIRS` cleanup automático |
 | `web/routes/cidade.py` | 2100+ | SSR + APIs + cache + dialogs em um arquivo |
 | `web/warm_cache.py` | 1700+ | Shadow rewarm, swap atômico, abort conditions, contextual rebuild |
 | `etl/run_queries.py:split_sql_statements` | ~60 | Parser custom de SQL (quotes + dollar-quoting), processa 125+ Q## |

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -84,7 +84,7 @@ Os comentários canônicos do mecanismo estão em [`web/warm_cache.py:94-178`](.
 | Modo | Operação | Downtime | Quando usar |
 |---|---|---|---|
 | **`drop_cache=true`** | `TRUNCATE web_cache` | **12-18h** (cache miss em TUDO até warm completar) | Mudança de schema, big rebuild |
-| **`invalidate_cache_keys=Q65,PERFIL`** | `DELETE` cirúrgico HARD por prefixo | Cache miss até warm rebuildar essas chaves | Dados live **broken** (bug produziu lixo, precisa sumir já) |
+| **`invalidate_cache_keys=Q65,PERFIL`** | `DELETE` cirúrgico HARD por **substring** (`LIKE '%termo%'`) | Cache miss até warm rebuildar essas chaves | Dados live **broken** (bug produziu lixo, precisa sumir já). Cuidado: `PERFIL` casa também `EMPRESA_PERFIL`, `PERFIL_DATED`, etc. |
 | **`rewarm_cache_keys=Q65,PERFIL`** | Shadow rewarm + swap atômico | **Zero** | **Default recomendado** para atualizar dados |
 
 ## Auto-expansão

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,160 @@
+# Cache — `web_cache` + shadow rewarm
+
+Este doc explica o pipeline de cache que sustenta `transparenciapb.org`. Para overview, ver [architecture.md](architecture.md); para operação via deploy, ver `docs/deploy.md` (a ser criado).
+
+## Por que cache?
+
+As Q## pesadas (Q65, Q67, Q70, KPI_SUMMARY, PERFIL...) levam de segundos a minutos no Postgres. Em request quente, o `TIMEOUT_PROFILE=3s` de [`web/config.py`](../web/config.py) tornaria essas páginas inviáveis. Solução: **pré-computar tudo offline** e servir HTML SSR lendo apenas de uma tabela. O FastAPI **nunca executa Q## pesada em request síncrono** — só lê `web_cache`.
+
+## Schema da tabela
+
+Definição real em [`web/warm_cache.py:41-51`](../web/warm_cache.py):
+
+```sql
+CREATE TABLE IF NOT EXISTS web_cache (
+    query_id   TEXT NOT NULL,
+    municipio  TEXT NOT NULL,
+    columns    JSONB NOT NULL DEFAULT '[]',
+    rows       JSONB NOT NULL DEFAULT '[]',
+    row_count  INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (query_id, municipio)
+);
+```
+
+`query_id` carrega:
+
+- **Q##** literal (ex: `Q65`) — variante all-time.
+- **Prefixo temporal** (ex: `ANO:Q65`, `12M:Q65`) — variantes datadas.
+- **Sufixo `__pending`** durante shadow rewarm (ver abaixo).
+- **Keys especiais:** `PERFIL`, `TOP_FORNECEDORES`, `TOP_SERVIDORES`, `HEATMAP`, `KPI_SUMMARY`, `EMPRESA_PERFIL`.
+
+## Warm cycle
+
+```bash
+python -m web.warm_cache --pb              # 1 ciclo: 223 munis PB
+python -m web.warm_cache --daemon --loop   # contínuo, pausa de 60s entre ciclos
+python -m web.warm_cache --mun "João Pessoa"
+```
+
+Configuração relevante:
+
+- `WARM_CACHE_WORKERS=4` (default) — paralelismo de municípios.
+- `WARM_WORK_MEM=192MB` por sessão (evita disk-based sorts).
+- `WARM_SKIP_RECENT_HOURS=-1` (default) — **skip se já cacheado em qualquer idade**; dados governamentais são estáticos após ETL. Para rebuild forçado, use `drop_cache` ou `invalidate_cache_keys`.
+- `TIMEOUT_PROFILE_WARM=600s` (10 min) por empresa em `compute_empresa_perfil_dict` — mega-empresas (BB, Caixa, INSS) têm milhões de empenhos.
+
+## Shadow rewarm — zero downtime
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as Operador (deploy.yml)
+    participant W as warm_cache
+    participant PG as web_cache
+    participant UI as cruza-web (live)
+
+    Op->>W: WARM_REWARM_KEYS="Q65,PERFIL"
+    Note over W: REWARM_KEYS = {Q65, PERFIL}<br/>+ auto-expand: KPI_SUMMARY entra<br/>(via CACHE_DEPENDENCY_GRAPH)
+
+    loop para cada município
+        W->>PG: INSERT em "Q65__pending"
+        W->>PG: INSERT em "PERFIL__pending"
+        W->>PG: INSERT em "KPI_SUMMARY__pending"<br/>(lê dep shadow, strict no-fallback)
+        UI->>PG: SELECT WHERE query_id='Q65' AND municipio=X
+        PG-->>UI: rows ANTIGOS (live intacto)
+    end
+
+    alt fail == 0 para TODAS as qids em shadow
+        W->>PG: BEGIN
+        W->>PG: UPSERT live ← pending (atômico, todos qids)
+        W->>PG: DELETE __pending rows
+        W->>PG: COMMIT
+        Note over UI,PG: readers passam a ver NOVOS<br/>todos os qids simultaneamente
+    else fail > 0 em qualquer qid
+        W->>W: ABORT swap
+        Note over PG: live ANTIGO mantido<br/>__pending será descartado no próximo deploy<br/>(Reset shadow rows step)
+    end
+```
+
+Os comentários canônicos do mecanismo estão em [`web/warm_cache.py:94-178`](../web/warm_cache.py).
+
+## 3 modos de atualização
+
+| Modo | Operação | Downtime | Quando usar |
+|---|---|---|---|
+| **`drop_cache=true`** | `TRUNCATE web_cache` | **12-18h** (cache miss em TUDO até warm completar) | Mudança de schema, big rebuild |
+| **`invalidate_cache_keys=Q65,PERFIL`** | `DELETE` cirúrgico HARD por prefixo | Cache miss até warm rebuildar essas chaves | Dados live **broken** (bug produziu lixo, precisa sumir já) |
+| **`rewarm_cache_keys=Q65,PERFIL`** | Shadow rewarm + swap atômico | **Zero** | **Default recomendado** para atualizar dados |
+
+## Auto-expansão
+
+Quando você passa `rewarm_cache_keys=PERFIL`, o sistema **automaticamente** coloca em shadow qualquer **derived** que dependa de PERFIL no mesmo prefixo. Definido em `CACHE_DEPENDENCY_GRAPH` ([`web/warm_cache.py:193-195`](../web/warm_cache.py)):
+
+```python
+CACHE_DEPENDENCY_GRAPH = {
+    "KPI_SUMMARY": ["PERFIL", "TOP_FORNECEDORES", "TOP_SERVIDORES"],
+}
+```
+
+Sem isso, `KPI_SUMMARY` continuaria sendo computado lendo `PERFIL` **velho** do live durante o warm, e o swap deixaria o UI inconsistente.
+
+## Match semantics
+
+Match é **exato**, não substring. Padrão casa com:
+
+- **`query_id` literal** (ex: `ANO:Q65` casa só `ANO:Q65`).
+- **`base`** (qid sem prefixo): `Q65` casa `Q65`, `ANO:Q65`, `12M:Q65`.
+
+```text
+rewarm_cache_keys = "PERFIL"
+✅ casa: PERFIL, ANO:PERFIL, 12M:PERFIL
+❌ NÃO casa: EMPRESA_PERFIL  (base inteira é EMPRESA_PERFIL)
+```
+
+Decisão de design (PR #105 review): evitar que `PERFIL` dispare warm de ~143K empresas via `EMPRESA_PERFIL`. Use prefixos explícitos para escopar (`ANO:Q65` ≠ `Q65`).
+
+## Endpoint admin
+
+```bash
+curl -X POST https://transparenciapb.org/api/cache/invalidate \
+     -H "X-Admin-Token: $CACHE_INVALIDATE_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"prefix": "Q65"}'
+```
+
+- Implementado em [`web/routes/cidade.py:1406-1430`](../web/routes/cidade.py) (PR #118).
+- **Fail-closed:** sem `CACHE_INVALIDATE_TOKEN` no `.env`, endpoint responde 503.
+- Em **produção**, prefira o workflow `deploy.yml` (auditável, gera log, integrado ao rewarm).
+
+## Caveats
+
+- **Swap exige `fail == 0`** para essa qid. Uma única falha em qualquer município aborta o swap dessa qid; rows `__pending` ficam até o próximo deploy executar a etapa "Reset shadow rows".
+- **Atomicity all-or-nothing:** o swap final é uma única transação cobrindo todas as qids elegíveis — readers nunca vêem derived NOVO + source VELHO. Em troca, basta uma qid falhar para abortar o swap **inteiro** desse ciclo.
+- **Sem TTL automático:** cache não expira sozinho. Refresh acontece quando `deploy.yml` é executado com `rewarm_cache_keys`. Não há cron de rewarm automático (ainda).
+- **`web_cache` cresce com dated:** cada Q## com `sql_full_dated` registra pelo menos all-time + ano-atual (`ANO:`), dobrando linhas. PB: ~223 munis × N queries × 2 variantes.
+- **Cobertura mínima 80%** antes de `expose_empresa_sitemap=enable` no deploy — gate manual no `deploy.yml`.
+- **Shadow rows persistem entre deploys?** Não. O step "Reset shadow rows" do `deploy.yml` deleta `*__pending` no início de cada deploy, evitando shadow stale quando o SQL mudou entre runs.
+
+## Operações em produção
+
+A receita operacional canônica (mudou SQL de uma query → quero atualizar cache sem downtime):
+
+1. PR com a nova SQL.
+2. Após merge, dispare `deploy.yml` com `rewarm_cache_keys=Q65,PERFIL` (vírgula separa múltiplas).
+3. Workflow:
+   - Sincroniza código.
+   - Reseta shadow rows (`DELETE WHERE query_id LIKE '%__pending'`).
+   - Roda `WARM_REWARM_KEYS=Q65,PERFIL python -m web.warm_cache --pb`.
+   - Se fail==0: swap atômico. UI nunca viu cache stale.
+   - Se fail>0: aborta swap; cache live antigo permanece servindo.
+
+Detalhes completos dos inputs em `docs/deploy.md` (a ser criado por outro PR).
+
+## Relacionados
+
+- [architecture.md](architecture.md) — sequence diagram shadow rewarm em alto nível.
+- [mv-guide.md](mv-guide.md) — mudou MV? Rewarm das Q## que a consomem.
+- [queries-guide.md](queries-guide.md) — registrar a query é pré-requisito para o warmer encontrá-la.
+- [web-guide.md](web-guide.md) — rotas cache-only (503 se miss) vs live fallback.
+- Sample dump da tabela (uma vez disponível): `docs/sample-data.md`.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,6 +1,6 @@
 # Cache — `web_cache` + shadow rewarm
 
-Este doc explica o pipeline de cache que sustenta `transparenciapb.org`. Para overview, ver [architecture.md](architecture.md); para operação via deploy, ver `docs/deploy.md` (a ser criado).
+Este doc explica o pipeline de cache que sustenta `transparenciapb.org`. Para overview, ver [architecture.md](architecture.md); para operação via deploy, ver [deploy.md](deploy.md).
 
 ## Por que cache?
 
@@ -149,7 +149,7 @@ A receita operacional canônica (mudou SQL de uma query → quero atualizar cach
    - Se fail==0: swap atômico. UI nunca viu cache stale.
    - Se fail>0: aborta swap; cache live antigo permanece servindo.
 
-Detalhes completos dos inputs em `docs/deploy.md` (a ser criado por outro PR).
+Detalhes completos dos inputs em [deploy.md](deploy.md).
 
 ## Relacionados
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,296 @@
+# Deploy pipeline
+
+Deploy de produção do `govbr-cruza-dados` para a VM Azure que hospeda o [transparenciapb.org](https://transparenciapb.org). O pipeline roda via GitHub Actions com runner self-hosted na própria VM, usa OIDC para operar Azure sem segredo de Service Principal, e divide o trabalho em 3 jobs: `preflight`, `deploy` e `postflight` ([`../.github/workflows/deploy.yml`](../.github/workflows/deploy.yml), linhas 3-6 e 149-153).
+
+A VM fica barata em modo web (`Standard_B2as_v2` + Standard SSD) e sobe temporariamente para ETL/warm (`Standard_B4as_v2` + Premium SSD) quando necessário. O custo base típico é cerca de **US$ 104/mês**, com operações pesadas cobradas por hora extra.
+
+## Visão geral
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Owner
+    participant GH as GitHub Actions<br/>workflow_dispatch
+    participant AZ as Azure OIDC<br/>preflight/postflight
+    participant VM as Azure VM<br/>self-hosted runner
+    participant DB as PostgreSQL/web_cache
+    participant WEB as Nginx + cruza-web
+
+    Owner->>GH: workflow_dispatch<br/>14 inputs
+    GH->>AZ: preflight<br/>login OIDC
+    AZ->>AZ: decide B2/B4 + Standard/Premium
+    alt etl_phase != web OU warm/rewarm
+        AZ->>AZ: deallocate VM
+        AZ->>AZ: resize B2 → B4
+        AZ->>AZ: disk Standard → Premium
+        AZ->>AZ: start VM
+    else web sem warm
+        AZ->>AZ: mantém B2 + Standard
+    end
+    AZ->>VM: wait SSH:22
+
+    GH->>VM: deploy job<br/>runner self-hosted
+    VM->>VM: checkout + git reset origin/main
+    VM->>VM: instala deps + escreve .env
+    VM->>DB: pg-autotune por RAM atual
+    alt etl_phase = all/sql/N/incremental
+        VM->>DB: executa ETL/SQL/fase/incremental
+    else etl_phase = web
+        VM->>VM: code sync only
+    end
+    VM->>WEB: setup nginx/fail2ban/goaccess/umami
+    opt warm_cache=true OU all/sql OU rewarm_cache_keys
+        VM->>DB: cruza-warm-cache.service<br/>oneshot bloqueante
+    end
+    opt invalidate_cache_keys
+        VM->>DB: DELETE web_cache live rows
+    end
+    opt rewarm_cache_keys
+        VM->>DB: shadow rewarm em __pending + swap
+    end
+    VM->>WEB: restart cruza-web após warm
+    opt expose_*_sitemap = enable
+        VM->>DB: gate cobertura >=80%
+        VM->>WEB: drop-in systemd + smoke
+    end
+    opt IndexNow
+        VM->>WEB: submit URLs selecionadas
+    end
+
+    GH->>AZ: postflight<br/>login OIDC
+    AZ->>AZ: deallocate VM
+    AZ->>AZ: resize B4 → B2
+    AZ->>AZ: disk Premium → Standard<br/>best-effort, limite 2/24h
+    AZ->>AZ: start VM
+```
+
+## Jobs do workflow
+
+### 1. `preflight` - GitHub-hosted + OIDC
+
+Roda em `ubuntu-latest` e decide o tamanho alvo da VM. Se `etl_phase=web`, `warm_cache=false` e `rewarm_cache_keys` vazio, mantém B2 + Standard SSD; qualquer trabalho pesado sobe para B4 + Premium SSD ([linhas 160-179](../.github/workflows/deploy.yml)). O login Azure usa `azure/login@v2` com OIDC ([linhas 181-186](../.github/workflows/deploy.yml)).
+
+Quando há mudança necessária, o job desaloca a VM, redimensiona, converte o SKU do disco, garante cache `ReadOnly` no data disk e liga a VM novamente ([linhas 235-275](../.github/workflows/deploy.yml)). Depois espera SSH na porta 22 antes de liberar o runner self-hosted ([linhas 278-287](../.github/workflows/deploy.yml)).
+
+### 2. `deploy` - self-hosted runner na VM
+
+Roda dentro da VM (`runs-on: [self-hosted, linux, azure]`) com timeout de 5 dias ([linhas 292-296](../.github/workflows/deploy.yml)). O job sincroniza código, escreve `.env`, instala dependências, aplica schemas web, roda `pg-autotune`, verifica disco, executa ETL/SQL/fase/incremental conforme input, faz deploy do frontend e controla cache/sitemaps.
+
+Ordem crítica:
+
+1. Para daemon antigo de warm-cache e mascara timers de auto-update ([linhas 308-346](../.github/workflows/deploy.yml)).
+2. `clean=true` derruba tabelas públicas e remove `.initialized`  **destrutivo** ([linhas 349-366](../.github/workflows/deploy.yml)).
+3. Instala PostgreSQL 16/deps se ausentes ([linhas 369-417](../.github/workflows/deploy.yml)).
+4. Faz clone/fetch/reset para `origin/main`, escreve `.env`, instala `pip install -e ".[web]"` ([linhas 419-482](../.github/workflows/deploy.yml)).
+5. Aplica `pg-autotune.service` e reinicia PostgreSQL se o tuning mudou ([linhas 501-538](../.github/workflows/deploy.yml)).
+6. Executa ETL conforme `etl_phase` ([linhas 573-683](../.github/workflows/deploy.yml)).
+7. Instala/configura Nginx, Let's Encrypt, fail2ban, GoAccess, traffic digest, Umami e systemd services ([linhas 695-827](../.github/workflows/deploy.yml)).
+8. Atualiza estatísticas hot e trata cache (`drop_cache`, skip mode, shadow reset, invalidate, warm) ([linhas 828-1164](../.github/workflows/deploy.yml)).
+9. Reinicia `cruza-web` **após** warm para evitar janela longa de cache miss ([linhas 1166-1203](../.github/workflows/deploy.yml)).
+10. Executa IndexNow/sitemaps/smokes e `etl.verify` ([linhas 1205-1850](../.github/workflows/deploy.yml)).
+
+### 3. `postflight`  GitHub-hosted + OIDC
+
+Roda só quando o deploy terminou com sucesso e houve motivo para upsize (`etl_phase != web`, `warm_cache=true` ou `rewarm_cache_keys` não vazio) ([linhas 1866-1872](../.github/workflows/deploy.yml)). Desaloca, volta para B2, tenta converter disco de volta para Standard SSD e liga a VM ([linhas 1882-1956](../.github/workflows/deploy.yml)). A conversão do disco é best-effort porque Azure limita mudanças de SKU por disco.
+
+## Inputs `workflow_dispatch`
+
+Definidos em [`../.github/workflows/deploy.yml`](../.github/workflows/deploy.yml), linhas 27-109.
+
+| Input | Tipo | Default | Função |
+|---|---|---:|---|
+| `etl_phase` | string | `all` | Seleciona o trabalho: `web`, `all`, `sql`, `incremental` ou fase numérica `N`. |
+| `clean` | boolean | `false` | Reset destrutivo antes do deploy: remove `.initialized` e tenta dropar tabelas públicas. Use só para rebuild zero. |
+| `skip_download` | boolean | `false` | Em `etl_phase=all`, pula download e começa de fase 2 usando arquivos já presentes em `DATA_DIR`. |
+| `warm_cache` | boolean | `false` | Força execução do `cruza-warm-cache.service`. Também força B4/Premium no preflight. Para `etl_phase=web`, é opt-in explícito. |
+| `run_queries` | boolean | `false` | Roda `python -m etl.run_queries` após ETL, exceto em deploy web. |
+| `incremental_only` | csv/string | vazio | Limita specs do incremental, ex. `tce_pb.tce_pb_despesa,dados_pb.pb_pagamento`; só vale com `etl_phase=incremental`. |
+| `drop_cache` | boolean | `false` | `TRUNCATE web_cache` antes do warm. Use apenas em mudança de schema do cache; causa cache miss até rebuild. |
+| `invalidate_cache_keys` | csv/string | vazio | DELETE cirúrgico **HARD** de rows live em `web_cache` por substring de `query_id`. Sanitizado para `[A-Za-z0-9_:]`. |
+| `rewarm_cache_keys` | csv/string | vazio | Shadow rewarm zero-downtime: escreve `<qid>__pending` e promove atomically se sucesso. Match exato/base. |
+| `warm_skip_hours` | string | vazio | Controle do warm: vazio = contextual; `-1` pula se já cacheado; `0` rebuild sempre; `N` legacy resume. |
+| `expose_empresa_sitemap` | choice | `keep` | `keep`, `enable` ou `disable` para `/empresa/<cnpj>` e `/empresa/<cnpj>/<slug>` no sitemap. `enable` exige 80% de cobertura. |
+| `expose_licitacoes_sitemap` | choice | `keep` | Controla `/licitacao/<mun>/<ano>/<ug>/<modnum>` no sitemap. `enable` exige cache e gate de 80%. |
+| `expose_cidade_resumo_sitemap` | choice | `keep` | Controla `/cidade/<slug>/<yyyy-mm>` no sitemap. `enable` exige cache e gate de 80%. |
+| `download_sources` | csv/string | vazio | Re-baixa fontes específicas via `etl.00_download --only` antes de rodar ETL/fase. Útil quando cleanup apagou CSVs. |
+
+## Cenários típicos
+
+### Deploy apenas frontend
+
+Mudanças em HTML/CSS/JS/Python web, sem ETL nem warm:
+
+```yaml
+etl_phase: web
+warm_cache: false
+```
+
+### Reload completo dos dados
+
+Reconstrói banco e MVs. Use `clean=true` apenas se quiser apagar estado anterior.
+
+```yaml
+etl_phase: all
+clean: false
+skip_download: false
+```
+
+### Recriar índices/MVs sem reload
+
+```yaml
+etl_phase: sql
+warm_cache: true
+```
+
+`sql` roda índices/normalização/views/MV sitemap, sem schema base destrutivo ([linhas 610-635](../.github/workflows/deploy.yml)).
+
+### Retomar fase específica
+
+Se a fase 19 falhou:
+
+```yaml
+etl_phase: "19"
+```
+
+O workflow chama `python -m etl.run_all "19"` ([linhas 674-683](../.github/workflows/deploy.yml)).
+
+### Rewarm zero-downtime após mudança em query
+
+```yaml
+etl_phase: web
+rewarm_cache_keys: Q65,PERFIL
+```
+
+Isso força B4/Premium, configura `WARM_REWARM_KEYS`, roda warm em shadow e mantém live antigo até swap seguro ([linhas 972-1001](../.github/workflows/deploy.yml)).
+
+### Habilitar sitemap de empresas
+
+```yaml
+expose_empresa_sitemap: enable
+warm_cache: true
+```
+
+Exige cobertura mínima de 80% para `EMPRESA_PERFIL` e `EMPRESA_PERFIL_MUN`, cria drop-in systemd, reinicia `cruza-web`, valida sitemap e faz smoke E2E ([linhas 1287-1532](../.github/workflows/deploy.yml)).
+
+### Incremental TCE-PB apenas
+
+```yaml
+etl_phase: incremental
+incremental_only: "tce_pb.tce_pb_despesa"
+```
+
+## Setup OIDC Azure (1x, ~5min)
+
+Exemplo para criar uma App Registration/Service Principal federado para o workflow da branch `main`. Substitua placeholders pelos valores reais.
+
+```bash
+APP_NAME="govbr-cruza-dados-deploy"
+SUBSCRIPTION_ID="<subscription-id>"
+RESOURCE_GROUP="<resource-group>"
+REPO="lucasdiniz/govbr-cruza-dados"
+
+az ad app create --display-name "$APP_NAME"
+APP_ID=$(az ad app list --display-name "$APP_NAME" --query '[0].appId' -o tsv)
+az ad sp create --id "$APP_ID"
+TENANT_ID=$(az account show --query tenantId -o tsv)
+
+az role assignment create \
+  --assignee "$APP_ID" \
+  --role "Virtual Machine Contributor" \
+  --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
+
+cat > federated-credential.json <<EOF
+{
+  "name": "github-main-deploy",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:$REPO:ref:refs/heads/main",
+  "audiences": ["api://AzureADTokenExchange"]
+}
+EOF
+
+az ad app federated-credential create \
+  --id "$APP_ID" \
+  --parameters federated-credential.json
+```
+
+Depois configure secrets no GitHub:
+
+```bash
+gh secret set AZURE_CLIENT_ID --body "$APP_ID"
+gh secret set AZURE_TENANT_ID --body "$TENANT_ID"
+gh secret set AZURE_SUBSCRIPTION_ID --body "$SUBSCRIPTION_ID"
+gh secret set AZURE_RESOURCE_GROUP --body "<resource-group>"
+gh secret set AZURE_VM_NAME --body "<vm-name>"
+gh secret set AZURE_DATA_DISK_NAME --body "<data-disk-name>"
+```
+
+## Secrets exigidos
+
+Sem valores no repositório. Configure em GitHub Actions secrets.
+
+| Secret | Obrigatório? | Uso |
+|---|---:|---|
+| `DB_PASSWORD` | sim | Senha PostgreSQL do usuário `govbr`. |
+| `ENV_FILE` | sim | Conteúdo completo do `.env` escrito na VM. |
+| `VM_HOST` | sim | Host/IP usado por preflight/postflight para testar SSH. |
+| `VM_SSH_KEY` | sim para setup runner/SSH ops | Chave privada usada por workflows auxiliares como setup/debug quando aplicável. |
+| `RUNNER_ADMIN_TOKEN` | opcional | Token admin para registrar/reparar runner self-hosted via `setup-runner.yml`. |
+| `AZURE_CLIENT_ID` | sim | Client ID da App Registration OIDC. |
+| `AZURE_TENANT_ID` | sim | Tenant Azure. |
+| `AZURE_SUBSCRIPTION_ID` | sim | Subscription que contém VM/disco. |
+| `AZURE_RESOURCE_GROUP` | sim | Resource group da VM. |
+| `AZURE_VM_NAME` | sim | Nome da VM Azure. |
+| `AZURE_DATA_DISK_NAME` | sim | Nome do disco de dados (PR #117). |
+| `GOACCESS_PASSWORD` | sim para `/_traffic/goaccess/` | Senha basic-auth do painel GoAccess. |
+
+Secrets opcionais relacionados a SEO/observabilidade aparecem no step de deploy: `INDEXNOW_KEY`, `SITE_URL`, `GOOGLE_SITE_VERIFICATION`, `BING_SITE_VERIFICATION`, `UMAMI_WEBSITE_ID`, `GOACCESS_USER`, `GOACCESS_DOMAIN`, `TRAFFIC_DIGEST_EMAIL_TO`, `TRAFFIC_DIGEST_EMAIL_FROM` ([linhas 445-463 e 697-707](../.github/workflows/deploy.yml)).
+
+## Custos VM Azure
+
+Valores aproximados usados pelo README e comentários do workflow ([linhas 134-144](../.github/workflows/deploy.yml)).
+
+| Modo | VM | Disco | Custo |
+|---|---|---|---:|
+| Web/base | B2as_v2 | Standard SSD E20 | ~US$55/mês VM + US$38/mês disco |
+| IP público |  |  | ~US$4/mês |
+| Total base típico | B2 + Standard |  | **~US$104/mês** |
+| ETL/warm extra | B4as_v2 | Premium SSD P20 | +~US$0,07/h VM + ~US$0,05/h disco = **~US$0,12/h extra** |
+
+Azure limita o disco a **2 mudanças de SKU em 24h**. O workflow tolera falha na conversão: se o downgrade para Standard não for aceito, a VM volta para B2 e o disco pode ficar Premium por algumas horas (~US$0,05/h extra) até novo postflight/deploy manual.
+
+## Concurrency
+
+O workflow usa lock global:
+
+```yaml
+concurrency:
+  group: deploy-azure-vm
+  cancel-in-progress: false
+```
+
+Esse lock ([linhas 116-123](../.github/workflows/deploy.yml)) impede dois deploys simultâneos mexendo na mesma VM/disco/banco. É crítico: um rebuild completo do banco leva muitas horas ou dias; dois runs concorrentes podem desalocar VM no meio de ETL ou corromper estado operacional.
+
+## Smoke tests e validações pós-deploy
+
+| Step | Linhas | Valida |
+|---|---:|---|
+| Wait SSH preflight | 278-287 | Porta 22 da VM responde após resize/start. |
+| Verify disk space | 540-557 | Pelo menos 50GB livres em `/data` ou `/`. |
+| Test download sources | 559-572 | Tor ativo e fontes remotas acessíveis quando download será executado. |
+| Full ETL verify key table | 600-608 | Tabela `empresa` existe e tem linhas após ETL completo. |
+| Deploy web services status | 822-826 | `nginx`, `cruza-web`, `cruza-umami` reportam estado esperado. |
+| Warm cache status | 1158-1164 | `cruza-warm-cache` terminou; falha parcial gera warning. |
+| Restart cruza-web | 1182-1203 | `/static/manifest.webmanifest` responde em `127.0.0.1:8000`; systemd ativo. |
+| Empresa sitemap enable | 1297-1532 | Cobertura >=80%, sitemap tem shards, amostras respondem 200, rollback em falha. |
+| Licitações sitemap enable | 1575-1706 | Cobertura >=80%, sitemap lista shards, 4/5 URLs 200, rollback em falha. |
+| Cidade resumo sitemap enable | 1735-1841 | Cobertura >=80%, sitemap index inclui resumo, 4/5 URLs 200, rollback em falha. |
+| Verify database | 1843-1850 | Executa `python -m etl.verify` best-effort. |
+| Wait SSH postflight | 1945-1956 | Porta 22 responde depois do downsize/start. |
+
+## Links relacionados
+
+- [`architecture.md`](architecture.md)  visão geral da arquitetura.
+- [`ops.md`](ops.md)  runbooks operacionais.
+- [`../.github/workflows/deploy.yml`](../.github/workflows/deploy.yml)  workflow real.
+- [`../.github/workflows/setup-runner.yml`](../.github/workflows/setup-runner.yml)  setup/reparo do runner self-hosted.
+- [`../.github/workflows/debug-logs.yml`](../.github/workflows/debug-logs.yml)  coleta remota de logs.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -146,10 +146,21 @@ warm_cache: true
 
 ### Retomar fase específica
 
-Se a fase 19 falhou:
+> ⚠️ **Cuidado**: o argumento `etl_phase: "N"` é o **índice 1-based da lista `phases`** em [`etl/run_all.py:76-101`](../etl/run_all.py), **não** o rótulo "Fase N" do nome. Por exemplo, `etl_phase: "18"` roda a 18ª entrada da lista (`Fase 13: TSE Prestacao`), não as MVs (`Fase 18: Views`).
+
+Mapeamento dos casos comuns:
+
+| Rótulo desejado | Índice na lista | `etl_phase` |
+|---|---|---|
+| Views materializadas (Fase 18) | 23ª entrada | `"23"` |
+| MV sitemap (Fase 19) | 24ª entrada | `"24"` |
+| Normalização CPF/CNPJ (Fase 17) | 22ª entrada | `"22"` |
+| TCE-PB (Fase 14) | 19ª entrada | `"19"` |
+
+Para retomar a partir de uma fase que falhou, identifique o índice no log e use:
 
 ```yaml
-etl_phase: "19"
+etl_phase: "19"   # exemplo: 19ª entrada = Fase 14 TCE-PB
 ```
 
 O workflow chama `python -m etl.run_all "19"` ([linhas 674-683](../.github/workflows/deploy.yml)).

--- a/docs/etl-guide.md
+++ b/docs/etl-guide.md
@@ -1,0 +1,282 @@
+# Guia ETL Clássico — Como adicionar uma fase
+
+Este guia descreve como **adicionar uma nova fase ao ETL clássico** do
+`govbr-cruza-dados`. Para o framework **incremental** (append-only com
+watermark, DLQ e role-segregação) veja [etl-incremental-guide.md](etl-incremental-guide.md).
+
+## O que é o ETL clássico
+
+O ETL clássico é um pipeline de **full reload**: cada fase tipicamente faz
+`TRUNCATE` da(s) sua(s) tabela(s)-alvo e reconstrói tudo a partir dos CSVs
+brutos baixados em `$DATA_DIR/<fonte>/`. As 24 fases vivem hardcoded na lista
+`_PHASES` de [`etl/run_all.py`](../etl/run_all.py) e são executadas na ordem em
+que aparecem — a posição importa porque fases tardias dependem de tabelas,
+colunas normalizadas (`cpf_digitos`, `cpf_cnpj_norm`) e índices criados por
+fases anteriores. Ver [architecture.md](architecture.md) para o panorama geral
+e o lugar do clássico dentro do projeto.
+
+**Quando escolher clássico vs incremental?**
+
+| Escolha clássico se… | Escolha incremental se… |
+|---|---|
+| Fonte publica snapshot full periódico (ex: RFB CNPJ mensal) | Fonte é append-only com janelas mês/ano (ex: Dados-PB pagamento_YYYY_MM.csv) |
+| Não há **natural key** estável | Há NK estável e perdê-la corromperia dados |
+| Histórico pode ser regenerado do zero | Preservação histórica é requisito |
+| Volume cabe em rebuild noturno | Volume exige carga delta + idempotência |
+
+A regra prática: se você fizer `TRUNCATE` e re-`COPY` for aceitável, é
+clássico. Se não, leia o [etl-incremental-guide.md](etl-incremental-guide.md).
+
+Convenções não-negociáveis (sem pandas, streaming, `COPY FROM STDIN`) estão
+registradas em [adr/0001-no-pandas.md](adr/0001-no-pandas.md) — leia antes de
+mandar PR.
+
+## Fluxo de uma fase ETL clássica
+
+```mermaid
+flowchart TB
+    A[Download CSV<br/>etl/00_download.py] --> B[Leitura streaming<br/>line-by-line]
+    B --> C{Encoding?}
+    C -->|RFB| C1[latin1_lines]
+    C -->|dados.pb| C2[utf-8 + fallback latin-1]
+    C -->|demais| C3[utf-8]
+    C1 --> D[Parsers BR<br/>etl/utils.py]
+    C2 --> D
+    C3 --> D
+    D --> D1[parse_date_br]
+    D --> D2[parse_decimal_br]
+    D --> D3[clean_cpf / clean_cnpj]
+    D1 --> E[COPY FROM STDIN<br/>etl/db.py]
+    D2 --> E
+    D3 --> E
+    E --> F[Tabela alvo<br/>PostgreSQL]
+    F --> G{_CSV_DIRS<br/>registrado?}
+    G -->|sim e não-compartilhado| H[Cleanup raw automático]
+    G -->|compartilhado<br/>_SHARED_DIRS| I[Aguarda fases<br/>dependentes]
+```
+
+## Anatomia de uma fase
+
+Toda fase é um módulo Python em `etl/NN_<nome>.py` que expõe **uma função
+`run() -> None`** — o orquestrador a chama via `importlib`.
+
+```python
+# etl/NN_minha_fonte.py
+import logging
+from etl.config import DATA_DIR
+from etl.db import get_conn, copy_csv_streaming, truncate_table
+from etl.utils import latin1_lines, parse_date_br, parse_decimal_br, clean_cnpj
+
+log = logging.getLogger(__name__)
+
+def run() -> None:
+    with get_conn() as conn:
+        truncate_table(conn, "minha_tabela")
+        # ... streaming + COPY ...
+        conn.commit()
+```
+
+### Helpers obrigatórios
+
+**`etl/db.py`** (use sempre — pool gerenciado, retries, COPY tuning):
+
+- `get_conn()` — context manager, devolve conexão do pool.
+- `copy_from_stream(conn, table, columns, stream)` — `COPY FROM STDIN` a partir
+  de um iterável de linhas TSV.
+- `copy_csv_streaming(conn, table, columns, csv_path, ...)` — wrapper para
+  arquivos CSV grandes, sem materializar em memória.
+- `batch_insert(conn, table, columns, rows)` — fallback para volumes
+  pequenos (< 10k linhas).
+- `execute_sql_file(conn, "NN_schema.sql")` — executa arquivo de `sql/`.
+- `truncate_table(conn, "tabela")` — padrão de início de fase clássica.
+
+**`etl/utils.py`** (parsers BR — reuse, não reimplemente):
+
+- `parse_date_br("31/12/2023")` → `date(2023, 12, 31)`. Aceita também
+  `2023-12-31` (ISO) e variantes com timestamp.
+- `parse_decimal_br("1.234,56")` → `Decimal("1234.56")`.
+- `clean_cpf` / `clean_cnpj` — remove pontuação, valida tamanho.
+- `extract_cpf_masked("***123456**")` → 6 dígitos do meio (padrão Portal
+  Transparência, ver [glossario.md](glossario.md)).
+- `normalize_name` — uppercase, sem acentos, espaços colapsados.
+- `latin1_lines(path)` — gerador de linhas para RFB (latin-1 obrigatório, ver
+  `RFB_ENCODING` em `etl/config.py`).
+
+### Encoding por fonte
+
+| Fonte | Encoding | Helper |
+|---|---|---|
+| RFB (Receita Federal) | **latin-1** | `latin1_lines` |
+| dados.pb (estadual) | utf-8 com fallback latin-1 | `open(..., encoding="utf-8", errors="replace")` |
+| TCE-PB, Portal Transparência, PNCP, demais | utf-8 | `open(..., encoding="utf-8")` |
+
+> **Caveat real:** misturar encodings causa `UnicodeDecodeError` silencioso
+> quando rodando dentro de `copy_csv_streaming`. Sempre teste com `head -1` do
+> CSV bruto antes de assumir utf-8.
+
+## Passo a passo: adicionar uma fase nova
+
+1. **Criar o módulo** `etl/NN_minha_fonte.py` com `def run() -> None`. Use `NN`
+   na posição lógica (depois das deps, antes dos consumidores).
+
+2. **Criar o DDL** em `sql/NN_schema_minha_fonte.sql`. Use `CREATE TABLE IF
+   NOT EXISTS` + `CREATE INDEX` separados (não inline em CREATE TABLE — eles
+   vão para `sql/11_indices.sql`).
+
+3. **Decidir onde o schema roda:**
+   - **Early** — adicionar `execute_sql_file(conn, "NN_schema_minha_fonte.sql")`
+     em `etl/01_schema.py`. Padrão para tabelas que outras fases consomem.
+   - **Late** — executar o SQL na própria `run()` da fase. Use quando a tabela
+     for autocontida.
+   Documente a decisão no docstring do módulo.
+
+4. **Registrar em `_PHASES`** de `etl/run_all.py` (lista hardcoded — a posição
+   define a ordem de execução):
+
+   ```python
+   ("Fase NN: Minha Fonte", "etl.NN_minha_fonte"),
+   ```
+
+5. **Adicionar o download** em `etl/00_download.py` se for fonte externa.
+   Use os helpers de download existentes (com retry e progress).
+
+6. **Cleanup de CSV bruto.** Registre em `_CSV_DIRS` (top de `etl/run_all.py`):
+
+   ```python
+   _CSV_DIRS = {
+       ...
+       "etl.NN_minha_fonte": ["minha_fonte"],
+   }
+   ```
+
+   Se você reutiliza um diretório raw já consumido por outra fase (ex: `rfb/`,
+   `tse/`), **adicione também em `_SHARED_DIRS`** — caso contrário a primeira
+   fase a terminar deletará os CSVs antes da sua rodar.
+
+7. **Normalização CPF/CNPJ.** Se sua tabela tem coluna CPF/CNPJ, adicione a
+   normalização em `etl/15_normalizar.py` (executada na **fase 17**). Essa
+   fase cria as colunas `cpf_digitos` (6) e `cpf_cnpj_norm` (14) usadas por
+   **todas** as queries cross-source (Q01–Q310). Sem isso, joins viram
+   `LIKE/regex` e a query timeouta.
+
+8. **Índices.** Se a tabela alimenta MV (`mv_municipio_pb_risco`,
+   `mv_empresa_pb`, etc — ver [architecture.md](architecture.md) layer L1/L2)
+   ou queries Q##:
+   - Índices gerais → `sql/11_indices.sql`
+   - Índices Q##-específicos → `sql/19_indices_queries.sql`
+
+9. **Atualizar contagem** "24 fases" → "25 fases" no `README.md` raiz e em
+   `.github/workflows/deploy.yml` (input `etl_phase`).
+
+## Convenções não-negociáveis
+
+Ver [adr/0001-no-pandas.md](adr/0001-no-pandas.md) para o racional completo.
+
+- **Sem pandas.** Box-alvo tem 16GB RAM; DataFrames não cabem em 350M linhas.
+  Sempre streaming + `COPY FROM STDIN`.
+- **Sem `executemany`** para volumes > 10k linhas — use `COPY`. `batch_insert`
+  só para tabelas de domínio (CNAEs, motivos, etc).
+- **Sempre `with get_conn() as conn:`** — o pool gerencia conexões; criar
+  `psycopg2.connect` direto vaza handles.
+- **Logging via `logging` module**, não `print`. Código novo que usa `print`
+  será rejeitado em review (ver issue #136).
+- **Idempotência explícita.** Declare no docstring qual padrão você usa:
+  - `TRUNCATE + rebuild` (padrão clássico), ou
+  - `INSERT ... ON CONFLICT DO NOTHING` (raro no clássico, padrão no
+    incremental — ver [etl-incremental-guide.md](etl-incremental-guide.md)).
+
+## Exemplo concreto
+
+```python
+# etl/NN_minha_fonte.py
+"""Carga full-reload da fonte 'Minha Fonte' (CSV anual, latin-1).
+
+Padrão: TRUNCATE + COPY FROM STDIN.
+"""
+import logging
+from etl.config import DATA_DIR
+from etl.db import get_conn, copy_from_stream, truncate_table
+from etl.utils import latin1_lines, parse_date_br, parse_decimal_br, clean_cnpj
+
+log = logging.getLogger(__name__)
+
+COLUMNS = ["cnpj", "data_emissao", "valor", "descricao"]
+
+def _rows(csv_path):
+    for i, line in enumerate(latin1_lines(csv_path)):
+        if i == 0:
+            continue  # header
+        cnpj_raw, data_raw, valor_raw, desc = line.rstrip("\n").split(";")
+        yield (
+            clean_cnpj(cnpj_raw),
+            parse_date_br(data_raw),
+            parse_decimal_br(valor_raw),
+            desc.strip(),
+        )
+
+def run() -> None:
+    src_dir = DATA_DIR / "minha_fonte"
+    with get_conn() as conn:
+        truncate_table(conn, "minha_tabela")
+        for csv in sorted(src_dir.glob("*.csv")):
+            log.info("Carregando %s", csv.name)
+            tsv = (
+                "\t".join("" if v is None else str(v) for v in row) + "\n"
+                for row in _rows(csv)
+            )
+            copy_from_stream(conn, "minha_tabela", COLUMNS, tsv)
+        conn.commit()
+    log.info("Fase concluída")
+```
+
+## Caveats conhecidos
+
+- **`_CSV_DIRS` vs `_SHARED_DIRS`.** O cleanup automático em `_cleanup_csvs`
+  (`etl/run_all.py:55`) deleta o raw após a primeira fase que o consome
+  *succeed*. Se sua fase nova consome `rfb/` mas você não adicionou ao
+  `_SHARED_DIRS`, a fase 3 (`etl.03_rfb`) deleta o CSV antes da sua rodar.
+- **Fase 17 (`etl.15_normalizar`) cria `cpf_digitos`/`cpf_cnpj_norm`** usadas
+  por todas as queries cross-source. Esquecer de adicionar sua tabela ali
+  quebra joins downstream silenciosamente (query simplesmente retorna 0 linhas
+  ao invés de erro).
+- **Erros silenciosos em `etl/15_normalizar.py:_exec`** — a função engole
+  exceções de `CREATE INDEX`, então uma fase pode "concluir" com índice
+  faltando. Sempre verifique `\d+ <tabela>` no psql após mudar normalização.
+- **`run_all` continua após falha de fase.** Cada fase é envolvida em
+  try/except — uma falha não aborta o pipeline. Verifique os logs (e o
+  resumo `_emit_notice` no GitHub Actions) ao final.
+
+## Como testar localmente
+
+Sem suite automatizada para o ETL clássico (ver seção abaixo). Smoke tests:
+
+```bash
+# Sintaxe — sempre rode antes de commit
+python -m compileall etl -q
+
+# Fase isolada (sem rodar as 24)
+python -m etl.NN_minha_fonte
+
+# Resume a partir da sua fase
+python -m etl.run_all NN
+
+# Validar contagem após carga
+psql -c "SELECT count(*) FROM minha_tabela"
+```
+
+Para testar com subset de dados, coloque manualmente alguns CSVs em
+`$DATA_DIR/minha_fonte/` antes de rodar a fase — pule o `etl.00_download`.
+
+## Testes
+
+O ETL clássico **não tem suite automatizada** hoje — fases novas não bloqueiam
+por testes. A suite existente (`tests/incremental/`) cobre apenas o framework
+incremental. Se você quiser adicionar testes, modele em cima de
+`tests/incremental/test_*.py` mas note que rodá-los exige Postgres com
+migrations 22–29+32+34+35 + role `etl_incremental`.
+
+A validação real acontece em produção via:
+- Contagens de linha por tabela (logged no fim de cada fase)
+- Auditoria de identificadores nos relatórios:
+  `python scripts/audit_report_identifiers.py`
+- Queries Q## em `python -m etl.run_queries` (resultados em `resultados/`)

--- a/docs/etl-guide.md
+++ b/docs/etl-guide.md
@@ -9,7 +9,7 @@ watermark, DLQ e role-segregação) veja [etl-incremental-guide.md](etl-incremen
 O ETL clássico é um pipeline de **full reload**: cada fase tipicamente faz
 `TRUNCATE` da(s) sua(s) tabela(s)-alvo e reconstrói tudo a partir dos CSVs
 brutos baixados em `$DATA_DIR/<fonte>/`. As 24 fases vivem hardcoded na lista
-`_PHASES` de [`etl/run_all.py`](../etl/run_all.py) e são executadas na ordem em
+`phases` de [`etl/run_all.py`](../etl/run_all.py) e são executadas na ordem em
 que aparecem — a posição importa porque fases tardias dependem de tabelas,
 colunas normalizadas (`cpf_digitos`, `cpf_cnpj_norm`) e índices criados por
 fases anteriores. Ver [architecture.md](architecture.md) para o panorama geral
@@ -130,7 +130,7 @@ def run() -> None:
      for autocontida.
    Documente a decisão no docstring do módulo.
 
-4. **Registrar em `_PHASES`** de `etl/run_all.py` (lista hardcoded — a posição
+4. **Registrar na lista `phases`** dentro da função `main()` de `etl/run_all.py:76-101` (lista local hardcoded — a posição
    define a ordem de execução):
 
    ```python
@@ -232,7 +232,7 @@ def run() -> None:
 ## Caveats conhecidos
 
 - **`_CSV_DIRS` vs `_SHARED_DIRS`.** O cleanup automático em `_cleanup_csvs`
-  (`etl/run_all.py:55`) deleta o raw após a primeira fase que o consome
+  (`etl/run_all.py:55-68`) deleta o raw após a primeira fase que o consome
   *succeed*. Se sua fase nova consome `rfb/` mas você não adicionou ao
   `_SHARED_DIRS`, a fase 3 (`etl.03_rfb`) deleta o CSV antes da sua rodar.
 - **Fase 17 (`etl.15_normalizar`) cria `cpf_digitos`/`cpf_cnpj_norm`** usadas

--- a/docs/etl-incremental-guide.md
+++ b/docs/etl-incremental-guide.md
@@ -1,0 +1,341 @@
+# Guia ETL Incremental — Como adicionar uma spec
+
+Este guia descreve como **adicionar uma nova `LoaderSpec`** ao framework
+incremental do `govbr-cruza-dados`. Para o ETL clássico (full reload,
+TRUNCATE+rebuild) veja [etl-guide.md](etl-guide.md).
+
+Os detalhes internos do framework (componentes, migrations, fluxo de 16
+passos) ficam em [`../etl/incremental/README.md`](../etl/incremental/README.md);
+este guia foca em **como adicionar uma fonte nova**.
+
+## Introdução
+
+O framework incremental existe para fontes que:
+
+- Publicam dados em **janelas mês/ano** (ex: `pagamento_2024_03.csv`)
+- São **append-only** com correções retroativas eventuais
+- Exigem **preservação histórica** (não pode haver `TRUNCATE`)
+- Têm uma **natural key estável** (corruptíveis se sobrescritas)
+
+Para fontes que não atendem essas condições — RFB CNPJ snapshot mensal, TSE
+prestação de contas anual full — **mantenha clássico**. Ver
+[architecture.md](architecture.md) para o panorama e
+[etl-guide.md](etl-guide.md) para o fluxo clássico.
+
+```mermaid
+flowchart TB
+    A[runner.py CLI] --> B[orchestrator]
+    B --> C[Conditional GET<br/>HEAD probe + If-None-Match<br/>+ If-Modified-Since]
+    C -->|304 Not Modified| Z[SKIP — não toca target]
+    C -->|200 OK| D[Stream + sha256 do CSV]
+    D --> E{bucket_token<br/>mudou?}
+    E -->|não| Z
+    E -->|sim| F[_incremental_load — 16 steps]
+    F --> F1[Validate header → csv_header_hash]
+    F1 --> F2[CSV stream → COPY staging RAW TEXT]
+    F2 --> F3[INSERT staging_typed<br/>cast BR/ISO]
+    F3 --> F4[DELETE rows com NK NULL<br/>→ DLQ autocommit]
+    F4 --> F5[INSERT target<br/>ON CONFLICT DO NOTHING]
+    F5 --> G[set_watermark<br/>via função SECURITY DEFINER]
+    G --> H[DROP staging tables]
+    H --> I[enqueue_cache_invalidation]
+```
+
+## Princípios não-negociáveis (P1–P6)
+
+Citados literalmente de [`../etl/incremental/README.md`](../etl/incremental/README.md):
+
+1. 🔴 **NÃO CORROMPER DADOS EXISTENTES** (sobrepõe tudo)
+2. **NÃO-DESTRUTIVO** — sem TRUNCATE/DROP/DELETE em targets
+3. **AUDITÁVEL** — rastro completo, imutável pelo ETL role
+4. **ERROR RESILIENT** — recuperável de qualquer crash
+5. **FAST** — download condicional + idempotency
+6. **ZERO TOLERANCE** — watermark nunca avança em failure; DLQ persiste mesmo
+   em rollback do `main_conn`
+
+A role `etl_incremental` (criada em `sql/28_etl_role_grants.sql`) tem apenas
+`SELECT/INSERT/UPDATE` nos targets — **nunca `DELETE`/`TRUNCATE`/`DROP`**.
+Qualquer spec que precise dessas grants viola P2 e deve ser rejeitada em
+review.
+
+## Quando NÃO usar incremental
+
+Mantenha clássico se **qualquer** for verdade:
+
+- Fonte é **snapshot full** (RFB CNPJ — substitui o universo todo a cada mês)
+- **Não há NK estável** (registros mudam de identidade entre publicações)
+- Reconstruir do zero é mais barato que delta
+- Dados não são append-only (sobrescrita esperada de linhas históricas)
+
+Caso clássico canônico: **RFB CNPJ** — 60M+ linhas, snapshot mensal, sem NK
+preservável → fica em `etl.03_rfb` clássico.
+
+## Passo a passo: adicionar uma spec incremental
+
+### 1. Profilar a natural key em prod (read-only)
+
+Antes de qualquer código, prove que a NK candidata é única:
+
+```sql
+-- read-only contra prod
+SELECT count(*) FROM (
+    SELECT nk1, nk2, nk3
+    FROM target_existente
+    GROUP BY nk1, nk2, nk3
+    HAVING count(*) > 1
+) d;
+-- deve retornar 0
+```
+
+Se você não consegue chegar a 0 com colunas naturais, use
+`nk_synthetic_md5=True` na spec (hash determinístico de todas as colunas).
+**Não fakeie NK** — corrompe dados (P1).
+
+### 2. Criar/alterar DDL do target
+
+Em `sql/NN_*.sql`, defina a tabela target e o índice único da NK:
+
+```sql
+CREATE TABLE IF NOT EXISTS minha_fonte_tabela (
+    -- colunas da NK + payload
+    exercicio          SMALLINT  NOT NULL,
+    codigo_ug          TEXT      NOT NULL,
+    numero_doc         TEXT,        -- pode ser NULL → COALESCE no índice
+    data_evento        DATE      NOT NULL,
+    -- ... payload ...
+    inserted_at        TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_minha_fonte_tabela_nk
+    ON minha_fonte_tabela (
+        exercicio,
+        codigo_ug,
+        COALESCE(NULLIF(numero_doc, ''), '__NULL__'),
+        data_evento
+    );
+```
+
+Colunas nullable da NK **devem** entrar via `COALESCE(NULLIF(col, ''), '__NULL__')`
+porque Postgres trata `NULL ≠ NULL` em índices únicos — sem isso, dois
+registros com `numero_doc IS NULL` viram duplicatas.
+
+### 3. Grants para `etl_incremental`
+
+Em `sql/28_etl_role_grants.sql`:
+
+```sql
+GRANT SELECT, INSERT, UPDATE ON minha_fonte_tabela TO etl_incremental;
+-- NUNCA: GRANT DELETE / TRUNCATE / DROP   (viola P2)
+```
+
+### 4. Criar a `LoaderSpec`
+
+Arquivo: `etl/incremental/specs/<fonte>_<tabela>.py`. Reuse helpers de
+`_pb_helpers.py` se for fonte Dados-PB-like. Esqueleto baseado em
+`pb_pagamento.py`:
+
+```python
+# etl/incremental/specs/minha_fonte_tabela.py
+"""LoaderSpec para minha_fonte_tabela.
+
+Source: https://exemplo.gov.br/csv?exercicio=YYYY&mes=MM
+Formato: CSV ; quote " encoding latin-1 datas DD/MM/YYYY decimais 1.234,56.
+NK: (exercicio, codigo_ug, numero_doc, data_evento)
+"""
+from __future__ import annotations
+import re
+from datetime import date
+from ..spec import LoaderSpec, CursorStrategy, DedupeStrategy
+
+
+def _bucket_from_filename(name: str) -> str | None:
+    m = re.match(r"^minha_(\d{4})_(\d{2})\.csv$", name, re.IGNORECASE)
+    return f"{m.group(1)}-{m.group(2)}" if m else None
+
+
+def _file_pattern(bucket_id: str) -> list[str]:
+    y, m = bucket_id.split("-")
+    return [f"minha_{y}_{m}.csv"]
+
+
+def _url_for_bucket(bucket_id: str) -> list[tuple[str, str]]:
+    y, m = bucket_id.split("-")
+    url = f"https://exemplo.gov.br/csv?exercicio={y}&mes={int(m)}"
+    return [(url, f"minha_{y}_{m}.csv")]
+
+
+def _enumerate_buckets() -> list[str]:
+    today = date.today()
+    out = []
+    for year in range(2018, today.year + 1):
+        last = today.month if year == today.year else 12
+        for month in range(1, last + 1):
+            out.append(f"{year}-{month:02d}")
+    return out
+
+
+COLUMNS = ["EXERCICIO", "CODIGO_UG", "NUMERO_DOC", "DATA_EVENTO", "VALOR"]
+COLUMN_RENAMES = {c: c.lower() for c in COLUMNS}
+COLUMN_TYPES = {c: "TEXT" for c in COLUMNS}
+COLUMN_TYPES["EXERCICIO"]   = "SMALLINT"
+COLUMN_TYPES["DATA_EVENTO"] = "DATE"
+COLUMN_TYPES["VALOR"]       = "NUMERIC"
+
+
+SPEC = LoaderSpec(
+    source="minha_fonte",
+    table="minha_fonte_tabela",
+    natural_key=["EXERCICIO", "CODIGO_UG", "NUMERO_DOC", "DATA_EVENTO"],
+    cursor_strategy=CursorStrategy.MONTH_WINDOW,
+    dedupe_strategy=DedupeStrategy.UPSERT_DO_NOTHING,
+    columns=COLUMNS,
+    column_types=COLUMN_TYPES,
+    column_renames=COLUMN_RENAMES,
+    nk_coalesce_cols=("numero_doc",),  # cols nullable da NK
+    csv_delimiter=";",
+    csv_quotechar='"',
+    watermark_col="DATA_EVENTO",
+    watermark_type="string",
+    encoding="latin-1",
+    encoding_fallback="utf-8-sig",
+    decimal_format="br",     # 1.234,56  (use "point" para 1234.56)
+    date_format="br",        # DD/MM/YYYY (use "iso" para 2024-01-31)
+    refetch_recent_buckets=2,  # ultimo + penultimo (publicação retroativa)
+    file_pattern=_file_pattern,
+    bucket_from_filename=_bucket_from_filename,
+    url_for_bucket=_url_for_bucket,
+    enumerate_buckets=_enumerate_buckets,
+)
+```
+
+### 5. Registrar no runner
+
+Em `etl/incremental/runner.py`, função `_load_all_specs()`. O registro é
+**manual hoje** — auto-descoberta via `pkgutil.iter_modules` está prevista na
+seção "Próximas iterações" do
+[`../etl/incremental/README.md`](../etl/incremental/README.md).
+
+```python
+from .specs.minha_fonte_tabela import SPEC as SPEC_MINHA
+# ...
+def _load_all_specs():
+    return [..., SPEC_MINHA]
+```
+
+### 6. Bootstrap inicial do watermark
+
+Antes do **primeiro INSERT real**, capture o estado-base do target (mesmo que
+vazio):
+
+```bash
+python -m etl.incremental.bootstrap_watermark \
+    --source minha_fonte --table minha_fonte_tabela
+```
+
+Isso grava `bootstrap_target_max`, `bootstrap_target_count` e
+`target_schema_hash` em `etl_watermark`. Esses campos são **imutáveis** após o
+primeiro INSERT (um trigger garante isso). Para re-baseline (ex: drift de
+schema), use `--force` — exige `approver` no log.
+
+### 7. Testar local
+
+A suite cobre o framework completo:
+
+```bash
+# Postgres local com migrations 22-29 + 32 + 34 + 35 aplicadas
+# + role etl_incremental criada
+pytest tests/incremental
+
+# Rodar apenas sua spec
+python -m etl.incremental.runner --only "minha_fonte.minha_fonte_tabela"
+
+# Status
+psql -c "SELECT * FROM v_etl_status WHERE table_name='minha_fonte_tabela'"
+psql -c "SELECT * FROM v_etl_dlq_summary WHERE source='minha_fonte'"
+```
+
+### 8. Debug: schema drift e DLQ inflando
+
+**Schema drift** (CSV ganhou colunas, target precisa evoluir):
+
+```bash
+# Após ALTER TABLE do target, re-baseline:
+python -m etl.incremental.bootstrap_watermark \
+    --source minha_fonte --table minha_fonte_tabela \
+    --force --approver "lucas@..."
+```
+
+**DLQ inflando** (linhas rejeitadas acumulando):
+
+```sql
+SELECT raw_line, reason, rejected_at
+FROM etl_rejected_rows
+WHERE source='minha_fonte'
+ORDER BY rejected_at DESC
+LIMIT 50;
+```
+
+Causas típicas:
+- **`coerce` incompleto** — adicionar regex/sentinel em
+  `default_null_sentinels` da spec.
+- **Encoding errado** — ajustar `encoding_fallback`.
+- **NK realmente faltante** — não invente, profile de novo (passo 1).
+
+## Observabilidade
+
+Três views consolidam o estado do framework (todas em `sql/29_etl_views.sql`):
+
+| View | Propósito |
+|---|---|
+| `v_etl_status` | Watermark atual + último bucket processado por tabela |
+| `v_etl_dlq_summary` | Contagem agregada de rejeições por source/reason |
+| `v_etl_run_summary` | Histórico de runs (sucesso/falha, duração, linhas) |
+
+Cache invalidation no `web_cache` é disparado via
+`enqueue_cache_invalidation` ao final de cada bucket bem-sucedido.
+
+## Convenções nominais
+
+- **Staging tables** seguem o padrão D12: `_stg_<src>_<tbl>_<run8>_<seq>_<kind>`
+  onde `<run8>` = primeiros 8 chars do `run_id`, `<seq>` = sequencial por
+  bucket, `<kind>` ∈ {`raw`, `typed`}. Tudo é dropado ao fim do bucket.
+- **`bucket_token`** = `uuid5(namespace=spec, name=sha256_csv)` — determinístico,
+  permite skip idempotente.
+- **`sha256`** do CSV é guardado em `etl_watermark.metadata` para auditoria e
+  comparação cross-run.
+
+## Exemplo concreto
+
+A spec mais simples e bem-comportada do projeto é
+[`etl/incremental/specs/pb_pagamento.py`](../etl/incremental/specs/pb_pagamento.py)
+(88 linhas). Copie-a como ponto de partida — ela ilustra todos os elementos
+do framework: bucket month-window, conditional refetch (`refetch_recent_buckets=2`
+para correções retroativas), NK com coluna nullable, encoding latin-1 com
+fallback, `DedupeStrategy.UPSERT_DO_NOTHING`.
+
+## Caveats conhecidos
+
+- **`pb_contrato 2022/2023 partial`** — CSVs com errors documentados no
+  README do framework. Não invente fix sem profilar a DLQ primeiro
+  (`v_etl_dlq_summary` filtrado por `source='dados_pb', table='pb_contrato'`).
+- **`enumerate_buckets` hardcoded `range(2018, today.year+1)`** em todas as
+  specs PB. Para uma fonte com início histórico diferente, copie o helper e
+  ajuste — não tem parametrização hoje.
+- **Heartbeat thread + watchdog ainda não cobertos por testes** em
+  isolamento. Issue [#135] cobre o smoke test pendente. Em prod, watchdog
+  mata bucket que excede `bucket_timeout_sec`.
+- **`refetch_recent_buckets`** força re-download dos N últimos buckets mesmo
+  com 304 — é o mecanismo de pegar correções retroativas. Default 0; use 2
+  para fontes que publicam ajustes do mês anterior.
+
+## Próximas fontes candidatas
+
+Da auditoria do projeto, ordenadas por payoff:
+
+1. **CEIS / CNEP** (sanções administrativas — ver [glossario.md](glossario.md)).
+   Alto valor para cruzamentos de fraude, NK clara `(CNPJ, data_inicio_sancao,
+   orgao_sancionador)`. Append-only.
+2. **SIAPE / Bolsa Família** — publicação mensal, idempotência crítica
+   (rebuild full = horas de ETL). NK estável (matrícula+mês).
+3. **PNCP** — maior payoff, mas exige novo `CursorStrategy=API_CURSOR` (API
+   paginada, não janela de arquivo). Trabalho de framework, não só spec.

--- a/docs/etl-incremental-guide.md
+++ b/docs/etl-incremental-guide.md
@@ -262,7 +262,7 @@ psql -c "SELECT * FROM v_etl_dlq_summary WHERE source='minha_fonte'"
 # Após ALTER TABLE do target, re-baseline:
 python -m etl.incremental.bootstrap_watermark \
     --source minha_fonte --table minha_fonte_tabela \
-    --force --approver "lucas@..."
+    --force
 ```
 
 **DLQ inflando** (linhas rejeitadas acumulando):

--- a/docs/glossario.md
+++ b/docs/glossario.md
@@ -1,0 +1,527 @@
+# Glossário
+
+Vocabulário do domínio público brasileiro usado no `govbr-cruza-dados`. Inclui termos legais, contábeis e técnicos das fontes integradas. Cada termo tem definição curta + onde aparece no projeto + fonte/lei quando aplicável.
+
+Para o catálogo completo de **colunas** das tabelas TCE-PB e dados.pb.gov.br, veja [`dicionario_dados_pb.md`](dicionario_dados_pb.md).
+
+## Sumário por categoria
+
+- [Ciclo orçamentário](#ciclo-orçamentário)
+- [Licitação](#licitação)
+- [Estrutura governamental](#estrutura-governamental)
+- [Sanções e cadastros de irregularidade](#sanções-e-cadastros-de-irregularidade)
+- [Empresas e pessoas](#empresas-e-pessoas)
+- [Programas sociais e folha](#programas-sociais-e-folha)
+- [Crédito e financiamento](#crédito-e-financiamento)
+- [Eleições](#eleições)
+- [Conflitos de interesse e fraudes](#conflitos-de-interesse-e-fraudes)
+- [Regulação de dados](#regulação-de-dados)
+
+---
+
+## Ciclo orçamentário
+
+### Empenho
+
+Ato administrativo que **reserva** dotação orçamentária para um gasto futuro. É o primeiro estágio da despesa pública: o município "promete" pagar X reais a Y fornecedor por Z motivo. Não é pagamento — é compromisso.
+
+- **Tabelas**: `tce_pb_despesa`, `pb_empenho`, `pncp_contratacao`, `pb_pagamento.numero_empenho`
+- **Base legal**: Lei 4.320/1964, art. 58
+- **Onde aparece**: queries Q01, Q03, Q43-Q58, dialogs de empresa/servidor
+
+### Liquidação
+
+Segundo estágio: verifica que o fornecedor cumpriu sua parte (entregou a mercadoria, prestou o serviço). Sem liquidação, o pagamento é ilegal.
+
+- **Tabelas**: `pb_liquidacao_despesa`, `pb_liquidacao_cge`
+- **Base legal**: Lei 4.320/1964, art. 63
+- **Caveat investigativo**: empenhos pagos *sem* liquidação correspondente sinalizam fraude (Q101, Q103)
+
+### Pagamento
+
+Terceiro estágio: efetivo desembolso financeiro. Pode ser parcial em relação ao empenho.
+
+- **Tabelas**: `pb_pagamento`, `pb_pagamento_anulacao`, `tce_pb_despesa.valor_pago`
+- **Base legal**: Lei 4.320/1964, art. 64
+
+### Anulação de empenho
+
+Cancela total ou parcialmente um empenho não-pago. Comum quando o gasto não vai acontecer (fornecedor desistiu, processo cancelado, ano fiscal acabou).
+
+- **Tabelas**: `pb_empenho_anulacao`, `pb_pagamento_anulacao`
+- **Padrão suspeito**: ciclo `empenho → anulação → re-empenho` próximo de eleições (queima de orçamento)
+
+### Suplementação orçamentária
+
+Aumento de dotação em uma rubrica que já existia, durante o exercício. Exige decreto ou lei autorizando.
+
+- **Tabela**: `pb_empenho_suplementacao`
+- **Padrão suspeito**: suplementações concentradas em poucos fornecedores ou véspera de eleição (relatório `relatorio_empenhos_semente.md`)
+
+### Dotação orçamentária
+
+Recurso autorizado pela LOA (Lei Orçamentária Anual) para uma despesa específica. Define o teto inicial.
+
+- **Tabela**: `pb_dotacao`
+- **Base legal**: Constituição Federal art. 165 + Lei 4.320/1964
+
+### Restos a pagar
+
+Empenhos do exercício anterior que ainda não foram pagos ao fim do ano. Carregam para o exercício seguinte. Grande estoque de restos sinaliza descontrole.
+
+- **Aparece em**: `tce_pb_despesa` filtrável por `exercicio_origem` vs `data_pagamento`
+
+### Subelemento de despesa
+
+Classificação detalhada do que está sendo comprado (4 dígitos): material de consumo, equipamento, serviço de terceiros, etc. Permite agregação por tipo.
+
+- **Coluna**: `tce_pb_despesa.subelemento`, `pb_empenho.subelemento`
+- **Codificação**: Portaria STN 163/2001
+
+### Natureza de despesa
+
+Classificação macro (8 dígitos): pessoal, dívida, capital, custeio. Engloba subelemento.
+
+- **Codificação**: Portaria STN 163/2001
+
+### Receita
+
+Entrada de recursos no caixa público — tributos, transferências, royalties, etc.
+
+- **Tabelas**: `tce_pb_receita`, `pb_extras` (alguns datasets)
+
+### Convênio
+
+Acordo formal entre ente público e ONG/outro ente para repasse de recursos com fim específico. NÃO usa licitação.
+
+- **Tabela**: `pb_convenio`, `pb_aditivo_convenio`
+- **Padrão suspeito**: convênios com entidades que têm dívida ativa PGFN (Q107)
+
+---
+
+## Licitação
+
+### Licitação
+
+Processo administrativo para escolher fornecedor, exigido pela Constituição e Lei 14.133/2021 (nova Lei de Licitações; substitui parcialmente a 8.666/93).
+
+### Modalidade de licitação
+
+Tipo do processo. Em ordem aproximada de rigor:
+
+- **Concorrência** — valor alto, regras estritas
+- **Tomada de preços** — valor médio
+- **Convite** — valor baixo, ~3 convidados
+- **Pregão (eletrônico ou presencial)** — bens e serviços comuns
+- **Concurso** — escolha de trabalho técnico/artístico
+- **Leilão** — venda de bens
+
+### Dispensa de licitação
+
+Compra sem processo licitatório formal, autorizada por exceções legais (valor baixo, emergência, calamidade, fornecedor único técnico, etc.).
+
+- **Base legal**: Lei 14.133/2021, art. 75 (era art. 24 da Lei 8.666/93)
+- **Caveat**: dispensa por valor (até R$ 50.000 para obras/serviços, R$ 17.600 para outras) é a mais comum e a mais abusada — fracionamento de despesa para ficar abaixo do limite
+
+### Inexigibilidade
+
+Subtipo de dispensa para casos onde competição é impossível (fornecedor exclusivo, artista consagrado, serviço técnico singular).
+
+- **Base legal**: Lei 14.133/2021, art. 74
+- **Caveat**: notoria especialidade frequentemente fabricada
+
+### ARP — Ata de Registro de Preços
+
+Sistema onde uma licitação resulta numa **ata** com preços e fornecedor selecionados, e outros órgãos podem aderir à ata sem fazer licitação própria.
+
+- **Base legal**: Lei 14.133/2021, art. 82-83
+- **Padrão suspeito**: "carona" (adesão de órgão muito diferente do que motivou a ata original) é frequentemente abusivo
+
+### Pregão eletrônico
+
+Modalidade preferencial para bens e serviços comuns. Disputa em tempo real online via SIASG/ComprasNet ou pregão BB/Banrisul.
+
+- **Base legal**: Lei 10.520/2002, agora absorvida pela Lei 14.133/2021
+
+### Credenciamento
+
+Procedimento para pré-qualificar **todos** os fornecedores que cumprem requisitos, sem competição entre eles. Comum em saúde (médicos, hospitais).
+
+- **Tabela**: `pb_saude` em alguns datasets
+- **Padrão suspeito**: credenciamento + concentração em poucos credenciados = monopólio mascarado (`relatorio_monopolios_terceiro_setor_pb.md`)
+
+### Proponente único
+
+Licitação com apenas 1 empresa apresentando proposta. Tecnicamente legal, mas estatisticamente raro em mercados competitivos.
+
+- **MV**: `mv_municipio_pb_risco.pct_proponente_unico`
+- **Caveat**: > 40% de licitações com proponente único = score 25/100 no risco composto
+
+### Aditivos (de contrato)
+
+Alterações no contrato após assinatura: valor, prazo, escopo. Limite legal 25% do valor original (50% para reforma de edifício).
+
+- **Tabela**: `pb_aditivo_contrato`, `pb_aditivo_convenio`
+- **Base legal**: Lei 14.133/2021, art. 125
+- **Padrão suspeito**: aditivos > 25% acumulados (relatorio `relatorio_aditivos_abusivos_estado_pb.md`)
+
+### Sem licitação
+
+Compras em que não houve processo licitatório identificável — pode ser dispensa, inexigibilidade, ARP-carona ou ausência de dado na fonte.
+
+- **MV**: `mv_municipio_pb_risco.pct_sem_licitacao`
+- **Caveat**: lógica em revisão (issue [#141](https://github.com/lucasdiniz/govbr-cruza-dados/issues/141))
+
+---
+
+## Estrutura governamental
+
+### UG — Unidade Gestora
+
+Subdivisão organizacional dentro de um órgão público que executa orçamento próprio. Uma prefeitura pode ter UG da Secretaria de Saúde, UG da Educação, etc.
+
+- **Coluna**: `tce_pb_despesa.codigo_ug`, `tce_pb_licitacao.codigo_ug`
+- **Tabela**: `pb_unidade_gestora`
+- **Caveat**: licitação canônica = `(municipio, ano, codigo_ug, modalidade, numero_licitacao)` — sem `codigo_ug` você junta licitações de UGs diferentes com mesmo `numero_licitacao`
+
+### Esfera de governo
+
+Federal, Estadual, Municipal. Determina jurisdição de fiscalização (TCU para Federal, TCE para Estadual e Municipal).
+
+- **Coluna**: `ceis_sancao.esfera_orgao_sancionador`
+- **Caveat**: abrangência de sanção depende da esfera (ver abaixo)
+
+### Município
+
+Menor ente da federação brasileira. Brasil tem 5570 municípios; Paraíba 223.
+
+- **Slug**: `web/utils/slug.py:slugify` — `'João Pessoa'` → `'joao-pessoa'`
+- **Coluna canônica**: `nome_municipio` (não `municipio`, que tem variações)
+
+### TCE-PB — Tribunal de Contas do Estado da Paraíba
+
+Órgão estadual que fiscaliza contas dos 223 municípios + governo estadual. Publica dados consolidados em [dados-abertos.tce.pb.gov.br](https://dados-abertos.tce.pb.gov.br).
+
+- **Tabelas**: `tce_pb_despesa`, `tce_pb_servidor`, `tce_pb_licitacao`, `tce_pb_receita`
+
+### PNCP — Portal Nacional de Contratações Públicas
+
+Sistema unificado nacional para publicar todas as contratações públicas, exigido pela Lei 14.133/2021.
+
+- **Tabelas**: `pncp_contratacao`, `pncp_contrato`, `pncp_item`
+- **Identificador**: `numero_controle_pncp`
+
+### dados.pb.gov.br
+
+Portal de dados abertos do governo estadual da Paraíba — pagamentos, empenhos, contratos, convênios.
+
+- **Tabelas**: `pb_pagamento`, `pb_empenho`, `pb_contrato`, `pb_convenio`, `pb_*` (~16 tabelas)
+
+### RFB — Receita Federal do Brasil
+
+Mantém a base oficial de CNPJs (~58GB raw), cadastros de empresas, sócios, estabelecimentos. Atualizada mensalmente.
+
+- **Tabelas**: `empresa`, `estabelecimento`, `socio`, `simples`
+- **Fonte**: [dadosabertos.rfb.gov.br/CNPJ](https://dadosabertos.rfb.gov.br/CNPJ/)
+- **Encoding**: latin-1 (usar `latin1_lines` em `etl/utils.py`)
+
+### SIAPE — Sistema Integrado de Administração de Pessoal
+
+Folha de pagamento do Executivo federal. Dados publicados no Portal da Transparência.
+
+- **Tabelas**: `siape_cadastro`, `siape_remuneracao`
+
+### CGU — Controladoria-Geral da União
+
+Órgão federal de controle interno e transparência. Mantém CEIS, CNEP, CEAF, e outros cadastros.
+
+---
+
+## Sanções e cadastros de irregularidade
+
+### CEIS — Cadastro de Empresas Inidôneas e Suspensas
+
+Lista pública de empresas impedidas de contratar com a administração pública por algum período, em algum escopo. Mantida pela CGU.
+
+- **Tabela**: `ceis_sancao`
+- **Fonte**: [Portal da Transparência → CEIS](https://portaldatransparencia.gov.br/sancoes/ceis)
+- **Atributos chave**: `tipo_sancao`, `abrangencia`, `data_inicio_sancao`, `data_final_sancao`, `orgao_sancionador`
+
+### CNEP — Cadastro Nacional de Empresas Punidas
+
+Sanções aplicadas em **acordos de leniência** ou condenações da Lei Anticorrupção (12.846/2013). Inclui multas.
+
+- **Tabela**: `cnep_sancao`
+- **Fonte**: Portal da Transparência
+
+### CEAF — Cadastro de Expulsões da Administração Federal
+
+Lista de **servidores públicos federais** expulsos (demissão, destituição, cassação). Aplica-se a pessoas físicas, não empresas.
+
+- **Tabela**: `ceaf_expulsao`
+- **Match key**: `cpf_digitos_6` + nome normalizado (raramente CPF completo)
+
+### Inidoneidade
+
+Status onde a empresa é declarada incapaz de contratar com **toda** administração pública até cumprir requisitos. Sanção mais grave.
+
+- **Caveat**: empresa inidônea que recebe empenho de qualquer ente público = ilegalidade (relatorio `relatorio_inidoneidade_ilegal_pb.md`)
+
+### Acordo de Leniência
+
+Empresa que confessa irregularidade em troca de redução de multa e cooperação. Status muda em CNEP.
+
+- **Tabela**: `acordo_leniencia`
+- **Base legal**: Lei 12.846/2013, art. 16
+
+### Abrangência de sanção
+
+Escopo onde a sanção é válida: nacional, estadual (UF), municipal. Determina se um empenho do município X é ilegal ou só "ruim".
+
+- **Coluna**: `ceis_sancao.abrangencia` (e similares)
+- **Caveat investigativo**: empresa com CEIS de abrangência nacional + empenho de qualquer município = vermelho. CEIS municipal de outra UF + empenho aqui = amarelo (informativo)
+
+### Situação cadastral (RFB)
+
+Status da empresa na Receita Federal:
+- `2 = Ativa`
+- `3 = Suspensa`
+- `4 = Inapta`
+- `8 = Baixada`
+
+- **Coluna**: `estabelecimento.situacao_cadastral`
+- **Padrão suspeito**: empresa baixada/inapta recebendo empenho = fraude (Q14, Q56)
+
+---
+
+## Empresas e pessoas
+
+### CPF — Cadastro de Pessoas Físicas
+
+Identificador único de pessoa física brasileira, 11 dígitos. Frequentemente aparece **mascarado** em fontes públicas (privacidade LGPD).
+
+- **Formatos mascarados**: `***.NNN.NNN-**` (6 dígitos), `***NNN***` (3 dígitos), formato PGFN `XXXNNN.NNNXX`
+- **Coluna normalizada**: `cpf_digitos` (6 centrais) ou `cpf_cnpj_norm` (completo se disponível)
+- **Convenção do projeto**: mascarar como `***.NNN.NNN-**` em relatórios
+
+### CNPJ — Cadastro Nacional da Pessoa Jurídica
+
+Identificador único de empresa brasileira, 14 dígitos.
+
+- **Estrutura**: `XX.YYY.YYY/ZZZZ-WW`
+  - `XX.YYY.YYY` (8 dígitos) = CNPJ básico (identifica a empresa-mãe)
+  - `ZZZZ` (4 dígitos) = estabelecimento (matriz = `0001`, filiais = `0002+`)
+  - `WW` = dígitos verificadores
+
+### CNPJ básico
+
+Primeiros 8 dígitos do CNPJ. Identifica a **empresa-mãe** (todas as filiais compartilham mesmo CNPJ básico).
+
+- **Caveat crítico**: em queries, NUNCA use `cnpj_basico` para identificar fornecedor — sofre colisão com CPFs cujos primeiros 8 dígitos coincidem. Use `cpf_cnpj` (14 dígitos) com `EXISTS (estabelecimento)`.
+
+### Matriz vs filial
+
+Cada CNPJ completo (14) é um estabelecimento. Filiais compartilham a mesma empresa-mãe (CNPJ básico). Estabelecimento `0001` é a matriz.
+
+- **Coluna**: `estabelecimento.identificador_matriz_filial` (1=matriz, 2=filial)
+
+### Sócio
+
+Pessoa física ou jurídica que detém participação na empresa. Pode ser administrador, representante, sócio-cotista.
+
+- **Tabela**: `socio`
+- **Coluna chave**: `qualificacao_socio` (sócio-administrador, sócio-quotista, etc.)
+- **Caveat**: CPF do sócio aparece mascarado em `socio.cpf_socio`
+
+### QSA — Quadro de Sócios e Administradores
+
+Lista atual de sócios de uma empresa. Junção de `empresa` + `socio` filtrando ativos.
+
+### Razão social vs nome fantasia
+
+- **Razão social** (`empresa.razao_social`) — nome jurídico oficial
+- **Nome fantasia** (`estabelecimento.nome_fantasia`) — nome comercial (opcional)
+
+### Capital social
+
+Valor declarado de investimento dos sócios. Indicador frágil — pode ser fictício.
+
+- **Caveat investigativo**: capital social baixo + recebimento alto = `flag_capital_desproporcional` (`mv_empresa_pb`)
+
+---
+
+## Programas sociais e folha
+
+### Bolsa Família
+
+Programa de transferência de renda federal. Beneficiário identificado por NIS (Número de Identificação Social), município, valor mensal.
+
+- **Tabela**: `bolsa_familia`
+- **CPF**: mascarado (`***.NNN.NNN-**`)
+- **Caveat investigativo**: servidor público recebendo Bolsa Família simultaneamente = `flag_servidor_bolsa_familia` (`mv_servidor_pb_risco`)
+
+### NIS — Número de Identificação Social
+
+Identificador para benefícios sociais (Bolsa Família, Auxílio Brasil, INSS). Não é CPF.
+
+### CPGF — Cartão de Pagamento do Governo Federal
+
+Cartão corporativo emitido pelo Banco do Brasil para órgãos federais comprarem itens de pequeno valor.
+
+- **Tabela**: `cpgf_transacao`
+- **Padrão suspeito**: fracionamento (vários gastos < R$ 800 do mesmo portador no mesmo dia/loja), conflito com sócios
+
+---
+
+## Crédito e financiamento
+
+### BNDES — Banco Nacional de Desenvolvimento Econômico e Social
+
+Banco federal de fomento. Concede empréstimos a empresas para investimento.
+
+- **Tabela**: `bndes_contrato`
+- **Padrão suspeito**: sócio de empresa tomadora de BNDES doando para campanhas eleitorais (`fraude_cruzamentos_avancados.sql` Q307)
+
+### PGFN — Procuradoria-Geral da Fazenda Nacional
+
+Cobra dívida ativa da União (impostos federais não-pagos). Mantém cadastro público.
+
+- **Tabela**: `pgfn_divida`
+- **Padrão investigativo**: empresa devedora PGFN recebendo empenho público = `flag_divida_pgfn` no `mv_empresa_pb`
+
+### Dívida ativa
+
+Conjunto de débitos não-pagos inscritos em CDA (Certidão de Dívida Ativa). Cobrança via Procuradoria.
+
+- **Base legal**: Lei 6.830/1980
+
+---
+
+## Eleições
+
+### TSE — Tribunal Superior Eleitoral
+
+Órgão máximo da Justiça Eleitoral. Publica dados de candidatos, doadores, prestação de contas, patrimônio declarado.
+
+- **Tabelas**: `tse_candidato`, `tse_bem_candidato`, `tse_receita_candidato`, `tse_despesa_candidato`
+
+### Doador eleitoral
+
+Pessoa física ou jurídica que doa para candidato ou partido. Limites legais por eleição.
+
+- **Tabela**: `tse_receita_candidato`
+- **Padrão investigativo**: sócio de fornecedor doando para prefeito do município que contrata a empresa (Q33, Q34)
+
+### Patrimônio declarado
+
+Bens declarados pelo candidato no momento da candidatura. Evolução entre candidaturas indica enriquecimento.
+
+- **Tabela**: `tse_bem_candidato`
+
+---
+
+## Conflitos de interesse e fraudes
+
+### Conflito de interesses
+
+Situação em que interesse privado de servidor público entra em conflito com sua função. Pode ser legal (servidor público com empresa privada em outro setor) ou ilegal (servidor que decide compra contrata empresa onde é sócio).
+
+- **Caveat investigativo central** do projeto — atravessa servidor × empresa × empenho × Bolsa Família × CEAF
+
+### Porta giratória
+
+Servidor público que se torna sócio/empregado de empresa do setor que regulava (ou vice-versa).
+
+- **Caveat**: no projeto, "porta giratória" também é usado para servidor ativo que é sócio de empresa fornecedora do mesmo município (Q302)
+
+### Pejotização
+
+Servidor público "contratado como empresa" (CNPJ) em vez de via concurso, fugindo da Constituição. Quando empresa do servidor recebe empenhos do órgão onde ele atua = fraude flagrante.
+
+- **Relatórios**: `relatorio_pejotizacao_*.md`
+
+### Empresa fenix
+
+Empresa com CNPJ que fecha (baixada) e reabre com CNPJ novo mantendo sócios/atividade. Estratégia para fugir de sanção CEIS herdada.
+
+- **Detecção**: sócios em comum + atividade similar + datas próximas
+
+### Empresa laranja
+
+Empresa registrada em nome de pessoa sem capacidade financeira/técnica para a atividade — usada para esconder beneficiário real.
+
+- **Sinais**: capital social baixo + recebimento alto, sócio com Bolsa Família
+
+### Cartel
+
+Grupo de empresas que combinam preços ou divisão de mercado em licitações.
+
+- **Detecção**: mesmo endereço cadastral, sócios em comum, propostas em sequência numérica
+
+### Queima de orçamento (de dezembro)
+
+Concentração anormal de empenhos no fim do ano fiscal para não "perder" dotação.
+
+- **MV**: `mv_municipio_pb_risco.pct_dezembro` (peso 20 do score composto)
+- **Query**: Q66
+
+### Bid rigging
+
+Combinação prévia entre licitantes para manipular o resultado. Sub-tipo de cartel.
+
+- **Sinal**: empresas-fachada apresentando "propostas-cobertura" para que uma específica ganhe
+
+### Empenho-semente
+
+Suplementação orçamentária concentrada em poucos fornecedores, pouco antes de eleição.
+
+- **Relatório**: `relatorio_empenhos_semente.md`
+
+---
+
+## Regulação de dados
+
+### LGPD — Lei Geral de Proteção de Dados (Lei 13.709/2018)
+
+Marco legal brasileiro para proteção de dados pessoais.
+
+- **Bases legais que o projeto usa**:
+  - **Art. 7º III** — administração pública para execução de políticas públicas
+  - **Art. 7º IV** — realização de estudos por órgão de pesquisa
+  - **Art. 26** — uso compartilhado de dados pelo Poder Público
+- **Doc**: [`../DATA-LICENSE.md`](../DATA-LICENSE.md), [`privacidade.md`](privacidade.md)
+
+### LAI — Lei de Acesso à Informação (Lei 12.527/2011)
+
+Garante acesso público a dados governamentais. Fundamenta a publicação de quase todas as fontes do projeto.
+
+### ANPD — Autoridade Nacional de Proteção de Dados
+
+Órgão regulador da LGPD. Pode aplicar sanções, ordenar bloqueio/eliminação de dados pessoais tratados sem base legal.
+
+### Dado pessoal sensível
+
+Categoria especial da LGPD (Art. 5º II): saúde, orientação política, religiosa, sexual, dados biométricos. Bolsa Família **não** se enquadra mecanicamente, mas combinação com município + nome se aproxima.
+
+### Mascaramento
+
+Técnica de redução de identificabilidade de dado pessoal. No projeto, padrão canônico para CPF é `***.NNN.NNN-**` (mantém 6 dígitos centrais), validado por `scripts/audit_report_identifiers.py --strict`.
+
+### Anonimização
+
+Processo de remover identificabilidade direta e indireta. **Diferente** de mascaramento — anonimização exige que o dado não possa ser re-identificado por qualquer meio. CPF mascarado em 6 dígitos centrais + nome + município ainda é re-identificável → não é anonimização técnica.
+
+---
+
+## Referências
+
+- **Lei 14.133/2021** — Nova Lei de Licitações e Contratos
+- **Lei 8.666/1993** — Lei de Licitações (antiga, ainda vigente para alguns processos)
+- **Lei 12.846/2013** — Lei Anticorrupção / Improbidade
+- **Lei 12.527/2011** — Lei de Acesso à Informação (LAI)
+- **Lei 13.709/2018** — Lei Geral de Proteção de Dados (LGPD)
+- **Lei 4.320/1964** — Normas Gerais de Direito Financeiro
+- **Lei 10.520/2002** — Pregão (absorvida pela 14.133)
+- **Lei 6.830/1980** — Execução Fiscal / Dívida Ativa
+- **Portaria STN 163/2001** — Classificação da despesa pública
+- **Constituição Federal**, art. 37 XXI — Princípio da licitação obrigatória

--- a/docs/mv-guide.md
+++ b/docs/mv-guide.md
@@ -150,7 +150,7 @@ Se adicionar uma _tmp backing, documente no comentário acima do CREATE quem a p
   grep -n 'MATERIALIZED VIEW\|CREATE OR REPLACE VIEW' sql/12_views.sql
   ```
 - **Drift Python ↔ SQL:** [`web/kpis/municipio_pb.py:sql_score_expression()`](../web/kpis/municipio_pb.py) define a expressão de score em Python, mas `mv_municipio_pb_risco` materializa essa mesma lógica em SQL inline. Mudanças precisam ser feitas **nos dois lugares** — `TODO.md` registra o drift como dívida técnica.
-- **L2 perde dep silenciosamente:** se você renomear coluna em L1 e esquecer L2, fase 18 falha tarde no pipeline. Rode `python -m etl.run_all 18` localmente após qualquer mudança em MV.
+- **L2 perde dep silenciosamente:** se você renomear coluna em L1 e esquecer L2, fase 18 falha tarde no pipeline. Rode `python -m etl.run_all 23` localmente após qualquer mudança em MV (`23` é a posição 1-based da Fase 18 Views na lista `phases` — ver [deploy.md](deploy.md)). Alternativamente, use `etl_phase=sql` no workflow que executa só índices + normalização + views.
 - **`REFRESH CONCURRENTLY` precisa de espaço em disco** equivalente ao tamanho da MV (escreve cópia inteira antes de swap). Em VMs com disk-pressure, plain refresh pode ser preferível.
 - **CASCADE** nos DROPs propaga para views planas e índices — saudável, mas exige recriação completa.
 

--- a/docs/mv-guide.md
+++ b/docs/mv-guide.md
@@ -1,0 +1,162 @@
+# MV guide — adicionando uma materialized view
+
+Este guia cobre o trabalho prático em [`sql/12_views.sql`](../sql/12_views.sql) (1500+ linhas). Para overview das camadas, ver [architecture.md](architecture.md). Para queries que consomem MVs, ver [queries-guide.md](queries-guide.md).
+
+## Camadas
+
+As MVs são organizadas em **três camadas** com dependências estritas:
+
+```mermaid
+flowchart TD
+    subgraph base["Tabelas base (ETL phases 1-17)"]
+        e[empresa / estabelecimento]
+        s[socio]
+        tcd[tce_pb_despesa]
+        tcl[tce_pb_licitacao]
+        srv[tce_pb_servidor]
+        pncp[pncp_contrato]
+        emenda[emenda_favorecido]
+        cpgf[cpgf]
+        ceis[ceis / cnep / inidoneo]
+        pgfn[pgfn]
+    end
+
+    subgraph L1["L1 — MVs independentes"]
+        meg[mv_empresa_governo]
+        mpb[mv_pessoa_pb]
+        mmr[mv_municipio_pb_risco]
+        msb[mv_servidor_pb_base]
+    end
+
+    subgraph L2["L2 — MVs derivadas"]
+        msr[mv_servidor_pb_risco]
+        mep[mv_empresa_pb<br/>+ _tmp_* backing]
+        mrp[mv_rede_pb]
+        mks[mv_municipio_pb_kpi_score]
+        mmp[mv_municipio_pb_mapa]
+        mq67[mv_q67_dated_pb]
+    end
+
+    subgraph L3["L3 — Views planas (sem materialização)"]
+        vre[v_risk_score_empresa]
+        vrp[v_risk_score_pb]
+    end
+
+    e --> meg
+    pncp --> meg
+    emenda --> meg
+    cpgf --> meg
+    ceis --> meg
+    pgfn --> meg
+
+    s --> mpb
+    e --> mpb
+
+    tcd --> mmr
+    tcl --> mmr
+    srv --> mmr
+
+    srv --> msb
+
+    msb --> msr
+    mpb --> msr
+
+    meg --> mep
+    mmr --> mep
+    s --> mep
+
+    mep --> mrp
+    mpb --> mrp
+
+    mmr --> mks
+    meg --> mks
+
+    mks --> mmp
+
+    tcd --> mq67
+    pgfn --> mq67
+
+    mep --> vre
+    mmr --> vrp
+    mks --> vrp
+```
+
+> **L2 silenciosamente quebra** se uma MV L1 mudar de coluna sem propagar. A fase 18 ([`etl/21_views.py`](../etl/21_views.py)) executa o arquivo inteiro em ordem — um CREATE quebrado aborta o resto.
+
+## Convenções do `sql/12_views.sql`
+
+1. **DROP no topo** em ordem reversa de dependência (views planas → L2 → L1).
+2. **CREATE por camadas** depois dos DROPs (L1 primeiro, depois L2, depois views).
+3. `REFRESH MATERIALIZED VIEW CONCURRENTLY` exige `UNIQUE INDEX` na MV. Sem isso, falha em runtime.
+4. **Notas de refresh** no rodapé do arquivo (linhas 1465+) — lista a ordem operacional dos REFRESH em produção.
+
+Exemplo real do topo do arquivo:
+
+```sql
+-- Drop em ordem reversa de dependência
+DROP VIEW IF EXISTS v_risk_score_pb CASCADE;
+DROP VIEW IF EXISTS v_risk_score_empresa CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_rede_pb CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_empresa_pb CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_servidor_pb_risco CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_servidor_pb_base CASCADE;
+-- ... (L1 por último)
+DROP MATERIALIZED VIEW IF EXISTS mv_empresa_governo CASCADE;
+```
+
+## Adicionando uma MV nova — checklist
+
+1. **Decida a camada** olhando as deps (L1 se só toca tabelas base; L2 se lê outra MV; view plana se for projeção barata).
+2. **Adicione `DROP MATERIALIZED VIEW IF EXISTS <nome> CASCADE`** no bloco de DROPs, **respeitando a ordem reversa** (mais derivada primeiro).
+3. **Escreva o `CREATE MATERIALIZED VIEW`** na seção correspondente (L1 / L2 / Views).
+4. **Crie `UNIQUE INDEX`** logo após o CREATE se quiser permitir `REFRESH ... CONCURRENTLY`:
+   ```sql
+   CREATE UNIQUE INDEX mv_minha_nova_pk
+       ON mv_minha_nova (cnpj_basico, municipio);
+   ```
+5. **Índices auxiliares** para joins/filtros frequentes (não-unique).
+6. **Atualize o bloco de refresh notes** no rodapé do arquivo (~linha 1465) adicionando a linha:
+   ```sql
+   --   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_minha_nova;
+   ```
+7. **Atualize consumidores** em [`web/queries/registry.py`](../web/queries/registry.py) e em `queries/*.sql` que dependerem da MV nova.
+8. **Verifique `etl/21_views.py`** — ele executa `sql/12_views.sql` inteiro; nenhuma mudança Python é necessária a menos que você adicione uma _tmp table backing (ver abaixo).
+9. **Atualize o diagrama** neste doc + o diagrama de MVs em [architecture.md](architecture.md).
+
+## Performance: REFRESH CONCURRENTLY vs plain
+
+| Modo | Lock | Tempo | Quando usar |
+|---|---|---|---|
+| `REFRESH ... CONCURRENTLY` | `ShareUpdateExclusive` (não bloqueia leitura) | ~2× (escreve nova cópia + reindex) | Padrão em prod — UI continua servindo |
+| `REFRESH ...` (plain) | `AccessExclusive` (bloqueia tudo) | ~1× | Bootstrap inicial; mudança de schema |
+
+`CONCURRENTLY` exige UNIQUE INDEX. Sem ele, escolha está feita: você só pode dar refresh plain (com downtime de leitura).
+
+## Tabelas `_tmp_*` backing
+
+Quando uma MV agrega muitas fontes e o SELECT inicial dá timeout, o padrão é usar tabelas auxiliares **`_tmp_<algo>`** povoadas antes do CREATE da MV. Exemplo em `mv_empresa_pb` (linhas ~664+). Caveat citado no próprio arquivo:
+
+```sql
+-- Na próxima execução, o CASCADE no DROP MATERIALIZED VIEW libera as _tmp tables,
+-- mas elas precisam ser recriadas/povoadas antes do CREATE MATERIALIZED VIEW.
+```
+
+Se adicionar uma _tmp backing, documente no comentário acima do CREATE quem a popula (geralmente uma função em `etl/21_views.py` antes de chamar o `execute_sql_file`).
+
+## Caveats
+
+- **Tamanho do arquivo:** 1500+ linhas. Qualquer mudança exige ler a ordem inteira de DROP/CREATE antes de inserir. Use grep para localizar:
+  ```bash
+  grep -n 'MATERIALIZED VIEW\|CREATE OR REPLACE VIEW' sql/12_views.sql
+  ```
+- **Drift Python ↔ SQL:** [`web/kpis/municipio_pb.py:sql_score_expression()`](../web/kpis/municipio_pb.py) define a expressão de score em Python, mas `mv_municipio_pb_risco` materializa essa mesma lógica em SQL inline. Mudanças precisam ser feitas **nos dois lugares** — `TODO.md` registra o drift como dívida técnica.
+- **L2 perde dep silenciosamente:** se você renomear coluna em L1 e esquecer L2, fase 18 falha tarde no pipeline. Rode `python -m etl.run_all 18` localmente após qualquer mudança em MV.
+- **`REFRESH CONCURRENTLY` precisa de espaço em disco** equivalente ao tamanho da MV (escreve cópia inteira antes de swap). Em VMs com disk-pressure, plain refresh pode ser preferível.
+- **CASCADE** nos DROPs propaga para views planas e índices — saudável, mas exige recriação completa.
+
+## Relacionados
+
+- [architecture.md](architecture.md) — diagrama macro das camadas + ERD.
+- [cache.md](cache.md) — `web_cache` lê queries que dependem de MVs; mudança de MV requer rewarm para evitar cache stale.
+- [queries-guide.md](queries-guide.md) — quando uma Q## lenta deve virar MV.
+- [`etl/21_views.py`](../etl/21_views.py) — phase 18 que aplica `sql/12_views.sql`.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,369 @@
+﻿# Onboarding: do clone ao `uvicorn` em uma tarde
+
+Este guia é para uma pessoa contribuindo casualmente  alguém como Marina, que
+quer entender o projeto, fazer uma melhoria pequena e talvez rodar parte do
+frontend localmente. O objetivo é ser honesto: documentação e relatórios são
+simples de editar; queries e web dependem de PostgreSQL com schema e dados.
+
+## TL;DR
+
+```bash
+git clone https://github.com/lucasdiniz/govbr-cruza-dados
+cd govbr-cruza-dados
+pip install -e .[web,dev] && npm ci
+```
+
+Para abrir o frontend:
+
+```bash
+python -m uvicorn web.main:app --port 8000
+```
+
+Mas atenção: o `uvicorn` sobe a aplicação, porém rotas reais como
+`/cidade/joao-pessoa` exigem **schema PostgreSQL + materialized views +
+`web_cache` populado**. Enquanto não houver sample data oficial, rodar o portal
+completo localmente é trabalhoso.
+
+## Pré-requisitos
+
+- Python **3.10+**  testado principalmente com 3.11 e 3.12.
+- Node.js **20+**.
+- PostgreSQL **16** para caminhos de queries/web.
+- Aproximadamente **5 GB livres** para setup mínimo sem ETL real.
+- **8 GB RAM** mínimos para desenvolvimento leve; o ETL completo usa muito mais
+  disco e tempo.
+- Git e um editor de texto.
+
+## Escolha seu caminho
+
+O projeto aceita três tipos de contribuição, em complexidade crescente.
+
+| Caminho | Para quê | Precisa Postgres? | Bom primeiro PR? |
+|---|---|---:|---:|
+| A. Documentação/relatórios | `README.md`, `docs/`, `relatorios/` | Não | Sim |
+| B. Queries Q## | `queries/*.sql`, MVs, índices, registry web | Sim, com schema e dados/subset | Médio |
+| C. Web frontend | `web/`, templates, cache, UX | Sim, com MVs e `web_cache` | Difícil sem dump |
+
+### A. Documentação e relatórios
+
+Este é o caminho recomendado para começar. Você consegue clonar o repositório,
+editar markdown, rodar o auditor de CPFs e abrir PR sem banco local.
+
+Use este caminho para:
+
+- corrigir typos;
+- melhorar explicações em `docs/`;
+- atualizar glossário;
+- escrever ou revisar relatórios em `relatorios/`;
+- melhorar exemplos de comandos.
+
+### B. Queries Q##
+
+Queries investigativas vivem em `queries/*.sql` e são identificadas por headers
+`-- Q##: Título`. Elas podem ser expostas no frontend via
+`web/queries/registry.py`.
+
+Você precisa de PostgreSQL com schema e dados relevantes. Não precisa ter todos
+os ~350M registros se a query usa um subset, mas precisa de tabelas suficientes
+para validar resultado, performance e índices.
+
+Hoje ainda não existe um dump público pequeno de sample data. Se a issue exigir
+dados, peça um snapshot reduzido nos comentários ou por contato.
+
+### C. Web frontend
+
+O frontend é FastAPI + Jinja2, sem ORM. Muitas rotas leem `web_cache` em vez de
+executar SQL pesado durante o request. Por isso, só subir `uvicorn` não basta
+para testar a experiência completa.
+
+Para PRs em `web/`, inclua no PR:
+
+- rota testada manualmente;
+- screenshot ou gravação curta;
+- estado do cache usado;
+- limitações do teste local, se rodou sem dados completos.
+
+## Setup detalhado  caminho A (5 min)
+
+### 1. Clone
+
+```bash
+git clone https://github.com/lucasdiniz/govbr-cruza-dados
+cd govbr-cruza-dados
+```
+
+### 2. Edite markdown
+
+Arquivos bons para primeira contribuição:
+
+```bash
+# exemplos de alvos comuns
+$EDITOR README.md
+$EDITOR CONTRIBUTING.md
+$EDITOR docs/glossario.md
+$EDITOR relatorios/algum_relatorio.md
+```
+
+### 3. Se mexer em CPFs, rode o auditor
+
+Relatórios não devem conter CPF completo formatado. O padrão público é
+`***.NNN.NNN-**`.
+
+```bash
+python scripts/audit_report_identifiers.py --strict
+```
+
+O modo `--strict` é offline: ele não precisa de banco. Ele falha se encontrar CPF
+completo no formato `NNN.NNN.NNN-NN` em markdown versionado.
+
+### 4. Commit
+
+Use uma mensagem curta. Se o commit foi produzido com auxílio do Copilot, inclua
+o trailer exigido pelo projeto:
+
+```bash
+git checkout -b docs/minha-melhoria
+git add docs/glossario.md
+git commit -m "docs: melhora explicação de empenho" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### 5. Push + PR
+
+```bash
+git push origin docs/minha-melhoria
+```
+
+Abra PR a partir do seu fork. Explique o motivo da mudança e cite se rodou o
+auditor.
+
+## Setup detalhado  caminhos B/C (45 min, sem contar dados)
+
+### 1. Instale PostgreSQL 16
+
+macOS/Homebrew:
+
+```bash
+brew install postgresql@16
+brew services start postgresql@16
+```
+
+Ubuntu/Debian:
+
+```bash
+sudo apt update
+sudo apt install postgresql-16 postgresql-client-16
+```
+
+Windows: use o instalador oficial do PostgreSQL 16 e garanta que `psql` esteja
+no `PATH`.
+
+### 2. Instale dependências Python
+
+```bash
+pip install -e .[web,dev]
+```
+
+### 3. Configure ambiente
+
+```bash
+cp .env.example .env
+```
+
+Edite `.env` com suas credenciais locais. O padrão esperado no README é algo
+como `localhost:5432/govbr` com usuário `govbr`.
+
+Crie usuário e banco, se ainda não existirem:
+
+```bash
+sudo -u postgres psql -c "CREATE USER govbr WITH PASSWORD 'govbr_dev';"
+sudo -u postgres psql -c "CREATE DATABASE govbr OWNER govbr;"
+```
+
+No Windows, execute comandos equivalentes no SQL Shell ou em um terminal com
+`psql` autenticado como administrador.
+
+### 4. Habilite extensões obrigatórias
+
+```bash
+psql -d govbr -c "CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS unaccent;"
+```
+
+### 5. Instale dependências Node
+
+```bash
+npm ci
+```
+
+### 6. Compile assets quando mexer no frontend
+
+```bash
+npm run build
+```
+
+### 7. Gap atual: schema vazio e sample data
+
+Aqui está o ponto mais importante: sem sample data, o banco local estará vazio.
+O projeto ainda não tem um caminho oficial schema-only + dados mínimos de 1
+município. Quando existir, ele deve ser documentado em `docs/sample-data.md`.
+
+Enquanto isso, opções reais são:
+
+1. rodar fases específicas do ETL para as fontes que sua query usa;
+2. rodar o ETL completo, se você tiver tempo, disco e rede;
+3. pedir um dump reduzido na issue ou por
+   [`contato@transparenciapb.org`](mailto:contato@transparenciapb.org).
+
+Comandos úteis:
+
+```bash
+python -m etl.run_all          # ETL completo: pesado
+python -m etl.run_all 4        # retoma de uma fase 1-based
+python -m etl.run_queries --query Q03
+python -m web.warm_cache --pb  # popula web_cache para municípios PB
+```
+
+### 8. Suba o frontend
+
+```bash
+python -m uvicorn web.main:app --port 8000
+```
+
+Em outro terminal:
+
+```bash
+curl http://localhost:8000/
+curl -i http://localhost:8000/cidade/joao-pessoa
+```
+
+Resultado esperado:
+
+- `/` deve retornar HTML se a aplicação subiu;
+- `/cidade/joao-pessoa` deve retornar 200 apenas se cache/MVs estiverem
+  populados;
+- rotas cache-only podem retornar **503** em cache miss, o que é esperado em
+  banco vazio.
+
+## Fluxo mental do projeto
+
+```mermaid
+flowchart LR
+    CLONE[Clone] --> A{Tipo de PR?}
+    A -->|Docs/relatórios| MD[Editar Markdown]
+    MD --> AUDIT[Rodar auditor se tiver CPF]
+    AUDIT --> PR[Pull Request]
+    A -->|Queries| PG[Postgres + schema + dados]
+    PG --> SQL[Validar Q## + índices]
+    SQL --> PR
+    A -->|Web| CACHE[Postgres + MVs + web_cache]
+    CACHE --> UV[uvicorn + screenshot]
+    UV --> PR
+```
+
+## O que abrir para entender o código
+
+Leia nesta ordem:
+
+1. [`README.md`](../README.md)  visão geral, comandos e variáveis de ambiente.
+2. [`CONTRIBUTING.md`](../CONTRIBUTING.md)  tipos de contribuição e convenções.
+3. [`docs/architecture.md`](architecture.md)  arquitetura do ETL, MVs, cache e
+   deploy.
+4. [`docs/glossario.md`](glossario.md)  termos de domínio público brasileiro.
+5. [`../etl/incremental/README.md`](../etl/incremental/README.md)  framework
+   incremental, se você for mexer em ETL.
+
+Depois, navegue pelo código conforme o alvo:
+
+| Área | Arquivos principais |
+|---|---|
+| ETL clássico | `etl/run_all.py`, `etl/00_download.py`, `etl/db.py` |
+| Normalização CPF/CNPJ | `etl/15_normalizar.py`, `etl/utils.py` |
+| SQL schema/MVs | `sql/*.sql`, especialmente `sql/12_views.sql` |
+| Queries | `queries/*.sql`, `etl/run_queries.py` |
+| Web | `web/main.py`, `web/routes/`, `web/templates/` |
+| Cache | `web/warm_cache.py`, `web/queries/registry.py` |
+
+## Validação rápida antes do PR
+
+Para docs/relatórios:
+
+```bash
+python scripts/audit_report_identifiers.py --strict
+```
+
+Para Python editado:
+
+```bash
+python -m compileall etl web scripts -q
+```
+
+Para frontend/assets:
+
+```bash
+npm run build
+```
+
+Para queries:
+
+```bash
+python -m etl.run_queries --query Q03
+```
+
+Troque `Q03` pela sua query. Em queries que serão expostas no web, valide também
+índices e tempo de execução; o timeout default no registry é curto.
+
+## Onde pedir ajuda
+
+- GitHub Discussions  canal planejado para perguntas abertas.
+- Issues com label `question`.
+- Issues com label `good first issue`  há uma fila de primeiras tarefas, como
+  #126#141.
+- E-mail: [`contato@transparenciapb.org`](mailto:contato@transparenciapb.org).
+
+Ao pedir ajuda, inclua:
+
+- sistema operacional;
+- versão de Python, Node e PostgreSQL;
+- comando executado;
+- erro completo;
+- se você tem ou não dados carregados.
+
+## Primeira contribuição sugerida
+
+Se você quer começar hoje:
+
+1. escolha uma issue `good first issue`;
+2. prefira uma mudança em `docs/` ou `relatorios/`;
+3. rode o auditor se tocar em identificadores pessoais;
+4. abra PR pequeno, com contexto claro.
+
+PR pequeno e bem explicado costuma ser melhor que PR grande tentando resolver
+vários problemas de uma vez.
+
+## Caveats conhecidos
+
+- `psycopg2-binary` pode falhar em combinações recentes como Python 3.13 ou ARM
+  Linux; o projeto declara Python 3.10+ e é testado principalmente em 3.11/3.12.
+- `pyproject.toml` ainda não tem lockfile Python; versões transitivas podem
+  variar entre máquinas.
+- O frontend depende de materialized views e `web_cache`; rotas cache-only
+  retornam 503 sem cache populado.
+- Não há sample data público ainda; contribuições B/C podem depender de apoio do
+  owner.
+- A instalação local padrão usa PostgreSQL nativo. Docker pode funcionar para o
+  banco, mas não é o caminho operacional de produção.
+- O ETL completo é pesado: baixar e processar todas as fontes não é requisito
+  para contribuir com documentação.
+
+## Checklist de PR
+
+Antes de abrir:
+
+- [ ] A mudança está pequena e focada.
+- [ ] Links relativos funcionam.
+- [ ] Exemplos de comando usam blocos `bash`.
+- [ ] CPFs em markdown estão mascarados.
+- [ ] Rodei `python scripts/audit_report_identifiers.py --strict` se toquei em
+      relatórios ou dados pessoais.
+- [ ] Para `web/`, anexei screenshot e expliquei o estado do cache.
+- [ ] Para `queries/`, indiquei como validei resultado e performance.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,4 +1,4 @@
-﻿# Onboarding: do clone ao `uvicorn` em uma tarde
+# Onboarding: do clone ao `uvicorn` em uma tarde
 
 Este guia é para uma pessoa contribuindo casualmente  alguém como Marina, que
 quer entender o projeto, fazer uma melhoria pequena e talvez rodar parte do

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -356,13 +356,13 @@ az disk show --resource-group <rg> --name <data-disk-name> --query sku.name -o t
 
 ## Runbook: ETL falhou
 
-1. Leia o log do step que falhou e identifique a fase `N`.
+1. Leia o log do step que falhou e identifique a **posição da fase na lista `phases`** de [`etl/run_all.py:76-101`](../etl/run_all.py) (`etl_phase` é índice 1-based, não rótulo "Fase N" — ver [deploy.md](deploy.md)).
 2. Se a fase depende de CSV que pode ter sido limpo, rode download seletivo:
 
 ```yaml
 download_sources: "tce_pb"
 skip_download: false
-etl_phase: "19"
+etl_phase: "19"   # exemplo: 19ª entrada = Fase 14 TCE-PB
 ```
 
 3. Se os CSVs ainda existem:

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,0 +1,426 @@
+# Operação e runbooks
+
+Runbooks operacionais para produção do `govbr-cruza-dados` / [transparenciapb.org](https://transparenciapb.org). Cada seção é independente: identifique o sintoma, execute o menor procedimento seguro e registre o que foi feito no PR/issue operacional.
+
+Para entender o pipeline, veja [`deploy.md`](deploy.md). Para visão geral de arquitetura, veja [`architecture.md`](architecture.md).
+
+## Decision tree: algo quebrou, o que faço?
+
+```mermaid
+flowchart TD
+    A[Algo quebrou] --> B{Site fora do ar?}
+    B -->|Sim| C[systemctl status cruza-web]
+    C --> D{cruza-web running?}
+    D -->|Sim| E[Erro na app<br/>journalctl -u cruza-web]
+    D -->|Não| F[Restart manual<br/>ou nginx config bad]
+    F --> G[systemctl status nginx<br/>nginx -t]
+
+    B -->|Não| H{Site lerdo?}
+    H -->|Sim| I{Cache miss em queries pesadas?}
+    I -->|Sim| J[Rodar deploy com<br/>rewarm_cache_keys]
+    I -->|Não| K{Disco saturado?}
+    K -->|Sim| L[df -h /data<br/>ver pg_dump/raw sobrando]
+    K -->|Não| M{Postgres ocupado?}
+    M -->|Sim| N[pg_stat_activity<br/>autovacuum/ETL/warm]
+    M -->|Não| O[Ver GoAccess/Umami<br/>pico de tráfego]
+
+    H -->|Não| P{ETL falhou?}
+    P -->|Sim| Q[Identificar etapa N no log]
+    Q --> R{CSV foi apagado pelo cleanup?}
+    R -->|Sim| S[download_sources=<fonte><br/>skip_download=false]
+    R -->|Não| T[Retomar com etl_phase=N]
+
+    P -->|Não| U{Runner offline?}
+    U -->|Sim| V[Rodar setup-runner.yml<br/>com RUNNER_ADMIN_TOKEN]
+    U -->|Não| W[Coletar logs via debug-logs.yml]
+```
+
+## Acesso rápido à VM
+
+Com SSH disponível:
+
+```bash
+ssh govbr@transparenciapb.org
+sudo systemctl status cruza-web --no-pager
+sudo journalctl -u cruza-web -n 200 --no-pager
+```
+
+Se SSH estiver bloqueado por fail2ban ou indisponível, use o workflow [`../.github/workflows/debug-logs.yml`](../.github/workflows/debug-logs.yml) para puxar `journalctl` via automação.
+
+## Runbook: rollback de deploy
+
+Objetivo: voltar a VM para um commit anterior conhecido bom e reiniciar serviços sem reconstruir banco.
+
+1. Identifique o último deploy bom:
+
+```bash
+gh run list --workflow "Deploy to Azure VM" --limit 10
+# ou veja o histórico da branch main / PR que introduziu a falha
+git log --oneline -20
+```
+
+2. Entre na VM e faça rollback do código:
+
+```bash
+ssh govbr@transparenciapb.org
+cd /home/govbr/govbr-project
+git fetch origin main --tags
+git status --short
+git reset --hard <COMMIT_BOM>
+source venv/bin/activate
+pip install -e ".[web]" -q
+npm ci --no-audit --no-fund
+node scripts/build-assets.mjs
+```
+
+3. Reinicie serviços web:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart cruza-web
+sudo systemctl status cruza-web --no-pager --lines=30
+curl -I -H "Host: transparenciapb.org" http://127.0.0.1:8000/
+```
+
+4. Se a falha estava em cache de query, prefira não truncar tudo. Rode um deploy `etl_phase=web` com `rewarm_cache_keys=<QID>` para regenerar zero-downtime.
+
+5. Depois abra PR revertendo/fixando a alteração em `main`. O próximo deploy normal sobrescreverá o rollback manual com `origin/main`.
+
+## Runbook: restore zero (DB perdido)
+
+### Com backup disponível
+
+1. Pare web/warm para evitar leituras inconsistentes:
+
+```bash
+sudo systemctl stop cruza-web
+sudo systemctl stop cruza-warm-cache || true
+```
+
+2. Restaure o dump mais recente. Exemplo com formato custom do `pg_dump -Fc`:
+
+```bash
+createdb -U govbr govbr_restore
+PGPASSWORD="$POSTGRES_PASSWORD" pg_restore \
+  -U govbr \
+  -d govbr_restore \
+  --clean --if-exists --no-owner \
+  /data/backups/govbr-latest.dump
+```
+
+3. Faça smoke mínimo:
+
+```bash
+PGPASSWORD="$POSTGRES_PASSWORD" psql -U govbr -d govbr_restore -c "SELECT COUNT(*) FROM empresa;"
+PGPASSWORD="$POSTGRES_PASSWORD" psql -U govbr -d govbr_restore -c "SELECT COUNT(*) FROM web_cache;"
+```
+
+4. Promova o banco restaurado conforme estratégia local (renomear databases ou restaurar diretamente sobre `govbr` em janela de manutenção). Depois:
+
+```bash
+sudo systemctl start cruza-web
+sudo systemctl status cruza-web --no-pager
+```
+
+### Sem backup disponível
+
+Faça reload completo pelo workflow:
+
+```yaml
+etl_phase: all
+clean: true
+skip_download: false
+warm_cache: true
+```
+
+Expectativa: ~24h ou mais, dependendo de fontes remotas, download, ETL, MVs e warm. O site pode ficar parcial/fora do ar até cache e MVs terminarem.
+
+## Runbook: runner self-hosted desconectou
+
+Sintomas: workflow fica em fila aguardando runner `self-hosted`, runner offline no GitHub, ou serviço `actions-runner` parado.
+
+1. Tente validar na VM:
+
+```bash
+sudo systemctl status actions-runner* --no-pager
+sudo journalctl -u 'actions-runner*' -n 200 --no-pager
+```
+
+2. Se token expirou ou runner foi removido, rode [`../.github/workflows/setup-runner.yml`](../.github/workflows/setup-runner.yml) com `RUNNER_ADMIN_TOKEN` configurado.
+
+3. Após setup, confirme:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl status actions-runner* --no-pager
+```
+
+4. Reexecute o deploy. O `preflight` liga/redimensiona a VM antes de o job self-hosted precisar iniciar.
+
+## Runbook: troubleshoot `warm_cache`
+
+O step `Warm cache` roda `cruza-warm-cache.service` como oneshot e falha quando mais de 5% das queries quebram. O workflow usa `continue-on-error`, então pode haver deploy com warning e postflight ainda reduzir a VM.
+
+1. Ver logs:
+
+```bash
+sudo journalctl -u cruza-warm-cache -n 500 --no-pager
+sudo systemctl status cruza-warm-cache --no-pager --lines=50
+```
+
+2. Identifique `query_id`, município/cache key e stack trace.
+
+3. Se é bug em SQL/registry, corrija e rode:
+
+```yaml
+etl_phase: web
+rewarm_cache_keys: <QID ou chave base>
+```
+
+4. Se é schema/MV stale, rode:
+
+```yaml
+etl_phase: sql
+warm_cache: true
+```
+
+5. Se live cache está quebrado e precisa remover imediatamente, use `invalidate_cache_keys=<QID>` sabendo que causa cache miss até rewarm.
+
+## Runbook: backup DB
+
+**Status atual: pendente.** Não há estratégia documentada de backup/restore validada em produção. Este é um gap operacional A4.
+
+Sugestões a formalizar:
+
+### Opção A  `pg_dump` para Azure Blob
+
+```bash
+mkdir -p /data/backups
+pg_dump -U govbr -Fc -d govbr -f /data/backups/govbr-$(date +%F).dump
+az storage blob upload \
+  --account-name <storage> \
+  --container-name backups \
+  --file /data/backups/govbr-$(date +%F).dump \
+  --name govbr-$(date +%F).dump
+```
+
+Pontos de atenção: dump de banco grande pode demorar muitas horas e competir com ETL/warm; rode em B4/Premium e monitore `/data`.
+
+### Opção B  snapshot Azure Disk
+
+Snapshot do data disk é mais rápido para disaster recovery, mas exige consistência. Idealmente pare PostgreSQL ou use mecanismo coordenado:
+
+```bash
+sudo systemctl stop postgresql
+az snapshot create \
+  --resource-group <rg> \
+  --source <disk-id> \
+  --name govbr-data-$(date +%F)
+sudo systemctl start postgresql
+```
+
+A estratégia final deve definir retenção, criptografia, teste periódico de restore e custo.
+
+## Runbook: fail2ban management
+
+Jails customizadas em `deploy/`:
+
+- `transparenciapb-429`  muitos HTTP 429/rate limit.
+- `transparenciapb-exploit-paths`  scanners tentando `/.env`, `/.git`, `/wp-admin`, etc.
+- `recidive`  reincidência.
+
+Comandos:
+
+```bash
+sudo fail2ban-client status
+sudo fail2ban-client status transparenciapb-429
+sudo fail2ban-client status transparenciapb-exploit-paths
+sudo fail2ban-client status recidive
+
+# Unban manual
+sudo fail2ban-client set transparenciapb-429 unbanip <IP>
+sudo fail2ban-client set transparenciapb-exploit-paths unbanip <IP>
+sudo fail2ban-client set recidive unbanip <IP>
+```
+
+Se você bloqueou o próprio SSH, use `debug-logs.yml` e/ou console Azure para recuperar acesso.
+
+## Runbook: logs ad-hoc
+
+Workflow [`../.github/workflows/debug-logs.yml`](../.github/workflows/debug-logs.yml) coleta logs da VM sem depender de sessão SSH interativa. Use quando:
+
+- SSH está bloqueado por fail2ban.
+- Precisa anexar logs a issue/PR.
+- Quer logs de `cruza-web`, `cruza-warm-cache`, `nginx`, `postgresql`, `goaccess` ou runner.
+
+Na VM, comandos equivalentes:
+
+```bash
+sudo journalctl -u cruza-web -n 300 --no-pager
+sudo journalctl -u cruza-warm-cache -n 300 --no-pager
+sudo journalctl -u nginx -n 200 --no-pager
+sudo journalctl -u postgresql -n 200 --no-pager
+sudo tail -n 200 /var/log/nginx/access.log
+sudo tail -n 200 /var/log/nginx/error.log
+```
+
+## Runbook: GoAccess / Umami
+
+Painéis admin ficam atrás de basic-auth em:
+
+- `https://transparenciapb.org/_traffic/goaccess/`
+- `https://transparenciapb.org/_traffic/analytics/`
+
+GoAccess usa basic-auth configurado por `deploy/setup-goaccess.sh` e secret `GOACCESS_PASSWORD`. Umami ainda exige login próprio no app.
+
+Trocar senha basic-auth:
+
+```bash
+sudo apt-get install -y apache2-utils
+sudo htpasswd -c /etc/nginx/.htpasswd-traffic <usuario>
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Nota de hardening: há memória operacional de que a senha atual foi admitida como fraca pelo owner; trate troca/rotação como issue de segurança operacional.
+
+## Runbook: disco cheio
+
+1. Verifique uso:
+
+```bash
+df -h / /data
+sudo du -h --max-depth=1 /data | sort -h
+```
+
+2. O cleanup raw deveria remover CSVs após cada fase. Se sobraram diretórios de fonte e **não há ETL rodando**, remova com cuidado:
+
+```bash
+sudo systemctl status cruza-warm-cache --no-pager
+ps aux | grep -E 'etl\.run_all|etl\.00_download|incremental.runner' | grep -v grep
+rm -rf /data/<fonte>
+```
+
+3. Procure dumps/logs grandes:
+
+```bash
+find /data -maxdepth 3 -type f -size +5G -print
+sudo journalctl --disk-usage
+```
+
+4. Se PostgreSQL cresceu, não delete arquivos em `/data/postgresql` manualmente. Investigue tabelas grandes e autovacuum.
+
+## Runbook: PostgreSQL autotune
+
+`pg-autotune.service` recalcula `shared_buffers`, `effective_cache_size`, `work_mem` e `maintenance_work_mem` conforme RAM atual da VM. O deploy instala o unit e o drop-in `pg-autotune-pg-dropin.conf`; quando VM sobe B2/B4, Postgres recebe tuning coerente.
+
+Validar:
+
+```bash
+sudo systemctl status pg-autotune --no-pager
+sudo journalctl -u pg-autotune -n 100 --no-pager
+sudo cat /etc/postgresql/16/main/conf.d/tuning.conf
+systemctl cat postgresql@16-main.service | grep -A5 -B5 pg-autotune
+```
+
+Aplicar manualmente:
+
+```bash
+sudo /usr/local/bin/pg-autotune.sh
+sudo systemctl restart postgresql
+```
+
+## Runbook: VM size lock / disco preso em Premium
+
+Azure limita mudanças de SKU de disco a 2 por 24h. O workflow trata conversão de disco como best-effort; se falhar, a VM pode voltar para B2 mas o disco ficar em Premium por algumas horas, custando ~US$0,05/h extra.
+
+O que fazer:
+
+1. Não force loops de deploy só para converter disco; isso pode consumir mais limite.
+2. Espere 24h desde a primeira mudança.
+3. Rode novo deploy web simples ou converta manualmente:
+
+```bash
+az login
+az disk update \
+  --resource-group <rg> \
+  --name <data-disk-name> \
+  --sku StandardSSD_LRS
+```
+
+4. Confirme no portal Azure ou CLI:
+
+```bash
+az disk show --resource-group <rg> --name <data-disk-name> --query sku.name -o tsv
+```
+
+## Runbook: ETL falhou
+
+1. Leia o log do step que falhou e identifique a fase `N`.
+2. Se a fase depende de CSV que pode ter sido limpo, rode download seletivo:
+
+```yaml
+download_sources: "tce_pb"
+skip_download: false
+etl_phase: "19"
+```
+
+3. Se os CSVs ainda existem:
+
+```yaml
+etl_phase: "19"
+```
+
+4. Se falhou após mudança de schema/índice, `etl_phase=sql` pode ser suficiente.
+5. Se o deploy falhou de verdade antes de postflight, a VM pode ficar em B4 para facilitar retomada. Depois de corrigir, rode o deploy normal; postflight fará downsize.
+
+## Métricas operacionais
+
+**Gap A4:** hoje não há alerta externo documentado para uptime/queda. Recomendações:
+
+- UptimeRobot free monitorando `/` e `/static/manifest.webmanifest`.
+- Better Stack free/low-cost para uptime + status page.
+- Alerta por email/Telegram/Slack quando HTTP != 200 ou latência alta.
+- Monitor separado para `/_traffic/goaccess/` não é necessário; é painel admin.
+
+## Monitoramento atual
+
+| Ferramenta | Onde | Uso |
+|---|---|---|
+| GoAccess | `/_traffic/goaccess/` | Dashboard quase em tempo real de acessos Nginx, status codes, IPs e user-agents. |
+| Umami | `/_traffic/analytics/` | Analytics de visitantes com login próprio. |
+| Traffic digest | systemd timer diário 10:00 UTC | Sumário markdown diário baseado no access log rotacionado. |
+| `journalctl` | VM | Fonte primária para systemd: `cruza-web`, warm, nginx, PostgreSQL, runner. |
+| GitHub Actions logs | UI do GitHub | Logs do pipeline, incluindo warm tailado e smokes. |
+
+## Quando escalar
+
+Escalar para owner/manutenção mais ampla quando:
+
+- VM B2 satura por tráfego web normal, não por ETL/warm.
+- Latência alta persiste com cache quente e Postgres ocioso.
+- Fail2ban mostra abuso constante ou scans distribuídos.
+- Warm-cache passa a exceder janela operacional aceitável.
+- Banco/disco se aproxima do limite estrutural.
+
+Opções antes de upgrade permanente:
+
+1. Validar cache hit rate e queries com `web_cache`.
+2. Confirmar que não há ETL, `pg_dump`, autovacuum pesado ou warm concorrendo.
+3. Adicionar CDN/cache estático para assets e páginas públicas cacheáveis.
+4. Considerar B4 permanente só se tráfego, não ETL, justificar o custo.
+
+## Checklist de saúde pós-incidente
+
+```bash
+systemctl is-active nginx
+systemctl is-active cruza-web
+systemctl is-active postgresql
+curl -I https://transparenciapb.org/
+curl -I https://transparenciapb.org/sitemap.xml
+df -h /data
+sudo fail2ban-client status
+sudo journalctl -p warning..alert -n 100 --no-pager
+```
+
+Se tudo está verde, registre causa raiz, comando executado e follow-up necessário.

--- a/docs/plano_novas_fontes.md
+++ b/docs/plano_novas_fontes.md
@@ -1,5 +1,13 @@
 # Plano: Novas Fontes de Dados (Iteracao 2)
 
+> ⚠️ **Documento legado.** Escrito antes da convenção atual de identificação
+> de fornecedores via `cpf_cnpj` completo (14 dígitos) + `EXISTS (estabelecimento)`.
+> Alguns exemplos de SQL abaixo usam o padrão antigo (`LEFT(...,8) = cnpj_basico`),
+> que sofre colisão entre CPFs e CNPJs com mesmo prefixo. Para queries
+> novas siga as convenções atuais documentadas em
+> [`architecture.md`](architecture.md) e [`queries-guide.md`](queries-guide.md).
+> Mantemos este plano como histórico das fontes propostas, não como guia técnico ativo.
+
 ## 1. TSE - Candidatos e Financiamento Eleitoral
 
 ### Dados

--- a/docs/privacidade.md
+++ b/docs/privacidade.md
@@ -1,6 +1,6 @@
-﻿# Política de privacidade e tratamento de dados pessoais
+# Política de privacidade e tratamento de dados pessoais
 
-**Última atualização:** 2026-05-16  
+**Última atualização:** 2026-05-16
 **Commit de referência:** `4982af7`
 
 Esta política explica como o **govbr-cruza-dados** e o portal

--- a/docs/privacidade.md
+++ b/docs/privacidade.md
@@ -1,0 +1,155 @@
+﻿# Política de privacidade e tratamento de dados pessoais
+
+**Última atualização:** 2026-05-16  
+**Commit de referência:** `4982af7`
+
+Esta política explica como o **govbr-cruza-dados** e o portal
+[transparenciapb.org](https://transparenciapb.org) tratam dados pessoais de
+visitantes, contributors, jornalistas e pessoas citadas em cruzamentos públicos.
+Ela expande a nota curta em [`../DATA-LICENSE.md`](../DATA-LICENSE.md), sem
+substituir os termos de cada fonte oficial. Não é parecer jurídico.
+
+## Quem somos
+
+O projeto é mantido por **Lucas Diniz**, pessoa física. Até existir estrutura
+pública formal, o mantenedor é referido como **owner**. O projeto não é entidade
+jurídica, órgão público nem jornalismo profissional; é uma iniciativa pessoal de
+transparência, controle social e pesquisa aplicada com dados públicos.
+
+## Quais dados coletamos
+
+### Diretamente do visitante
+
+| Origem | Dados | Uso |
+|---|---|---|
+| Formulário `/contato` | nome, e-mail, assunto e mensagem | responder contatos, correções e pedidos LGPD |
+| Logs do `/contato` | IP e User-Agent por mensagem | anti-abuse, rate limit e auditoria |
+| Umami self-hosted | visitas, paths, browser, OS e eventos | métricas de uso sem tracking cross-site |
+| Logs técnicos | IP, User-Agent, path, horário e status HTTP | segurança, diagnóstico e fail2ban |
+
+As mensagens são salvas em `contato_messages` no PostgreSQL. Quando a integração
+está ativa, a mensagem também é enviada via Resend para a caixa do projeto.
+Umami roda no mesmo domínio e não usa Google Analytics, Facebook Pixel ou rede de
+anúncios. GoAccess é usado para observabilidade operacional; a política pública
+é manter IP anonimizado em estatísticas históricas quando compatível com a
+investigação de abuso. Logs brutos podem conter IP completo e ficam restritos ao
+owner/operadores.
+
+### De fontes públicas
+
+O projeto integra 18+ fontes públicas brasileiras, em geral publicadas sob a Lei
+de Acesso à Informação  **Lei 12.527/2011 (LAI)**. Podem aparecer: CPFs
+parciais ou completos conforme a fonte, vínculos servidor-município, remuneração
+e cargo, valores de Bolsa Família no contexto de vínculo público, candidatos e
+dados TSE, sócios RFB, sanções CEIS/CNEP/CEAF, fornecedores, empenhos,
+pagamentos, contratos, licitações, emendas, PGFN, CPGF, SIAPE, BNDES, PNCP e
+ComprasNet.
+
+## Bases legais consideradas
+
+- **LGPD art. 7º, III**  tratamento pela administração pública para execução de
+  políticas públicas; aplica-se à coleta/divulgação pela fonte original.
+- **LGPD art. 7º, IV**  estudos com anonimização quando possível; o projeto
+  aplica minimização, especialmente CPF parcial.
+- **LGPD art. 26**  uso compartilhado pelo Poder Público, regime sob o qual as
+  fontes divulgam muitos datasets.
+- **Interesse público/transparência**  servidores públicos, fornecedores do
+  Estado, candidatos, sancionados e pessoas ligadas a recursos públicos têm
+  contexto de publicidade ampliado, observados necessidade e proporcionalidade.
+
+## Como tratamos os dados
+
+- **Armazenamento:** PostgreSQL 16 em VM Azure única, sem replicação geográfica
+  estruturada. Ver [`architecture.md`](architecture.md).
+- **Mascaramento:** CPFs em relatórios markdown versionados usam
+  `***.NNN.NNN-**`. O script `scripts/audit_report_identifiers.py --strict`
+  falha se encontrar CPF completo formatado (`NNN.NNN.NNN-NN`).
+- **Normalização:** joins técnicos usam `cpf_digitos`, `cpf_digitos_6` e
+  `cpf_cnpj_norm`; a UI evita expor identificador completo quando o parcial
+  basta. CNPJs completos podem aparecer por serem dados cadastrais públicos.
+- **Bolsa Família:** o portal mostra valores apenas durante período de vínculo
+  ativo do servidor público, mitigando exposição fora do contexto investigativo.
+- **Logs:** retenção operacional recomendada de 90 dias para access logs usados
+  por fail2ban/anti-abuse e até 6 meses para `journalctl`, sujeitos à rotação do
+  servidor.
+- **Backups:** ainda não há rotina estruturada de backup/restore; é um gap
+  operacional documentado em `ops.md`/runbooks de operação.
+
+## Direitos do titular (LGPD art. 18)
+
+Você pode solicitar: confirmação de tratamento; acesso; correção; anonimização,
+bloqueio ou eliminação; portabilidade quando aplicável; eliminação de dados
+tratados com consentimento; informação sobre compartilhamento; informação sobre
+não fornecer consentimento; e revogação de consentimento. Em dados públicos de
+interesse público, sanções obrigatórias e vínculos funcionais, alguns direitos
+podem ter limites legais.
+
+## Como exercer direitos
+
+Envie e-mail para
+[`contato@transparenciapb.org`](mailto:contato@transparenciapb.org) com assunto
+**`[LGPD]`**. Inclua, se possível: nome, CPF ou CPF mascarado, URL exata, fonte
+pública de origem e pedido específico. O objetivo é responder em até **15 dias
+úteis**. O pedido cobre dados pessoais identificados pelo solicitante que
+apareçam no portal ou repositório; não substitui solicitação às fontes oficiais.
+
+## Takedown
+
+Pedidos de remoção/anonimização podem ser aceitos quando: a fonte oficial removeu
+ou retificou o dado; a divulgação causar dano desproporcional; houver ordem
+judicial, decisão administrativa ou orientação aplicável da ANPD/STF; ou houver
+erro de matching por CPF parcial, homônimo ou inconsistência. Envie e-mail com
+assunto **`[LGPD] Takedown`**, URL, identificação do dado e base legal específica.
+
+## Limitações
+
+- Não controlamos as fontes originais; remover daqui não remove do Portal da
+  Transparência, TCE, CGU, Receita Federal ou outros portais.
+- CEIS, CNEP e CEAF têm publicidade obrigatória, com limites mais estreitos para
+  remoção.
+- Servidores públicos e fornecedores pagos com recurso público têm interesse
+  público relevante (LGPD art. 23), mitigando expectativa de sigilo sobre atos
+  funcionais, remuneração pública, contratos e sanções.
+- O projeto pode ocultar a apresentação pública sem alterar registros oficiais de
+  origem.
+
+## Cookies e armazenamento local
+
+| Item | Função |
+|---|---|
+| Sessão | estado técnico de navegação ou autenticação administrativa, quando necessário |
+| CSRF | proteção de formulários contra submissões forjadas, quando necessário |
+| Umami | analytics self-hosted, sem tracking cross-site e com respeito a Do Not Track |
+| `localStorage` Umami | marcação opcional de navegador de operador para depuração |
+
+Não usamos cookies de publicidade comportamental, retargeting, Google Analytics
+ou Facebook Pixel.
+
+## Compartilhamento com terceiros
+
+| Terceiro | Dados | Finalidade |
+|---|---|---|
+| Resend | dados inseridos no `/contato` e metadados mínimos | envio de e-mail ao owner |
+| Microsoft Azure | aplicação, banco, logs e arquivos hospedados | infraestrutura/hosting |
+| Fontes oficiais | não recebem dados do portal por padrão | são a origem dos datasets |
+
+Não vendemos dados pessoais nem compartilhamos listas de visitantes com
+anunciantes.
+
+## Crianças
+
+O portal não é destinado a menores de 12 anos e não coleta ativamente dados de
+crianças. Bases públicas podem conter dados de menores em situações específicas;
+nesses casos, a exposição deve ser minimizada e avaliada com cuidado.
+
+## Contato DPO
+
+Não há DPO formal; este é um gap operacional. O owner atua como ponto de contato
+LGPD. Use [`contato@transparenciapb.org`](mailto:contato@transparenciapb.org)
+com assunto **`[LGPD] descrição curta`**.
+
+## Histórico de modificações
+
+| Data | Mudança | Commit |
+|---|---|---|
+| 2026-05-16 | Primeira versão pública da política LGPD, expandindo `DATA-LICENSE.md`. | `4982af7` |

--- a/docs/queries-guide.md
+++ b/docs/queries-guide.md
@@ -58,7 +58,7 @@ Gaps existem (queries deprecadas). Pode reaproveitar números livres ou pegar o 
 - **Se passar de 30s:**
   1. **Índice cirúrgico** em [`sql/19_indices_queries.sql`](../sql/19_indices_queries.sql) (separado do schema base em `11_indices.sql` para evitar conflitos durante ETL).
   2. **MV pré-computada** em [`sql/12_views.sql`](../sql/12_views.sql) — útil quando muitas Q## compartilham o mesmo agregado. Ver [mv-guide.md](mv-guide.md).
-  3. **Override de timeout** em `_reg(..., timeout_sec=60)` — última opção; só justificado quando a query é raramente acionada na UI.
+  3. **Override de timeout** em `_reg(..., timeout=60)` — última opção; só justificado quando a query é raramente acionada na UI. (Note: o argumento é `timeout`, não `timeout_sec` — ver [`web/queries/registry.py:98`](../web/queries/registry.py).)
 - **Padrões medidos hoje:** 122/125 queries têm `ORDER BY`, 32/125 usam CTEs, 16/125 têm `LIMIT`. Sempre prefira `LIMIT` quando a UI renderiza só top-N.
 
 ## Identidade de fornecedor — caveat crítico
@@ -132,19 +132,35 @@ Use o conjunto que fizer sentido:
 
 ## Registrando na UI
 
+Há duas formas — prefira `_reg()` (padrão atual do código):
+
 ```python
 # web/queries/registry.py
+# Forma preferida — _reg() é wrapper conveniente
+_reg(
+    "Q199",                                              # qid
+    "Servidores com vínculo CPF→CNPJ em fornecedor pago",  # title
+    "Cruza CPF de servidor ativo com sócios de empresas pagas pela prefeitura.",  # desc
+    "conflito-interesses",                               # cat
+    SQL_Q199,                                            # sql_full
+    timeout=30,                                          # default; raise só se justificado
+    sql_dated=SQL_Q199_DATED,                            # opcional (variante temporal)
+)
+
+# Forma manual — QueryDef direto (raramente necessário)
 CIDADE_QUERIES["Q199"] = QueryDef(
     id="Q199",
     title="Servidores com vínculo CPF→CNPJ em fornecedor pago",
     description="Cruza CPF de servidor ativo com sócios de empresas pagas pela prefeitura.",
     category="conflito-interesses",
-    sql_count=SQL_Q199_COUNT,
+    sql_count=SQL_Q199_COUNT,    # query de contagem (paginação)
     sql_full=SQL_Q199,
     sql_full_dated=SQL_Q199_DATED,  # opcional
     timeout_sec=30,
 )
 ```
+
+Assinaturas reais em [`web/queries/registry.py:7-18,98`](../web/queries/registry.py).
 
 Categorias atualmente em uso:
 

--- a/docs/queries-guide.md
+++ b/docs/queries-guide.md
@@ -1,0 +1,208 @@
+# Queries guide — adicionando uma Q##
+
+Este guia cobre o ciclo de vida de uma query nova no `govbr-cruza-dados`. Para contexto arquitetural, ver [architecture.md](architecture.md); para registrá-la na UI, ver [web-guide.md](web-guide.md).
+
+## Panorama
+
+- **125 queries ativas** em **17 arquivos** `queries/*.sql`, numeradas globalmente de `Q01` a `Q310` (com gaps históricos).
+- Executor: [`etl/run_queries.py`](../etl/run_queries.py) com parser custom `split_sql_statements` que trata aspas simples/duplas (`''` escapado). **Dollar-quoting (`$$...$$`) ainda não é suportado** — issue P0 #9.
+- Saída padrão: `resultados/Q##_<titulo>.csv` (uma por query).
+- Registro na UI web em [`web/queries/registry.py`](../web/queries/registry.py).
+
+## Ciclo de vida
+
+```mermaid
+flowchart TD
+    A[Definir tema/objeto da investigação] --> B[Escolher Q## livre<br/>(grep -h '-- Q' queries/*.sql)]
+    B --> C[Header obrigatório<br/>-- Q##: Titulo curto]
+    C --> D[Escrever SQL<br/>placeholders %(municipio)s, etc.]
+    D --> E[EXPLAIN ANALYZE local]
+    E --> F{Custo > 30s?}
+    F -- não --> G[python -m etl.run_queries --query Q##]
+    F -- sim --> H[Adicionar índice em<br/>sql/19_indices_queries.sql]
+    H --> I{Ainda lento?}
+    I -- sim --> J[Pré-computar via MV<br/>em sql/12_views.sql]
+    I -- não --> G
+    J --> G
+    G --> K{Query da UI?}
+    K -- sim --> L[Registrar via _reg em<br/>web/queries/registry.py]
+    K -- não --> M[Relatório markdown<br/>opcional em relatorios/]
+    L --> M
+    M --> N[PR]
+```
+
+## Header obrigatório
+
+```sql
+-- Q199: Servidores com vínculo CPF→CNPJ em fornecedor pago
+WITH ...
+```
+
+O regex em `etl/run_queries.py:67` é literalmente `r"(-- Q(\d+): ([^\n]+)\n.*?)(?=-- Q\d+:|$)"`. Sem o header, a query não é detectada e nem o `run_queries.py` nem a UI a encontram.
+
+## Numeração
+
+A numeração é **global** — não reinicia por arquivo. Antes de escolher um número:
+
+```bash
+grep -h '^-- Q' queries/*.sql | sort -u
+grep -E '"Q[0-9]+"' web/queries/registry.py
+```
+
+Gaps existem (queries deprecadas). Pode reaproveitar números livres ou pegar o próximo após o maior em uso.
+
+## Performance
+
+- **Timeout default:** `QueryDef.timeout_sec = 30` ([`web/queries/registry.py:15`](../web/queries/registry.py)). Aplicado como `SET statement_timeout = 30000` em `web/db.py:53`.
+- **EXPLAIN ANALYZE obrigatório** antes do PR. Se a query consome MV nova, lembre que `21_views.py` deve ter rodado primeiro.
+- **Se passar de 30s:**
+  1. **Índice cirúrgico** em [`sql/19_indices_queries.sql`](../sql/19_indices_queries.sql) (separado do schema base em `11_indices.sql` para evitar conflitos durante ETL).
+  2. **MV pré-computada** em [`sql/12_views.sql`](../sql/12_views.sql) — útil quando muitas Q## compartilham o mesmo agregado. Ver [mv-guide.md](mv-guide.md).
+  3. **Override de timeout** em `_reg(..., timeout_sec=60)` — última opção; só justificado quando a query é raramente acionada na UI.
+- **Padrões medidos hoje:** 122/125 queries têm `ORDER BY`, 32/125 usam CTEs, 16/125 têm `LIMIT`. Sempre prefira `LIMIT` quando a UI renderiza só top-N.
+
+## Identidade de fornecedor — caveat crítico
+
+Use **`cpf_cnpj` completo (14 dígitos)**, **NÃO** `cnpj_basico` (8 dígitos):
+
+```sql
+-- ❌ ERRADO: cnpj_basico colide com CPFs cujos primeiros 8 dígitos coincidem
+SELECT cnpj_basico, SUM(valor)
+FROM tce_pb_despesa
+GROUP BY cnpj_basico;
+
+-- ✅ CORRETO: cpf_cnpj 14 dígitos + filtro de existência em estabelecimento
+SELECT d.cpf_cnpj, SUM(d.valor)
+FROM tce_pb_despesa d
+WHERE EXISTS (
+    SELECT 1 FROM estabelecimento e
+    WHERE e.cpf_cnpj = d.cpf_cnpj
+)
+GROUP BY d.cpf_cnpj;
+```
+
+Sem o `EXISTS`, CPFs de pessoa física entram no resultado como se fossem empresas, inflando contagens e gerando falsos positivos em relatórios. Ver convenção em [CONTRIBUTING.md](../CONTRIBUTING.md) e nas instruções do repo.
+
+## TCE-PB quirks
+
+Cruzar `tce_pb_licitacao` com `tce_pb_despesa` exige cuidado:
+
+| Campo | Em `licitacao` | Em `despesa` |
+|---|---|---|
+| `numero_licitacao` | `'00003/2025'` (com `/`) | `'000032025'` (sem separador) |
+| `modalidade_licitacao` | sufixo `LIC` ou similar | sufixo distinto |
+
+**Chave canônica de licitação** no mesmo município: a tripla `(codigo_ug, modalidade_licitacao, numero_licitacao)`. Sem `codigo_ug`, podem existir **7+ licitações distintas com mesmo `numero_licitacao` em um único município** — chave incompleta gera produto cartesiano.
+
+```sql
+-- ✅ chave canônica completa
+JOIN tce_pb_licitacao l
+  ON l.municipio       = d.municipio
+ AND l.codigo_ug       = d.codigo_ug
+ AND l.modalidade      = d.modalidade_licitacao
+ AND REPLACE(l.numero_licitacao, '/', '') = d.numero_licitacao
+```
+
+## sql_full vs sql_full_dated
+
+Variante datada aceita 6 placeholders opcionais — a UI passa só os que o filtro ativo definiu:
+
+```sql
+-- Q199 (sql_full)
+WITH base AS (
+  SELECT * FROM tce_pb_despesa
+  WHERE municipio = %(municipio)s
+)
+SELECT ...
+
+-- Q199 (sql_full_dated) — mesma query, com janela temporal
+WITH base AS (
+  SELECT * FROM tce_pb_despesa
+  WHERE municipio = %(municipio)s
+    AND data_empenho BETWEEN %(data_inicio)s AND %(data_fim)s
+)
+SELECT ...
+```
+
+Use o conjunto que fizer sentido:
+
+- **Datas exatas:** `%(data_inicio)s`, `%(data_fim)s` (DATE).
+- **Por ano:** `%(ano_inicio)s`, `%(ano_fim)s` (INT).
+- **Por ano-mês:** `%(ano_mes_inicio)s`, `%(ano_mes_fim)s` (`'YYYY-MM'`).
+
+## Registrando na UI
+
+```python
+# web/queries/registry.py
+CIDADE_QUERIES["Q199"] = QueryDef(
+    id="Q199",
+    title="Servidores com vínculo CPF→CNPJ em fornecedor pago",
+    description="Cruza CPF de servidor ativo com sócios de empresas pagas pela prefeitura.",
+    category="conflito-interesses",
+    sql_count=SQL_Q199_COUNT,
+    sql_full=SQL_Q199,
+    sql_full_dated=SQL_Q199_DATED,  # opcional
+    timeout_sec=30,
+)
+```
+
+Categorias atualmente em uso:
+
+- `fornecedores-irregulares`
+- `conflito-interesses`
+- `politico-eleitoral`
+- `licitacao-concorrencia`
+- `cruzamento-estado-municipio`
+- `orcamento-financeiro`
+
+Traduções leigas (Modo Cidadão) ficam em `_LAY_TEXT` no mesmo arquivo — opcionais.
+
+## Exemplo concreto
+
+```sql
+-- Q199: Servidores com vínculo CPF→CNPJ em fornecedor pago
+-- EXPLAIN ANALYZE local (joao-pessoa, 2024):
+--   Aggregate (cost=1842..1843 rows=1)  actual time=2103 ms
+--   → HashAgg em socio (cpf_socio_norm) usa idx_socio_cpf_norm
+WITH fornecedores AS (
+    SELECT DISTINCT d.cpf_cnpj
+    FROM tce_pb_despesa d
+    WHERE d.municipio = %(municipio)s
+      AND EXISTS (SELECT 1 FROM estabelecimento e WHERE e.cpf_cnpj = d.cpf_cnpj)
+)
+SELECT s.nome_servidor, s.cpf_digitos, f.cpf_cnpj AS cnpj_fornecedor, soc.nome_socio
+FROM fornecedores f
+JOIN socio   soc ON soc.cnpj_basico = LEFT(f.cpf_cnpj, 8)
+JOIN tce_pb_servidor s ON s.cpf_digitos = soc.cpf_socio_norm
+WHERE s.municipio = %(municipio)s
+  AND s.situacao = 'ATIVO'
+ORDER BY s.nome_servidor;
+```
+
+Rodar isolada:
+
+```bash
+python -m etl.run_queries --query Q199
+ls resultados/Q199_*.csv
+```
+
+## Relatório markdown (opcional)
+
+Investigações narradas vão em `relatorios/relatorio_<tema>.md`. Convenções:
+
+- **Mascarar CPFs:** `***.NNN.NNN-**` (apenas dígitos do meio expostos).
+- **CNPJs completos:** sempre validados — devem existir em `empresa`/`estabelecimento`.
+- **Auditoria automática** antes do PR:
+
+```bash
+python scripts/audit_report_identifiers.py --report relatorios/relatorio_meu_tema.md --strict
+```
+
+O script valida CNPJs contra o banco local; CPFs são best-effort (a maioria está mascarada nos dados-fonte).
+
+## Relacionados
+
+- [architecture.md](architecture.md) — overview e onde Q## se encaixam no pipeline.
+- [mv-guide.md](mv-guide.md) — quando promover query lenta para MV.
+- [cache.md](cache.md) — como o resultado é warmed em `web_cache` para a UI.
+- [web-guide.md](web-guide.md) — registrar e renderizar a query na rota da cidade.

--- a/docs/web-guide.md
+++ b/docs/web-guide.md
@@ -1,0 +1,208 @@
+# Web guide — adicionando query, rota, template ou componente MD3
+
+Este guia complementa [architecture.md](architecture.md) e o [glossario.md](glossario.md) com os fluxos práticos do frontend.
+
+## Stack
+
+- **Backend:** FastAPI + Uvicorn (`web/main.py`), pool de conexões `psycopg2` em [`web/db.py`](../web/db.py).
+- **Templates:** Jinja2 SSR — sem React, sem SPA. Cada rota retorna HTML completo.
+- **JS:** scripts clássicos (não-módulos) carregados em ordem fixa por `JS_FILES` em [`web/main.py`](../web/main.py) (linhas ~363-439). Funções compartilhadas via globais.
+- **CSS:** Material Design 3 tokens + camadas (layers), zero Tailwind.
+- **Mapa:** Leaflet em `web/static/js/components/mapa.js`.
+- **Build de assets:** esbuild (`scripts/build-assets.mjs`) gera bundles com content-hash em `web/static/dist/manifest.json`.
+- **SQL:** raw, sem ORM. Toda query passa por `cached_query()`, `read_web_cache()` ou `execute_query()` de [`web/db.py`](../web/db.py).
+
+## Fluxo de um request
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant N as Nginx (rate limit)
+    participant R as FastAPI route
+    participant D as web/db.py
+    participant PG as PostgreSQL
+    participant T as Jinja2
+
+    B->>N: GET /cidade/joao-pessoa
+    N->>R: proxy (host allowed, RPS ok)
+    R->>D: read_web_cache(qid="KPI_SUMMARY", municipio="João Pessoa")
+    alt cache hit
+        D-->>R: (cols, rows)
+        R->>T: render(cidade.html, ctx)
+        T-->>B: HTML SSR
+    else cache miss em rota cache-only
+        D-->>R: None
+        R-->>B: 503 (warm pendente)
+    else live fallback (rotas leves: perfil, autocomplete)
+        R->>D: execute_query(sql, timeout=TIMEOUT_PROFILE=3s)
+        D->>PG: SET statement_timeout=3000; SELECT ...
+        PG-->>D: rows ou timeout
+        D-->>R: (cols, rows)
+        R->>T: render
+        T-->>B: HTML
+    end
+```
+
+> **Cache-only by design:** rotas pesadas (`/api/cidade/q/*`) só leem `web_cache`; nunca tocam Postgres em request quente. Quem popula o cache é [`web/warm_cache.py`](../web/warm_cache.py). Detalhes em [cache.md](cache.md).
+
+## 1. Adicionando uma query nova ao registry
+
+As Q## do modo deep-dive são registradas em [`web/queries/registry.py`](../web/queries/registry.py) via `QueryDef`:
+
+```python
+_reg(
+    qid="Q199",
+    titulo="Servidores com vínculo CPF→CNPJ em fornecedor pago",
+    categoria="conflito-interesses",  # ver categorias existentes
+    sql_full=SQL_Q199,
+    sql_full_dated=SQL_Q199_DATED,    # opcional
+    timeout_sec=30,                   # default; raise só se justificado
+)
+```
+
+Placeholders nomeados aceitos:
+
+| Placeholder | Quando aparece | Origem |
+|---|---|---|
+| `%(municipio)s` | sempre (filtro principal) | path param |
+| `%(data_inicio)s`, `%(data_fim)s` | variante `_dated` (datas exatas) | UI date filter |
+| `%(ano_inicio)s`, `%(ano_fim)s` | variante `_dated` por ano | UI date filter |
+| `%(ano_mes_inicio)s`, `%(ano_mes_fim)s` | variante `_dated` por ano-mês | UI date filter |
+
+**Checklist:**
+
+1. Cabeçalho `-- Q##: Titulo` no `.sql` (parser de `etl/run_queries.py` depende dele — ver [queries-guide.md](queries-guide.md)).
+2. Rodar `EXPLAIN ANALYZE` localmente.
+3. Se passar de 30s ou tiver `Seq Scan` em tabelões: adicionar índice em [`sql/19_indices_queries.sql`](../sql/19_indices_queries.sql).
+4. Categoria existente: `fornecedores-irregulares`, `conflito-interesses`, `politico-eleitoral`, `licitacao-concorrencia`, `cruzamento-estado-municipio`, `orcamento-financeiro`.
+5. Criar índice/MV se a query for cache-eligible — o warmer só consegue popular se rodar dentro do timeout em produção.
+
+Detalhes completos em [queries-guide.md](queries-guide.md).
+
+## 2. Adicionando uma rota nova
+
+Crie um módulo em `web/routes/<feature>.py`:
+
+```python
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from web import db
+from web.main import templates  # ou injete via dependency
+
+router = APIRouter()
+
+
+@router.get("/feature/{municipio}", response_class=HTMLResponse)
+async def feature_page(request: Request, municipio: str):
+    cache = db.read_web_cache("FEATURE_KEY", municipio)
+    if cache is None:
+        # 503 cache-only; warm.py é quem popula
+        return templates.TemplateResponse("503_warm.html", {"request": request}, status_code=503)
+    cols, rows = cache
+    return templates.TemplateResponse(
+        "feature.html",
+        {"request": request, "cols": cols, "rows": rows, "municipio": municipio},
+    )
+```
+
+Registre em `web/main.py`:
+
+```python
+from web.routes.feature import router as feature_router
+app.include_router(feature_router)
+```
+
+**Regras de ouro:**
+
+- **Sem ORM.** Toda SQL é raw, parametrizada via `%(name)s` (psycopg2). f-strings em SQL só com whitelist hardcoded (ver caveat em `routes/cidade.py:1450-1466`).
+- **Use `read_web_cache()` para queries pesadas** — request quente nunca espera Postgres mais que `TIMEOUT_PROFILE=3s`.
+- **Para queries leves** (autocomplete, perfil simples), use `cached_query()` com `timeout_sec=TIMEOUT_AUTOCOMPLETE` (2s) ou `TIMEOUT_PROFILE` (3s) de [`web/config.py`](../web/config.py).
+- **POST em `/api/*`** passa pelo Origin guard de `web/main.py:65-110` — só hosts em `_ALLOWED_API_HOSTS` (`transparenciapb.org`, `localhost`...).
+
+## 3. Adicionando um template novo
+
+Estenda `base.html` e preencha os blocks SEO:
+
+```html
+{% extends "base.html" %}
+
+{% block title %}Minha feature — {{ municipio }} | transparenciapb.org{% endblock %}
+{% block meta_description %}Resumo curto, 140-160 chars, para SERP.{% endblock %}
+{% block og_title %}{{ self.title() }}{% endblock %}
+{% block og_image %}{{ asset_url('og-default.png') }}{% endblock %}
+
+{% block content %}
+  <link rel="stylesheet" href="{{ asset_url('feature.css') }}">
+  <article>
+    <h1>{{ municipio }}</h1>
+    <!-- ... -->
+  </article>
+{% endblock %}
+```
+
+- `asset_url('feature.css')` resolve via manifest (`web/static/dist/manifest.json`) com hash de conteúdo; em dev sem build, devolve o arquivo cru com `?v=ASSET_VERSION`.
+- `canonical_url(request)` é Jinja global (`web/main.py:589`) — use em `<link rel="canonical">`.
+- Não use `i18n`: o projeto é **PT-BR hardcoded** (decisão de produto, não roadmap).
+
+## 4. Adicionando um componente Material Design 3
+
+Os tags `<md-*>` são custom elements do `@material/web` carregados via importmap em `base.html:115-134` (módulo deferido em `web/static/js/md3/imports.js`).
+
+**Race condition real:** os custom elements fazem upgrade async. Qualquer JS clássico que toque propriedades de um `<md-*>` (ex: `.value`, `.selected`, `.open`) **deve** esperar o helper de [`web/static/js/lib/md3-ready.js`](../web/static/js/lib/md3-ready.js):
+
+```html
+<md-filled-select id="filtro-ano">
+  <md-select-option value="2024">2024</md-select-option>
+  <md-select-option value="2025">2025</md-select-option>
+</md-filled-select>
+
+<script>
+  window.whenMD3Ready(() => {
+    const sel = document.getElementById("filtro-ano");
+    sel.value = "2025";              // safe — upgrade já aconteceu
+    sel.addEventListener("change", e => { /* ... */ });
+  });
+</script>
+```
+
+Sem `whenMD3Ready`, em mobile e em conexões lentas o setter executa antes do upgrade — set vira no-op, listener pode ficar órfão.
+
+**Adicione o JS** ao final do array `JS_FILES` em `web/main.py:363-439`, respeitando dependências (helpers como `lib/format.js` precisam vir antes dos componentes que os usam).
+
+## Build pipeline
+
+```bash
+npm install                # uma vez
+npm run build              # esbuild concat + minify + sourcemap → web/static/dist/
+npm run build:check        # smoke usado no CI
+```
+
+- Lista de entradas é lida por `scripts/build-assets.mjs:75-105` a partir de `JS_FILES` em `web/main.py`.
+- Output: `web/static/dist/<nome>.<hash>.min.js` + `manifest.json` mapeando nome lógico → URL com hash.
+- `asset_url('cidade.js')` busca no manifest em runtime; com `ASSETS_STRICT=1` ausência de bundle falha (prod), sem strict cai pro arquivo cru (dev).
+
+## Caveats reais
+
+- **f-strings em SQL com lista `IN`:** `routes/cidade.py:1450-1466` ainda monta `IN (...)` por concatenação. Há issue aberta para helper central; até lá, **nunca interpolar input do usuário** — só constantes whitelisted.
+- **Templates com `|safe`:** `templates/cidade.html:120-160` injeta HTML com `|safe` para rich snippets. Política: autoescape ligado por padrão (Jinja default) + `|safe` só em strings montadas no servidor com whitelist.
+- **`/api/cache/invalidate`** exige header `X-Admin-Token` (PR #118). Fail-closed: se `CACHE_INVALIDATE_TOKEN` não estiver no `.env`, endpoint responde 503. Ver `web/routes/cidade.py:1406-1430`.
+- **Service Worker:** `web/static/sw.js` faz stale-while-revalidate para assets estáticos. Bump `ASSET_VERSION` (atualmente `"112"` em `web/main.py:441`) quando publicar mudança que precise invalidar SW.
+- **Origin guard** bloqueia `POST /api/*` sem Origin/Referer válido. Bots casuais (curl, scrapy default) são filtrados; é defesa em profundidade, não autenticação.
+- **Acessibilidade:** skip link + ARIA estão em `base.html` e templates principais. Auditoria automatizada (axe/lighthouse no CI) é issue #131, ainda aberta.
+
+## Testando localmente
+
+```bash
+pip install -e .[web]
+# Postgres rodando com schema + cache populado:
+python -m web.warm_cache --pb           # popula web_cache para 223 munis PB
+python -m uvicorn web.main:app --port 8000 --reload
+# smoke estático:
+python -m compileall web -q
+```
+
+Para `web.warm_cache` e cache em geral, ver [cache.md](cache.md).
+Para mudanças em queries Q##, ver [queries-guide.md](queries-guide.md).
+Para mudanças em MVs, ver [mv-guide.md](mv-guide.md).

--- a/docs/web-guide.md
+++ b/docs/web-guide.md
@@ -51,14 +51,25 @@ sequenceDiagram
 As Q## do modo deep-dive são registradas em [`web/queries/registry.py`](../web/queries/registry.py) via `QueryDef`:
 
 ```python
+# Padrão: _reg() (positional + kwargs) — chama QueryDef internamente
 _reg(
-    qid="Q199",
-    titulo="Servidores com vínculo CPF→CNPJ em fornecedor pago",
-    categoria="conflito-interesses",  # ver categorias existentes
-    sql_full=SQL_Q199,
-    sql_full_dated=SQL_Q199_DATED,    # opcional
-    timeout_sec=30,                   # default; raise só se justificado
+    "Q199",                                         # qid
+    "Servidores com vínculo CPF→CNPJ em fornecedor pago",  # title
+    "Cruza CPF normalizado entre servidor e sócio de fornecedor pago no município.",  # description
+    "conflito-interesses",                          # category
+    SQL_Q199,                                       # sql_full
+    timeout=30,                                     # default; raise só se justificado
+    sql_dated=SQL_Q199_DATED,                       # opcional (variante temporal)
+    title_lay="Servidor que é sócio de empresa contratada",
+    desc_lay="...",
 )
+```
+
+Assinatura real de `_reg` em [`web/queries/registry.py:98`](../web/queries/registry.py):
+
+```python
+def _reg(qid, title, desc, cat, sql_full, timeout=30, sql_dated=None, title_lay="", desc_lay=""):
+    ...
 ```
 
 Placeholders nomeados aceitos:

--- a/docs/web-guide.md
+++ b/docs/web-guide.md
@@ -116,10 +116,10 @@ app.include_router(feature_router)
 
 **Regras de ouro:**
 
-- **Sem ORM.** Toda SQL é raw, parametrizada via `%(name)s` (psycopg2). f-strings em SQL só com whitelist hardcoded (ver caveat em `routes/cidade.py:1450-1466`).
+- **Sem ORM.** Toda SQL é raw, parametrizada via `%(name)s` (psycopg2). f-strings em SQL só com whitelist hardcoded (ver caveat em `web/routes/cidade.py` nas funções que montam `IN (...)` por concatenação).
 - **Use `read_web_cache()` para queries pesadas** — request quente nunca espera Postgres mais que `TIMEOUT_PROFILE=3s`.
 - **Para queries leves** (autocomplete, perfil simples), use `cached_query()` com `timeout_sec=TIMEOUT_AUTOCOMPLETE` (2s) ou `TIMEOUT_PROFILE` (3s) de [`web/config.py`](../web/config.py).
-- **POST em `/api/*`** passa pelo Origin guard de `web/main.py:65-110` — só hosts em `_ALLOWED_API_HOSTS` (`transparenciapb.org`, `localhost`...).
+- **POST em `/api/*`** passa pelo Origin guard de [`web/main.py:99-118`](../web/main.py) — só hosts em `_ALLOWED_API_HOSTS` (`transparenciapb.org`, `localhost`...).
 
 ## 3. Adicionando um template novo
 
@@ -185,8 +185,8 @@ npm run build:check        # smoke usado no CI
 
 ## Caveats reais
 
-- **f-strings em SQL com lista `IN`:** `routes/cidade.py:1450-1466` ainda monta `IN (...)` por concatenação. Há issue aberta para helper central; até lá, **nunca interpolar input do usuário** — só constantes whitelisted.
-- **Templates com `|safe`:** `templates/cidade.html:120-160` injeta HTML com `|safe` para rich snippets. Política: autoescape ligado por padrão (Jinja default) + `|safe` só em strings montadas no servidor com whitelist.
+- **f-strings em SQL com lista `IN`:** `web/routes/cidade.py` (várias funções de detalhes) monta `IN (...)` por concatenação. Há issue aberta para helper central; até lá, **nunca interpolar input do usuário** — só constantes whitelisted.
+- **Templates com `|safe`:** `web/templates/results/cidade.html` injeta HTML com `|safe` para rich snippets (linhas em torno de `202`, `215-216`, `433`). Política: autoescape ligado por padrão (Jinja default) + `|safe` só em strings montadas no servidor com whitelist.
 - **`/api/cache/invalidate`** exige header `X-Admin-Token` (PR #118). Fail-closed: se `CACHE_INVALIDATE_TOKEN` não estiver no `.env`, endpoint responde 503. Ver `web/routes/cidade.py:1406-1430`.
 - **Service Worker:** `web/static/sw.js` faz stale-while-revalidate para assets estáticos. Bump `ASSET_VERSION` (atualmente `"112"` em `web/main.py:441`) quando publicar mudança que precise invalidar SW.
 - **Origin guard** bloqueia `POST /api/*` sem Origin/Referer válido. Bots casuais (curl, scrapy default) são filtrados; é defesa em profundidade, não autenticação.


### PR DESCRIPTION
## Resumo

Documentação técnica completa para contributors externos. **18 docs novos** (~187 KB) + **16 diagramas Mermaid** + atualização da seção "Documentação adicional" do README.

Identificado como gap pelos 11 agentes da análise distribuída inicial (síntese consolidada). Implementado em 5 agentes paralelos (1 Opus + 1 GPT por escopo) + revisão final por GPT 5.5 que pegou 2 críticos + 7 importantes + 2 nits (todos corrigidos antes deste PR).

## Conteúdo

### Fundação (escrita manualmente)

| Arquivo | Tamanho | Mermaid | Resumo |
|---|---|---|---|
| `docs/architecture.md` | 17 KB | 7 | Landing page arquitetural — overview, data flow ETL, entity resolution, ERD, MV layers L1→L2→L3, shadow rewarm sequence, deploy pipeline |
| `docs/glossario.md` | 22 KB | — | 60+ termos do domínio (empenho, UG, CEIS, LGPD, etc.) em 10 categorias |

### Guias por área (5 agentes paralelos)

| Arquivo | Tamanho | Mermaid | Origem |
|---|---|---|---|
| `docs/etl-guide.md` | 12 KB | 1 | Como adicionar fase ETL clássica |
| `docs/etl-incremental-guide.md` | 13 KB | 1 | 8 passos para adicionar spec incremental (princípios P1-P6) |
| `docs/web-guide.md` | 10 KB | 1 | Como adicionar query/rota/template/MD3 |
| `docs/queries-guide.md` | 8 KB | 1 | Como adicionar Q## (header, EXPLAIN, índices) |
| `docs/mv-guide.md` | 7 KB | 1 | Como adicionar MV (camadas L1/L2/L3) |
| `docs/cache.md` | 8 KB | 1 | `web_cache` + shadow rewarm |
| `docs/deploy.md` | 15 KB | 1 | 14 inputs do `deploy.yml` + cenários + OIDC setup |
| `docs/ops.md` | 14 KB | 1 | Runbooks (rollback, restore, backup, runner repair, troubleshoot warm) |
| `docs/privacidade.md` | 8 KB | — | Política LGPD pública |
| `docs/onboarding.md` | 11 KB | 1 | Walk-through clone → `uvicorn` |

### ADRs (Architecture Decision Records)

| Arquivo | Tamanho |
|---|---|
| `docs/adr/README.md` | 4 KB (index + template) |
| `docs/adr/0001-no-pandas.md` | 4 KB |
| `docs/adr/0002-mv-layered.md` | 5 KB |
| `docs/adr/0003-shadow-rewarm.md` | 4 KB |
| `docs/adr/0004-etl-incremental-framework.md` | 6 KB |
| `docs/adr/0005-no-orm-web.md` | 5 KB |

### Adicionais

- `README.md` — seção "Documentação adicional" reescrita com 5 subseções (4 categorias + referência)
- `docs/plano_novas_fontes.md` — disclaimer "LEGADO" no topo (exemplos SQL antigos contradizem convenção `cpf_cnpj` atual)

## Processo

1. **D1 Fundação** (manualmente, ~3h) — `architecture.md` + `glossario.md`
2. **D2-D6** (5 agentes paralelos, ~5min real) — guias temáticos e ADRs
3. **Revisor consistência** (GPT 5.5) — cruzou 222 links Markdown, validou contra código real, conferiu terminologia, detectou Mermaid syntax issues
4. **Fix-ups** — 2 críticos + 7 importantes + 2 nits corrigidos

Detalhes dos fix-ups no commit `c0c7fca`.

## Validações OK (do revisor final)

- **222 links Markdown** verificados, **0 quebrados**, 0 leaks `C:\...`
- **16 diagramas Mermaid** com sintaxe válida (após fix do `COL1` em `architecture.md:113`)
- **Terminologia** consistente entre todos os docs (siglas, MV layers, P1-P6, timeouts, semântica `invalidate_cache_keys` vs `rewarm_cache_keys`)
- **TIMEOUT_PROFILE=3, TIMEOUT_AUTOCOMPLETE=2, TIMEOUT_QUERY_LIGHT=15** batem com `web/config.py`
- **14 inputs** documentados batem com `.github/workflows/deploy.yml:27-109`
- **P1-P6** princípios consistentes entre `etl/incremental/README.md`, `etl-incremental-guide.md` e ADR-0004
- **Narrativa de leitura** (`architecture` → `glossario` → guias → operacionais → ADRs) bem encadeada

## Como testar

```bash
# Validar Mermaid via GitHub (basta abrir o PR no browser)
gh pr view --web

# Validar links internos
cd docs
grep -rE '\]\([^)]+\)' . | wc -l    # ~222 links

# Validar nenhum CPF não-mascarado nos docs
python scripts/audit_report_identifiers.py --strict
```

---

🤖 Esforço distribuído de 5 agentes paralelos + revisor consistency. Memória "PR workflow" salva para futuras sessões de docs em escala.
