### PR TITLE
fix(docs): corrigir sintaxe Mermaid que quebrava render no GitHub

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -292,28 +292,28 @@ A tabela `web_cache` armazena resultados pré-computados de queries pesadas. Fas
 
 ```mermaid
 sequenceDiagram
-    participant Op as Owner / Workflow
+    participant Op as Owner ou Workflow
     participant Warm as warm_cache.py
-    participant Cache as web_cache (live)
-    participant Pending as web_cache (__pending)
+    participant Cache as web_cache live
+    participant Pending as web_cache __pending
     participant Web as FastAPI
 
-    Note over Cache,Web: Estado: live serve todos os usuários
+    Note over Cache,Web: Estado — live serve todos os usuários
 
     Op->>Warm: rewarm_cache_keys=Q65
-    Warm->>Pending: INSERT INTO Q65__pending<br/>(execução completa)
+    Warm->>Pending: INSERT INTO Q65__pending<br/>execução completa
 
     par Live continua servindo
-        Web->>Cache: SELECT Q65 (live)
+        Web->>Cache: SELECT Q65 live
         Cache-->>Web: rows existentes
     and Warm escreve em shadow
         Warm->>Pending: queries calmas, 12-18h
     end
 
-    alt Todas as queries Q65 succeeded (fail==0)
+    alt Todas as queries Q65 succeeded — fail==0
         Warm->>Cache: SWAP ATÔMICO<br/>RENAME Q65__pending → Q65
         Note over Cache: Nova versão visível
-    else Qualquer query Q65 falhou (fail>0)
+    else Qualquer query Q65 falhou — fail&gt;0
         Warm->>Pending: ABORT — descarta __pending
         Note over Cache: Live mantido intacto
     end

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -49,31 +49,31 @@ Configuração relevante:
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Op as Operador (deploy.yml)
+    participant Op as Operador — deploy.yml
     participant W as warm_cache
     participant PG as web_cache
-    participant UI as cruza-web (live)
+    participant UI as cruza-web — live
 
-    Op->>W: WARM_REWARM_KEYS="Q65,PERFIL"
-    Note over W: REWARM_KEYS = {Q65, PERFIL}<br/>+ auto-expand: KPI_SUMMARY entra<br/>(via CACHE_DEPENDENCY_GRAPH)
+    Op->>W: WARM_REWARM_KEYS=Q65,PERFIL
+    Note over W: REWARM_KEYS = Q65, PERFIL<br/>+ auto-expand: KPI_SUMMARY entra<br/>via CACHE_DEPENDENCY_GRAPH
 
     loop para cada município
-        W->>PG: INSERT em "Q65__pending"
-        W->>PG: INSERT em "PERFIL__pending"
-        W->>PG: INSERT em "KPI_SUMMARY__pending"<br/>(lê dep shadow, strict no-fallback)
-        UI->>PG: SELECT WHERE query_id='Q65' AND municipio=X
-        PG-->>UI: rows ANTIGOS (live intacto)
+        W->>PG: INSERT em Q65__pending
+        W->>PG: INSERT em PERFIL__pending
+        W->>PG: INSERT em KPI_SUMMARY__pending<br/>lê dep shadow, strict no-fallback
+        UI->>PG: SELECT WHERE query_id=Q65 AND municipio=X
+        PG-->>UI: rows ANTIGOS — live intacto
     end
 
     alt fail == 0 para TODAS as qids em shadow
         W->>PG: BEGIN
-        W->>PG: UPSERT live ← pending (atômico, todos qids)
+        W->>PG: UPSERT live ← pending — atômico, todos qids
         W->>PG: DELETE __pending rows
         W->>PG: COMMIT
         Note over UI,PG: readers passam a ver NOVOS<br/>todos os qids simultaneamente
-    else fail > 0 em qualquer qid
+    else fail &gt; 0 em qualquer qid
         W->>W: ABORT swap
-        Note over PG: live ANTIGO mantido<br/>__pending será descartado no próximo deploy<br/>(Reset shadow rows step)
+        Note over PG: live ANTIGO mantido<br/>__pending será descartado no próximo deploy<br/>via Reset shadow rows step
     end
 ```
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -10,14 +10,14 @@ A VM fica barata em modo web (`Standard_B2as_v2` + Standard SSD) e sobe temporar
 sequenceDiagram
     autonumber
     actor Owner
-    participant GH as GitHub Actions<br/>workflow_dispatch
-    participant AZ as Azure OIDC<br/>preflight/postflight
-    participant VM as Azure VM<br/>self-hosted runner
-    participant DB as PostgreSQL/web_cache
+    participant GH as GitHub Actions
+    participant AZ as Azure OIDC
+    participant VM as Azure VM
+    participant DB as PostgreSQL + web_cache
     participant WEB as Nginx + cruza-web
 
-    Owner->>GH: workflow_dispatch<br/>14 inputs
-    GH->>AZ: preflight<br/>login OIDC
+    Owner->>GH: workflow_dispatch — 14 inputs
+    GH->>AZ: preflight — login OIDC
     AZ->>AZ: decide B2/B4 + Standard/Premium
     alt etl_phase != web OU warm/rewarm
         AZ->>AZ: deallocate VM
@@ -29,7 +29,7 @@ sequenceDiagram
     end
     AZ->>VM: wait SSH:22
 
-    GH->>VM: deploy job<br/>runner self-hosted
+    GH->>VM: deploy job — runner self-hosted
     VM->>VM: checkout + git reset origin/main
     VM->>VM: instala deps + escreve .env
     VM->>DB: pg-autotune por RAM atual
@@ -40,7 +40,7 @@ sequenceDiagram
     end
     VM->>WEB: setup nginx/fail2ban/goaccess/umami
     opt warm_cache=true OU all/sql OU rewarm_cache_keys
-        VM->>DB: cruza-warm-cache.service<br/>oneshot bloqueante
+        VM->>DB: cruza-warm-cache.service — oneshot bloqueante
     end
     opt invalidate_cache_keys
         VM->>DB: DELETE web_cache live rows
@@ -50,14 +50,14 @@ sequenceDiagram
     end
     VM->>WEB: restart cruza-web após warm
     opt expose_*_sitemap = enable
-        VM->>DB: gate cobertura >=80%
+        VM->>DB: gate cobertura &gt;=80%
         VM->>WEB: drop-in systemd + smoke
     end
     opt IndexNow
         VM->>WEB: submit URLs selecionadas
     end
 
-    GH->>AZ: postflight<br/>login OIDC
+    GH->>AZ: postflight — login OIDC
     AZ->>AZ: deallocate VM
     AZ->>AZ: resize B4 → B2
     AZ->>AZ: disk Premium → Standard<br/>best-effort, limite 2/24h

--- a/docs/queries-guide.md
+++ b/docs/queries-guide.md
@@ -13,20 +13,20 @@ Este guia cobre o ciclo de vida de uma query nova no `govbr-cruza-dados`. Para c
 
 ```mermaid
 flowchart TD
-    A[Definir tema/objeto da investigação] --> B[Escolher Q## livre<br/>(grep -h '-- Q' queries/*.sql)]
-    B --> C[Header obrigatório<br/>-- Q##: Titulo curto]
-    C --> D[Escrever SQL<br/>placeholders %(municipio)s, etc.]
-    D --> E[EXPLAIN ANALYZE local]
-    E --> F{Custo > 30s?}
-    F -- não --> G[python -m etl.run_queries --query Q##]
-    F -- sim --> H[Adicionar índice em<br/>sql/19_indices_queries.sql]
-    H --> I{Ainda lento?}
-    I -- sim --> J[Pré-computar via MV<br/>em sql/12_views.sql]
+    A["Definir tema/objeto da investigação"] --> B["Escolher Q## livre<br/>grep -h '-- Q' queries/*.sql"]
+    B --> C["Header obrigatório<br/>-- Q##: Titulo curto"]
+    C --> D["Escrever SQL<br/>placeholders %(municipio)s, etc."]
+    D --> E["EXPLAIN ANALYZE local"]
+    E --> F{"Custo > 30s?"}
+    F -- não --> G["python -m etl.run_queries --query Q##"]
+    F -- sim --> H["Adicionar índice em<br/>sql/19_indices_queries.sql"]
+    H --> I{"Ainda lento?"}
+    I -- sim --> J["Pré-computar via MV<br/>em sql/12_views.sql"]
     I -- não --> G
     J --> G
-    G --> K{Query da UI?}
-    K -- sim --> L[Registrar via _reg em<br/>web/queries/registry.py]
-    K -- não --> M[Relatório markdown<br/>opcional em relatorios/]
+    G --> K{"Query da UI?"}
+    K -- sim --> L["Registrar via _reg em<br/>web/queries/registry.py"]
+    K -- não --> M["Relatório markdown<br/>opcional em relatorios/"]
     L --> M
     M --> N[PR]
 ```

--- a/docs/web-guide.md
+++ b/docs/web-guide.md
@@ -18,27 +18,27 @@ Este guia complementa [architecture.md](architecture.md) e o [glossario.md](glos
 sequenceDiagram
     autonumber
     participant B as Browser
-    participant N as Nginx (rate limit)
+    participant N as Nginx
     participant R as FastAPI route
-    participant D as web/db.py
+    participant D as web db py
     participant PG as PostgreSQL
     participant T as Jinja2
 
     B->>N: GET /cidade/joao-pessoa
-    N->>R: proxy (host allowed, RPS ok)
-    R->>D: read_web_cache(qid="KPI_SUMMARY", municipio="João Pessoa")
+    N->>R: proxy — host allowed, RPS ok
+    R->>D: read_web_cache qid=KPI_SUMMARY, municipio=JP
     alt cache hit
-        D-->>R: (cols, rows)
-        R->>T: render(cidade.html, ctx)
+        D-->>R: cols, rows
+        R->>T: render cidade.html
         T-->>B: HTML SSR
     else cache miss em rota cache-only
         D-->>R: None
-        R-->>B: 503 (warm pendente)
-    else live fallback (rotas leves: perfil, autocomplete)
-        R->>D: execute_query(sql, timeout=TIMEOUT_PROFILE=3s)
+        R-->>B: 503 — warm pendente
+    else live fallback — rotas leves
+        R->>D: execute_query — timeout=TIMEOUT_PROFILE=3s
         D->>PG: SET statement_timeout=3000; SELECT ...
         PG-->>D: rows ou timeout
-        D-->>R: (cols, rows)
+        D-->>R: cols, rows
         R->>T: render
         T-->>B: HTML
     end


### PR DESCRIPTION
## Resumo

5 diagramas Mermaid em `docs/` não renderizavam no GitHub por causa de caracteres especiais (parens, %, slash, colon) em labels sem aspas duplas e participants de sequenceDiagram. Validado via regex que detecta os padrões problemáticos: **0 issues restantes**.

## Diagramas afetados

| Arquivo | Diagrama | Issue principal |
|---|---|---|
| `docs/queries-guide.md` | flowchart TD (ciclo Q##) | `B[Escolher Q## livre<br/>(grep -h '-- Q' queries/*.sql)]` — parens dentro de `[...]` quebram parser |
| `docs/web-guide.md` | sequenceDiagram (request flow) | `participant N as Nginx (rate limit)` + `participant D as web/db.py` — parens e slash em alias |
| `docs/architecture.md` | sequenceDiagram (shadow rewarm) | `participant Op as Owner / Workflow` + parens em `web_cache (live)` + `(fail==0)` em alt |
| `docs/cache.md` | sequenceDiagram (shadow rewarm detalhado) | `participant Op as Operador (deploy.yml)` + chaves `{Q65, PERFIL}` em labels |
| `docs/deploy.md` | sequenceDiagram (deploy pipeline) | 4 participants com `<br/>` + chars especiais (`/`, `:`) em alias |

## Padrão seguido (registrar para evitar regressão)

- **Flowchart**: labels com chars especiais → aspas duplas: `node["label com (parens) e %(coisa)s"]`
- **sequenceDiagram**: participants sem chars especiais — sem parens, sem slash, sem `<br/>` em alias
- **alt/else conditions**: `>` literal → escapar como `&gt;` (idem `<` → `&lt;`)
- **`<br/>` em participants**: NUNCA. Em mensagens (após `:`) ok.

Os outros 11 blocos Mermaid (etl-guide, etl-incremental-guide, mv-guide, ops, onboarding e os outros 6 de architecture) já estavam corretos.

## Como testar

Renderiza no GitHub direto: `gh pr view 153 --web` deve mostrar os 5 diagramas corretamente.

## Diff stats

```
 docs/architecture.md  | 16 ++++++++--------
 docs/cache.md         | 24 ++++++++++++------------
 docs/deploy.md        | 20 ++++++++++----------
 docs/queries-guide.md | 24 ++++++++++++------------
 docs/web-guide.md     | 20 ++++++++++----------
 5 files changed, 52 insertions(+), 52 deletions(-)
```

Mudança puramente cosmética em diagramas Mermaid — zero impacto em código de produção.

---

🤖 Issue detectada pelo owner ao revisar render no GitHub Web UI. Fix validado por busca regex automática de padrões problemáticos.
