### PR TITLE
fix(docs): corrigir 4 diagramas Mermaid que ainda nao renderizavam (validado via parser oficial)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,7 +313,7 @@ sequenceDiagram
     alt Todas as queries Q65 succeeded — fail==0
         Warm->>Cache: SWAP ATÔMICO<br/>RENAME Q65__pending → Q65
         Note over Cache: Nova versão visível
-    else Qualquer query Q65 falhou — fail&gt;0
+    else Qualquer query Q65 falhou — fail diferente de zero
         Warm->>Pending: ABORT — descarta __pending
         Note over Cache: Live mantido intacto
     end

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -71,7 +71,7 @@ sequenceDiagram
         W->>PG: DELETE __pending rows
         W->>PG: COMMIT
         Note over UI,PG: readers passam a ver NOVOS<br/>todos os qids simultaneamente
-    else fail &gt; 0 em qualquer qid
+    else fail diferente de zero em qualquer qid
         W->>W: ABORT swap
         Note over PG: live ANTIGO mantido<br/>__pending será descartado no próximo deploy<br/>via Reset shadow rows step
     end

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -50,7 +50,7 @@ sequenceDiagram
     end
     VM->>WEB: restart cruza-web após warm
     opt expose_*_sitemap = enable
-        VM->>DB: gate cobertura &gt;=80%
+        VM->>DB: gate cobertura minima 80 pct
         VM->>WEB: drop-in systemd + smoke
     end
     opt IndexNow

--- a/docs/web-guide.md
+++ b/docs/web-guide.md
@@ -36,7 +36,7 @@ sequenceDiagram
         R-->>B: 503 — warm pendente
     else live fallback — rotas leves
         R->>D: execute_query — timeout=TIMEOUT_PROFILE=3s
-        D->>PG: SET statement_timeout=3000; SELECT ...
+        D->>PG: SET statement_timeout=3000 e SELECT ...
         PG-->>D: rows ou timeout
         D-->>R: cols, rows
         R->>T: render


### PR DESCRIPTION
## Resumo

Owner identificou que `docs/web-guide.md` ainda quebrava no GitHub render. Investigando com o parser oficial `@mermaid-js/mermaid@10` (mesmo que o GitHub usa) descobri **4 blocos quebrados** (não só web-guide).

**Validação:** `npx mermaid.parse()` em todos os 16 blocos Mermaid de `docs/` — **0 FAILs após o fix**.

## Causas (Mermaid parser quirks documentadas)

### 1. `;` em mensagens de sequenceDiagram quebra o parser

`docs/web-guide.md` linha 39 do bloco:
```diff
- D->>PG: SET statement_timeout=3000; SELECT ...
+ D->>PG: SET statement_timeout=3000 e SELECT ...
```

Parser interpreta `;` como terminador de comando mesmo dentro de label de mensagem. Erro do parser: `Expecting 'SOLID_ARROW'... got 'NEWLINE'`.

### 2. `&gt;` (entity HTML) NÃO é decodificado em condition labels

Em `alt`/`else`/`opt`, o `&gt;` chega no lexer como `&`+`gt`+`;`+ próximo char interpretado como `NUM`. Resultado: parse error.

| Arquivo | Antes | Depois |
|---|---|---|
| `architecture.md` (block 6) | `else Qualquer query Q65 falhou — fail&gt;0` | `else Qualquer query Q65 falhou — fail diferente de zero` |
| `cache.md` | `else fail &gt; 0 em qualquer qid` | `else fail diferente de zero em qualquer qid` |
| `deploy.md` | `gate cobertura &gt;=80%` | `gate cobertura minima 80 pct` |

## Por que o PR #154 não pegou isso

PR #154 corrigiu padrões mais óbvios (parens em participants, `<br/>` em alias). Os 4 blocos restantes passavam a validação por regex mas tropeçavam só no parser real. Lição: **rodar `@mermaid-js/mermaid@10 .parse()` em CI vale a pena** (potencial issue futuro: adicionar check no workflow de lint).

## Como testar

```bash
gh pr checkout 155
# Abrir docs/web-guide.md no GitHub Web e ver o diagrama renderizar
```

## Diff

```
 docs/architecture.md | 2 +-
 docs/cache.md        | 2 +-
 docs/deploy.md       | 2 +-
 docs/web-guide.md    | 2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)
```

Mudança puramente cosmética em labels de diagramas — zero impacto em código de produção.
