### PR TITLE
fix(deploy): relaxar rate-limits que estavam atingindo usuários legítimos

### DIFF
--- a/deploy/nginx-cruza.conf
+++ b/deploy/nginx-cruza.conf
@@ -159,9 +159,15 @@ server {
     # API HEAVY: drilldowns, batch, kpis, perfil, run, count, top, cache.
     # Estes podem rodar queries SQL com timeout até 90s. POOL_MAX=4, então
     # 1 IP nao pode ocupar todo o pool sozinho.
+    #
+    # burst=8: drilldowns disparam 4-6 endpoints em paralelo no JS (ex:
+    # cidade/<slug> chama /api/batch + /api/heatmap + /api/perfil + /api/kpis
+    # + /api/top quase simultaneamente). burst=5 era apertado e gerava 429
+    # silencioso em usuarios reais (ex: 168.228.208.35 16/May 18:30 BR
+    # bateu 429 em /api/run/Q77 + /api/run/Q61 disparados juntos).
     location ~ ^/api/(servidor|fornecedor|empenho|licitacao)/detalhes$ {
         if ($tpb_block_api_ua) { return 403; }
-        limit_req zone=api_heavy burst=5 nodelay;
+        limit_req zone=api_heavy burst=8 nodelay;
         limit_conn perip 4;
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
@@ -173,7 +179,7 @@ server {
     }
     location ~ ^/api/(batch|kpis|perfil|run|count|top|cache|export)(/|$) {
         if ($tpb_block_api_ua) { return 403; }
-        limit_req zone=api_heavy burst=5 nodelay;
+        limit_req zone=api_heavy burst=8 nodelay;
         limit_conn perip 4;
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
@@ -350,15 +356,43 @@ server {
         proxy_read_timeout 60s;
     }
 
-    # Dashboard HTML/assets (login page, /_next/*, /share/*, etc) —
+    # Assets imutaveis do bundle Next.js (chunks JS/CSS/images com hash no
+    # nome de arquivo). Cold load do dashboard puxa ~40 chunks em <1s, o
+    # que estourava o burst do zone `general` (resultando em 429s silenciosos
+    # nos chunks e UI quebrada). Como os hashes mudam a cada build, podem
+    # ser cacheados forever no browser — primeira sessao paga o custo, o
+    # resto vem do cache local. auth_basic mantida (mesma proteçao do
+    # location parent); rate limit removido (sao arquivos estaticos
+    # protegidos por basic-auth — nao ha risco de DoS por anonimo).
+    location ^~ /_traffic/analytics/_next/static/ {
+        auth_basic "Restricted — Analytics admin";
+        auth_basic_user_file /etc/nginx/.htpasswd-traffic;
+        limit_conn perip 20;
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # Dashboard HTML/assets (login page, /share/*, imagens nao-hashed, etc) —
     # basic-auth + auth proprio do Umami (defesa em profundidade).
     # Trocar a senha default admin/umami no primeiro acesso e obrigatorio.
     # IMPORTANTE: apenas a UI cai aqui — as APIs do dashboard (acima)
     # usam Bearer JWT e NAO podem ter basic-auth (vide comentario acima).
+    #
+    # burst=100: dashboard carrega imagens (browser/os/country icons),
+    # paginas HTML do Next.js e poll de stats em rajadas. burst=30 era
+    # apertado e gerava 429s na pratica (16/May: 343 hits 429 no painel,
+    # todos do admin/owner navegando). Como ja tem auth_basic, qualquer
+    # atacante anonimo eh bloqueado antes do rate limit.
     location /_traffic/analytics/ {
         auth_basic "Restricted — Analytics admin";
         auth_basic_user_file /etc/nginx/.htpasswd-traffic;
-        limit_req zone=general burst=30 nodelay;
+        limit_req zone=general burst=100 nodelay;
         limit_conn perip 8;
         proxy_pass http://127.0.0.1:3001;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Contexto

Análise de tráfego de 16/May identificou **343 hits 429** no dia, dos quais ~99% afetando usuários legítimos:
- **341 hits** distribuídos entre IPs do owner navegando o painel Umami (Mac/iPhone casa + 6 IPs rotativos do iCloud Private Relay)
- **2 hits** de um visitante real (`168.228.208.35`, iPhone navegando Massaranduba) em `/api/run/Q77` + `/api/run/Q61` disparados simultaneamente

A causa raiz foram **rate limits apertados em paths que ficam atrás de basic-auth** (painel admin) e em **APIs heavy chamadas em rajada pelo próprio JS do site** (drilldowns disparam 4-6 endpoints em paralelo).

## Mudanças

### 1. `/_traffic/analytics/_next/static/*` — novo location dedicado
Chunks JS/CSS imutáveis (hash no nome) servidos com:
- `Cache-Control: public, max-age=31536000, immutable`
- **Sem rate limit** (`auth_basic` continua exigida — proteção contra DoS anônimo)

Cold load do bundle Umami puxa ~40 chunks em <1s. Antes estourava `burst=30` da zone `general`; agora primeira sessão paga o custo, depois browser cacheia forever.

### 2. `/_traffic/analytics/` (UI HTML)
- `burst=30` → `burst=100`
- Justificativa: imagens de browser/os/country icons + poll de stats em rajadas. `auth_basic` mantida.

### 3. `/api/(batch|kpis|perfil|run|count|top|cache|export)` (api_heavy)
- `burst=5` → `burst=8`
- Justificativa: `cidade/<slug>` dispara batch + heatmap + perfil + kpis + top quase simultaneamente. `burst=5` era apertado e quebrava drilldowns multi-query.

### 4. `/api/(servidor|fornecedor|empenho|licitacao)/detalhes` (api_heavy)
- `burst=5` → `burst=8`
- Mesma justificativa (mesma zone, mesmo padrão de disparo paralelo).

## Não mudou

- Zonas de rate limit (`general` 60r/s, `api_heavy` 2r/s, `api_light` 10r/s) — limites sustentados continuam iguais.
- `/api/contato` continua `burst=2` (risco de spam).
- `/_traffic/ws` continua `burst=10` (WebSocket, sem auth_basic).
- `/_traffic/raw` continua `burst=10`.
- `/` (default) continua `burst=120`.

## Validação em prod (hotpatch antes do PR)

```
=== 20 reqs em rajada em /api/run/Q01 (burst=8) ===
  8 passaram (405 Method Not Allowed, ok — burst absorvido)
 12 receberam 429 (esperado — sustained rate 2r/s)

=== 50 reqs em rajada em /_traffic/analytics/ (burst=100) ===
 50 receberam 401 (auth challenge antes do rate limit)
  0 receberam 429 ✅

=== Cache headers em /_traffic/analytics/_next/static/* ===
cache-control: public, max-age=31536000, immutable ✅
```

`nginx -t` passou. `systemctl reload nginx` aplicado. Backup mantido em `/etc/nginx/sites-available/cruza.bak.1778979689`.