### PR TITLE
docs(agents): AGENTS.md canonico + CLAUDE.md/copilot-instructions pointers + ADR-0008

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,61 +1,22 @@
-# Copilot instructions — govbr-cruza-dados
+# Copilot instructions
 
-ETL pipeline (Python 3.10+ / PostgreSQL 16) that loads ~350M records from ~18 Brazilian open-data sources and cross-references them by CNPJ/CPF to detect fraud. Includes a FastAPI frontend for municipality profiles.
+> Canonical instructions for AI coding agents — including GitHub Copilot CLI —
+> live in [`AGENTS.md`](../AGENTS.md) at the repository root.
+>
+> The Copilot CLI reads **both** this file and `AGENTS.md` automatically. This
+> file exists only to make the entry point obvious; all content is maintained
+> in `AGENTS.md` ([ADR-0008](../docs/adr/0008-agents-md-canonical.md)).
 
-## Setup & commands
+**TL;DR:**
 
-Config is loaded from `.env` by `etl/config.py` (see `.env.example`). `DATA_DIR` points at raw CSV/JSON downloads; `DSN` is built from `POSTGRES_*` vars.
+- Working language: **Portuguese (BR)** — identifiers, comments, commits, PRs.
+- No pandas in ETL; streaming + `COPY FROM STDIN` ([ADR-0001](../docs/adr/0001-no-pandas.md)).
+- No ORM in web; raw SQL via psycopg2 ([ADR-0005](../docs/adr/0005-no-orm-web.md)).
+- Every commit ends with
+  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+- Every PR checks **README / `docs/` / ADR** for matching updates — see the
+  checklist in `AGENTS.md`.
 
-```bash
-pip install -e .                  # core deps
-pip install -e .[web]             # + FastAPI/uvicorn/jinja2
-
-python -m etl.run_all             # full ETL (23 phases)
-python -m etl.run_all 4           # resume from phase N (1-based)
-python -m etl.00_download         # downloads only
-python -m etl.probe_sources       # test source availability (runs in deploy)
-
-python -m etl.run_queries                 # run all Q## fraud queries → resultados/
-python -m etl.run_queries --query Q03     # single query
-
-python -m uvicorn web.main:app --port 8000
-python -m web.warm_cache --pb             # warm web_cache table
-```
-
-No automated test suite exists. Basic validation: `python -m compileall etl -q`.
-
-## Architecture
-
-**Phase-based ETL (`etl/run_all.py`).** 23 phases in a fixed list; each phase is a module with a `run()` function. Order matters — later phases depend on tables/columns created earlier. To resume mid-pipeline, pass the 1-based phase index. Phase 0 is download, phase 17 (`15_normalizar.py`) creates normalized CPF/CNPJ digit columns that every cross-source join relies on, phase 18 (`21_views.py`) builds MVs.
-
-**Automatic disk cleanup.** After each phase's `run()` succeeds, `_cleanup_csvs` deletes the raw CSV dirs listed in `_CSV_DIRS` (e.g. `etl.03_rfb` → `rfb/`). Shared dirs in `_SHARED_DIRS` (`rfb/`, `tse/`) are only removed once **all** dependent phases have succeeded. When adding a new phase that consumes existing raw files, register it in `_SHARED_DIRS` or the directory will be wiped before your phase runs.
-
-**Schema in `sql/`.** Numbered `.sql` files executed by `etl.db.execute_sql_file`. `sql/11_indices.sql` and `sql/19_indices_queries.sql` hold the indices the fraud queries depend on — changing column names there usually breaks queries in `queries/` and `web/queries/registry.py`.
-
-**Entity resolution.** CPFs come masked in different formats per source (see README “Entity Resolution”). Phase 17 writes `cpf_digitos` / `cpf_cnpj_norm` columns so cross-source joins are equality joins, not LIKE/regex. Prefer joining on these normalized columns. For supplier identity, use full `cpf_cnpj` (14 digits) not `cnpj_basico` (8 digits) to avoid CPF/CNPJ prefix collisions — filter with `EXISTS (SELECT 1 FROM estabelecimento …)` to exclude CPFs when a query should only hit real CNPJs.
-
-**Fraud queries (`queries/*.sql`).** Each file groups queries by theme; individual queries are labeled `Q01`…`Q310` in SQL comments. `etl/run_queries.py` parses them with a custom splitter (`split_sql_statements`) that tracks quotes and dollar-quoting — query bodies are free to contain `;`. Results land in `resultados/Q##_*.csv`.
-
-**Materialized views (`sql/12_views.sql`).** Built by phase 18 (`etl.21_views`). Layered: L1 independent MVs (`mv_empresa_governo`, `mv_pessoa_pb`, `mv_municipio_pb_risco`, `mv_servidor_pb_base`) → L2 MVs that depend on them (`mv_servidor_pb_risco`, `mv_empresa_pb`, `mv_rede_pb`) → plain views (`v_risk_score_empresa`, `v_risk_score_pb`). The file drops everything in reverse-dependency order at the top; when adding an MV keep that pattern and add a `REFRESH MATERIALIZED VIEW CONCURRENTLY` line in the footer comment. The web UI reads heavily from `mv_municipio_pb_risco`, `mv_servidor_pb_risco`, and `mv_empresa_pb` — breaking a column there cascades into `web/queries/registry.py`.
-
-**Reports (`relatorios/`).** Markdown investigations (40+) written against query outputs in `resultados/`. Each report cites CNPJs/CPFs from real data; before merging new reports or editing identifiers, run `python scripts/audit_report_identifiers.py [--report relatorios/foo.md]` — it validates CNPJs against the local `empresa`/`estabelecimento` tables. CPF validation is best-effort (most CPFs are masked).
-
-**Web app (`web/`).** FastAPI + Jinja2, no ORM — raw SQL via `web/db.py` pool. Two query flavours per cidade query are registered in `web/queries/registry.py`: `sql_full` (all time) and optional `sql_full_dated` that accepts `%(data_inicio)s`, `%(data_fim)s`, `%(ano_inicio)s`, `%(ano_fim)s`, `%(ano_mes_inicio)s`, `%(ano_mes_fim)s`. Results are cached in a `web_cache` PostgreSQL table; `web/warm_cache.py` pre-computes both all-time and current-year variants. PB municipalities use TCE/dados.pb tables; other states fall back to PNCP.
-
-## Conventions
-
-- **No pandas.** ETL streams line-by-line and loads via `COPY FROM STDIN` (see `etl/db.py`: `copy_from_stream`, `copy_csv_streaming`, `batch_insert`). Target box is 16GB RAM — don't introduce DataFrame-based loads.
-- **BR data parsing** lives in `etl/utils.py` (`parse_date_br`, `parse_decimal_br`, `clean_cpf`, `clean_cnpj`, `extract_cpf_masked`, `normalize_name`). Reuse these rather than reimplementing; date/decimal inputs come in multiple formats per source.
-- **RFB encoding is latin-1** (`RFB_ENCODING` in `etl/config.py`); use `latin1_lines` when reading RFB CSVs.
-- **Portuguese is the working language** for identifiers, comments, SQL, query titles, and commit messages; match that style.
-- **Queries are numbered globally** (Q01-Q310). When adding one, keep the `-- Q##:` comment header so `run_queries.py` and the registry can find it, and add the matching index in `sql/19_indices_queries.sql` if the query is expected to run in the web UI (queries time out at `QueryDef.timeout_sec`, default 30s).
-- **Deploy is GitHub-Actions-driven** against a self-hosted runner (`.github/workflows/deploy.yml`). The `etl_phase` input is the 1-based position in the `run_all` phases list (phase 0 = Download counts as item 1). `etl_phase=sql` runs indices/normalization/views only; `etl_phase=web` just syncs code and restarts systemd units from `deploy/`.
-- **Do not commit** files in the repo root like `db_*.txt`, `pg_*.txt`, `mv_status.txt`, `*_debug*.txt`, `*.log`, `q##_result.csv` — they're scratch outputs from local DB inspection.
-
-## Git
-
-Commit trailer required by tooling:
-
-```
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
-```
+See [`AGENTS.md`](../AGENTS.md) for the full setup, architecture, conventions,
+discovered quirks (Mermaid parser, MD3 upgrade gate, MV layering, cache type
+coercion, deploy quirks, …) and PR checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,329 @@
+# AGENTS.md
+
+> **Instructions for AI coding agents** working in `lucasdiniz/govbr-cruza-dados`.
+> Read by GitHub Copilot CLI, Claude Code, Cursor, Aider, Codex and any tool
+> that follows the [agents.md](https://agents.md) convention. `CLAUDE.md` and
+> `.github/copilot-instructions.md` are short pointers to this file
+> ([ADR-0008](docs/adr/0008-agents-md-canonical.md)).
+>
+> Human contributors: see [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Project at a glance
+
+ETL pipeline (Python 3.10+ / PostgreSQL 16) that loads ~350M records from ~18
+Brazilian open-data sources and cross-references them by CNPJ/CPF to detect
+fraud. Includes a FastAPI/Jinja2 frontend at
+[transparenciapb.org](https://transparenciapb.org) for municipal profiles.
+
+**Working language is Portuguese (BR)** for identifiers, comments, SQL, query
+titles, commit messages, PR descriptions, issues and user-facing strings. This
+file is in English so generic AI agents can parse it; everything you produce in
+the repo should be PT-BR.
+
+## Documentation map (read in this order on a fresh task)
+
+1. [`README.md`](README.md) — project overview, quick start, full feature list.
+2. [`docs/architecture.md`](docs/architecture.md) — **landing page** with 7 Mermaid
+   diagrams (data flow, entity resolution, ERD, MV layers, shadow rewarm,
+   deploy pipeline).
+3. [`docs/glossario.md`](docs/glossario.md) — 60+ domain terms (empenho, UG, CEIS,
+   LGPD, etc.).
+4. [`docs/onboarding.md`](docs/onboarding.md) — clone → `uvicorn` in 3 paths.
+5. [`CONTRIBUTING.md`](CONTRIBUTING.md) — code/commit/PR conventions, what you
+   can and can't touch.
+6. **Area guides** (only the one(s) relevant to your task):
+   - [`docs/etl-guide.md`](docs/etl-guide.md) — classic phase-based ETL
+   - [`docs/etl-incremental-guide.md`](docs/etl-incremental-guide.md) — incremental framework (P1-P6)
+   - [`docs/web-guide.md`](docs/web-guide.md) — query/route/template/MD3 component
+   - [`docs/queries-guide.md`](docs/queries-guide.md) — adding Q##
+   - [`docs/mv-guide.md`](docs/mv-guide.md) — adding Materialized Views
+   - [`docs/cache.md`](docs/cache.md) — `web_cache` + shadow rewarm
+   - [`docs/deploy.md`](docs/deploy.md) — `deploy.yml` inputs and scenarios
+   - [`docs/ops.md`](docs/ops.md) — runbooks (rollback, restore, backup)
+7. [`docs/adr/`](docs/adr/) — Architecture Decision Records (the institutional memory).
+
+## Setup & commands
+
+Config loaded from `.env` by `etl/config.py` (see `.env.example`). `DATA_DIR`
+points at raw CSV/JSON downloads; `DSN` is built from `POSTGRES_*` vars.
+
+```bash
+pip install -e .                  # core deps
+pip install -e .[web]             # + FastAPI/uvicorn/jinja2
+
+python -m etl.run_all             # full ETL (24 phases incl. Download)
+python -m etl.run_all 4           # resume from phase N (1-based index into phases list)
+python -m etl.00_download         # downloads only
+python -m etl.probe_sources       # test source availability
+
+python -m etl.run_queries                 # run all Q## fraud queries → resultados/
+python -m etl.run_queries --query Q03     # single query
+
+python -m uvicorn web.main:app --port 8000
+python -m web.warm_cache --pb             # warm web_cache table
+```
+
+No automated test suite outside `tests/incremental/` exists yet. Basic
+validation for ETL changes: `python -m compileall etl -q`.
+
+## Architecture (essentials)
+
+**Phase-based ETL** (`etl/run_all.py`): 24 phases in a fixed list (`phases`);
+each phase is a module with a `run()` function. Order matters — later phases
+depend on tables/columns created earlier. Phase 17 (`15_normalizar.py`) creates
+normalized CPF/CNPJ digit columns; phase 18 (`21_views.py`) builds MVs. Full
+detail: [`docs/etl-guide.md`](docs/etl-guide.md).
+
+**Automatic disk cleanup**: after each phase `run()` succeeds, `_cleanup_csvs`
+deletes raw CSV dirs in `_CSV_DIRS`. Shared dirs in `_SHARED_DIRS` (`rfb/`,
+`tse/`) only get removed once **all** dependent phases have succeeded. When
+adding a phase that consumes existing raw files, register it in `_SHARED_DIRS`
+or the directory will be wiped before your phase runs.
+
+**Schema** in `sql/`: numbered `.sql` files executed by `etl.db.execute_sql_file`.
+`sql/11_indices.sql` and `sql/19_indices_queries.sql` hold the indices the
+fraud queries depend on — changing column names there usually breaks queries
+in `queries/` and `web/queries/registry.py`.
+
+**Entity resolution**: CPFs come masked in different formats per source. Phase
+17 writes `cpf_digitos` / `cpf_cnpj_norm` columns so cross-source joins are
+equality joins, not LIKE/regex. **Always join on these normalized columns.**
+For supplier identity, use full `cpf_cnpj` (14 digits), **not `cnpj_basico`**
+(8 digits — collides with CPFs); filter with `EXISTS (SELECT 1 FROM
+estabelecimento …)` to exclude CPFs when a query should only hit real CNPJs.
+
+**Fraud queries** (`queries/*.sql`): labeled `Q01`…`Q310` in SQL comments.
+`etl/run_queries.py` parses with a custom splitter (`split_sql_statements`)
+that tracks quotes and dollar-quoting — query bodies are free to contain `;`.
+Results land in `resultados/Q##_*.csv`.
+
+**Materialized views** (`sql/12_views.sql`): layered — **L1** independent MVs
+(`mv_empresa_governo`, `mv_pessoa_pb`, `mv_municipio_pb_risco`,
+`mv_servidor_pb_base`) → **L2** MVs that depend on them (`mv_servidor_pb_risco`,
+`mv_empresa_pb`, `mv_rede_pb`) → plain views (`v_risk_score_empresa`,
+`v_risk_score_pb`). The file drops everything in reverse-dependency order at
+the top; when adding an MV keep that pattern and add a
+`REFRESH MATERIALIZED VIEW CONCURRENTLY` line in the footer comment. Detail:
+[`docs/mv-guide.md`](docs/mv-guide.md) and [ADR-0002](docs/adr/0002-mv-layered.md).
+
+**Web app** (`web/`): FastAPI + Jinja2, **no ORM** — raw SQL via `web/db.py`
+pool. Two query flavours per cidade query are registered in
+`web/queries/registry.py`: `sql_full` (all time) and optional `sql_full_dated`
+that accepts `%(data_inicio)s`, `%(data_fim)s`, `%(ano_inicio)s`, `%(ano_fim)s`,
+`%(ano_mes_inicio)s`, `%(ano_mes_fim)s`. Results cached in `web_cache`
+PostgreSQL table; `web/warm_cache.py` pre-computes both all-time and
+current-year variants. PB municipalities use TCE/dados.pb tables; other states
+fall back to PNCP. Rationale: [ADR-0005](docs/adr/0005-no-orm-web.md).
+
+**Reports** (`relatorios/`): markdown investigations citing CNPJs/CPFs from
+real data. Before merging new reports or editing identifiers, run
+`python scripts/audit_report_identifiers.py [--report relatorios/foo.md]`.
+
+## Conventions
+
+- **No pandas.** ETL streams line-by-line and loads via `COPY FROM STDIN` (see
+  `etl/db.py`: `copy_from_stream`, `copy_csv_streaming`, `batch_insert`).
+  Target box is 16GB RAM — don't introduce DataFrame-based loads.
+  [ADR-0001](docs/adr/0001-no-pandas.md).
+- **BR data parsing** lives in `etl/utils.py` (`parse_date_br`,
+  `parse_decimal_br`, `clean_cpf`, `clean_cnpj`, `extract_cpf_masked`,
+  `normalize_name`). Reuse these.
+- **RFB encoding is latin-1** (`RFB_ENCODING` in `etl/config.py`); use
+  `latin1_lines` when reading RFB CSVs.
+- **Queries are numbered globally** (Q01–Q310). Keep the `-- Q##:` comment
+  header so `run_queries.py` and the registry can find it. Add a matching index
+  in `sql/19_indices_queries.sql` if the query is expected to run in the web UI
+  (queries time out at `QueryDef.timeout_sec`, default 30s).
+- **Reports mask CPFs** as `***.NNN.NNN-**` (keeps the 6 middle digits, mirrors
+  `cpf_digitos_6` in MVs). CNPJs stay fully visible (public RFB data).
+- **Deploy is GitHub Actions** against a self-hosted runner
+  (`.github/workflows/deploy.yml`). The `etl_phase` input is the **1-based
+  index into the `phases` list** in `etl/run_all.py` (Phase 0 Download counts
+  as item 1) — **not** the "Fase N" label in the phase name. `etl_phase=sql`
+  runs indices/normalization/views only; `etl_phase=web` syncs code and
+  restarts systemd units only.
+- **Do not commit** scratch outputs from local DB inspection: `db_*.txt`,
+  `pg_*.txt`, `mv_status.txt`, `*_debug*.txt`, `*.log`, `q##_result.csv`.
+
+## Agent-discovered quirks
+
+These are gotchas the maintainer + previous agents have hit. Internalize
+before editing the relevant area.
+
+### Frontend / JS / MD3
+
+- **MD3 custom-element upgrade is async.** Calling methods like `dialog.show()`
+  on a `<md-dialog>` before its custom element upgraded triggers
+  `dialog.show is undefined`. Gate behind
+  `window.whenMD3Ready(cb)` from
+  [`web/static/js/lib/md3-ready.js`](web/static/js/lib/md3-ready.js) for
+  anything that depends on the upgraded API.
+- **In-page anchor expansion is centralized.**
+  [`web/static/js/lib/expand-context.js#expandReportContext`](web/static/js/lib/expand-context.js)
+  is the single entry point for "open content via in-page anchor" (supports
+  `.report-section`, `.finding-card`, `details.collapsible-details`). New
+  collapsible components should register there.
+- **`anchor-auto-expand` intercepts every `a[href^="#"]` click** with
+  `preventDefault()` + `replaceState()` and does **not** dispatch
+  `hashchange`. Components that react to anchor navigation must hook into
+  `expandReportContext`, not `hashchange`.
+- **`<details>` `toggle` event fires asynchronously** (queued task). To suppress
+  handlers during programmatic expansion (e.g. print mode), use a flag and
+  clear it with `setTimeout(0)` — never clear synchronously after setting
+  `d.open = X`.
+- **Collapsible sections** use the macro
+  [`web/templates/partials/_collapsible.html`](web/templates/partials/_collapsible.html):
+  `{% call collapsible(id, title, count=N, section_attrs={...}) %}…{% endcall %}`.
+  Default is `open=True`. Reuse this — do not roll your own `<details>`.
+- **Service Worker cache version** in
+  [`web/static/sw.js`](web/static/sw.js):
+  bump `FALLBACK_CACHE_VERSION` whenever you rename assets or change the SW
+  pipeline. `ASSET_VERSION` in [`web/main.py`](web/main.py) is hash-based via
+  `web/static/dist/manifest.json` — no manual bump needed in prod, but bump the
+  string when you change JS/CSS so dev fallback (`?v=NNN`) invalidates browser
+  caches.
+- **Umami event names**: kebab-case, no page prefix. Valid: `secao-toggle`,
+  `dialog-tab-change`, `modo-toggle`, `font-size-change`. Avoid `empresa-X`,
+  `cidade-X`. See [`web/static/js/components/`](web/static/js/components/).
+- **Dual-mode UI.** Frontend has two technicality levels. Use
+  `dualLabel('cidadao', 'auditor')` in JS and `citizen-only` / `auditor-only`
+  CSS classes in templates. Always provide both texts when you add a new
+  label, stat or dialog content.
+
+### Templates / Jinja
+
+- **Cached numeric values come back as strings.** `cached_query()` returns
+  dicts without type normalization; `web/warm_cache.py` serializes with
+  `default=str` → numbers become strings. In templates, coerce with `|float` /
+  `|int` before `round()` / `|tojson` (see
+  [`web/templates/results/cidade.html`](web/templates/results/cidade.html)
+  for the canonical coerce setblock pattern).
+- **Jinja smoke-parse outside FastAPI.** For templates using custom filters
+  (`short_brl`, `clean_text`, `municipio_slug`, `date_br`, etc.) in a test
+  harness, catch `TemplateAssertionError` "No filter named X" and register
+  `env.filters[name] = lambda x: x` dynamically before retrying. Custom
+  filters are registered in [`web/main.py`](web/main.py) (~lines 185-188).
+
+### SQL / Materialized Views
+
+- **MV file structure**: `sql/12_views.sql` drops in reverse-dependency order
+  at the top, recreates L1 → L2 → views. Adding a new MV requires updating
+  both blocks **and** the `REFRESH MATERIALIZED VIEW CONCURRENTLY` footer.
+  `REFRESH CONCURRENTLY` needs a UNIQUE INDEX on the MV.
+- **Query timeouts in production.** Q61/Q65/Q77 (heatmap/kpis/run) timeout in
+  large cities (São Bento do Una, João Pessoa). Nginx `proxy_read_timeout=60s`
+  kills the request before `QueryDef.timeout_sec` (default 30s). When tuning,
+  audit `sql/19_indices_queries.sql` indices and consider pre-computing into
+  a MV instead.
+
+### Mermaid in `docs/`
+
+Two parser quirks discovered in the Mermaid 10 build that GitHub uses:
+
+1. **`;` in `sequenceDiagram` message labels** acts as a command terminator
+   → `Expecting SOLID_ARROW … got NEWLINE`. Replace with " e " or another
+   separator word.
+2. **`&gt;` / `&lt;` HTML entities are NOT decoded** in `alt` / `else` / `opt`
+   condition labels. Spell out with words: `fail diferente de zero` instead of
+   `fail&gt;0`.
+
+Also avoid `(`, `)`, `/`, `:`, `<br/>` inside `participant ID as Display Name`
+aliases — they break the parser. Use plain ASCII names; put any rich text in
+the message bodies instead.
+
+**Local validation without rendering** (avoids puppeteer/Chromium):
+
+```bash
+mkdir mermaid-check && cd mermaid-check
+npm init -y && npm install mermaid jsdom
+# write parse.mjs that loops mermaid.parse(code) over fenced ```mermaid blocks
+```
+
+A working `parse.mjs` was used to validate
+[`docs/architecture.md`](docs/architecture.md) and friends — all 16 blocks
+parse clean as of PR #155. See those PRs for the exact pattern.
+
+### ETL / Data quirks
+
+- **`mv_empresa_pb` slug bug**: two variants of the same municipality coexist
+  (correct `olho-dagua` + buggy `olho-d-agua`; same for `mae-d-agua` vs
+  `mae-dagua`). Sitemap generates the buggy URLs → ~50 Googlebot 404s/day.
+  Fix at source in [`etl/15_normalizar.py`](etl/15_normalizar.py).
+- **`audit_report_identifiers.py`** with `--strict` runs offline (no Postgres),
+  checks only CPF masking. Without `--strict` it validates CNPJs against
+  local `empresa` + `estabelecimento` (requires ~58GB of RFB data loaded).
+
+### Git / Workflow / Deploy
+
+- **`gh` labels available**: only the 9 GitHub defaults (`bug`,
+  `documentation`, `enhancement`, `good-first-issue`, `help wanted`, `invalid`,
+  `question`, `duplicate`, `wontfix`). No custom labels yet — use
+  `enhancement` for tech-debt / web / infra.
+- **Self-hosted runner is single-slot** — deploys process one at a time.
+  Long ETL deploys (8h+) block queued `web` deploys. Plan accordingly.
+- **`deploy.yml` etl_phase**: `web` = code sync + systemd restart only;
+  `sql` = indices/normalization/views only; numeric `N` = 1-based index into
+  the `phases` list (Phase 0 Download counts as item 1).
+- **Multi-worktree `gh pr merge` warning.** When merging from a worktree that
+  isn't `main`, `gh pr merge --squash --delete-branch` may print
+  `fatal: 'main' is already used by worktree at ...`. **This is cosmetic** —
+  the merge on GitHub still completes. Verify with `gh pr view <N> --json
+  mergedAt`.
+- **Recommended for significant PRs**: launch two parallel reviewers
+  (Opus 4.7 + GPT 5.5). Convergence on a HIGH-severity finding validates it;
+  divergence weakens confidence. Used routinely for PRs touching templates +
+  SQL + cached data.
+
+## PR checklist
+
+Before opening or merging a PR, verify:
+
+- [ ] **README** — does this change introduce a new feature, command, env var,
+  or fundamental concept the README should mention?
+- [ ] **`docs/`** — is the right area guide updated
+  (`etl-guide` / `web-guide` / `queries-guide` / `mv-guide` / `cache` /
+  `deploy` / `ops`)? Add or update Mermaid diagrams if the data flow or
+  topology changed.
+- [ ] **ADR** — is this a non-obvious architectural decision (affects multiple
+  modules, has trade-offs, future contributors will ask "why?")? If yes, add
+  `docs/adr/NNNN-titulo.md` following the template in
+  [`docs/adr/README.md`](docs/adr/README.md). ADRs are **immutable** once
+  `Accepted` — supersede with a new ADR rather than rewriting.
+- [ ] **Glossary** — new domain term that needs an entry in
+  [`docs/glossario.md`](docs/glossario.md)?
+- [ ] **Tests** — `tests/incremental/` covers the framework; for one-shot
+  changes, `python -m compileall etl -q` is the minimum baseline.
+- [ ] **Audit scripts** — touched `relatorios/` or report identifiers? Run
+  `python scripts/audit_report_identifiers.py --strict`.
+- [ ] **Commit trailer** — every commit has
+  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+
+## Privacy & security
+
+- This is a **private repo** at the moment (basic-auth hardening on
+  `/_traffic/*` pending) — don't post repo URLs publicly. See [security
+  policy](SECURITY.md) when it lands.
+- Data is public BR open data. Reports may cite real CNPJs (public);
+  CPFs must always be masked as `***.NNN.NNN-**`. LGPD considerations live in
+  [`docs/privacidade.md`](docs/privacidade.md) and
+  [`DATA-LICENSE.md`](DATA-LICENSE.md).
+- Never commit secrets. `.env` is gitignored; `.env.example` is the template.
+- Do not expose VM hostnames, Azure resource IDs, IPs or basic-auth credentials
+  in code, commit messages, PR bodies or issues.
+
+## Trailer (required)
+
+Every commit message must end with:
+
+```
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+Tooling that produces deploy artefacts and review summaries depends on this
+trailer being present.
+
+---
+
+When in doubt, prefer the most recent guidance you find in `docs/` and the
+ADRs over older commits or this file. If an ADR contradicts this file, the
+ADR wins.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,14 @@ Results land in `resultados/Q##_*.csv`.
 **Materialized views** (`sql/12_views.sql`): layered — **L1** independent MVs
 (`mv_empresa_governo`, `mv_pessoa_pb`, `mv_municipio_pb_risco`,
 `mv_servidor_pb_base`) → **L2** MVs that depend on them (`mv_servidor_pb_risco`,
-`mv_empresa_pb`, `mv_rede_pb`) → plain views (`v_risk_score_empresa`,
-`v_risk_score_pb`). The file drops everything in reverse-dependency order at
-the top; when adding an MV keep that pattern and add a
-`REFRESH MATERIALIZED VIEW CONCURRENTLY` line in the footer comment. Detail:
+`mv_empresa_pb`, `mv_rede_pb`, `mv_municipio_pb_kpi_score`,
+`mv_municipio_pb_mapa`, `mv_q67_dated_pb`) → plain views
+(`v_risk_score_empresa`, `v_risk_score_pb`). The file drops everything at
+the top with `CASCADE` in intended reverse-dependency order, then recreates
+L1 → L2 → views. When adding an MV, follow the pattern in both blocks **and**
+add a `REFRESH MATERIALIZED VIEW CONCURRENTLY` line in the footer comment
+(needs a `UNIQUE INDEX` on the MV). The L2 list above is the current set;
+treat `sql/12_views.sql` as the source of truth. Detail:
 [`docs/mv-guide.md`](docs/mv-guide.md) and [ADR-0002](docs/adr/0002-mv-layered.md).
 
 **Web app** (`web/`): FastAPI + Jinja2, **no ORM** — raw SQL via `web/db.py`
@@ -137,11 +141,15 @@ real data. Before merging new reports or editing identifiers, run
 - **Reports mask CPFs** as `***.NNN.NNN-**` (keeps the 6 middle digits, mirrors
   `cpf_digitos_6` in MVs). CNPJs stay fully visible (public RFB data).
 - **Deploy is GitHub Actions** against a self-hosted runner
-  (`.github/workflows/deploy.yml`). The `etl_phase` input is the **1-based
-  index into the `phases` list** in `etl/run_all.py` (Phase 0 Download counts
-  as item 1) — **not** the "Fase N" label in the phase name. `etl_phase=sql`
-  runs indices/normalization/views only; `etl_phase=web` syncs code and
-  restarts systemd units only.
+  (`.github/workflows/deploy.yml`). The `etl_phase` input accepts:
+  - `all` — full ETL from Phase 0 Download through MV refresh + warm
+  - `incremental` — runs the P1-P6 framework ([ADR-0004](docs/adr/0004-etl-incremental-framework.md));
+    optional `incremental_specs` input narrows which specs run
+  - `sql` — indices/normalization/views only (no ETL)
+  - `web` — code sync + systemd restart only (no ETL/SQL)
+  - Numeric `N` — **1-based index** into the `phases` list in
+    `etl/run_all.py` (Phase 0 Download counts as item 1) — **not** the
+    "Fase N" label in the phase name.
 - **Do not commit** scratch outputs from local DB inspection: `db_*.txt`,
   `pg_*.txt`, `mv_status.txt`, `*_debug*.txt`, `*.log`, `q##_result.csv`.
 
@@ -164,9 +172,14 @@ before editing the relevant area.
   `.report-section`, `.finding-card`, `details.collapsible-details`). New
   collapsible components should register there.
 - **`anchor-auto-expand` intercepts every `a[href^="#"]` click** with
-  `preventDefault()` + `replaceState()` and does **not** dispatch
-  `hashchange`. Components that react to anchor navigation must hook into
-  `expandReportContext`, not `hashchange`.
+  `preventDefault()` + `history.replaceState()`. Because `replaceState`
+  doesn't fire a `hashchange` event, click-driven anchor navigation never
+  triggers `hashchange` handlers. The component itself **does** listen on
+  `hashchange` to handle browser back/forward across hash anchors. When
+  adding components that should respond to anchor navigation, register them
+  in `expandReportContext` rather than wiring your own `hashchange`
+  listener — the central registry covers both click and browser-history
+  paths.
 - **`<details>` `toggle` event fires asynchronously** (queued task). To suppress
   handlers during programmatic expansion (e.g. print mode), use a flag and
   clear it with `setTimeout(0)` — never clear synchronously after setting
@@ -210,11 +223,18 @@ before editing the relevant area.
   at the top, recreates L1 → L2 → views. Adding a new MV requires updating
   both blocks **and** the `REFRESH MATERIALIZED VIEW CONCURRENTLY` footer.
   `REFRESH CONCURRENTLY` needs a UNIQUE INDEX on the MV.
-- **Query timeouts in production.** Q61/Q65/Q77 (heatmap/kpis/run) timeout in
-  large cities (São Bento do Una, João Pessoa). Nginx `proxy_read_timeout=60s`
-  kills the request before `QueryDef.timeout_sec` (default 30s). When tuning,
-  audit `sql/19_indices_queries.sql` indices and consider pre-computing into
-  a MV instead.
+- **Query timeouts in production.** `QueryDef.timeout_sec` is per-query in
+  [`web/queries/registry.py`](web/queries/registry.py); default `30s`. Real
+  values for the heavy queries:
+  - **Q65** (fornecedor sancionado recebendo) — `timeout=90`; Nginx
+    `proxy_read_timeout=60s` is the binding ceiling here — large cities
+    (São Bento do Una, João Pessoa) hit nginx 504 before the app times out.
+  - **Q77** (fracionamento de despesa) — `timeout=45`; tight per-query
+    budget, can still trigger app-side timeout in big municipalities.
+  - **Q61** (divergência empenhado vs pago) — `timeout=15`; rarely reaches
+    nginx ceiling.
+  When tuning, audit `sql/19_indices_queries.sql` indices first, then
+  consider pre-computing into a MV instead of raising the timeout.
 
 ### Mermaid in `docs/`
 
@@ -261,9 +281,9 @@ parse clean as of PR #155. See those PRs for the exact pattern.
   `enhancement` for tech-debt / web / infra.
 - **Self-hosted runner is single-slot** — deploys process one at a time.
   Long ETL deploys (8h+) block queued `web` deploys. Plan accordingly.
-- **`deploy.yml` etl_phase**: `web` = code sync + systemd restart only;
-  `sql` = indices/normalization/views only; numeric `N` = 1-based index into
-  the `phases` list (Phase 0 Download counts as item 1).
+- **`deploy.yml` etl_phase** (see the "Conventions" section above for the
+  full enumeration): `all` / `incremental` / `sql` / `web` / numeric `N`
+  (1-based index into the `phases` list).
 - **Multi-worktree `gh pr merge` warning.** When merging from a worktree that
   isn't `main`, `gh pr merge --squash --delete-branch` may print
   `fatal: 'main' is already used by worktree at ...`. **This is cosmetic** —
@@ -301,8 +321,9 @@ Before opening or merging a PR, verify:
 ## Privacy & security
 
 - This is a **private repo** at the moment (basic-auth hardening on
-  `/_traffic/*` pending) — don't post repo URLs publicly. See [security
-  policy](SECURITY.md) when it lands.
+  `/_traffic/*` pending) — don't post repo URLs publicly. A formal
+  `SECURITY.md` is pending; in the meantime report vulnerabilities via
+  [GitHub Security Advisory](https://github.com/lucasdiniz/govbr-cruza-dados/security/advisories).
 - Data is public BR open data. Reports may cite real CNPJs (public);
   CPFs must always be masked as `***.NNN.NNN-**`. LGPD considerations live in
   [`docs/privacidade.md`](docs/privacidade.md) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md
+
+> Canonical instructions for AI coding agents live in [`AGENTS.md`](AGENTS.md)
+> at the repository root.
+>
+> Claude Code should read **both** this file and `AGENTS.md` automatically.
+> This file exists only to make the entry point obvious; all content is
+> maintained in `AGENTS.md` ([ADR-0008](docs/adr/0008-agents-md-canonical.md)).
+
+**TL;DR:**
+
+- Working language: **Portuguese (BR)** — identifiers, comments, commits, PRs.
+- No pandas in ETL; streaming + `COPY FROM STDIN` ([ADR-0001](docs/adr/0001-no-pandas.md)).
+- No ORM in web; raw SQL via psycopg2 ([ADR-0005](docs/adr/0005-no-orm-web.md)).
+- Every commit ends with
+  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+- Every PR checks **README / `docs/` / ADR** for matching updates — see the
+  checklist in `AGENTS.md`.
+
+See [`AGENTS.md`](AGENTS.md) for the full setup, architecture, conventions,
+discovered quirks (Mermaid parser, MD3 upgrade gate, MV layering, cache type
+coercion, deploy quirks, …) and PR checklist.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ Este documento descreve o que precisa para contribuir. Para entender a arquitetu
 - [Convenções de SQL e queries Q##](#convenções-de-sql-e-queries-q)
 - [Convenções de relatórios](#convenções-de-relatórios)
 - [Convenções de commits e PRs](#convenções-de-commits-e-prs)
+- [Checklist de PR](#checklist-de-pr)
+- [Contribuindo com agentes de IA](#contribuindo-com-agentes-de-ia)
 - [O que você pode tocar / pode não tocar](#o-que-você-pode-tocar--pode-não-tocar)
 - [Onde pedir ajuda](#onde-pedir-ajuda)
 
@@ -228,6 +230,76 @@ Escopo é livre (`web`, `etl`, `deploy`, `queries`, `seguranca`, etc.).
 ### Tamanho do PR
 
 PRs menores são preferíveis. Se a mudança naturalmente quebra em fases (ex: refactor + feature), separe em PRs encadeados (`base: feat/parte-1`).
+
+## Checklist de PR
+
+Antes de abrir ou mergear um PR, **sempre revise estes pontos** — mudanças
+não-óbvias na arquitetura ou na superfície pública do projeto exigem
+documentação acompanhada:
+
+- [ ] **README** — a mudança introduz uma feature nova, comando, env var, ou
+  conceito fundamental que o `README.md` precisa mencionar? Atualize a seção
+  apropriada (quick start, features, ou "Documentação adicional").
+- [ ] **`docs/`** — o guia de área correto está atualizado?
+  - `etl-guide.md` / `etl-incremental-guide.md` — mudou pipeline ETL
+  - `web-guide.md` — mudou rota, template, componente MD3
+  - `queries-guide.md` — adicionou Q##
+  - `mv-guide.md` — mexeu em MV
+  - `cache.md` — mexeu em `web_cache` ou shadow rewarm
+  - `deploy.md` / `ops.md` — mudou deploy ou runbook
+  - Atualize ou adicione diagramas Mermaid se o fluxo/topologia mudou.
+- [ ] **ADR** — a mudança é uma decisão arquitetural não-óbvia (afeta múltiplos
+  módulos, tem trade-offs não-triviais, alguém razoável poderia ter escolhido
+  diferente)? Se sim, **crie `docs/adr/NNNN-titulo.md`** seguindo o template em
+  [`docs/adr/README.md`](docs/adr/README.md). ADRs são **imutáveis** uma vez
+  `Accepted` — para revisar uma decisão, crie um ADR novo que supersede o
+  antigo.
+- [ ] **Glossário** — termo novo do domínio que merece entrada em
+  [`docs/glossario.md`](docs/glossario.md)?
+- [ ] **Testes** — `tests/incremental/` cobre o framework incremental;
+  para mudanças one-off, `python -m compileall etl -q` é o baseline mínimo.
+- [ ] **Audit scripts** — mexeu em `relatorios/` ou identificadores? Rode
+  `python scripts/audit_report_identifiers.py --strict` (offline) antes do PR.
+- [ ] **Trailer Copilot** em todo commit:
+  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+
+Esse checklist é a versão "humana" do que o [`AGENTS.md`](AGENTS.md) também
+exige para agentes de IA — fica consistente entre as duas audiências.
+
+## Contribuindo com agentes de IA
+
+O projeto foi escrito majoritariamente com auxílio de assistentes de IA
+(GitHub Copilot, Claude Code, Codex) e está estruturado para que novos
+contributors usem seus próprios agentes com baixa fricção.
+
+A fonte canônica de instruções para agentes vive em
+[`AGENTS.md`](AGENTS.md) na raiz do repositório. Ela é lida automaticamente
+por:
+
+- **GitHub Copilot CLI** — também lê `.github/copilot-instructions.md`
+- **Claude Code** — também lê `CLAUDE.md`
+- **Cursor**, **Aider**, **Codex CLI**, **Continue.dev** — leem `AGENTS.md`
+  diretamente
+
+`CLAUDE.md` e `.github/copilot-instructions.md` são arquivos-ponteiro curtos
+que apontam para `AGENTS.md`. **Edite só o `AGENTS.md`** — os outros dois
+ficam quase imutáveis. Justificativa em
+[ADR-0008](docs/adr/0008-agents-md-canonical.md).
+
+O `AGENTS.md` cobre:
+
+- Mapa de leitura dos `docs/` em ordem de prioridade
+- Comandos críticos de setup
+- Arquitetura essencial (com pointers para detalhes)
+- Convenções (no-pandas, no-ORM, RFB latin-1, etc.)
+- **Quirks descobertos pelos agentes** — gotchas em MD3, Jinja, MV, Mermaid,
+  cache typing, deploy. Internalize antes de mexer na área correspondente.
+- Checklist de PR (mesma versão acima, para consumo do agente)
+- Trailer obrigatório
+
+Se você adicionar uma convenção nova ou descobrir um quirk não-óbvio durante
+sua contribuição, **atualize o `AGENTS.md`** no mesmo PR — esse arquivo é o
+contrato de conhecimento institucional.
 
 ## O que você pode tocar / pode não tocar
 

--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Comece pela [arquitetura](docs/architecture.md), depois siga pro guia específic
 - [`docs/glossario.md`](docs/glossario.md) — 60+ termos do domínio público brasileiro (empenho, UG, CEIS, LGPD, etc.)
 - [`docs/onboarding.md`](docs/onboarding.md) — walk-through clone → `uvicorn` em 3 caminhos
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — convenções de código, commits, PRs
+- [`AGENTS.md`](AGENTS.md) — instruções canônicas para agentes de IA (Copilot CLI, Claude Code, Cursor, Aider, Codex). Inclui mapa de docs, comandos, convenções, quirks descobertos e checklist obrigatório de PR. Veja [ADR-0008](docs/adr/0008-agents-md-canonical.md)
 
 ### Guias por área
 
@@ -411,7 +412,7 @@ Comece pela [arquitetura](docs/architecture.md), depois siga pro guia específic
 
 ### Decisões arquiteturais (ADRs)
 
-- [`docs/adr/`](docs/adr/) — 5 ADRs: no-pandas, MV layered, shadow rewarm, framework incremental, no-ORM web
+- [`docs/adr/`](docs/adr/) — 8 ADRs: no-pandas, MV layered, shadow rewarm, framework incremental, no-ORM web, MV atomic swap, ETL normalize fix, AGENTS.md canonical
 
 ### Referência
 

--- a/docs/adr/0008-agents-md-canonical.md
+++ b/docs/adr/0008-agents-md-canonical.md
@@ -1,0 +1,130 @@
+# ADR-0008: AGENTS.md como fonte canônica de instruções para agentes de IA
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+O projeto já era escrito majoritariamente com auxílio de assistentes de IA
+(GitHub Copilot, Claude Code, Codex — ver banner do
+[`README.md`](../../README.md)) e o repositório está agora aberto para
+contribuições externas. Com isso, novos contributors trazem **seus próprios
+agentes**, cada um esperando arquivos de instruções em locais diferentes:
+
+- **GitHub Copilot CLI** lê `.github/copilot-instructions.md`,
+  `CLAUDE.md`, `GEMINI.md`, `AGENTS.md` (raiz e `cwd`), e
+  `.github/instructions/**/*.instructions.md`.
+- **Claude Code** lê `CLAUDE.md` (e em versões recentes também `AGENTS.md`).
+- **Cursor** lê `.cursorrules` (formato legacy) e `AGENTS.md` (formato novo).
+- **Aider**, **Codex CLI**, **Continue.dev** e outros adotaram `AGENTS.md`
+  como padrão a partir da spec [agents.md](https://agents.md).
+
+Até esta decisão, o repositório só tinha
+`.github/copilot-instructions.md` (~6.4 KB) e o conteúdo nele evoluiu junto
+com a base. As alternativas consideradas para suportar os múltiplos
+ecossistemas:
+
+1. **Duplicar conteúdo em três (ou mais) arquivos.** Garantia máxima de que
+   qualquer agente encontra o conteúdo, mas multiplica o esforço de
+   manutenção — toda mudança de convenção precisa ser replicada em 3+
+   lugares, com risco de drift entre cópias.
+2. **Symlinks `CLAUDE.md → AGENTS.md` etc.** Bonito em Linux/macOS, frágil no
+   Windows (que é onde o mantenedor trabalha — symlinks Git no Windows
+   exigem permissões especiais e quebram em alguns clientes). Pior, o
+   GitHub web UI não renderiza symlinks como o destino.
+3. **Arquivo canônico único + arquivos-ponteiro curtos.** Mantém um arquivo
+   com o conteúdo real; os outros são "stub" de 10-20 linhas explicando que
+   o canônico está em `AGENTS.md` e listando o que é essencial saber. Agentes
+   modernos leem todos os arquivos relevantes automaticamente, então enxergam
+   o ponteiro **e** o canônico no contexto.
+
+A discussão foi acelerada por uma observação concreta: a documentação oficial
+do GitHub Copilot CLI lista explicitamente
+[`AGENTS.md` entre os arquivos de instrução que o CLI respeita](https://docs.github.com/copilot/concepts/agents/about-copilot-cli),
+em pé de igualdade com `CLAUDE.md` e
+`.github/copilot-instructions.md`.
+
+## Decision
+
+**`AGENTS.md` na raiz do repositório é a fonte canônica de instruções para
+agentes de IA.** Ele segue a spec [agents.md](https://agents.md) e contém:
+
+- Visão geral do projeto e mapa de documentação
+- Comandos de setup
+- Arquitetura essencial (com pointers para `docs/`)
+- Convenções (no-pandas, no-ORM, latin-1 do RFB, identificadores em PT-BR…)
+- Quirks descobertos pelos agentes e mantenedor (Mermaid, MD3, MV layering,
+  cache typing, deploy, …)
+- Checklist obrigatório de PR (README / `docs/` / ADR / glossary / testes /
+  audit scripts / trailer)
+
+**`CLAUDE.md` e `.github/copilot-instructions.md` são arquivos-ponteiro
+curtos** (~25 linhas) que:
+
+- Apontam para `AGENTS.md`
+- Listam um TL;DR com 4-5 itens críticos (idioma, no-pandas, no-ORM, trailer,
+  PR checklist)
+- Referenciam este ADR
+
+Esse padrão preserva a descoberta automática (cada agente continua encontrando
+o arquivo que ele espera), evita duplicação de conteúdo, e mantém o canônico
+discoverable também para humanos navegando pelo repositório.
+
+## Consequences
+
+### Positive
+
+- **Uma única fonte de verdade.** Convenções, quirks e checklist de PR estão
+  num só lugar; mudanças não vazam de um arquivo para outro.
+- **Manutenção 1×** em vez de 3×.
+- **Cobertura ampla de agentes**: a spec `AGENTS.md` é o ponto de
+  convergência da indústria em 2025-2026; quase todos os agentes modernos
+  já leem.
+- **Discoverable também para humanos.** `AGENTS.md` na raiz aparece no
+  preview do GitHub e ajuda contributors sem agente a entender as
+  convenções do projeto.
+- **Pointer files explicam o padrão**, então mesmo agentes que só leem
+  `CLAUDE.md` ou `copilot-instructions.md` recebem um redirecionamento
+  legível.
+
+### Negative / Trade-offs
+
+- **Agentes muito antigos** que ignoram `AGENTS.md` e leem só seu arquivo
+  específico verão apenas o ponteiro + TL;DR — não o conteúdo completo.
+  Mitigação: o TL;DR cobre os ~5 itens mais críticos e o ponteiro instrui
+  explicitamente a abrir `AGENTS.md`.
+- **Risco de duplicar contexto.** Agentes que leem múltiplos arquivos
+  (Copilot CLI, Claude Code recente) podem carregar pointer + canônico
+  no mesmo prompt. O custo de tokens é baixo (pointer < 1 KB cada),
+  aceitável.
+- **Convenção precisa ser ensinada aos contributors humanos.** O
+  `CONTRIBUTING.md` agora referencia `AGENTS.md` explicitamente para que
+  contributors saibam onde editar.
+
+### Mitigations
+
+- TL;DR nos pointer files cobre o mínimo crítico para um agente legacy
+  fazer trabalho útil mesmo sem ler `AGENTS.md`.
+- `CONTRIBUTING.md` e `README.md` referenciam `AGENTS.md` como ponto de
+  partida para contributors usando agentes.
+- Se um novo agente popular surgir com formato próprio, adicionar um
+  novo pointer file segue o mesmo padrão (3 ou 4 arquivos pointer não
+  muda a economia da decisão).
+
+## Related
+
+- Code:
+  - [`AGENTS.md`](../../AGENTS.md) — canônico
+  - [`CLAUDE.md`](../../CLAUDE.md) — pointer
+  - [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md) — pointer
+- Other ADRs: nenhum diretamente, mas o conteúdo de `AGENTS.md` referencia
+  todos os outros ADRs como contexto arquitetural.
+- External:
+  - [agents.md spec](https://agents.md)
+  - [GitHub Copilot CLI — files respected](https://docs.github.com/copilot/concepts/agents/about-copilot-cli)
+  - [Anthropic Claude Code — CLAUDE.md docs](https://docs.anthropic.com/claude-code)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ veja [`docs/architecture.md`](../architecture.md).
 | ADR-0005 | [Sem ORM no web — raw SQL via psycopg2](0005-no-orm-web.md) | Accepted | 2024-08-01 |
 | ADR-0006 | [Atomic swap de Materialized Views (zero-downtime updates)](0006-mv-atomic-swap.md) | Accepted | 2026-05-16 |
 | ADR-0007 | [ETL-level fix para contaminação de cnpj_basico + REFRESH CONCURRENTLY](0007-etl-normalize-fix.md) | Accepted | 2026-05-16 |
+| ADR-0008 | [AGENTS.md como fonte canônica de instruções para agentes de IA](0008-agents-md-canonical.md) | Accepted | 2026-05-17 |
 
 ## Convenções
 


### PR DESCRIPTION
## Resumo

Consolida instruções para agentes de IA num arquivo canônico (`AGENTS.md`)
seguindo a spec [agents.md](https://agents.md). `CLAUDE.md` e
`.github/copilot-instructions.md` viram ponteiros curtos. Justificativa em
[ADR-0008](docs/adr/0008-agents-md-canonical.md).

## Por quê agora

Estamos preparando o repo para contribuições externas e contributors usam
agentes diferentes (Copilot CLI, Claude Code, Cursor, Aider, Codex). Cada um
busca seu arquivo de instruções em local diferente — sem padrão único,
teríamos que duplicar conteúdo em 3+ arquivos com risco de drift.

A doc oficial do Copilot CLI já lista `AGENTS.md` como arquivo respeitado
em pé de igualdade com `CLAUDE.md` e `.github/copilot-instructions.md`.

## Arquivos

| Operação | Arquivo | Tamanho | Conteúdo |
|---|---|---|---|
| 🆕 add | `AGENTS.md` | 17.5 KB | Canonical |
| 🆕 add | `CLAUDE.md` | 1.0 KB | Pointer + TL;DR |
| ✏️ replace | `.github/copilot-instructions.md` | 1.1 KB (era 6.4 KB) | Pointer + TL;DR |
| 🆕 add | `docs/adr/0008-agents-md-canonical.md` | 6.0 KB | ADR |
| ✏️ update | `docs/adr/README.md` | +1 linha | Índice ADRs |
| ✏️ update | `README.md` | +1 entry, count 5→8 | Documentação adicional |
| ✏️ update | `CONTRIBUTING.md` | +72 linhas | Sumário + checklist + seção agentes |

## O que `AGENTS.md` cobre

Além do conteúdo existente do `copilot-instructions.md` (setup, arquitetura,
convenções), incorpora **quirks descobertos pelos agentes em sessões
recentes** — coisas que já causaram retrabalho e merecem virar conhecimento
institucional:

**Frontend / MD3 / JS**
- `whenMD3Ready(cb)` gate antes de chamar métodos em custom elements
- `expandReportContext` como ponto único de in-page anchor expansion
- `anchor-auto-expand` intercepta `hashchange` — não dá pra ouvir nele
- `<details>` `toggle` é assíncrono — `setTimeout(0)` clear
- Macro `_collapsible.html` em vez de roll-your-own `<details>`
- `FALLBACK_CACHE_VERSION` em `sw.js` vs `ASSET_VERSION` em `web/main.py`
- Convenção kebab-case sem prefixo para eventos Umami
- `dualLabel('cidadao', 'auditor')` + classes `citizen-only`/`auditor-only`

**Templates / Jinja**
- Numéricos de `cached_query()` voltam como strings (warm_cache serializa com `default=str`) — coerce com `|float`/`|int` antes de `round()`
- Smoke-parse de templates Jinja registrando lambda noops para filtros customizados

**SQL / MV**
- Drops em ordem reversa no topo de `sql/12_views.sql`, footer com `REFRESH CONCURRENTLY`
- Q61/Q65/Q77 timeout em cidades grandes; nginx mata antes do `QueryDef.timeout_sec`

**Mermaid em docs** (lições das PRs #154 e #155)
- `;` em mensagens de `sequenceDiagram` quebra parser
- `&gt;`/`&lt;` NÃO decodificados em condition labels (alt/else/opt) — usar palavras
- Validação local sem render: `npm i mermaid jsdom` + `mermaid.parse()`

**ETL / Data**
- Bug do slug `olho-d-agua`/`mae-d-agua` em `mv_empresa_pb` (~50 Googlebot 404s/dia)
- `audit_report_identifiers.py --strict` roda offline

**Git / Workflow / Deploy**
- Apenas 9 labels GH padrão — usar `enhancement` para tudo
- Runner self-hosted single-slot — long ETL bloqueia web deploys
- `etl_phase=N` é 1-based index na lista local `phases` (não rótulo "Fase N")
- `gh pr merge` em worktree emite "main is already used" — cosmético, merge completa
- Prática recomendada: 2 reviewers paralelos (Opus + GPT) para PRs significativos

## Checklist de PR (novidade)

Agora explicitamente cobrado tanto em `AGENTS.md` quanto em `CONTRIBUTING.md`:

- [ ] README
- [ ] `docs/` (guia de área + diagramas Mermaid)
- [ ] ADR (decisões não-óbvias)
- [ ] `docs/glossario.md` (termos novos)
- [ ] Testes (`tests/incremental/` ou `compileall` baseline)
- [ ] `audit_report_identifiers.py --strict` (se mexeu em relatórios)
- [ ] Trailer Copilot em todo commit

## Por que pointer pattern e não duplicar

Discutido em detalhe no ADR-0008. Resumo:

1. **Duplicar em 3 arquivos** = 3× manutenção + drift garantido
2. **Symlinks** = frágil no Windows, GitHub web UI não renderiza
3. **Canonical + pointers** ✅ — agentes modernos lêem todos os arquivos
   relevantes automaticamente; cada um vê pointer + canônico, sem custo
   real de tokens

## Mermaid validation

Não tem novos blocos Mermaid neste PR (só atualização de texto). Verificado
que os 16 blocos existentes seguem validando OK.

## Próximo passo

Após merge, atualizar memórias dos agentes (incluindo a "Todo PR deve
verificar README/docs/ADR") que já está sendo aplicada **neste próprio PR**
de forma demonstrativa.
