### PR TITLE
feat(cache): cleanup_orphan_empresa_cache standalone (ADR-0009)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,6 +127,11 @@ on:
         required: false
         type: string
         default: ''
+      cleanup_orphan_empresa_cache:
+        description: 'Roda DELETE em web_cache (EMPRESA_PERFIL + EMPRESA_PERFIL_MUN) para entries cujo cnpj_basico nao existe mais em mv_empresa_pb. Usar APOS run_normalize_fix + refresh_mvs (que removeram empresas contaminadas por CPF padded). Sintoma sem cleanup: paginas /empresa/<cnpj>/<slug> orfas servem KPIs falsos do cache enquanto tabela live retorna 0. STANDALONE — nao redispara warm. Idempotente. Tempo: ~1-5 min. Ver ADR-0009.'
+        required: false
+        type: boolean
+        default: false
 
 # OIDC federado pro Azure (sem secrets de SP, sem expiracao).
 permissions:
@@ -848,6 +853,31 @@ jobs:
             END=$(date +%s)
             echo "=== $MV refreshed in $((END-START))s ==="
           done
+
+      # ── Cleanup orphan empresa cache (opt-in, standalone) ──
+      # DELETE entries em web_cache (EMPRESA_PERFIL + EMPRESA_PERFIL_MUN)
+      # apontando para CNPJs nao mais qualificados em mv_empresa_pb. Stale
+      # entries surgem apos ETL normalize fix (ADR-0007) remover CPFs
+      # padded contaminados que faziam empresas reais "fantasma" aparecerem
+      # recebendo R$ X mil. Apos refresh_mvs=mv_empresa_pb a MV fica limpa,
+      # mas o web_cache mantem entries antigas — warm cycle sobrescreve
+      # apenas empresas qualificadas atuais. Cleanup faz hard DELETE
+      # cirurgico (NOT EXISTS na MV).
+      #
+      # Use APOS run_normalize_fix + refresh_mvs (mv_empresa_pb incluso).
+      # Idempotente. NAO dispara warm. Tempo: ~1-5 min em prod (DELETE
+      # em batches via ctid pra nao segurar lock).
+      #
+      # Ver ADR-0009 + docs/cache.md secao "Cleanup de entries orfas".
+      - name: "Cleanup orphan empresa cache"
+        if: inputs.cleanup_orphan_empresa_cache == true
+        run: |
+          set -euo pipefail
+          cd ${{ env.PROJECT_DIR }}
+          source venv/bin/activate
+          source .env 2>/dev/null || true
+          echo "=== Cleanup orphan empresa cache (standalone) ==="
+          python -m web.warm_cache --cleanup-orphan-empresa 2>&1
 
       # ── Deploy web services ──
       - name: Deploy web frontend and cache warmer

--- a/README.md
+++ b/README.md
@@ -166,11 +166,12 @@ Use `cpf_cnpj` completo (14 dígitos) — não `cnpj_basico` (8 dígitos), que s
 
 ### Web cache e shadow rewarm
 
-A tabela `web_cache` armazena resultados pré-computados (FastAPI lê direto dela, sem rodar SQL pesado em request time). Três modos de atualização:
+A tabela `web_cache` armazena resultados pré-computados (FastAPI lê direto dela, sem rodar SQL pesado em request time). Quatro modos de manutenção:
 
 - **drop_cache** — `TRUNCATE web_cache` (12-18h de cache miss; use só em mudança de schema).
 - **invalidate_cache_keys** — `DELETE` cirúrgico HARD por **substring** de qid (causa cache miss até warm). Cuidado: `PERFIL` casa também `EMPRESA_PERFIL`, `PERFIL_DATED`, etc.
 - **rewarm_cache_keys** — shadow rewarm **zero-downtime**: warm escreve em `<qid>__pending`, swap atômico promove `__pending` → live só se todas as queries da chave passaram (fail==0); caso contrário, aborta e mantém live antigo. **Default recomendado** para mudanças em `web/queries/registry.py`.
+- **cleanup_orphan_empresa_cache** — `DELETE` standalone de entries `EMPRESA_PERFIL` + `EMPRESA_PERFIL_MUN` cujo `cnpj_basico` não existe mais em `mv_empresa_pb` (típico após `run_normalize_fix` + `refresh_mvs=mv_empresa_pb` que removeu empresas contaminadas por CPF padded). Não dispara warm. Ver [ADR-0009](docs/adr/0009-orphan-empresa-cache-cleanup.md).
 
 Auto-expansão: shadow de `PERFIL`/`TOP_FORN`/`TOP_SERV` propaga para `KPI_SUMMARY` (mesmo prefixo).
 
@@ -339,6 +340,7 @@ O `preflight` faz resize VM/disco para cima quando o `etl_phase` exige; o `postf
 | `drop_cache` | bool | TRUNCATE web_cache antes do warm |
 | `invalidate_cache_keys` | csv | DELETE cirúrgico HARD por **substring** (`LIKE '%termo%'`); `PERFIL` casa também `EMPRESA_PERFIL` |
 | `rewarm_cache_keys` | csv | shadow rewarm zero-downtime (preferido) |
+| `cleanup_orphan_empresa_cache` | bool | DELETE entries de `EMPRESA_PERFIL`/`EMPRESA_PERFIL_MUN` para CNPJs fora de `mv_empresa_pb` (após `refresh_mvs=mv_empresa_pb`) |
 | `warm_skip_hours` | int | controle de skip/rebuild do warm |
 | `expose_empresa_sitemap` / `_licitacoes_` / `_cidade_resumo_` | keep/enable/disable | toggle de URLs no sitemap |
 | `download_sources` | csv | re-baixa fontes específicas antes da fase |
@@ -412,7 +414,7 @@ Comece pela [arquitetura](docs/architecture.md), depois siga pro guia específic
 
 ### Decisões arquiteturais (ADRs)
 
-- [`docs/adr/`](docs/adr/) — 8 ADRs: no-pandas, MV layered, shadow rewarm, framework incremental, no-ORM web, MV atomic swap, ETL normalize fix, AGENTS.md canonical
+- [`docs/adr/`](docs/adr/) — 9 ADRs: no-pandas, MV layered, shadow rewarm, framework incremental, no-ORM web, MV atomic swap, ETL normalize fix, AGENTS.md canonical, orphan empresa cache cleanup
 
 ### Referência
 

--- a/docs/adr/0009-orphan-empresa-cache-cleanup.md
+++ b/docs/adr/0009-orphan-empresa-cache-cleanup.md
@@ -1,0 +1,224 @@
+# ADR-0009: Cleanup de entries órfãs em `web_cache` pós-MV refresh
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+Após o ETL normalize fix de [ADR-0007](0007-etl-normalize-fix.md) (PR #156),
+empresas que existiam em `mv_empresa_pb` apenas por contaminação de CPFs
+padded (ex: AVICOLA CHESTER MONGAGUA LTDA, CNPJ `00014020000111`, cujos
+8 dígitos `00014020` colidiam com o prefixo de CPFs mascarados
+`000.014.020-XX`) foram **removidas** da MV via `REFRESH MATERIALIZED
+VIEW CONCURRENTLY`.
+
+Mas o `web_cache` reteve as entries antigas dessas empresas órfãs:
+
+- `EMPRESA_PERFIL` (1 row por CNPJ): ~43.853 entries órfãs
+- `EMPRESA_PERFIL_MUN` (1 row por par `<cnpj14>:<slug-municipio>`): ~467.659
+  entries órfãs
+
+Total: ~511k rows de cache servindo agregados falsos.
+
+O warm cycle de `web/warm_cache.py` é UPSERT-only e enumera **apenas
+empresas qualificadas atuais** (de `mv_empresa_pb`). Empresas que
+deixaram de qualificar nunca são tocadas pelo warm — suas entries no
+cache permanecem stale indefinidamente.
+
+**Sintoma visível**: páginas `/empresa/<cnpj>/<slug>` órfãs renderizavam
+KPIs (R$ 100k, 112 empenhos, "atua em 3+ municípios") do cache stale,
+mas a tabela de empenhos (live query no banco) retornava "Nenhum
+empenho disponível". Inconsistência clara para o usuário.
+
+### Alternativas consideradas
+
+1. **Zerar agregados no payload (UPDATE JSONB)** — mantém entries no
+   cache com `total_tce_pago=0`, `empenhos_total=0`, etc. Preserva
+   cadastrais (estabelecimento, sócios, sanções, PGFN) e SEO.
+   Vantagem: páginas indexadas pelo Google continuam servindo
+   conteúdo "magro" mas válido. Desvantagem: 511k URLs vazias
+   continuam consumindo crawl budget, polui qualidade percebida do
+   site, e exige mapear ~25 campos do payload para zerar.
+
+2. **Tabela durável `empresa_url_indexada`** — registra cada CNPJ
+   emitido em sitemap/cache. Warm enumera UNION (qualifying ∪
+   indexada). Sobrevive a `drop_cache`. Vantagem: cobertura ampla.
+   Desvantagem: ~200 linhas de código novo + migração + tests; 3
+   pontos de falha (warm enum, tabela, `compute_empty` flag);
+   mantém 511k URLs vazias no índice.
+
+3. **DELETE entries stale** — hard remove do cache. Sitemap regenera
+   natural (só qualifying da MV). URLs órfãs acessadas via cache
+   miss → 503 com Retry-After, Google de-indexa em semanas.
+   Vantagem: simplicidade, self-healing, qualidade do índice
+   melhorada. Desvantagem: ~511k URLs indexadas viram 503/404
+   durante de-indexação.
+
+4. **Adicionar `allow_empty=True` em `compute_empresa_perfil_dict`** —
+   warm processaria empresas órfãs reescrevendo cache com payload
+   zerado. Combina com (2) acima.
+
+### Avaliação
+
+URLs com dados falsos prejudicam mais o site do que URLs ausentes.
+Manter páginas vazias indexadas confunde usuário ("essa empresa tem
+CNPJ válido mas zero empenho? bug?") sem benefício SEO real — essas
+são empresas fantasma de outros estados (AVICOLA SP, etc) sem
+backlinks externos.
+
+Tabela durável adiciona complexidade arquitetural permanente para um
+problema pontual: contaminação por CPF padded foi um bug de longa
+data corrigido em PR #156. Novas contaminações podem aparecer mas
+serão raras (RFB sync não delista, ETL normalize agora aplica EXISTS
+guard).
+
+## Decision
+
+Adotamos **alternativa 3** (DELETE entries stale) com função
+**standalone** invocável independentemente do warm cycle:
+
+### Implementação
+
+`web/warm_cache.py` ganha função `cleanup_orphan_empresa_cache(dry_run,
+batch_size, verbose)`:
+
+```python
+WITH stale AS (
+    SELECT wc.ctid
+    FROM web_cache wc
+    WHERE wc.query_id = 'EMPRESA_PERFIL'
+      AND NOT EXISTS (
+          SELECT 1 FROM mv_empresa_pb m
+          WHERE m.cnpj_basico = substring(wc.municipio, 1, 8)
+      )
+    LIMIT 5000
+)
+DELETE FROM web_cache wc
+USING stale s
+WHERE wc.ctid = s.ctid;
+-- Repete em loop ate rowcount=0; mesmo para EMPRESA_PERFIL_MUN.
+```
+
+Por que **batches via `ctid`**:
+
+- `LIMIT` direto em `DELETE` não é suportado pelo Postgres.
+- Batches evitam segurar lock longo em `web_cache` (read-heavy pelo
+  `cruza-web` servindo páginas).
+- Permite log de progresso entre batches.
+
+Por que **`substring(municipio, 1, 8)`** funciona para ambos qids:
+
+- `EMPRESA_PERFIL`: `municipio = cnpj_completo` (14 dígitos). Primeiros
+  8 = `cnpj_basico`.
+- `EMPRESA_PERFIL_MUN`: `municipio = '<cnpj14>:<slug>'`. Primeiros 8
+  = `cnpj_basico` (pois `cnpj14` tem 14 dígitos, slug vem após `:`).
+
+CLI:
+
+```bash
+python -m web.warm_cache --cleanup-orphan-empresa            # delete
+python -m web.warm_cache --cleanup-orphan-empresa --dry-run  # count only
+```
+
+### Deploy workflow
+
+Novo input em `.github/workflows/deploy.yml`:
+
+```yaml
+cleanup_orphan_empresa_cache:
+  description: 'Roda DELETE em web_cache (EMPRESA_PERFIL + EMPRESA_PERFIL_MUN)
+    para entries cujo cnpj_basico nao existe mais em mv_empresa_pb. ...'
+  required: false
+  type: boolean
+  default: false
+```
+
+Step novo "Cleanup orphan empresa cache" entre `MV refresh concurrently`
+e `Deploy web frontend and cache warmer`. **Não dispara warm cycle**
+(standalone) — diferentemente de `rewarm_cache_keys` que roda 3+ horas
+de warm.
+
+Sequência típica pós-ETL normalize fix:
+
+```bash
+# 1. ETL fix (idempotente)
+gh workflow run deploy.yml -f etl_phase=web -f run_normalize_fix=true
+
+# 2. Propagar fix nas MVs L1
+gh workflow run deploy.yml -f etl_phase=web \
+  -f refresh_mvs=mv_empresa_pb,mv_pessoa_pb,mv_municipio_pb_risco,mv_empresa_governo
+
+# 3. Propagar fix nas MVs L2
+gh workflow run deploy.yml -f etl_phase=web \
+  -f refresh_mvs=mv_servidor_pb_risco,mv_municipio_pb_kpi_score,mv_municipio_pb_mapa,mv_q67_dated_pb
+
+# 4. CLEANUP cache stale (este ADR) — leve, ~1-5 min
+gh workflow run deploy.yml -f etl_phase=web -f cleanup_orphan_empresa_cache=true
+
+# 5. (Opcional) Rewarm cache atualizado pra qualifying remanescentes
+gh workflow run deploy.yml -f etl_phase=web \
+  -f rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN,PERFIL,KPI_SUMMARY
+```
+
+## Consequences
+
+### Positive
+
+- **Simplicidade arquitetural**: ~30 linhas de código + step no
+  deploy. Sem tabela nova, sem mudança na rota, sem flag no compute.
+- **Self-healing futuro**: se nova contaminação aparecer (improvável
+  pós ADR-0007), basta rerodar `cleanup_orphan_empresa_cache=true`.
+  Idempotente.
+- **Standalone**: roda em ~1-5 min sem disparar warm de ~3 horas. VM
+  permanece em B2 (não dispara auto-resize do preflight).
+- **Sitemap regenera natural**: usa `_get_qualifying_empresas` da
+  `mv_empresa_pb`. Sem URLs órfãs no sitemap novo.
+- **Qualidade do índice melhora**: 511k URLs servindo dados falsos
+  saem do Google (semanas via 503 → de-index).
+
+### Negative / Trade-offs
+
+- **511k URLs indexadas viram 503 transient**: Google demora semanas
+  para de-indexar. Período de transição com URLs "quebradas" no
+  índice. Mitigação: dados serviam contaminação, perda real é zero.
+- **Sem rastro histórico de URLs órfãs**: se um dia precisarmos saber
+  "quais empresas foram cacheadas antes do fix", a info é perdida.
+  Mitigação: git tem o código antigo; Google Search Console mantém
+  histórico de URLs descobertas.
+- **Acessos diretos a URLs órfãs durante de-indexação**: usuário com
+  link salvo vê 503 com Retry-After 1h. Confuso mas raro — URLs de
+  empresas fantasma têm baixíssimo tráfego.
+- **Drop_cache risk inalterado**: se `drop_cache=true` rodar, todo
+  cache vai e qualifying empresas são re-warmadas via warm cycle.
+  Empresas órfãs sumem do cache (que é o resultado desejado).
+
+### Mitigations
+
+- **Idempotente**: re-run não corrompe.
+- **DELETE em batches**: lock curto, permite cancelar limpo.
+- **`--dry-run` flag**: conta sem deletar antes de comitar.
+- **Pre-flight**: função verifica `to_regclass` de `web_cache` e
+  `mv_empresa_pb` antes de tentar DELETE.
+
+## Related
+
+- Code:
+  - [`web/warm_cache.py::cleanup_orphan_empresa_cache`](../../web/warm_cache.py)
+- Workflow:
+  - [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml)
+    (input `cleanup_orphan_empresa_cache`).
+- Other ADRs:
+  - [ADR-0007](0007-etl-normalize-fix.md) — ETL normalize fix que
+    introduziu a inconsistência cache vs MV.
+  - [ADR-0003](0003-shadow-rewarm.md) — shadow rewarm (warm cycle
+    completo, alternativa pesada).
+- Docs:
+  - [`docs/cache.md`](../cache.md) seção "Cleanup de entries órfãs".
+- PRs:
+  - [#156](https://github.com/lucasdiniz/govbr-cruza-dados/pull/156) —
+    ETL normalize fix que motivou este ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ veja [`docs/architecture.md`](../architecture.md).
 | ADR-0006 | [Atomic swap de Materialized Views (zero-downtime updates)](0006-mv-atomic-swap.md) | Accepted | 2026-05-16 |
 | ADR-0007 | [ETL-level fix para contaminação de cnpj_basico + REFRESH CONCURRENTLY](0007-etl-normalize-fix.md) | Accepted | 2026-05-16 |
 | ADR-0008 | [AGENTS.md como fonte canônica de instruções para agentes de IA](0008-agents-md-canonical.md) | Accepted | 2026-05-17 |
+| ADR-0009 | [Cleanup de entries órfãs em `web_cache` pós-MV refresh](0009-orphan-empresa-cache-cleanup.md) | Accepted | 2026-05-17 |
 
 ## Convenções
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -136,6 +136,32 @@ curl -X POST https://transparenciapb.org/api/cache/invalidate \
 - **Cobertura mínima 80%** antes de `expose_empresa_sitemap=enable` no deploy — gate manual no `deploy.yml`.
 - **Shadow rows persistem entre deploys?** Não. O step "Reset shadow rows" do `deploy.yml` deleta `*__pending` no início de cada deploy, evitando shadow stale quando o SQL mudou entre runs.
 
+## Cleanup de entries órfãs (`cleanup_orphan_empresa_cache`)
+
+Entries órfãs surgem quando o ETL normalize remove dados-fonte que sustentavam uma empresa (caso típico: contaminação por CPF padded — ver [ADR-0007](adr/0007-etl-normalize-fix.md)). Após `REFRESH MATERIALIZED VIEW CONCURRENTLY mv_empresa_pb`, a MV fica limpa, mas `web_cache` mantém entries antigas para CNPJs não mais qualificados — o warm cycle só faz UPSERT sobre **empresas qualificadas atuais**, nunca toca órfãs.
+
+**Sintoma**: páginas `/empresa/<cnpj>/<slug>` órfãs servem KPIs do cache stale (R$ X mil, N empenhos) enquanto a tabela live retorna "Nenhum empenho disponível".
+
+**Fix**: função standalone `cleanup_orphan_empresa_cache` em [`web/warm_cache.py`](../web/warm_cache.py) faz hard DELETE em batches via `ctid` das entries `EMPRESA_PERFIL` + `EMPRESA_PERFIL_MUN` onde `substring(municipio, 1, 8) NOT IN mv_empresa_pb.cnpj_basico`:
+
+```bash
+# Dry-run: conta sem deletar
+python -m web.warm_cache --cleanup-orphan-empresa --dry-run
+
+# Live: DELETE em batches de 5000 (default)
+python -m web.warm_cache --cleanup-orphan-empresa
+```
+
+Via deploy:
+
+```bash
+gh workflow run deploy.yml -f etl_phase=web -f cleanup_orphan_empresa_cache=true
+```
+
+**Não dispara warm cycle** — standalone, ~1-5 min em prod. URLs órfãs viram cache miss (503 com Retry-After 1h) e Google de-indexa em semanas. Sitemap regenera natural só com qualifying da MV.
+
+Use **após** `run_normalize_fix=true` + `refresh_mvs=mv_empresa_pb` (que removeram empresas contaminadas). Idempotente. Ver [ADR-0009](adr/0009-orphan-empresa-cache-cleanup.md) para racional completo (alternativas avaliadas, trade-offs).
+
 ## Operações em produção
 
 A receita operacional canônica (mudou SQL de uma query → quero atualizar cache sem downtime):

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -384,6 +384,161 @@ def _swap_all_pending_shadows(verbose: bool = True) -> tuple[int, int]:
         )
     return swapped, len(aborted) + len(skipped_zero)
 
+
+# ─────────────────────────────────────────────────────────────────────────
+# CLEANUP ORPHAN EMPRESA CACHE — DELETE entries stale pos-MV refresh
+# ─────────────────────────────────────────────────────────────────────────
+# Stale entries surgem quando o ETL normalize remove CPFs padded contaminados
+# de tabelas-fonte (ADR-0007). Empresas "fantasma" (ex: AVICOLA CHESTER
+# MONGAGUA LTDA com cnpj_basico 00014020 colidindo com prefixo de CPFs
+# mascarados 000.014.020-XX) saem de mv_empresa_pb apos REFRESH CONCURRENTLY,
+# mas suas entries em web_cache (EMPRESA_PERFIL, EMPRESA_PERFIL_MUN)
+# permanecem stale: o warm cycle sobrescreve apenas empresas qualificadas
+# atuais, nunca toca as orfas.
+#
+# Sintoma: paginas /empresa/<cnpj>/<slug> orfas servem KPIs falsos do cache
+# (R$ X mil, N empenhos) com tabela live retornando 0 — inconsistencia
+# visivel ao usuario (descoberta apos PR #156 / ADR-0007).
+#
+# Decisao de DELETE (vs zerar agregados ou tabela durable de URLs): ver
+# ADR-0009. Resumo: simplicidade arquitetural, sitemap regenera natural
+# (so qualifying da MV), Google de-indexa URLs orfas via 503 transient
+# (cache miss). Dados "vazios" (cadastrais OK + agregados zero) sao tao
+# uteis ao usuario quanto a ausencia da pagina.
+#
+# Esta funcao roda STANDALONE — nao depende nem dispara warm cycle. Pode
+# ser invocada via:
+#   python -m web.warm_cache --cleanup-orphan-empresa
+#   python -m web.warm_cache --cleanup-orphan-empresa --dry-run
+# Ou via deploy.yml input `cleanup_orphan_empresa_cache=true`.
+# ─────────────────────────────────────────────────────────────────────────
+
+def cleanup_orphan_empresa_cache(
+    dry_run: bool = False, batch_size: int = 5000, verbose: bool = True
+) -> tuple[int, int]:
+    """DELETE entries em web_cache (EMPRESA_PERFIL, EMPRESA_PERFIL_MUN)
+    apontando para CNPJs nao mais qualificados em mv_empresa_pb.
+
+    Identifica stale via NOT EXISTS (SELECT 1 FROM mv_empresa_pb WHERE
+    cnpj_basico = substring(municipio, 1, 8)):
+      - EMPRESA_PERFIL: municipio = cnpj_completo (14 digitos)
+      - EMPRESA_PERFIL_MUN: municipio = '<cnpj14>:<slug>' (composite)
+
+    Em ambos os casos substring(municipio, 1, 8) extrai o cnpj_basico.
+    Filtros casam.
+
+    DELETEs sao em batches via WITH ... USING ctid pra:
+      - Nao segurar lock longo em web_cache (que e read-heavy pelo cruza-web).
+      - Permitir progress log e interrupcao limpa.
+
+    Args:
+        dry_run: se True, so loga contagem (sem DELETE).
+        batch_size: rows por iteracao. Default 5k = ~100 iteracoes pra
+            511k rows tipicas pos-fix.
+        verbose: log progresso a cada batch.
+
+    Returns: (deleted_perfil, deleted_perfil_mun).
+    """
+    print(
+        f"=== Cleanup orphan empresa cache ({'DRY-RUN' if dry_run else 'LIVE'}) ===",
+        flush=True,
+    )
+    conn = psycopg2.connect(DSN)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            # Pre-flight: web_cache existe? mv_empresa_pb existe?
+            cur.execute("SELECT to_regclass('public.web_cache')")
+            wc_ok = cur.fetchone()[0]
+            cur.execute("SELECT to_regclass('public.mv_empresa_pb')")
+            mv_ok = cur.fetchone()[0]
+            if not wc_ok or not mv_ok:
+                print(
+                    f"  web_cache={wc_ok}, mv_empresa_pb={mv_ok} — abortando "
+                    f"(uma das relacoes nao existe).",
+                    flush=True,
+                )
+                return 0, 0
+
+            # Conta total estimado antes de comecar (info pro user).
+            for qid in ("EMPRESA_PERFIL", "EMPRESA_PERFIL_MUN"):
+                cur.execute(
+                    """
+                    SELECT count(*) FROM web_cache wc
+                    WHERE wc.query_id = %s
+                      AND NOT EXISTS (
+                          SELECT 1 FROM mv_empresa_pb m
+                          WHERE m.cnpj_basico = substring(wc.municipio, 1, 8)
+                      )
+                    """,
+                    (qid,),
+                )
+                est = cur.fetchone()[0]
+                print(f"  {qid}: {est} entries orfas identificadas", flush=True)
+
+            if dry_run:
+                print("  DRY-RUN — nenhuma row deletada.", flush=True)
+                return 0, 0
+
+            # DELETE em batches por qid. Usa WITH ... USING ctid pra
+            # contornar a limitacao do PG (LIMIT direto em DELETE nao
+            # suportado) E permitir progress log entre batches.
+            deleted_total: dict[str, int] = {
+                "EMPRESA_PERFIL": 0,
+                "EMPRESA_PERFIL_MUN": 0,
+            }
+            for qid in ("EMPRESA_PERFIL", "EMPRESA_PERFIL_MUN"):
+                batch = 0
+                t0 = time.time()
+                while True:
+                    cur.execute(
+                        """
+                        WITH stale AS (
+                            SELECT wc.ctid
+                            FROM web_cache wc
+                            WHERE wc.query_id = %s
+                              AND NOT EXISTS (
+                                  SELECT 1 FROM mv_empresa_pb m
+                                  WHERE m.cnpj_basico = substring(wc.municipio, 1, 8)
+                              )
+                            LIMIT %s
+                        )
+                        DELETE FROM web_cache wc
+                        USING stale s
+                        WHERE wc.ctid = s.ctid
+                        """,
+                        (qid, batch_size),
+                    )
+                    n = cur.rowcount
+                    deleted_total[qid] += n
+                    batch += 1
+                    if verbose and (batch % 10 == 0 or n < batch_size):
+                        elapsed = time.time() - t0
+                        rate = deleted_total[qid] / elapsed if elapsed > 0 else 0
+                        print(
+                            f"  {qid}: batch {batch} ({n} deleted) — "
+                            f"total {deleted_total[qid]} ({rate:.0f}/s, "
+                            f"{elapsed:.1f}s)",
+                            flush=True,
+                        )
+                    if n == 0:
+                        break
+                print(
+                    f"  {qid}: DONE — {deleted_total[qid]} deleted em {batch} batches",
+                    flush=True,
+                )
+    finally:
+        conn.close()
+
+    print(
+        f"=== Cleanup complete: "
+        f"{deleted_total['EMPRESA_PERFIL']} EMPRESA_PERFIL + "
+        f"{deleted_total['EMPRESA_PERFIL_MUN']} EMPRESA_PERFIL_MUN ===",
+        flush=True,
+    )
+    return deleted_total["EMPRESA_PERFIL"], deleted_total["EMPRESA_PERFIL_MUN"]
+
+
 # Timeouts (segundos) usados pelo warmer. Sao MAIORES que os do frontend
 # porque rodamos em background e queremos popular o cache mesmo para queries
 # pesadas. Falhar aqui significa cache miss eterno no usuario final.
@@ -1186,7 +1341,29 @@ def main():
             "Use com --mun ou --loop (que ja sao escopados a cidades)."
         ),
     )
+    parser.add_argument(
+        "--cleanup-orphan-empresa",
+        action="store_true",
+        help=(
+            "STANDALONE: DELETE entries em web_cache (EMPRESA_PERFIL, "
+            "EMPRESA_PERFIL_MUN) apontando para CNPJs nao mais qualificados "
+            "em mv_empresa_pb. NAO dispara warm cycle. Use apos ETL "
+            "normalize fix (ADR-0007) ou refresh de mv_empresa_pb que "
+            "removeu empresas (ex: contaminacao por CPF padded). Idempotente. "
+            "Combine com --dry-run pra so contar."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Usado com --cleanup-orphan-empresa: so loga contagem sem deletar.",
+    )
     args = parser.parse_args()
+
+    # Standalone cleanup: nao dispara warm, sai apos limpar.
+    if args.cleanup_orphan_empresa:
+        cleanup_orphan_empresa_cache(dry_run=args.dry_run, verbose=True)
+        sys.exit(0)
 
     conn = psycopg2.connect(DSN)
     conn.autocommit = True


### PR DESCRIPTION
## Contexto

Apos PR #156 (ADR-0007) corrigir contaminacao por CPF padded em tabelas-fonte e os deploys subsequentes (`run_normalize_fix` + `refresh_mvs=mv_empresa_pb,...`) propagarem o fix nas MVs, foram descobertas ~511k entries stale em `web_cache`:

- `EMPRESA_PERFIL`: **43.853** CNPJs orfaos
- `EMPRESA_PERFIL_MUN`: **467.659** pares orfaos

Empresas fantasma como AVICOLA CHESTER MONGAGUA LTDA (CNPJ `00014020000111`, empresa SP-Mongagua) sairam de `mv_empresa_pb` apos o refresh (CPFs padded `000.014.020-XX` que coincidiam com o `cnpj_basico` foram limpos), mas suas entries no cache permaneceram com **dados falsos**: KPIs mostrando R$ 100k recebidos em 9 municipios PB enquanto a tabela live (frontend renderiza direto do banco) retornava "Nenhum empenho disponivel". Inconsistencia visivel ao usuario.

Confirmado empiricamente: 0/43.853 CNPJs stale tem empenhos legitimos (`cpf_cnpj=cnpj_completo`) em `tce_pb_despesa`.

## Por que warm cycle nao resolve sozinho

`web/warm_cache.py` faz UPSERT-only e enumera apenas empresas **qualificadas atuais** (de `mv_empresa_pb`). Empresas que deixaram de qualificar nunca sao tocadas pelo warm — entries permanecem stale indefinidamente.

## Mudancas

- `web/warm_cache.py`: funcao standalone `cleanup_orphan_empresa_cache(dry_run, batch_size, verbose)`. DELETE em batches via `ctid` de entries com `substring(municipio, 1, 8) NOT IN mv_empresa_pb.cnpj_basico`. Idempotente. CLI: `--cleanup-orphan-empresa` + `--dry-run`.
- `.github/workflows/deploy.yml`: input `cleanup_orphan_empresa_cache` (boolean) + step entre `MV refresh concurrently` e `Deploy web frontend`. **Nao dispara VM upsize** (B2 basta, DELETE leve), **nao dispara warm cycle** (standalone, ~1-5 min vs ~3h do rewarm shadow).
- `docs/adr/0009-orphan-empresa-cache-cleanup.md`: ADR avaliando 4 alternativas (zerar agregados, tabela durable, DELETE simples, compute_empty flag) e justificando DELETE.
- `docs/cache.md`: secao "Cleanup de entries orfas" antes de "Operacoes em producao".
- `README.md`: cleanup_orphan_empresa_cache no listing de modos de manutencao + tabela de inputs + bump "8 ADRs" -> "9 ADRs".
- `docs/adr/README.md`: entry ADR-0009.

## Trade-offs (ADR-0009)

Escolhemos **DELETE simples** sobre alternativas mais elaboradas:

| Opcao | Codigo | Pontos de falha | 511k URLs vazias indexadas |
| --- | --- | --- | --- |
| DELETE (escolhida) | ~30 linhas + step | 1 (funcao stand.) | Nao |
| Zerar agregados (UPDATE) | ~80 linhas mapeando ~25 campos | 1 | Sim |
| Tabela durable + UNION enum | ~200 linhas + migracao + tests | 3 | Sim |

URLs com dados falsos prejudicam mais que URLs ausentes. Empresas fantasma (de outros estados, sem backlinks externos) sem dado real nao agregam SEO. Google de-indexa via 503 transient em semanas.

## Sequencia de uso pos-ADR-0007

```bash
gh workflow run deploy.yml -f etl_phase=web -f run_normalize_fix=true
gh workflow run deploy.yml -f etl_phase=web -f refresh_mvs=mv_empresa_pb,...
gh workflow run deploy.yml -f etl_phase=web -f cleanup_orphan_empresa_cache=true  # ESTE PR
```

## Validacao

- `python -m compileall web -q` OK
- `python -c "import ast; ast.parse(open('web/warm_cache.py').read())"` OK
- `python -m web.warm_cache --help` mostra novas flags
- Funcao tem pre-flight (`to_regclass` check) + idempotencia por design (NOT EXISTS)
- DELETE em batches de 5k via `ctid` evita locks longos em `web_cache` (read-heavy pelo cruza-web)

## Cuidados pre-merge

- [ ] Review Opus 4.7 + GPT 5.5
- [ ] Deploy: `gh workflow run deploy.yml -f etl_phase=web -f cleanup_orphan_empresa_cache=true`
- [ ] Verificar contagem de entries deletadas vs estimativa (~511k)
- [ ] Smoke test: /empresa/00014020000111 retorna 503 (URL orfa)
