### PR TITLE
feat(empresa): cache miss = 404 (era 503) + deploy.yml one-off hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,19 @@ real data. Before merging new reports or editing identifiers, run
   - Numeric `N` — **1-based index** into the `phases` list in
     `etl/run_all.py` (Phase 0 Download counts as item 1) — **not** the
     "Fase N" label in the phase name.
+- **`deploy.yml` one-off inputs are technical debt.** Inputs like
+  `run_normalize_fix`, `rebuild_tmp_for_servidor`, `cleanup_orphan_empresa_cache`,
+  and ad-hoc `refresh_mvs` targets were created to remediate specific bugs
+  (typically a corresponding ADR). After they run **once** in production
+  they become dead code. When adding a similar one-off step:
+  1. Document the **trigger condition** and **expected removal criteria** in
+     the related ADR (e.g. "remove after running once in prod and verifying
+     X").
+  2. Open a follow-up issue to remove it.
+  3. Periodically (every few months) sweep `deploy.yml` and delete inputs
+     whose ADRs are `Status: Superseded` / no longer applicable.
+  See [`docs/deploy.md`](docs/deploy.md) section "One-off inputs hygiene" for
+  the current debt list.
 - **Do not commit** scratch outputs from local DB inspection: `db_*.txt`,
   `pg_*.txt`, `mv_status.txt`, `*_debug*.txt`, `*.log`, `q##_result.csv`.
 

--- a/docs/adr/0009-orphan-empresa-cache-cleanup.md
+++ b/docs/adr/0009-orphan-empresa-cache-cleanup.md
@@ -54,10 +54,11 @@ empenho disponível". Inconsistência clara para o usuário.
 
 3. **DELETE entries stale** — hard remove do cache. Sitemap regenera
    natural (só qualifying da MV). URLs órfãs acessadas via cache
-   miss → 503 com Retry-After, Google de-indexa em semanas.
+   miss → **404 Not Found** (rota mudou de 503 para 404 junto com
+   este ADR — ver "Decision" abaixo). Google de-indexa em ~7-30 dias.
    Vantagem: simplicidade, self-healing, qualidade do índice
-   melhorada. Desvantagem: ~511k URLs indexadas viram 503/404
-   durante de-indexação.
+   melhorada. Desvantagem: ~511k URLs indexadas viram 404 durante
+   de-indexação.
 
 4. **Adicionar `allow_empty=True` em `compute_empresa_perfil_dict`** —
    warm processaria empresas órfãs reescrevendo cache com payload
@@ -80,9 +81,42 @@ guard).
 ## Decision
 
 Adotamos **alternativa 3** (DELETE entries stale) com função
-**standalone** invocável independentemente do warm cycle:
+**standalone** invocável independentemente do warm cycle, **acompanhada
+de mudança no contrato de cache miss da rota `/empresa/<cnpj>` (e
+`/empresa/<cnpj>/<slug>`)** de `503 Service Unavailable` para
+`404 Not Found`.
 
-### Implementação
+### Rota: cache miss = 404 (era 503)
+
+Antes deste ADR, `web/routes/empresa.py` retornava `503` com
+`Retry-After: 3600` em cache miss. A intenção original era proteger o
+DB em cold start (warm ainda não completou) e dizer ao crawler "volte
+depois". Mas com:
+
+- **Warm cycle pós-PR #156** que cobre todas as empresas qualificadas
+  em `mv_empresa_pb`,
+- **`cleanup_orphan_empresa_cache`** que remove entries de CNPJs não
+  mais qualificados,
+- **Sitemap gated** (só inclui CNPJs após warm),
+
+um cache miss em `/empresa/<cnpj>` significa essencialmente uma das
+três situações:
+
+1. CNPJ inexistente / URL inventada;
+2. CNPJ órfão (foi removido do cache pelo cleanup);
+3. CNPJ recém-qualificado entre warms (caso raríssimo — crawler só
+   descobre via sitemap, que só lista pós-warm).
+
+Em todos os casos, **a URL não representa um recurso válido no
+domínio PB**. `404 Not Found` é semanticamente correto e produz
+melhor sinal SEO: Google de-indexa URLs 404 em ~7-30 dias, vs
+semanas-meses pra 503 transient. Para as ~511k URLs órfãs que estão
+sendo limpas, isso acelera materialmente a saída do índice.
+
+Cold start (warm ainda rodando após restart) continua possível mas é
+caso transitório e raro — o trade-off pra produção é favorável.
+
+### Implementação do cleanup
 
 `web/warm_cache.py` ganha função `cleanup_orphan_empresa_cache(dry_run,
 batch_size, verbose)`:
@@ -170,7 +204,7 @@ gh workflow run deploy.yml -f etl_phase=web \
 ### Positive
 
 - **Simplicidade arquitetural**: ~30 linhas de código + step no
-  deploy. Sem tabela nova, sem mudança na rota, sem flag no compute.
+  deploy. Sem tabela nova, sem flag no compute.
 - **Self-healing futuro**: se nova contaminação aparecer (improvável
   pós ADR-0007), basta rerodar `cleanup_orphan_empresa_cache=true`.
   Idempotente.
@@ -179,23 +213,29 @@ gh workflow run deploy.yml -f etl_phase=web \
 - **Sitemap regenera natural**: usa `_get_qualifying_empresas` da
   `mv_empresa_pb`. Sem URLs órfãs no sitemap novo.
 - **Qualidade do índice melhora**: 511k URLs servindo dados falsos
-  saem do Google (semanas via 503 → de-index).
+  saem do Google em ~7-30 dias (vs semanas-meses se rota fosse 503).
+- **Semântica HTTP correta**: 404 reflete "URL não existe" para
+  CNPJs fora de `mv_empresa_pb`.
 
 ### Negative / Trade-offs
 
-- **511k URLs indexadas viram 503 transient**: Google demora semanas
-  para de-indexar. Período de transição com URLs "quebradas" no
-  índice. Mitigação: dados serviam contaminação, perda real é zero.
+- **511k URLs indexadas viram 404 transient**: Google ainda demora
+  ~7-30 dias para de-indexar. Período de transição com URLs "Not
+  Found" no índice. Mitigação: dados serviam contaminação, perda
+  real é zero.
 - **Sem rastro histórico de URLs órfãs**: se um dia precisarmos saber
   "quais empresas foram cacheadas antes do fix", a info é perdida.
   Mitigação: git tem o código antigo; Google Search Console mantém
   histórico de URLs descobertas.
-- **Acessos diretos a URLs órfãs durante de-indexação**: usuário com
-  link salvo vê 503 com Retry-After 1h. Confuso mas raro — URLs de
-  empresas fantasma têm baixíssimo tráfego.
-- **Drop_cache risk inalterado**: se `drop_cache=true` rodar, todo
-  cache vai e qualifying empresas são re-warmadas via warm cycle.
-  Empresas órfãs sumem do cache (que é o resultado desejado).
+- **Cold start mostra 404 em vez de 503**: usuário/crawler acessando
+  durante warm ainda rodando vê 404 (era 503 transient). Mitigação:
+  cold start é raro (deploys ~mensais), e o caso "novo CNPJ qualificado
+  ainda não cacheado" só é descoberto via sitemap (que só lista pós-
+  warm).
+- **Drop_cache risk**: se `drop_cache=true` rodar, **todas** as URLs
+  retornam 404 até o warm reconstruir o cache. Antes era 503 (less
+  drastic). Mitigação: `drop_cache=true` é operação rara/manual com
+  janela controlada.
 
 ### Mitigations
 
@@ -209,6 +249,7 @@ gh workflow run deploy.yml -f etl_phase=web \
 
 - Code:
   - [`web/warm_cache.py::cleanup_orphan_empresa_cache`](../../web/warm_cache.py)
+  - [`web/routes/empresa.py`](../../web/routes/empresa.py) — `empresa_perfil` + `empresa_perfil_municipio` (cache miss = 404).
 - Workflow:
   - [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml)
     (input `cleanup_orphan_empresa_cache`).

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -158,7 +158,7 @@ Via deploy:
 gh workflow run deploy.yml -f etl_phase=web -f cleanup_orphan_empresa_cache=true
 ```
 
-**Não dispara warm cycle** — standalone, ~1-5 min em prod. URLs órfãs viram cache miss (503 com Retry-After 1h) e Google de-indexa em semanas. Sitemap regenera natural só com qualifying da MV.
+**Não dispara warm cycle** — standalone, ~1-5 min em prod. URLs órfãs viram cache miss → **404 Not Found** (a rota `/empresa/<cnpj>` retorna 404 em cache miss desde a mudança que acompanhou ADR-0009/ADR-0007). Google de-indexa em ~7-30 dias (vs semanas/meses se fosse 503 transient). Sitemap regenera natural só com qualifying da MV.
 
 Use **após** `run_normalize_fix=true` + `refresh_mvs=mv_empresa_pb` (que removeram empresas contaminadas). Idempotente. Ver [ADR-0009](adr/0009-orphan-empresa-cache-cleanup.md) para racional completo (alternativas avaliadas, trade-offs).
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -239,6 +239,26 @@ etl_phase: incremental
 incremental_only: "tce_pb.tce_pb_despesa"
 ```
 
+## One-off inputs hygiene
+
+Alguns inputs do `deploy.yml` foram criados para remediar incidentes ou bugs específicos. Após rodarem em produção e o problema ser resolvido, **viram débito técnico**: inflam o UI do `workflow_dispatch`, confundem novos contributors, e arrastam código de step que nunca mais é executado.
+
+**Inputs atualmente nessa categoria** (candidatos a remoção em sweeps periódicos):
+
+| Input | Origem | Remoção sugerida quando... |
+| --- | --- | --- |
+| `run_normalize_fix` | [ADR-0007](adr/0007-etl-normalize-fix.md) | Rodou em prod + ETL atual já aplica EXISTS guard automaticamente |
+| `rebuild_tmp_for_servidor` | [ADR-0007](adr/0007-etl-normalize-fix.md) | Rodou em prod + `_tmp_*` rebuilds reincorporados no fluxo normal |
+| `cleanup_orphan_empresa_cache` | [ADR-0009](adr/0009-orphan-empresa-cache-cleanup.md) | Rodou em prod + nenhuma nova contaminação esperada por meses |
+
+**Diretriz**: ao introduzir input novo nessa categoria:
+
+1. **Documente o trigger condition + critério de remoção** no ADR associado.
+2. **Abra issue de followup** referenciando o ADR.
+3. **Periodicamente** (a cada 3-6 meses), faça PR de sweep removendo inputs cujos critérios de remoção foram satisfeitos. ADRs ficam como histórico institucional; o YAML fica enxuto.
+
+Caso alternativo (preferível quando possível): em vez de adicionar input permanente no `deploy.yml`, escreva script ad-hoc em `scripts/` invocado manualmente uma vez no servidor via SSH. Sem dívida técnica subsequente.
+
 ## Setup OIDC Azure (1x, ~5min)
 
 Exemplo para criar uma App Registration/Service Principal federado para o workflow da branch `main`. Substitua placeholders pelos valores reais.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -242,7 +242,9 @@ Resultado esperado:
 - `/cidade/joao-pessoa` deve retornar 200 apenas se cache/MVs estiverem
   populados;
 - rotas cache-only podem retornar **503** em cache miss, o que é esperado em
-  banco vazio.
+  banco vazio. (Exceção: `/empresa/<cnpj>` e `/empresa/<cnpj>/<slug>` retornam
+  **404** em cache miss desde ADR-0009 — semântica de "URL não representa
+  recurso qualificado em `mv_empresa_pb`".)
 
 ## Fluxo mental do projeto
 

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -2,10 +2,14 @@
 
 ARQUITETURA pos-incidente do PR #57:
 - Rota e CACHE-ONLY: le de web_cache (chave EMPRESA_PERFIL:<cnpj>) e renderiza.
-- Cache miss = 503 com Retry-After (NAO faz live query — protege DB do
-  thundering herd que derrubou o site quando IndexNow notificou Bing sobre
-  45K URLs simultaneamente). Cache-miss-only e seguro porque empresas so
-  entram no sitemap depois de warmed.
+- Cache miss = 404 (NAO faz live query — protege DB do thundering herd que
+  derrubou o site quando IndexNow notificou Bing sobre 45K URLs simultaneamente).
+  Cache-miss-only e seguro porque empresas so entram no sitemap depois de
+  warmed, e cleanup_orphan_empresa_cache (ADR-0009) garante que entries
+  stale para CNPJs nao mais qualificados sao removidas. Miss aqui significa
+  URL nao representa empresa qualificada na PB — 404 e semanticamente
+  correto e acelera de-index de URLs antigas no Google (vs 503 transient
+  que demora semanas-meses).
 - A funcao `compute_empresa_perfil_dict` executa as 8 queries e monta o
   dict completo. Eh chamada APENAS pelo warmer (web/warm_cache.py), nunca
   inline na rota.
@@ -627,7 +631,7 @@ def compute_empresa_municipio_perfil_dict(
 
 @router.get("/empresa/{cnpj}")
 async def empresa_perfil(request: Request, cnpj: str):
-    """Renderiza /empresa/<14-digits>. Le de web_cache. Cache miss = 503.
+    """Renderiza /empresa/<14-digits>. Le de web_cache. Cache miss = 404.
 
     NUNCA executa as 8 queries inline. O incidente do PR #57 mostrou que
     sob trafego de crawler agressivo (Bing + 45K URLs do IndexNow), o pool
@@ -653,7 +657,7 @@ async def empresa_perfil(request: Request, cnpj: str):
     # de filial (ordem != 0001), redireciona pra matriz canonica usando DV
     # computado matematicamente (sem DB hit, mantem cache-only invariant).
     # Sem isso, links do dialog de fornecedor que usam exactDoc da filial
-    # cairiam em 503 mesmo apos warmer rodar (caught by GPT-5.5 review #58).
+    # cairiam em 404 mesmo apos warmer rodar (caught by GPT-5.5 review #58).
     cnpj_ordem = canonical[8:12]
     if cnpj_ordem != "0001":
         try:
@@ -680,21 +684,26 @@ async def empresa_perfil(request: Request, cnpj: str):
                     request, "results/empresa.html", data
                 )
 
-    # Cache miss. Em fluxo normal (pos-warm), so deveria acontecer pra:
-    # (a) CNPJ que nao ta em mv_empresa_pb (deveria ser 404), ou
-    # (b) primeiras requests apos restart antes de warm completar.
-    # Retornamos 503 com Retry-After 1h pra crawler back off. A AUSENCIA
-    # do CNPJ no sitemap (gated) significa que crawlers nem deveriam
-    # estar aqui — se chegou ate aqui, eh acesso direto/legado.
-    _log.info("cache miss /empresa/%s — returning 503", canonical)
-    return Response(
-        status_code=503,
-        headers={"Retry-After": "3600"},
-        content=(
-            "Perfil em construcao — esta empresa ainda nao foi pre-processada. "
-            "Tente novamente mais tarde."
-        ),
-        media_type="text/plain; charset=utf-8",
+    # Cache miss. Pos-warm cycle + cleanup_orphan_empresa_cache (ADR-0009),
+    # a tabela web_cache contem apenas CNPJs qualificados em mv_empresa_pb.
+    # Miss aqui significa:
+    #   (a) CNPJ inexistente (URL inventada ou digitada errada);
+    #   (b) CNPJ orfao (foi removido do cache pelo cleanup pos-MV refresh
+    #       que retirou empresas-fantasma contaminadas por CPF padded);
+    #   (c) edge case raro: empresa nova entre warms (so visivel via
+    #       sitemap apos proximo warm).
+    # Em (a) e (b), 404 e o codigo HTTP correto (URL nao representa um
+    # recurso valido na PB). Em (c), 404 pode causar de-index transiente
+    # de uma URL recem-criada, mas como crawlers descobrem essas URLs
+    # via sitemap (que so lista apos warm), o caso e improvavel.
+    # 404 acelera de-index das ~511k URLs orfas no Google (vs 503 que
+    # Google trata como transient e demora semanas-meses pra de-indexar).
+    _log.info("cache miss /empresa/%s — returning 404 (URL not in qualifying set)", canonical)
+    return templates.TemplateResponse(
+        request,
+        "errors/404.html",
+        {"path": str(request.url.path)},
+        status_code=404,
     )
 
 
@@ -708,7 +717,7 @@ async def empresa_perfil_municipio(
     request: Request, cnpj: str, municipio_slug_in: str
 ):
     """Renderiza /empresa/<14-digits>/<municipio-slug>. Cache-only (mesmo
-    invariant da rota global): cache miss = 503 com Retry-After 1h.
+    invariant da rota global): cache miss = 404 (ver docstring do modulo).
 
     Validacoes em ordem:
     1. CNPJ canonico (14 digitos numericos puros, sem mascara).
@@ -716,7 +725,7 @@ async def empresa_perfil_municipio(
     3. Slug municipio resolve via slug_to_municipio. None = 404.
     4. Slug nao canonico -> 301 pro slug canonico.
     5. Lookup web_cache(EMPRESA_PERFIL_MUN, "<cnpj>:<slug>"). Hit -> render.
-       Miss -> 503.
+       Miss -> 404.
     """
     from web.main import templates
 
@@ -805,17 +814,14 @@ async def empresa_perfil_municipio(
                 )
 
     _log.info(
-        "cache miss /empresa/%s/%s — returning 503",
+        "cache miss /empresa/%s/%s — returning 404 (URL not in qualifying set)",
         canonical_cnpj, canonical_slug,
     )
-    return Response(
-        status_code=503,
-        headers={"Retry-After": "3600"},
-        content=(
-            "Perfil em construcao — este recorte (empresa × municipio) "
-            "ainda nao foi pre-processado. Tente novamente mais tarde."
-        ),
-        media_type="text/plain; charset=utf-8",
+    return templates.TemplateResponse(
+        request,
+        "errors/404.html",
+        {"path": str(request.url.path)},
+        status_code=404,
     )
 
 


### PR DESCRIPTION
## Contexto

Apos PR #165 ([ADR-0009](docs/adr/0009-orphan-empresa-cache-cleanup.md)) limpar ~511k entries orfas em `web_cache` (empresas-fantasma contaminadas por CPF padded), as URLs orfas comecaram a retornar **503 transient com Retry-After 1h** em cache miss. Google trata 503 como "tente de novo" — de-indexa em **semanas/meses**, mantendo URLs falsas no indice por muito tempo.

## Mudanca

Cache miss em `/empresa/<cnpj>` e `/empresa/<cnpj>/<slug>` agora retorna **404 Not Found**.

**Justificativa**: pos-PR #156 + PR #165, cache miss significa:

- (a) CNPJ inexistente — URL inventada/digitada errada → 404 correto
- (b) CNPJ orfao — limpo pelo cleanup pos-MV refresh → 404 correto
- (c) cold start raro (warm rodando apos restart) → 404 transient, aceitavel

Em todos os casos, a URL **nao representa recurso valido na PB**. 404 e:

- Semanticamente correto (URL nao existe no dominio PB)
- Acelera de-index das ~511k URLs orfas no Google (~7-30 dias vs semanas/meses)
- Libera crawl budget do Google pras URLs validas

## Comparativo 503 vs 404 (Google)

| | 503 | 404 |
| --- | --- | --- |
| Re-crawl | Sim, frequente | Sim, mas reduz gradualmente |
| De-index | Semanas/meses | ~7-30 dias |
| Crawl budget | Mantem | Libera |
| Semantica | "Volta depois" | "Nao existe" |

Pro nosso caso (URLs orfas permanentes, sem volta possivel), 404 e estritamente melhor.

## Mudancas

- `web/routes/empresa.py`: cache miss em `empresa_perfil()` e `empresa_perfil_municipio()` retorna 404 (template `errors/404.html`). Docstrings + logs atualizados. `SlugLookupError` no slug resolver continua 503 (cold start legitimo de cache de slugs, nao caso orfao).
- `docs/adr/0009-orphan-empresa-cache-cleanup.md`: ampliado "Decision" pra cobrir mudanca de rota, atualizado Positive/Negative com trade-offs.
- `docs/cache.md`: secao "Cleanup de entries orfas" atualizada.
- `docs/onboarding.md`: nota sobre excecao da rota empresa.

## Bonus: deploy.yml one-off hygiene

Aproveitando o PR, adicionei documentacao sobre **debito tecnico de inputs one-off no deploy.yml**. Inputs como `run_normalize_fix`, `rebuild_tmp_for_servidor`, `cleanup_orphan_empresa_cache` foram criados pra remediar bugs especificos. Apos rodarem em prod, viram dead code — inflam o UI do `workflow_dispatch` e confundem novos contributors.

- `docs/deploy.md`: nova secao "One-off inputs hygiene" listando inputs candidatos a remocao em sweeps periodicos.
- `AGENTS.md`: bullet na secao Conventions apontando pra doc.

Diretriz: ao criar input one-off novo, documente trigger condition + criterio de remocao no ADR associado, abra issue de followup. Sweeps a cada 3-6 meses removem inputs cujos criterios ja foram satisfeitos.

## Trade-offs

- **511k URLs orfas viram 404 transient**: Google leva ~7-30 dias pra de-indexar. Aceitavel — dados serviam contaminacao.
- **Cold start raro mostra 404**: improvavel porque sitemap so lista pos-warm. Empresa nova entre warms tem inbound zero.
- **`drop_cache=true` torna site mais "agressivo"**: 404 ate warm reconstruir. Operacao manual rara com janela controlada.

## Validacao

- `python -m compileall web -q` OK
- `python -c "import ast; ast.parse(open('web/routes/empresa.py').read())"` OK
- `Response` import preservado (`SlugLookupError` continua usando)

## Cuidados pre-merge

- [ ] Review Opus 4.7 + GPT 5.5
- [ ] Smoke test pos-deploy: `/empresa/00014020000111` retorna 404 (orfa, foi limpa pelo PR #165)
- [ ] Smoke test: `/empresa/<cnpj-valido>` continua renderizando 200
- [ ] Confirmar template `errors/404.html` renderiza bem nessa rota (sem dependencias quebradas)
