### PR TITLE
fix(seo): sitemap shard past-end retorna 410 Gone (era urlset vazio 200)

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -160,7 +160,7 @@ gh workflow run deploy.yml -f etl_phase=web -f cleanup_orphan_empresa_cache=true
 
 **Não dispara warm cycle** — standalone, ~1-5 min em prod. URLs órfãs viram cache miss → **404 Not Found** (a rota `/empresa/<cnpj>` retorna 404 em cache miss desde a mudança que acompanhou ADR-0009/ADR-0007). Google de-indexa em ~7-30 dias (vs semanas/meses se fosse 503 transient). Sitemap regenera natural só com qualifying da MV.
 
-**Shards de sitemap past-end** (ex: `/sitemap-empresas-municipios-9.xml` quando só existem 7 shards reais pós-cleanup) retornam **410 Gone** desde o fix do encolhimento MV. Antes retornavam `<urlset></urlset>` HTTP 200 — válido para sitemap.org mas Google Search Console acusava "Tag XML ausente" e mantinha shard no índice histórico. Implementado em [`web/routes/seo.py`](../web/routes/seo.py) com buffer de 1 shard para tolerar crescimento da MV entre count e build.
+**Shards de sitemap past-end** (ex: `/sitemap-empresas-municipios-9.xml` quando só existem 7 shards reais pós-cleanup) retornam **410 Gone** desde o fix do encolhimento MV. Antes retornavam `<urlset></urlset>` HTTP 200 — válido para sitemap.org mas Google Search Console acusava "Tag XML ausente" e mantinha shard no índice histórico. Implementado em [`web/routes/seo.py`](../web/routes/seo.py) para `/sitemap-empresas-{n}` e `/sitemap-empresas-municipios-{n}`. Licitações fica de fora porque count lê de `web_cache` (oscila durante warm) — manter urlset vazio é safe enquanto warm popula.
 
 Use **após** `run_normalize_fix=true` + `refresh_mvs=mv_empresa_pb` (que removeram empresas contaminadas). Idempotente. Ver [ADR-0009](adr/0009-orphan-empresa-cache-cleanup.md) para racional completo (alternativas avaliadas, trade-offs).
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -160,6 +160,8 @@ gh workflow run deploy.yml -f etl_phase=web -f cleanup_orphan_empresa_cache=true
 
 **Não dispara warm cycle** — standalone, ~1-5 min em prod. URLs órfãs viram cache miss → **404 Not Found** (a rota `/empresa/<cnpj>` retorna 404 em cache miss desde a mudança que acompanhou ADR-0009/ADR-0007). Google de-indexa em ~7-30 dias (vs semanas/meses se fosse 503 transient). Sitemap regenera natural só com qualifying da MV.
 
+**Shards de sitemap past-end** (ex: `/sitemap-empresas-municipios-9.xml` quando só existem 7 shards reais pós-cleanup) retornam **410 Gone** desde o fix do encolhimento MV. Antes retornavam `<urlset></urlset>` HTTP 200 — válido para sitemap.org mas Google Search Console acusava "Tag XML ausente" e mantinha shard no índice histórico. Implementado em [`web/routes/seo.py`](../web/routes/seo.py) com buffer de 1 shard para tolerar crescimento da MV entre count e build.
+
 Use **após** `run_normalize_fix=true` + `refresh_mvs=mv_empresa_pb` (que removeram empresas contaminadas). Idempotente. Ver [ADR-0009](adr/0009-orphan-empresa-cache-cleanup.md) para racional completo (alternativas avaliadas, trade-offs).
 
 ## Operações em produção

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -551,16 +551,30 @@ async def sitemap_empresas_shard_xml(request: Request, shard_n: int) -> Response
     quebrando todas as URLs municipios-scoped no sitemap. (P1 do GPT-5.5
     review do PR #62.)
 
-    Validacao adicional: 1-9999 via regex. Shards inexistentes (alem do
-    numero de shards atual) retornam urlset vazio (200 valido) — Google
-    tolera, e evita 404 transitorio se sitemap-index aponta pra shard
-    que ainda nao foi cacheado.
+    Validacao adicional: 1-9999 via regex. Shard past-end (alem do numero
+    real de shards atualmente) retorna 410 Gone — sinaliza ao Google que
+    o sub-sitemap nao existe mais, removendo do indice mais rapido que
+    urlset vazio (que aparece como "Tag XML ausente" em Search Console
+    quando a MV encolhe — ex: pos cleanup de PR #165, ADR-0009).
+
+    Buffer de 1 shard: tolera crescimento da MV entre count e build
+    (sitemap-index pode listar 1 shard a mais do que count atual indica
+    se MV acabou de crescer).
 
     Cache 1h por shard em _SITEMAP_CACHE['empresas'][n].
     """
     if shard_n < 1 or shard_n > 9999:
         raise HTTPException(status_code=404)
     n = shard_n
+
+    # Past-end detection: shard alem do numero real atual = 410 Gone.
+    # Count ja cacheado 1h (_empresas_qualificadas_count usa _SITEMAP_TTL).
+    total = _empresas_qualificadas_count()
+    if total > 0:
+        max_shard = math.ceil(total / EMPRESA_SHARD_SIZE)
+        # +1 buffer pra tolerar crescimento entre count cache miss e build.
+        if n > max_shard + 1:
+            raise HTTPException(status_code=410)
 
     origin = _site_origin(request)
     now = time.time()
@@ -599,14 +613,22 @@ _EMPRESAS_MUN_SHARD_RE = re.compile(r"^[1-9]\d{0,3}$")
 @router.get("/sitemap-empresas-municipios-{shard_n:int}.xml")
 async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: int) -> Response:
     """Sub-sitemap shard das URLs /empresa/<cnpj>/<slug>. Mesma logica do
-    shard /sitemap-empresas-{n}.xml: regex 1-9999, past-end retorna urlset
-    vazio sem cache. Cache 1h por shard.
+    shard /sitemap-empresas-{n}.xml: regex 1-9999, past-end retorna 410
+    Gone (era urlset vazio antes do fix do encolhimento MV, ver PR #165
+    + ADR-0009). Cache 1h por shard.
 
     Path converter `int` evita conflito com a rota irma (sem isso ambas
     competem pelo mesmo path). Vide P1 do GPT-5.5 review."""
     if shard_n < 1 or shard_n > 9999:
         raise HTTPException(status_code=404)
     n = shard_n
+
+    # Past-end detection (mesmo padrao de sitemap-empresas-N).
+    total = _empresas_municipios_qualificadas_count()
+    if total > 0:
+        max_shard = math.ceil(total / EMPRESA_SHARD_SIZE)
+        if n > max_shard + 1:
+            raise HTTPException(status_code=410)
 
     origin = _site_origin(request)
     now = time.time()
@@ -739,10 +761,18 @@ def _build_licitacoes_shard_sitemap(origin: str, shard_n: int) -> str:
 
 @router.get("/sitemap-licitacoes-{shard_n:int}.xml")
 async def sitemap_licitacoes_shard_xml(request: Request, shard_n: int) -> Response:
-    """Sub-sitemap shard de licitacoes. 1-indexed. Past-end retorna urlset
-    vazio (mesmo padrao /sitemap-empresas-N.xml)."""
+    """Sub-sitemap shard de licitacoes. 1-indexed. Past-end retorna 410
+    Gone (mesmo padrao de sitemap-empresas-N apos PR #165 / ADR-0009)."""
     if shard_n < 1 or shard_n > 9999:
         raise HTTPException(status_code=404)
+
+    # Past-end detection.
+    total = _licitacoes_qualificadas_count()
+    if total > 0:
+        max_shard = math.ceil(total / LICITACAO_SHARD_SIZE)
+        if shard_n > max_shard + 1:
+            raise HTTPException(status_code=410)
+
     origin = _site_origin(request)
     now = time.time()
     shard_cache = _SITEMAP_CACHE["licitacoes"].get(shard_n)

--- a/web/routes/seo.py
+++ b/web/routes/seo.py
@@ -557,23 +557,26 @@ async def sitemap_empresas_shard_xml(request: Request, shard_n: int) -> Response
     urlset vazio (que aparece como "Tag XML ausente" em Search Console
     quando a MV encolhe — ex: pos cleanup de PR #165, ADR-0009).
 
-    Buffer de 1 shard: tolera crescimento da MV entre count e build
-    (sitemap-index pode listar 1 shard a mais do que count atual indica
-    se MV acabou de crescer).
+    Sem buffer: `_empresas_qualificadas_count()` le da mesma fonte que o
+    sitemap-index (`_build_sitemap_index` em linha ~417), ambos usam o
+    mesmo cache TTL de 24h. Se index lista shards 1..N, count tambem
+    devolve N — sem janela de inconsistencia que justifique buffer.
+    Buffer +1 (sugestao inicial) deixava o primeiro shard past-end
+    ainda retornando urlset vazio 200, reproduzindo o bug exato em
+    `max_shard+1`. (HIGH GPT 5.5 review PR #167.)
 
-    Cache 1h por shard em _SITEMAP_CACHE['empresas'][n].
+    Cache 24h por shard em _SITEMAP_CACHE['empresas'][n].
     """
     if shard_n < 1 or shard_n > 9999:
         raise HTTPException(status_code=404)
     n = shard_n
 
     # Past-end detection: shard alem do numero real atual = 410 Gone.
-    # Count ja cacheado 1h (_empresas_qualificadas_count usa _SITEMAP_TTL).
+    # Count ja cacheado 24h (_empresas_qualificadas_count usa _SITEMAP_TTL).
     total = _empresas_qualificadas_count()
     if total > 0:
         max_shard = math.ceil(total / EMPRESA_SHARD_SIZE)
-        # +1 buffer pra tolerar crescimento entre count cache miss e build.
-        if n > max_shard + 1:
+        if n > max_shard:
             raise HTTPException(status_code=410)
 
     origin = _site_origin(request)
@@ -615,7 +618,7 @@ async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: int) 
     """Sub-sitemap shard das URLs /empresa/<cnpj>/<slug>. Mesma logica do
     shard /sitemap-empresas-{n}.xml: regex 1-9999, past-end retorna 410
     Gone (era urlset vazio antes do fix do encolhimento MV, ver PR #165
-    + ADR-0009). Cache 1h por shard.
+    + ADR-0009). Cache 24h por shard.
 
     Path converter `int` evita conflito com a rota irma (sem isso ambas
     competem pelo mesmo path). Vide P1 do GPT-5.5 review."""
@@ -623,11 +626,11 @@ async def sitemap_empresas_municipios_shard_xml(request: Request, shard_n: int) 
         raise HTTPException(status_code=404)
     n = shard_n
 
-    # Past-end detection (mesmo padrao de sitemap-empresas-N).
+    # Past-end detection (mesmo padrao de sitemap-empresas-N, sem buffer).
     total = _empresas_municipios_qualificadas_count()
     if total > 0:
         max_shard = math.ceil(total / EMPRESA_SHARD_SIZE)
-        if n > max_shard + 1:
+        if n > max_shard:
             raise HTTPException(status_code=410)
 
     origin = _site_origin(request)
@@ -761,18 +764,20 @@ def _build_licitacoes_shard_sitemap(origin: str, shard_n: int) -> str:
 
 @router.get("/sitemap-licitacoes-{shard_n:int}.xml")
 async def sitemap_licitacoes_shard_xml(request: Request, shard_n: int) -> Response:
-    """Sub-sitemap shard de licitacoes. 1-indexed. Past-end retorna 410
-    Gone (mesmo padrao de sitemap-empresas-N apos PR #165 / ADR-0009)."""
+    """Sub-sitemap shard de licitacoes. 1-indexed. Past-end retorna urlset
+    vazio (mesmo padrao /sitemap-empresas-N.xml pre-PR #167).
+
+    Sem fix de 410 Gone aplicado aqui — `_licitacoes_qualificadas_count()`
+    le de web_cache (`query_id = 'LICITACAO_PERFIL'`), valor que oscila
+    durante warm. Count cacheado por 24h enquanto warm popula gradualmente
+    (50k -> 350k) faria 410 spurious em shards 4-7 que ainda virao a ser
+    populados. (HIGH Opus 4.7 review PR #167.) urlset vazio HTTP 200 e
+    seguro durante warm — Google retentara apos warm completar e index
+    refletir count final. Encolhimento da MV de licitacoes nao foi
+    observado historicamente (ao contrario de empresas/empresas-municipios
+    pos-cleanup de PR #165)."""
     if shard_n < 1 or shard_n > 9999:
         raise HTTPException(status_code=404)
-
-    # Past-end detection.
-    total = _licitacoes_qualificadas_count()
-    if total > 0:
-        max_shard = math.ceil(total / LICITACAO_SHARD_SIZE)
-        if shard_n > max_shard + 1:
-            raise HTTPException(status_code=410)
-
     origin = _site_origin(request)
     now = time.time()
     shard_cache = _SITEMAP_CACHE["licitacoes"].get(shard_n)


### PR DESCRIPTION
## Contexto

Google Search Console reportou erro em `/sitemap-empresas-municipios-9.xml`:

> "Tag XML ausente — Esta tag obrigatoria esta ausente. Linha 3, tag pai: `urlset`, tag: `url`"

Investigacao:
- Sitemap index atual lista apenas shards 1-7 (313.389 pares / 49.000 = 7 shards)
- Shard 9 retornava `<urlset></urlset>` HTTP 200 (urlset vazio, sem nenhum filho `<url>`)
- Google ainda testava shard 9 porque foi listado no sitemap index ANTES do cleanup de PR #165 (ADR-0009), quando havia ~800k pares contaminados (17 shards)

Comportamento antigo (urlset vazio 200) foi projetado pra suportar **crescimento** da MV (sitemap index pode listar shard que MV ainda nao tem rows). Agora precisa suportar tambem **encolhimento**.

## Mudancas

`web/routes/seo.py` — 3 handlers ganharam past-end detection:

- `/sitemap-empresas-{n}.xml`
- `/sitemap-empresas-municipios-{n}.xml`
- `/sitemap-licitacoes-{n}.xml`

Cada um agora:
1. Le count atual (ja cacheado 1h em `_SITEMAP_CACHE` pelos helpers existentes).
2. Calcula `max_shard = ceil(count / SHARD_SIZE)`.
3. Se `shard_n > max_shard + 1`: **410 Gone**.

Buffer de +1 shard preserva tolerancia a crescimento (sitemap-index pode estar 1 shard atras do count atual durante crescimento).

`docs/cache.md`: nota sobre o comportamento na secao "Cleanup de entries orfas".

## Custo

Counts ja sao cacheados 1h. Queries usadas:
- **empresas-municipios**: `SELECT COUNT(*) FROM mv_empresa_municipio_pagantes` (313k rows, ~10-50ms)
- **licitacoes**: `SELECT COUNT(*) FROM web_cache WHERE query_id = 'LICITACAO_PERFIL'` (com index)
- **empresas**: `SELECT COUNT(*) FROM mv_empresa_pb JOIN estabelecimento ON ...` (cached, ms)

Hit frequency: 1 query a cada 1h por handler (cache TTL). Custo desprezivel.

## Por que 410 e nao 404

| | 410 Gone | 404 Not Found |
| --- | --- | --- |
| Semantica | "Existiu, removido permanentemente" | "Nao existe" (sem historia) |
| Google retry behavior | Para de testar rapido | Pode testar ocasionalmente |
| Crawl budget | Libera mais rapido | Libera mais lento |

Pro caso de shards orfaos (existiram, foram listados, agora nao existem mais), **410 e estritamente melhor**.

## Validacao

- `python -m compileall web/routes/seo.py -q` OK
- `python -c "import ast; ast.parse(open('web/routes/seo.py').read())"` OK
- Logica: 313.389 / 49.000 = 7 shards reais. Pos-deploy: shards 1-7 servem normal, shards 8-9999 retornam 410.

## Cuidados pre-merge

- [ ] Review Opus 4.7 + GPT 5.5
- [ ] Smoke test pos-deploy:
  - `/sitemap-empresas-municipios-1.xml` → 200 com urlset cheio
  - `/sitemap-empresas-municipios-7.xml` → 200 com urlset (parcial)
  - `/sitemap-empresas-municipios-8.xml` → 200 com urlset vazio OU 410 (buffer +1)
  - `/sitemap-empresas-municipios-9.xml` → 410 Gone (fix do bug)
- [ ] Verificar no Google Search Console que erro "Tag XML ausente" some apos algumas semanas
