### PR TITLE
feat(bolsa-familia): ETL incremental + historico cumulativo no frontend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -671,12 +671,55 @@ jobs:
           sudo systemctl restart tor 2>/dev/null || true
           cd ${{ env.PROJECT_DIR }}
           source venv/bin/activate
+          source .env 2>/dev/null || true
+          PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
           echo "=== Incremental ETL framework ==="
+
+          # Determinar se BF esta no escopo desta run.
+          # Match preciso (regex bounded) — evita falso-positivo se outra spec
+          # tiver "bolsa_familia" no nome no futuro.
+          BF_IN_SCOPE=false
+          if [ -z "${{ inputs.incremental_only }}" ]; then
+            BF_IN_SCOPE=true
+          elif echo "${{ inputs.incremental_only }}" | grep -qE "(^|,)bolsa_familia\.bolsa_familia(,|$)"; then
+            BF_IN_SCOPE=true
+          fi
+
+          # Migration idempotente sql/41 antes do runner (apenas se BF in scope).
+          # Aplica defs (cols, COMMENTs, trigger, procedure). ON_ERROR_STOP=1 +
+          # SEM --single-transaction. As DDL aqui sao seguras em transacao;
+          # CREATE INDEX CONCURRENTLY fica para sql/41z apos o populate.
+          if [ "$BF_IN_SCOPE" = "true" ]; then
+            echo "=== sql/41 (defs idempotent: _nk_md5 + trigger + procedure) ==="
+            PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \
+              -f sql/41_bolsa_familia_incremental.sql
+
+            # Populate _nk_md5 em rows legacy via psycopg2 autocommit (CALL via
+            # psql wrappa em transacao e COMMIT-em-PROCEDURE falha no PG 16).
+            # Idempotente: WHERE _nk_md5 IS NULL.
+            # ETA: ~30min em prod SSD (18.7M rows, batches de 100k). Index
+            # parcial automatico no plan path. Pode ser interrompido e retomado.
+            echo "=== Populate _nk_md5 (BATCHED via psycopg2 autocommit) ==="
+            python -m etl.refresh_post_incremental --source bolsa_familia --populate-only
+
+            echo "=== sql/41z (dedupe + UNIQUE INDEX CONCURRENTLY) ==="
+            PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \
+              -f sql/41z_bolsa_familia_finalize.sql
+          fi
+
+          # Framework incremental runner
           if [ -n "${{ inputs.incremental_only }}" ]; then
             python -m etl.incremental.runner --only "${{ inputs.incremental_only }}" 2>&1
           else
             python -m etl.incremental.runner 2>&1
           fi
+
+          # Refresh post-incremental para sources com MVs dependentes.
+          if [ "$BF_IN_SCOPE" = "true" ]; then
+            echo "=== Refresh MVs apos bolsa_familia ==="
+            python -m etl.refresh_post_incremental --source bolsa_familia 2>&1
+          fi
+
           # Refresh da MV de sitemap apos incremental: mv_empresa_municipio_pagantes
           # depende de tce_pb_despesa que pode ter ganhado novos rows na fase
           # incremental (TCE-PB esta no escopo POC v7). Sem refresh, sitemap fica

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1066,6 +1066,7 @@ jobs:
           inputs.warm_cache == true ||
           inputs.etl_phase == 'all' ||
           inputs.etl_phase == 'sql' ||
+          inputs.etl_phase == 'incremental' ||
           inputs.rewarm_cache_keys != ''
         run: |
           set -euo pipefail
@@ -1073,7 +1074,7 @@ jobs:
           source .env 2>/dev/null || true
           PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
           echo "=== ANALYZE em tabelas hot ==="
-          for tbl in tce_pb_despesa pgfn_divida estabelecimento socio mv_pessoa_pb mv_empresa_governo mv_empresa_pb mv_servidor_pb_risco mv_municipio_pb_mapa mv_municipio_pb_kpi_score mv_q67_dated_pb; do
+          for tbl in tce_pb_despesa pgfn_divida estabelecimento socio mv_pessoa_pb mv_empresa_governo mv_empresa_pb mv_servidor_pb_risco mv_municipio_pb_mapa mv_municipio_pb_kpi_score mv_q67_dated_pb bolsa_familia; do
             echo "  ANALYZE $tbl..."
             PGPASSWORD="$PASS" psql -U govbr -d govbr -c "ANALYZE $tbl" 2>&1 | tail -1
           done
@@ -1245,6 +1246,7 @@ jobs:
           inputs.warm_cache == true ||
           inputs.etl_phase == 'all' ||
           inputs.etl_phase == 'sql' ||
+          inputs.etl_phase == 'incremental' ||
           inputs.rewarm_cache_keys != ''
         run: |
           set -euo pipefail
@@ -1343,6 +1345,7 @@ jobs:
           inputs.warm_cache == true ||
           inputs.etl_phase == 'all' ||
           inputs.etl_phase == 'sql' ||
+          inputs.etl_phase == 'incremental' ||
           inputs.rewarm_cache_keys != ''
         continue-on-error: true
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,25 @@ before editing the relevant area.
   at the top, recreates L1 → L2 → views. Adding a new MV requires updating
   both blocks **and** the `REFRESH MATERIALIZED VIEW CONCURRENTLY` footer.
   `REFRESH CONCURRENTLY` needs a UNIQUE INDEX on the MV.
+- **`_tmp_bf` rebuild via TRUNCATE+INSERT** (ADR-0010): `DROP TABLE _tmp_bf`
+  falha porque `mv_servidor_pb_risco` mantém dependência por OID
+  (sql/12_views.sql:645-651). SELECT body extraído para
+  [`sql/41c_tmp_bf_body.sql`](sql/41c_tmp_bf_body.sql) e usado tanto por
+  [`12_views.sql:563-584`](sql/12_views.sql) quanto por
+  [`etl/refresh_post_incremental.py`](etl/refresh_post_incremental.py).
+  Drift entre os dois quebra a MV — comentário cross-ref no `12_views.sql`.
+- **PG 16 quirk — COMMIT em PROCEDURE bloqueado por psql `-c`/`-f`** (ADR-0010):
+  `CALL` que executa `COMMIT` interno falha com `ERRO: encerramento de
+  transação inválido` quando rodada via `psql -c "CALL ..."` ou `psql -f`
+  com a CALL no arquivo (PG wrappa em transação implícita). Workaround:
+  rodar a procedure via `psycopg2.connect()` com `conn.autocommit = True`
+  explícito (ver `etl/refresh_post_incremental.py:populate_nk_md5_bolsa_familia`).
+  Padrão `sql/35b_pb_extras_synthetic_nk_populate.sql` usa o mesmo design
+  de PROCEDURE batched + COMMIT.
+- **Bolsa Família tem `cpf_digitos` com 6 dígitos**, não 11 (ADR-0010).
+  Portal divulga CPF mascarado `***.NNN.NNN-**`. `mv_pessoa_pb.cpf_digitos_6`
+  faz o match. `COMMENT ON COLUMN bolsa_familia.cpf_digitos` documenta isso
+  em `sql/41_bolsa_familia_incremental.sql`.
 - **Query timeouts in production.** `QueryDef.timeout_sec` is per-query in
   [`web/queries/registry.py`](web/queries/registry.py); default `30s`. Real
   values for the heavy queries:
@@ -285,6 +304,23 @@ parse clean as of PR #155. See those PRs for the exact pattern.
 - **`audit_report_identifiers.py`** with `--strict` runs offline (no Postgres),
   checks only CPF masking. Without `--strict` it validates CNPJs against
   local `empresa` + `estabelecimento` (requires ~58GB of RFB data loaded).
+- **Bolsa Família incremental** (ADR-0010): a tabela `bolsa_familia` agora
+  acumula snapshots mensais via framework P1-P6. Spec em
+  [`etl/incremental/specs/bolsa_familia.py`](etl/incremental/specs/bolsa_familia.py).
+  Acionamento: `etl_phase=incremental` (todas specs) ou `etl_phase=incremental`
+  + `incremental_only=bolsa_familia.bolsa_familia`. Migration `sql/41_*.sql`
+  é idempotente e roda no step `ETL: Incremental`. Refresh de MVs dependentes
+  (`mv_pessoa_pb`, `mv_servidor_pb_risco`, `mv_municipio_pb_kpi_score`) +
+  `_tmp_bf` rebuild fica em `etl/refresh_post_incremental.py`.
+- **BF usa NK synthetic md5** (ADR-0010): NK natural não cobre 100% dos
+  casos (21% rows com CPF vazio, parcelas retroativas no mesmo `mes_competencia`).
+  Trigger `BEFORE INSERT compute_nk_md5_bolsa_familia` calcula hash das 9
+  cols. `UNIQUE INDEX ix_bolsa_familia_nk_md5`. Mesmo padrão de `pb_extras`
+  (`sql/35a-d`).
+- **CSV headers do Portal BF** vêm com acento e espaço (`"MÊS COMPETÊNCIA"`).
+  Framework agora suporta `spec.csv_header_rewrites: dict[str, str]` que
+  mapeia raw → SQL-safe antes do match com `spec.columns`. Default `{}` =
+  no-op para specs existentes (TCE-PB / Dados-PB / pb_extras).
 
 ### Git / Workflow / Deploy
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Alimenta o portal público **[transparenciapb.org](https://transparenciapb.org)*
 Carrega ~350M registros (~210GB raw) de 18+ fontes públicas brasileiras em um PostgreSQL 16 e cruza pessoas/empresas por CPF/CNPJ para revelar padrões suspeitos, conflitos de interesse e anomalias de contratação.
 
 - **24 fases de ETL** orquestradas por `python -m etl.run_all` (modelo full-reload)
-- **Framework ETL incremental** ([`etl/incremental/`](etl/incremental/README.md)) para fontes append-only com watermark, conditional GET e DLQ — hoje cobre 20 specs do TCE-PB e dados.pb.gov.br (~40M rows)
+- **Framework ETL incremental** ([`etl/incremental/`](etl/incremental/README.md)) para fontes append-only com watermark, conditional GET e DLQ — hoje cobre 21 specs do TCE-PB, dados.pb.gov.br e Bolsa Família (~60M rows)
 - **125+ queries SQL** em 17 arquivos temáticos (Q01-Q310)
 - **40+ relatórios** investigativos derivados dos resultados
 - **Materialized views em camadas** (L1 → L2 → views planas) para score de risco por município, empresa, pessoa e rede societária
@@ -414,7 +414,7 @@ Comece pela [arquitetura](docs/architecture.md), depois siga pro guia específic
 
 ### Decisões arquiteturais (ADRs)
 
-- [`docs/adr/`](docs/adr/) — 9 ADRs: no-pandas, MV layered, shadow rewarm, framework incremental, no-ORM web, MV atomic swap, ETL normalize fix, AGENTS.md canonical, orphan empresa cache cleanup
+- [`docs/adr/`](docs/adr/) — 11 ADRs: no-pandas, MV layered, shadow rewarm, framework incremental, no-ORM web, MV atomic swap, ETL normalize fix, AGENTS.md canonical, orphan empresa cache cleanup, Bolsa Família incremental (ADR-0010), remover LIMIT top tabelas (ADR-0011 Proposed)
 
 ### Referência
 

--- a/docs/adr/0010-bolsa-familia-incremental.md
+++ b/docs/adr/0010-bolsa-familia-incremental.md
@@ -1,0 +1,257 @@
+# ADR-0010: Bolsa Família incremental + histórico cumulativo
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+O ETL clássico do Bolsa Família (`etl/17_bolsa_familia.py` + `sql/17_schema_bolsa_familia.sql`)
+era destrutivo:
+
+1. `DROP TABLE bolsa_familia CASCADE` a cada execução.
+2. `download_bolsa_familia` em `etl/00_download.py` baixava só o snapshot
+   mais recente e **deletava ativamente** snapshots anteriores do disco
+   (linhas 1272-1278: `if str(ym) not in old.name: old.unlink()`).
+3. Resultado: a tabela `bolsa_familia` em qualquer momento continha
+   apenas o **último mês** publicado pelo Portal da Transparência.
+
+Limitações desse modelo:
+
+- **Sem histórico**: queries que cruzam BF × servidor (`mv_servidor_pb_risco`,
+  `_tmp_bf`) só conseguem detectar recebimento no mês corrente. Beneficiário
+  que recebeu BF em 2024 mas não em 2026-01 é invisível no Q42/Q80.
+- **Sem auditoria temporal**: relatórios de fraude não conseguem citar
+  "essa pessoa recebeu BF de 2023-05 a 2024-08" — só o snapshot atual.
+- **Re-download massivo**: 600 MB / mês baixados todo deploy.
+
+Após smoke test empírico (2026-05-17) na base local e VM (read-only),
+descobrimos que **a NK natural não é única em produção**:
+
+- 18,7M rows em 1 snapshot (202601).
+- **21,3% das rows (~4M)** têm `cpf_favorecido = ''` — adultos reais cujo
+  CPF não está vinculado no CADUNICO (hipótese inicial "menores de 16 anos"
+  foi rejeitada: apenas 305 rows têm o nome mascarado especial).
+- Portal publica **parcelas retroativas** no mesmo `mes_competencia` com
+  `mes_referencia` diferentes (legítimo — recebimentos atrasados).
+  Exemplo real: SUELENE recebeu 8 parcelas em janeiro/26 referentes a
+  8 meses distintos (mai/25 a jan/26).
+- NK trio (`mes_competencia, cpf_favorecido, nis_favorecido`): 93.569
+  grupos duplicados.
+- NK 5-uplo (+ `mes_referencia` + `cd_municipio_siafi`): ainda 36 duplicados.
+- 9 grupos com **todas 9 cols iguais** (22 rows) — true duplicates do
+  ETL clássico legacy.
+
+## Decision
+
+Migrar Bolsa Família para o framework ETL incremental (P1-P6, ADR-0004),
+acumulando snapshots mensais cumulativamente.
+
+### Pontos críticos
+
+1. **NK synthetic md5** (padrão `pb_extras` em `sql/35a-d`):
+   - `_nk_md5 TEXT` em `bolsa_familia`.
+   - Trigger `BEFORE INSERT compute_nk_md5_bolsa_familia` calcula hash das
+     9 cols via `etl_admin.row_hash_md5(...)`.
+   - `UNIQUE INDEX CONCURRENTLY ix_bolsa_familia_nk_md5 ON bolsa_familia(_nk_md5)`.
+   - Spec `nk_synthetic_md5=True` → `build_upsert_sql` emite
+     `ON CONFLICT (_nk_md5) DO NOTHING`.
+   - **Justificativa**: cobre 100% sem perda de dado. NK natural exigiria
+     descartar os 21% sem CPF ou aceitar duplicação retroativa.
+
+2. **DedupeStrategy = UPSERT_DO_NOTHING**:
+   - Intenção do incremental: **acumular novos meses, não corrigir
+     existentes**. Reruns nunca alteram rows commitadas.
+   - `refetch_recent_buckets=1` cobre republish atrasado do mês corrente
+     (DO_NOTHING garante dados commitados intactos).
+
+3. **Esquema canônico idempotente** (`sql/17_schema_bolsa_familia.sql`):
+   - `CREATE TABLE IF NOT EXISTS` em vez de `DROP CASCADE + CREATE`.
+   - Adicionado ao `SQL_FILES` em `etl/01_schema.py` (antes só era aplicado
+     pela fase 17 classica que virou no-op).
+
+4. **Migration `sql/41_bolsa_familia_incremental.sql`** (defs idempotent):
+   - `ADD COLUMN IF NOT EXISTS` para `cpf_digitos` + `inserted_at` + `_nk_md5`.
+   - `COMMENT ON COLUMN cpf_digitos` documenta que armazena **6 dígitos
+     centrais** do CPF mascarado (não 11 como em outras tabelas).
+   - `CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_bolsa_familia`.
+   - `CREATE TRIGGER trg_compute_nk_md5 BEFORE INSERT`.
+   - `CREATE OR REPLACE PROCEDURE etl_admin.populate_nk_md5_bolsa_familia`
+     (batched + COMMIT entre batches).
+
+5. **Populate `_nk_md5` via psycopg2 autocommit**:
+   - PG 16 wrappa `CALL` em transação implícita quando invocada via
+     `psql -c` ou `psql -f` (testado), causando `ERRO: encerramento de
+     transação inválido` no `COMMIT` interno da PROCEDURE.
+   - Workaround: `python -m etl.refresh_post_incremental --source
+     bolsa_familia --populate-only` usa `conn.autocommit = True` explícito.
+   - Logica equivalente à PROCEDURE mas client-side.
+
+6. **`sql/41z_bolsa_familia_finalize.sql`** (dedupe + UNIQUE INDEX):
+   - Pré-flight valida `_nk_md5` 100% populada.
+   - DELETE de duplicates (ROW_NUMBER PARTITION BY `_nk_md5`, mantém
+     menor `id` = mais antiga). Empirical 22 rows em 9 grupos.
+   - `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_bolsa_familia_nk_md5`.
+   - Validação `pg_index.indisvalid` no fim (hard-fail se INVALID).
+
+7. **Refresh post-incremental** (`etl/refresh_post_incremental.py`):
+   - `SOURCE_REFRESH_FNS` dict — extensível para futuras sources.
+   - `refresh_for_bolsa_familia`:
+     1. ANALYZE bolsa_familia.
+     2. REFRESH mv_pessoa_pb CONCURRENTLY (L1).
+     3. `_tmp_bf` TRUNCATE+INSERT atomic consumindo `sql/41c_tmp_bf_body.sql`
+        (DROP `_tmp_bf` falha — `mv_servidor_pb_risco` depende por OID).
+     4. REFRESH mv_servidor_pb_risco CONCURRENTLY.
+     5. Detecta via `pg_depend` se `mv_municipio_pb_kpi_score` depende
+        de `mv_pessoa_pb`; se sim, REFRESH CONCURRENTLY.
+   - Hard-fail: qualquer step lança → deploy aborta (warm cache subsequente
+     não roda com dados velhos).
+
+8. **Spec `etl/incremental/specs/bolsa_familia.py`**:
+   - `cursor_strategy=MONTH_WINDOW`, `watermark_col=MES_COMPETENCIA`.
+   - `is_zip_source=True` (framework extrai ZIP automaticamente).
+   - `encoding="latin-1"` (Portal usa Latin-1 com acentos preservados).
+   - `decimal_format="br"` (valor com vírgula: `1886,00`).
+   - `derived_columns={"cpf_digitos": "REGEXP_REPLACE(CPF_FAVORECIDO, '[^0-9]', '', 'g')"}`
+     — **UPPERCASE** (raw staging col name, não rename target).
+   - `enumerate_buckets`: 2023-03 (Novo BF) até mês atual.
+
+9. **Feature nova no framework: `csv_header_rewrites`**:
+   - Campo em `LoaderSpec` (default `{}`).
+   - Aplicado em `parser.validate_csv_header` ANTES do match com `spec.columns`.
+   - Necessário porque o Portal publica headers raw com acentos e espaços
+     (`"MÊS COMPETÊNCIA"`) — PostgreSQL CREATE TABLE staging com esses
+     identifiers falha por syntax.
+   - Spec BF mapeia 9 headers raw para SQL-safe (`MES_COMPETENCIA`, etc).
+
+10. **Download dual** (compromisso com transição):
+    - `download_bolsa_familia` em `etl/00_download.py` mantido em
+      `all_downloaders` — clássico ETL continua tendo cache hot do último
+      mês para inspeção manual.
+    - Mudança mínima: linhas 1272-1278 removidas (unlink destrutivo).
+    - `etl/17_bolsa_familia.py:run()` virou no-op (preserva índice de fase).
+    - `_CSV_DIRS["etl.17_bolsa_familia"]` removido em `etl/run_all.py`
+      (evita limpeza prematura entre fase clássica e framework).
+
+11. **Frontend `/api/servidor/detalhes`**:
+    - Removido `LIMIT 5`. Retorna histórico completo: agregados + lista
+      cronológica `LIMIT 240` (20 anos × 12 meses defensivo).
+    - Response shape: `{parcelas: [...], stats: {qtd_parcelas, qtd_meses,
+      total_recebido, valor_medio, primeiro_mes, ultimo_mes,
+      qtd_durante_vinculo, total_durante_vinculo}}`.
+    - Cache in-memory via `web.db.cached_query` por
+      `servidor:<cpf6>:<NOME>:bolsa_familia` (TTL padrão).
+    - `servidor-dialog.js`: nova seção dedicada com stat cells + `<details>`
+      nativo + dual labels (cidadão/auditor). Linhas dentro do período do
+      vínculo TCE-PB recebem highlight visual.
+
+### Deploy
+
+Step `ETL: Incremental` em `.github/workflows/deploy.yml`:
+
+```
+if BF in scope (incremental_only vazio OU contém bolsa_familia.bolsa_familia):
+    psql -f sql/41_bolsa_familia_incremental.sql    # defs idempotent
+    python -m etl.refresh_post_incremental --source bolsa_familia --populate-only
+    psql -f sql/41z_bolsa_familia_finalize.sql       # dedupe + UNIQUE INDEX
+
+python -m etl.incremental.runner --only <inputs.incremental_only>
+
+if BF in scope:
+    python -m etl.refresh_post_incremental --source bolsa_familia  # MVs
+
+python -m etl.22_mv_sitemap  # mv_empresa_municipio_pagantes (sitemap)
+```
+
+Gates de cache (`ANALYZE`, `Reset shadow`, `Warm cache`) passaram a incluir
+`inputs.etl_phase == 'incremental'` — warm automático sem precisar
+`warm_cache=true` manual.
+
+### Padrão de uso (acionamento)
+
+```bash
+# Carregar todos os meses faltantes + refresh MVs + warm cache:
+gh workflow run deploy.yml -f etl_phase=incremental
+
+# Só Bolsa Família (sem reprocessar TCE-PB/Dados-PB):
+gh workflow run deploy.yml -f etl_phase=incremental \
+    -f incremental_only=bolsa_familia.bolsa_familia
+```
+
+## Trade-offs aceitos
+
+1. **Synthetic NK md5 em vez de NK natural**:
+   - Contra: hash não tem significado semântico; uma row deletada e
+     re-inserida com mesmo conteúdo "perde a história" do `inserted_at`.
+   - Pro: cobre 100% sem perda de dado e segue padrão `pb_extras` já
+     testado em prod (7 tabelas, 60M+ rows). Trigger BEFORE INSERT
+     popula automaticamente, então `INSERT` do framework não precisa
+     calcular o hash.
+
+2. **UPSERT_DO_NOTHING em vez de DO_UPDATE**:
+   - Contra: republish do Portal com correção de valor em mês já carregado
+     não atualiza a row local.
+   - Pro: previsibilidade total. Reruns sempre seguros. F1 da rodada de
+     revisão (predicate `EXCLUDED.{wm} > {target}.{wm}` estrito em
+     `staging.py:244`) tornaria DO_UPDATE ineficaz para correções no
+     mesmo bucket anyway.
+
+3. **Populate via psycopg2 (não PROCEDURE)**:
+   - Contra: lógica duplicada (PROCEDURE em SQL + Python). Drift potencial.
+   - Pro: contorna bug de PG 16 (`COMMIT em PROCEDURE` falha em
+     `psql -c/-f`). PROCEDURE serve como documentação SQL e ponto de
+     entrada para manutenção emergencial (`psql -f sql/41` + `psql -c
+     "CALL etl_admin.populate_nk_md5_bolsa_familia();"` — funciona se
+     rodado em sessão psql interativa).
+
+4. **`/api/servidor/detalhes` cache in-memory, não server-side persistente**:
+   - Contra: cache morre em restart, e cada worker tem cache próprio.
+   - Pro: zero acoplamento com `LIMIT 200` dos top servidores
+     (`web/queries/cidade.py:805`). ADR-0011 (proposta) discute remover
+     esse LIMIT — se acontecer, cache server-side teria que migrar para
+     lazy warm. In-memory escapa dessa interação.
+
+5. **`_tmp_bf` SELECT body duplicado em `sql/12_views.sql` + `sql/41c_tmp_bf_body.sql`**:
+   - Contra: drift entre os dois arquivos quebra `mv_servidor_pb_risco`.
+   - Pro: `12_views.sql` é monolítico (executado por `etl/21_views.py`
+     via `execute_sql_file` sem include dinâmico). Comentário cross-ref
+     no `12_views.sql:563` + smoke test cobrindo isso reduzem o risco.
+   - Padrão similar já documentado como tech debt em
+     `sql/15c_rebuild_tmp_for_servidor.sql:30-33`.
+
+## Consequences
+
+### Positivas
+- BF acumula meses ao longo do tempo (auditoria forense possível).
+- Queries Q38/Q40/Q42/Q74/Q80 + relatórios podem citar período completo
+  de recebimento BF de cada beneficiário.
+- Re-download massivo do Portal cai (HEAD probe + `If-None-Match` do
+  framework). 600 MB/mês → 0 quando mês não mudou.
+- Frontend de servidor mostra histórico real (não apenas "Sim/Não").
+
+### Negativas / Riscos
+- Tabela `bolsa_familia` cresce **~600 MB/mês** com snapshots cumulativos.
+  18,7M rows hoje → ~600M rows em 5 anos. Plano de mitigação: revisitar
+  particionamento ou archive de meses > 5 anos no momento certo.
+- Trigger `BEFORE INSERT` em cada INSERT adiciona overhead — medido em
+  ~5% do tempo de COPY no smoke local.
+- `populate_nk_md5` em 18,7M rows local levou ~90min (disco rotacional).
+  Em SSD prod estimamos 15-30 min. Step rodando em deploy `incremental`
+  significa primeira aplicação leva ~30min adicionais.
+
+## References
+
+- [ADR-0001: Sem pandas](./0001-no-pandas.md) — princípio de streaming.
+- [ADR-0002: MVs layered](./0002-mv-layered.md) — `_tmp_bf` faz parte L1/L2.
+- [ADR-0004: ETL incremental](./0004-etl-incremental-framework.md) —
+  princípios P1-P6 que esta migração aplica.
+- [ADR-0011 (Proposed): Remover LIMIT top tabelas](./0011-remover-limit-top-tabelas.md)
+  — interage com cache do endpoint `/api/servidor/detalhes`.
+- `sql/35a-d` — padrão synthetic NK md5 estabelecido em PR anterior.
+- `sql/15c_rebuild_tmp_for_servidor.sql` — padrão TRUNCATE+INSERT atomic
+  para `_tmp_*` tables.
+- `etl/incremental/specs/bolsa_familia.py` — spec final.

--- a/docs/adr/0011-remover-limit-top-tabelas.md
+++ b/docs/adr/0011-remover-limit-top-tabelas.md
@@ -1,0 +1,126 @@
+# ADR-0011: Remover LIMIT 200 / 500 dos top resultados de cidade
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-17
+
+## Context
+
+Várias queries do frontend (`web/queries/cidade.py`, `web/queries/registry.py`)
+truncam resultados com `LIMIT N`:
+
+| Local | Limit | Comentário inferido |
+|-------|------:|---------------------|
+| `web/queries/cidade.py:289` | 200 | Top servidores PB / agregação |
+| `web/queries/cidade.py:393` | 200 | Idem |
+| `web/queries/cidade.py:512` | 200 | Idem |
+| `web/queries/cidade.py:614` | 200 | Idem |
+| `web/queries/cidade.py:805` | 200 | **TOP_SERVIDORES_PB — alvo principal** |
+| `web/queries/registry.py:169-849` | 500 | ~30 queries Q## (fornecedores sancionados, vínculos, etc) |
+
+Motivações históricas (inferidas):
+
+1. **Performance early-stage**: queries pesadas (Q##) sem MVs específicas
+   timeoutavam com cidades grandes (João Pessoa, Campina Grande). LIMIT
+   conteve dano.
+2. **Warm cache scale**: `web/warm_cache.py` precisava cachear N munícipios
+   × M queries. Com LIMIT, o universo cacheado é controlável.
+3. **UX tabela paginada inexistente**: frontend renderiza tudo em uma
+   página. Sem virtual scroll / paginação real, 5000+ rows quebraria UX.
+
+**Limitação atual**: a intenção do produto é **listar todos os servidores
+PB de uma cidade**, não apenas top 200. Cidades pequenas (~700 munícipios
+do estado têm <200 servidores TCE-PB cadastrados) já são cobertas
+completamente; mas João Pessoa (~13k servidores) só mostra 200 no UI.
+
+## Decision (proposed)
+
+Remover progressivamente os LIMITs hardcoded, começando por
+`web/queries/cidade.py:805` (TOP_SERVIDORES_PB) como caso piloto.
+
+### Plano de execução (PR futura)
+
+1. **Caso piloto**: `web/queries/cidade.py:805`
+   - Substituir `LIMIT 200` por LIMIT configurável via `web/config.py`
+     (`SERVIDORES_PB_LIMIT`, default = `None` = sem limit).
+   - Validar performance: rodar query sem limit contra João Pessoa,
+     Campina Grande, Santa Rita (top 3 PB por volume). Medir P95.
+   - Se P95 > 30s, criar MV específica `mv_servidores_pb_cidade` agregando
+     o necessário com índices apropriados.
+
+2. **Frontend**: implementar paginação real ou virtual scroll
+   (`web/templates/results/cidade.html` na seção de servidores).
+   Sem isso, response de 5000+ rows quebra layout.
+
+3. **Warm cache strategy** — DEPENDÊNCIA CRÍTICA:
+   - Hoje, `web/warm_cache.py` cacheia top-200 servidores por cidade.
+   - Removendo LIMIT, cachear todos os 13k servidores × ~70 cidades
+     ativas = ~900k keys. Tempo de warm cresceria proporcionalmente.
+   - **Alternativas a avaliar**:
+     - **Lazy warm**: só cachear servidor quando hit no endpoint
+       (`/api/servidor/detalhes`). Cache miss = compute on-demand. ADR-0010
+       já adota essa estratégia para o sub-bloco BF.
+     - **Top-N warm**: continuar warm dos top-200 (cobertura "popular"),
+       cache miss em outros = compute on-demand.
+     - **Full warm seletivo**: warm só de servidores em cidades > N
+       habitantes, lazy nas pequenas.
+
+4. **Endpoint `/api/servidor/detalhes` BF cache** (interage com ADR-0010):
+   - ADR-0010 implementou cache **in-memory** justamente porque o
+     universo dependeria de LIMIT futuro. Quando este ADR for executado,
+     revisitar:
+     - Se ficar lazy warm: ok, in-memory já casa.
+     - Se ficar full warm: migrar para `web_cache` persistente via
+       padrão `_upsert` (igual `EMPRESA_PERFIL`).
+
+5. **Queries Q## em `registry.py`** (LIMIT 500):
+   - Avaliar caso-a-caso. Algumas queries (Q65, Q77) já estouraram
+     timeout em cidades grandes (memória do CLI). Remover LIMIT pode
+     reintroduzir 504.
+   - Prioridade: queries onde "ver mais" é semanticamente útil
+     (fornecedores sancionados, sócios laranjas).
+
+## Status
+
+`Proposed` — depende de decisão arquitetural sobre warm cache strategy
+e implementação de paginação real no frontend. Não bloqueia o ETL
+incremental BF (ADR-0010).
+
+## Quando implementar
+
+Quando alguma das condições se materializar:
+
+1. Reclamação concreta de usuário sobre "não vejo todos os servidores".
+2. Auditoria/relatório pede top-N > 200 (já aconteceu informalmente:
+   investigação em João Pessoa precisava top-1000 servidores por
+   suspeita de fraude em folha).
+3. Tempo de warm cache cair muito (>3h) e justificar refator geral
+   da estratégia.
+
+## Trade-offs
+
+### Pro (remover LIMIT)
+- **Completude**: todos os servidores listados, sem perder cauda longa.
+- **Auditoria**: relatórios podem citar todos os ~13k servidores de JP
+  sem ter que rodar query ad-hoc.
+- **Consistência**: cidades pequenas e grandes têm comportamento idêntico
+  no UI (hoje JP "esconde" rows; Santa Rita mostra tudo).
+
+### Contra
+- **Warm cache cresce N×**: estratégia precisa ser repensada.
+- **Frontend precisa paginação real**: virtual scroll ou infinite scroll.
+  Sem isso, payload de ~5000 rows quebra mobile.
+- **Queries pesadas precisam revisão de índices/MVs**: Q## específicas
+  podem reintroduzir 504. Cuidadoso testing por cidade.
+
+## References
+
+- ADR-0010 — depende da estratégia de warm cache definida aqui.
+- `web/queries/cidade.py:805` — primeiro alvo, caso piloto.
+- Memória sessão 2026-05-17: usuário pediu "incluir nessa plano um ADR
+  para uma proxima PR para tirar esse LIMIT de servidores e possivelmente
+  de outras tabelas tambem".

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,8 @@ veja [`docs/architecture.md`](../architecture.md).
 | ADR-0007 | [ETL-level fix para contaminação de cnpj_basico + REFRESH CONCURRENTLY](0007-etl-normalize-fix.md) | Accepted | 2026-05-16 |
 | ADR-0008 | [AGENTS.md como fonte canônica de instruções para agentes de IA](0008-agents-md-canonical.md) | Accepted | 2026-05-17 |
 | ADR-0009 | [Cleanup de entries órfãs em `web_cache` pós-MV refresh](0009-orphan-empresa-cache-cleanup.md) | Accepted | 2026-05-17 |
+| ADR-0010 | [Bolsa Família incremental + histórico cumulativo](0010-bolsa-familia-incremental.md) | Accepted | 2026-05-17 |
+| ADR-0011 | [Remover LIMIT 200/500 dos top resultados de cidade](0011-remover-limit-top-tabelas.md) | Proposed | 2026-05-17 |
 
 ## Convenções
 

--- a/docs/etl-incremental-guide.md
+++ b/docs/etl-incremental-guide.md
@@ -313,6 +313,48 @@ do framework: bucket month-window, conditional refetch (`refetch_recent_buckets=
 para correções retroativas), NK com coluna nullable, encoding latin-1 com
 fallback, `DedupeStrategy.UPSERT_DO_NOTHING`.
 
+### Caso especial: Bolsa Família (ADR-0010)
+
+[`etl/incremental/specs/bolsa_familia.py`](../etl/incremental/specs/bolsa_familia.py)
+ilustra dois pontos não cobertos pelo exemplo padrão:
+
+1. **`nk_synthetic_md5=True`** — quando a NK natural não cobre 100% sem perda
+   de dado (no caso BF: 21% rows com CPF vazio + parcelas retroativas no
+   mesmo `mes_competencia`). Padrão `sql/35a-d` aplica: coluna `_nk_md5` +
+   trigger `BEFORE INSERT etl_admin.compute_nk_md5_X` + `UNIQUE INDEX` em
+   `(_nk_md5)`. Cobre 100% via hash de todas as cols semanticamente relevantes.
+
+2. **`csv_header_rewrites`** — quando os headers raw do CSV têm caracteres
+   não-SQL-safe (espaços, acentos). Portal da Transparência publica
+   `"MÊS COMPETÊNCIA"`, `"CÓDIGO MUNICÍPIO SIAFI"`, etc. O dict mapeia raw → SQL-safe
+   antes do match com `spec.columns`. Encoding `latin-1` preserva acentos.
+
+3. **Refresh de MVs dependentes** — BF feeds `mv_pessoa_pb`,
+   `mv_servidor_pb_risco`, `mv_municipio_pb_kpi_score` + `_tmp_bf`. O hook é
+   [`etl/refresh_post_incremental.py`](../etl/refresh_post_incremental.py)
+   com `SOURCE_REFRESH_FNS = {"bolsa_familia": refresh_for_bolsa_familia}`.
+   Step `ETL: Incremental` no deploy.yml chama automaticamente quando BF
+   está no escopo da run.
+
+### Padrão de uso (acionamento)
+
+```bash
+# Processa TODAS as specs incrementais:
+gh workflow run deploy.yml -f etl_phase=incremental
+
+# Apenas uma spec específica (CSV — pode ser múltiplas separadas por vírgula):
+gh workflow run deploy.yml -f etl_phase=incremental \
+    -f incremental_only=bolsa_familia.bolsa_familia
+
+# Múltiplas:
+gh workflow run deploy.yml -f etl_phase=incremental \
+    -f incremental_only=tce_pb.tce_pb_despesa,bolsa_familia.bolsa_familia
+```
+
+**NÃO** criar novo `etl_phase=<source>_incremental` (polui enum + vira dead
+code após primeira execução). Padrão único: `etl_phase=incremental` +
+`incremental_only=<source>.<table>`. Ver ADR-0010.
+
 ## Caveats conhecidos
 
 - **`pb_contrato 2022/2023 partial`** — CSVs com errors documentados no

--- a/docs/glossario.md
+++ b/docs/glossario.md
@@ -358,7 +358,14 @@ Programa de transferência de renda federal. Beneficiário identificado por NIS 
 
 - **Tabela**: `bolsa_familia`
 - **CPF**: mascarado (`***.NNN.NNN-**`)
-- **Caveat investigativo**: servidor público recebendo Bolsa Família simultaneamente = `flag_servidor_bolsa_familia` (`mv_servidor_pb_risco`)
+- **`cpf_digitos`**: tem **6 dígitos** centrais (não 11 como em outras tabelas — ver ADR-0010 e `COMMENT ON COLUMN bolsa_familia.cpf_digitos`).
+- **ETL**: incremental (snapshots mensais cumulativos, ADR-0010). `etl_phase=incremental` carrega tudo; `incremental_only=bolsa_familia.bolsa_familia` só BF.
+- **NK**: synthetic md5 das 9 cols (padrão `pb_extras`, `sql/35a-d`). Coluna `_nk_md5` + trigger `BEFORE INSERT`.
+- **Caveat investigativo**: servidor público recebendo Bolsa Família simultaneamente = `flag_servidor_bolsa_familia` (`mv_servidor_pb_risco`). Histórico completo agora visível em `/api/servidor/detalhes` (não apenas "Sim/Não" como antes do ADR-0010).
+
+### Novo Bolsa Família
+
+Substituiu o Auxílio Brasil em **março/2023**. Mesma estrutura de tabela (`bolsa_familia`), mesma fonte (Portal da Transparência), URL diferente (`/download-de-dados/novo-bolsa-familia/{YYYYMM}`). `etl/incremental/specs/bolsa_familia.py:_enumerate_buckets` começa em 2023-03.
 
 ### NIS — Número de Identificação Social
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -186,6 +186,59 @@ warm_cache: true
 
 5. Se live cache está quebrado e precisa remover imediatamente, use `invalidate_cache_keys=<QID>` sabendo que causa cache miss até rewarm.
 
+## Runbook: Bolsa Família — populate `_nk_md5` interrompido (ADR-0010)
+
+Sintoma: deploy `etl_phase=incremental` falhou no step "Populate _nk_md5" (ou foi cancelado manualmente). Tabela `bolsa_familia` tem coluna `_nk_md5` mas com rows IS NULL.
+
+```bash
+# 1. Confirmar quantas rows faltam:
+PGPASSWORD=$PASS psql -U govbr -d govbr -c "
+SELECT count(*) FILTER (WHERE _nk_md5 IS NULL) AS missing,
+       count(*) AS total FROM bolsa_familia"
+
+# 2. Re-rodar APENAS o populate (idempotente — WHERE _nk_md5 IS NULL):
+cd /home/govbr/govbr-project && source venv/bin/activate
+python -m etl.refresh_post_incremental --source bolsa_familia --populate-only
+
+# 3. Quando 0 rows IS NULL, finalizar com sql/41z (dedupe + UNIQUE INDEX):
+PGPASSWORD=$PASS psql -U govbr -d govbr -v ON_ERROR_STOP=1 -f sql/41z_bolsa_familia_finalize.sql
+```
+
+Tempo estimado: ~15-30min em SSD VM para 18,7M rows.
+
+Workaround interativo (se psycopg2 não estiver disponível):
+
+```bash
+# Sessão psql interativa — autocommit por padrão, COMMIT em PROCEDURE funciona:
+PGPASSWORD=$PASS psql -U govbr -d govbr
+govbr=# CALL etl_admin.populate_nk_md5_bolsa_familia(100000);
+```
+
+(NÃO funciona com `psql -c "CALL ..."` por causa de transação implícita — ver AGENTS.md.)
+
+## Runbook: Bolsa Família — `ix_bolsa_familia_nk_md5` INVALID
+
+Sintoma: `sql/41z_bolsa_familia_finalize.sql` aborta com `ERRO: ix_bolsa_familia_nk_md5 esta INVALID`. Significa que `CREATE UNIQUE INDEX CONCURRENTLY` falhou no meio (provavelmente por duplicata em `_nk_md5`).
+
+```bash
+# 1. Drop INVALID index:
+PGPASSWORD=$PASS psql -U govbr -d govbr -c "DROP INDEX IF EXISTS ix_bolsa_familia_nk_md5"
+
+# 2. Identificar duplicatas restantes:
+PGPASSWORD=$PASS psql -U govbr -d govbr -c "
+SELECT _nk_md5, count(*) FROM bolsa_familia
+WHERE _nk_md5 IS NOT NULL
+GROUP BY 1 HAVING count(*) > 1 LIMIT 10"
+
+# 3. Investigar manualmente. Se forem true duplicates (todas 9 cols iguais),
+#    sql/41z step "6. Dedupe" já lida (DELETE WHERE rn>1).
+#    Re-rodar:
+PGPASSWORD=$PASS psql -U govbr -d govbr -v ON_ERROR_STOP=1 -f sql/41z_bolsa_familia_finalize.sql
+```
+
+Se forem rows que parecem distintas mas hash colidiu: investigar
+`etl_admin.row_hash_md5` (não deve acontecer com a versão atual `array_to_json` — collision-free).
+
 ## Runbook: backup DB
 
 **Status atual: pendente.** Não há estratégia documentada de backup/restore validada em produção. Este é um gap operacional A4.

--- a/etl/00_download.py
+++ b/etl/00_download.py
@@ -1247,6 +1247,14 @@ def download_bolsa_familia(anos=None):
 
     Baixa apenas o snapshot mais recente disponivel, tentando do mes atual
     para tras ate encontrar um que esteja publicado.
+
+    NOTA: preserva zips/CSVs de meses anteriores no disco (mudanca em
+    relacao a versao classica). A logica destrutiva de unlink foi removida
+    porque o framework ETL incremental (etl/incremental/specs/bolsa_familia.py)
+    pode reaproveitar snapshots ja baixados, e o auto-cleanup post-load do
+    framework e responsavel pela limpeza apos carga bem-sucedida.
+
+    Ver ADR-0009.
     """
     dest = DATA_DIR / "bolsa_familia"
     dest.mkdir(parents=True, exist_ok=True)
@@ -1268,14 +1276,6 @@ def download_bolsa_familia(anos=None):
             return
         if _download(url, zip_path):
             _unzip(zip_path, dest)
-            # Remove old zips/csvs to keep only the latest
-            for old in dest.iterdir():
-                if old == zip_path:
-                    continue
-                if old.name.endswith(".zip") or old.name.endswith(".csv"):
-                    if str(ym) not in old.name:
-                        old.unlink()
-                        print(f"    [limpou] {old.name}")
             return
     print("    [falhou] nenhum snapshot encontrado nos ultimos 12 meses")
 

--- a/etl/00_download.py
+++ b/etl/00_download.py
@@ -1254,7 +1254,7 @@ def download_bolsa_familia(anos=None):
     pode reaproveitar snapshots ja baixados, e o auto-cleanup post-load do
     framework e responsavel pela limpeza apos carga bem-sucedida.
 
-    Ver ADR-0009.
+    Ver ADR-0010.
     """
     dest = DATA_DIR / "bolsa_familia"
     dest.mkdir(parents=True, exist_ok=True)

--- a/etl/01_schema.py
+++ b/etl/01_schema.py
@@ -15,7 +15,7 @@ SQL_FILES = [
     "09_schema_complementar.sql",
     "10_schema_pessoa.sql",
     # Bolsa Familia: schema canonico idempotente; tabela e criada aqui (em vez
-    # de pela fase classica neutralizada). Ver ADR-0009.
+    # de pela fase classica neutralizada). Ver ADR-0010.
     "17_schema_bolsa_familia.sql",
 ]
 

--- a/etl/01_schema.py
+++ b/etl/01_schema.py
@@ -14,6 +14,9 @@ SQL_FILES = [
     "08_schema_renuncias.sql",
     "09_schema_complementar.sql",
     "10_schema_pessoa.sql",
+    # Bolsa Familia: schema canonico idempotente; tabela e criada aqui (em vez
+    # de pela fase classica neutralizada). Ver ADR-0009.
+    "17_schema_bolsa_familia.sql",
 ]
 
 

--- a/etl/17_bolsa_familia.py
+++ b/etl/17_bolsa_familia.py
@@ -12,7 +12,7 @@ Acionamento:
 - Migration `sql/41_bolsa_familia_incremental.sql` aplicada pelo step
   "ETL: Incremental" do deploy.
 
-Ver ADR-0009 para a decisao completa.
+Ver ADR-0010 para a decisao completa.
 """
 
 
@@ -20,7 +20,7 @@ def run():
     print(
         "    SKIP: Bolsa Familia migrou para ETL incremental "
         "(etl_phase=incremental, spec bolsa_familia.bolsa_familia). "
-        "Ver ADR-0009 e docs/etl-incremental-guide.md.",
+        "Ver ADR-0010 e docs/etl-incremental-guide.md.",
         flush=True,
     )
     return

--- a/etl/17_bolsa_familia.py
+++ b/etl/17_bolsa_familia.py
@@ -1,95 +1,29 @@
-"""Carrega dados do Novo Bolsa Familia.
+"""Bolsa Familia — fase classica desativada (migrada para framework incremental).
 
-Fonte: portaldatransparencia.gov.br/download-de-dados/novo-bolsa-familia
-Arquivos: YYYYMM_NovoBolsaFamilia.csv (;, Latin-1, com header, valor com virgula)
-~20M registros por mes.
+A carga de Bolsa Familia agora roda via `etl/incremental/specs/bolsa_familia.py`
+(framework P1-P6, snapshots mensais acumulativos). Esta fase classica permanece
+no orquestrador `etl/run_all.py` apenas como no-op para preservar o indice de
+fases (etl_phase numerico do deploy.yml e tests).
+
+Acionamento:
+- `etl_phase=incremental` (com `incremental_only=bolsa_familia.bolsa_familia` opcional)
+- Schema canonico (`sql/17_schema_bolsa_familia.sql`) continua sendo aplicado
+  pela fase 1 (`etl.01_schema`) de forma idempotente (CREATE IF NOT EXISTS).
+- Migration `sql/41_bolsa_familia_incremental.sql` aplicada pelo step
+  "ETL: Incremental" do deploy.
+
+Ver ADR-0009 para a decisao completa.
 """
-
-from etl.config import DATA_DIR, SQL_DIR
-from etl.db import get_conn, table_count
 
 
 def run():
-    conn = get_conn()
-    try:
-        sql = (SQL_DIR / "17_schema_bolsa_familia.sql").read_text(encoding="utf-8")
-        with conn.cursor() as cur:
-            cur.execute(sql)
-        conn.commit()
-
-        bf_dir = DATA_DIR / "bolsa_familia"
-        files = sorted(bf_dir.glob("*_NovoBolsaFamilia.csv"))
-        if not files:
-            print("    AVISO: Nenhum arquivo *_NovoBolsaFamilia.csv encontrado.")
-            return
-
-        staging = "_stg_bolsa_familia"
-
-        for filepath in files:
-            print(f"    Carregando {filepath.name} para staging...")
-
-            with conn.cursor() as cur:
-                cur.execute(f"TRUNCATE {staging}")
-            conn.commit()
-
-            copy_sql = f"""COPY {staging} FROM STDIN WITH (
-                FORMAT csv, DELIMITER ';', HEADER true, NULL '',
-                ENCODING 'LATIN1', QUOTE '"'
-            )"""
-
-            with open(filepath, "rb") as f:
-                with conn.cursor() as cur:
-                    cur.copy_expert(copy_sql, f)
-            conn.commit()
-
-            print(f"    Inserindo em bolsa_familia...")
-            with conn.cursor() as cur:
-                cur.execute(f"""
-                    INSERT INTO bolsa_familia (
-                        mes_competencia, mes_referencia, uf, cd_municipio_siafi,
-                        nm_municipio, cpf_favorecido, nis_favorecido, nm_favorecido,
-                        valor_parcela
-                    )
-                    SELECT
-                        TRIM(c0), TRIM(c1), TRIM(c2), TRIM(c3),
-                        TRIM(c4), TRIM(c5), TRIM(c6), TRIM(c7),
-                        CASE WHEN TRIM(c8) ~ '^[\\d.,]+$' AND TRIM(c8) != ''
-                             THEN CAST(REPLACE(REPLACE(TRIM(c8), '.', ''), ',', '.') AS NUMERIC)
-                             ELSE NULL END
-                    FROM {staging}
-                """)
-            conn.commit()
-            print(f"    {filepath.name} carregado.")
-
-        # Limpar staging
-        with conn.cursor() as cur:
-            cur.execute(f"DROP TABLE IF EXISTS {staging}")
-        conn.commit()
-
-        count = table_count(conn, "bolsa_familia")
-        print(f"    bolsa_familia: {count} registros")
-
-        print("    Criando indices...")
-        # Disable parallel workers to reduce temp disk usage on large tables
-        with conn.cursor() as cur:
-            cur.execute("SET max_parallel_maintenance_workers = 0;")
-        conn.commit()
-
-        # Create indexes one at a time, committing after each to release temp space
-        bf_indexes = [
-            "CREATE INDEX IF NOT EXISTS idx_bf_cpf ON bolsa_familia(cpf_favorecido);",
-            "CREATE INDEX IF NOT EXISTS idx_bf_nis ON bolsa_familia(nis_favorecido);",
-            "CREATE INDEX IF NOT EXISTS idx_bf_nome ON bolsa_familia USING gin(nm_favorecido gin_trgm_ops);",
-            "CREATE INDEX IF NOT EXISTS idx_bf_municipio ON bolsa_familia(cd_municipio_siafi);",
-            "CREATE INDEX IF NOT EXISTS idx_bf_uf ON bolsa_familia(uf);",
-        ]
-        for idx_sql in bf_indexes:
-            with conn.cursor() as cur:
-                cur.execute(idx_sql)
-            conn.commit()
-        print("    Indices Bolsa Familia criados.")
-    finally:
-        conn.close()
+    print(
+        "    SKIP: Bolsa Familia migrou para ETL incremental "
+        "(etl_phase=incremental, spec bolsa_familia.bolsa_familia). "
+        "Ver ADR-0009 e docs/etl-incremental-guide.md.",
+        flush=True,
+    )
+    return
 
 
 if __name__ == "__main__":

--- a/etl/incremental/parser.py
+++ b/etl/incremental/parser.py
@@ -68,7 +68,7 @@ def validate_csv_header(csv_path: Path, spec: LoaderSpec) -> str:
     # Aplica csv_header_rewrites: mapa nomes raw (acentos/espacos do CSV) para
     # nomes SQL-safe declarados em spec.columns. Necessario p/ fontes como
     # Portal da Transparencia (e.g. "MES COMPETENCIA" -> "MES_COMPETENCIA").
-    # Default {} = no-op para specs existentes. Ver ADR-0009.
+    # Default {} = no-op para specs existentes. Ver ADR-0010.
     if spec.csv_header_rewrites:
         headers = [spec.csv_header_rewrites.get(h, h) for h in headers]
 

--- a/etl/incremental/parser.py
+++ b/etl/incremental/parser.py
@@ -65,6 +65,13 @@ def validate_csv_header(csv_path: Path, spec: LoaderSpec) -> str:
                         quotechar=spec.csv_quotechar)
     headers = next(reader)
 
+    # Aplica csv_header_rewrites: mapa nomes raw (acentos/espacos do CSV) para
+    # nomes SQL-safe declarados em spec.columns. Necessario p/ fontes como
+    # Portal da Transparencia (e.g. "MES COMPETENCIA" -> "MES_COMPETENCIA").
+    # Default {} = no-op para specs existentes. Ver ADR-0009.
+    if spec.csv_header_rewrites:
+        headers = [spec.csv_header_rewrites.get(h, h) for h in headers]
+
     expected = list(spec.columns)
     if headers != expected:
         raise SchemaDriftError(

--- a/etl/incremental/runner.py
+++ b/etl/incremental/runner.py
@@ -27,6 +27,7 @@ def _load_all_specs():
     """Discover all LoaderSpec instances in etl.incremental.specs.*"""
     from etl.incremental.specs import pb_pagamento, pb_empenho, pb_contrato
     from etl.incremental.specs import tce_pb_despesa, tce_pb_servidor, tce_pb_licitacao, tce_pb_receita
+    from etl.incremental.specs import bolsa_familia
     from etl.incremental.specs.pb_extras import ALL_SPECS as PB_EXTRAS
 
     specs = {
@@ -39,6 +40,7 @@ def _load_all_specs():
             pb_pagamento.SPEC,
             pb_empenho.SPEC,
             pb_contrato.SPEC,
+            bolsa_familia.SPEC,
         ]
     }
     for spec in PB_EXTRAS.values():

--- a/etl/incremental/spec.py
+++ b/etl/incremental/spec.py
@@ -118,6 +118,14 @@ class LoaderSpec:
     bootstrap_tolerance_pct: float = 0.0
     max_field_size: int = 1_048_576            # 1MB per field
     refetch_recent_buckets: int = 1            # N tail buckets sempre re-baixados
+    # CSV header rewrites: mapeia nomes raw do CSV (potencialmente com acentos
+    # e/ou espacos — e.g. "MES COMPETENCIA") para os nomes que aparecem em
+    # spec.columns (e.g. "MES_COMPETENCIA"). Aplicado ANTES do header match em
+    # validate_csv_header (parser.py). Default `{}` — sem efeito para specs
+    # existentes. Necessario para fontes como Portal da Transparencia que
+    # publicam headers nao-SQL-safe. Ver etl/incremental/specs/bolsa_familia.py
+    # e ADR-0009.
+    csv_header_rewrites: dict[str, str] = field(default_factory=dict)
     # Bucket file pattern: callable que dado bucket_id (str) retorna lista de
     # nomes de arquivo esperados (sem path).
     file_pattern: Optional[Callable[[str], list[str]]] = None
@@ -186,6 +194,19 @@ class LoaderSpec:
                 "bootstrap_tolerance_pct must be in [0.0, 50.0]"
             )
 
+        # Validate csv_header_rewrites: valores devem estar em columns
+        if self.csv_header_rewrites:
+            cols_set_post = set(self.columns)
+            for raw, renamed in self.csv_header_rewrites.items():
+                if not raw or not renamed:
+                    raise ConfigError(
+                        "csv_header_rewrites: empty key/value not allowed"
+                    )
+                if renamed not in cols_set_post:
+                    raise ConfigError(
+                        f"csv_header_rewrites: target {renamed!r} not in columns"
+                    )
+
         # Validate derived_columns expressions (D9 AST-lite)
         # NOTA: skip validation se expr contém placeholders {bucket_id} —
         # serão resolvidos em runtime, não armazenados no SQL final puro.
@@ -228,6 +249,7 @@ class LoaderSpec:
             "derived_columns": dict(self.derived_columns),
             "is_zip_source": self.is_zip_source,
             "bootstrap_tolerance_pct": self.bootstrap_tolerance_pct,
+            "csv_header_rewrites": dict(self.csv_header_rewrites),
         }
         return hashlib.sha256(
             json.dumps(canonical, sort_keys=True, ensure_ascii=False).encode()

--- a/etl/incremental/spec.py
+++ b/etl/incremental/spec.py
@@ -124,7 +124,7 @@ class LoaderSpec:
     # validate_csv_header (parser.py). Default `{}` — sem efeito para specs
     # existentes. Necessario para fontes como Portal da Transparencia que
     # publicam headers nao-SQL-safe. Ver etl/incremental/specs/bolsa_familia.py
-    # e ADR-0009.
+    # e ADR-0010.
     csv_header_rewrites: dict[str, str] = field(default_factory=dict)
     # Bucket file pattern: callable que dado bucket_id (str) retorna lista de
     # nomes de arquivo esperados (sem path).

--- a/etl/incremental/specs/bolsa_familia.py
+++ b/etl/incremental/specs/bolsa_familia.py
@@ -119,7 +119,24 @@ CSV_HEADER_REWRITES = {
     "VALOR PARCELA": "VALOR_PARCELA",
 }
 
-COLUMN_RENAMES = {c: c.lower() for c in COLUMNS}
+# Column renames: CSV col raw (UPPERCASE) -> target col (lowercase).
+# CRITICO: a tabela bolsa_familia usa nomes LEGADOS estilo SIAFI antigo
+# (cd_municipio_siafi, nm_municipio, nm_favorecido), NAO o padrao Portal
+# (codigo_municipio_siafi, nome_municipio, nome_favorecido). Mapping
+# explicito abaixo evita o bug que blanket lowercase causaria (INSERT em
+# coluna inexistente). Validado contra sql/17_schema_bolsa_familia.sql
+# (schema canonico) e information_schema.columns em prod 2026-05.
+COLUMN_RENAMES = {
+    "MES_COMPETENCIA": "mes_competencia",
+    "MES_REFERENCIA": "mes_referencia",
+    "UF": "uf",
+    "CODIGO_MUNICIPIO_SIAFI": "cd_municipio_siafi",
+    "NOME_MUNICIPIO": "nm_municipio",
+    "CPF_FAVORECIDO": "cpf_favorecido",
+    "NIS_FAVORECIDO": "nis_favorecido",
+    "NOME_FAVORECIDO": "nm_favorecido",
+    "VALOR_PARCELA": "valor_parcela",
+}
 
 COLUMN_TYPES = {c: "TEXT" for c in COLUMNS}
 COLUMN_TYPES["VALOR_PARCELA"] = "NUMERIC"

--- a/etl/incremental/specs/bolsa_familia.py
+++ b/etl/incremental/specs/bolsa_familia.py
@@ -1,0 +1,174 @@
+"""LoaderSpec para Bolsa Familia (Portal da Transparencia).
+
+Source: portaldatransparencia.gov.br/download-de-dados/novo-bolsa-familia/{YYYYMM}
+Formato: ZIP contendo CSV {YYYYMM}_NovoBolsaFamilia.csv
+         (delimiter ';', quotechar '"', encoding latin-1, decimal BR virgula).
+
+Filename ZIP: novo_bf_{YYYYMM}.zip (consistente com etl/00_download.py).
+Filename CSV (apos extracao automatica pelo framework): {YYYYMM}_NovoBolsaFamilia.csv.
+
+Cursor: MONTH_WINDOW (bucket_id = "YYYY-MM").
+Watermark: MES_COMPETENCIA (string YYYYMM).
+Dedupe: UPSERT_DO_NOTHING. Intencao do incremental e ACUMULAR snapshots
+        mensais novos, NAO corrigir dados existentes — escolhi DO_NOTHING
+        em vez de DO_UPDATE para que reruns nunca alterem rows existentes
+        (mais conservador). refetch_recent_buckets=1 cobre republish do
+        mes corrente.
+
+NK: synthetic md5 (nk_synthetic_md5=True), pattern dos 7 pb_extras tables.
+   Por que nao NK natural: empirical analysis (2026-05) na base local + VM:
+   * 21% rows tem cpf_favorecido='' (CADUNICO com CPF nao-vinculado).
+   * Portal publica parcelas RETROATIVAS no mesmo mes_competencia com
+     mes_referencia diferentes (legitimo — recebimentos atrasados).
+   * Nenhuma combinacao razoavel de cols cobre 100% sem perda de dado.
+   * 22 rows EXATAMENTE iguais (todas 9 cols) sao true legacy duplicates.
+   Synthetic md5 das 9 cols cobre 100% via trigger BEFORE INSERT
+   (ver sql/41_bolsa_familia_incremental.sql).
+   natural_key abaixo e DECLARATIVO (semantico) — quando nk_synthetic_md5
+   esta True, build_upsert_sql usa ON CONFLICT (_nk_md5).
+
+Header rewrite: o CSV do Portal Transparencia publica headers com acentos e
+espacos (e.g. "MES COMPETENCIA"). spec.csv_header_rewrites mapeia esses
+nomes raw para os SQL-safe que aparecem em spec.columns (e.g.
+"MES_COMPETENCIA"). Encoding latin-1 garante leitura correta dos acentos
+antes do rewrite.
+
+Ver ADR-0009 e docs/etl-incremental-guide.md.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date
+
+from ..spec import CursorStrategy, DedupeStrategy, LoaderSpec
+
+_PORTAL_BASE = "https://portaldatransparencia.gov.br/download-de-dados/novo-bolsa-familia"
+
+
+def _bucket_from_filename(name: str) -> str | None:
+    """Aceita tanto o ZIP baixado (novo_bf_YYYYMM.zip) quanto o CSV interno
+    (YYYYMM_NovoBolsaFamilia.csv). framework chama com o CSV apos extracao."""
+    m = re.match(r"^(\d{6})_NovoBolsaFamilia\.csv$", name, re.IGNORECASE)
+    if m:
+        ym = m.group(1)
+        return f"{ym[:4]}-{ym[4:]}"
+    m = re.match(r"^novo_bf_(\d{6})\.zip$", name, re.IGNORECASE)
+    if m:
+        ym = m.group(1)
+        return f"{ym[:4]}-{ym[4:]}"
+    return None
+
+
+def _file_pattern(bucket_id: str) -> list[str]:
+    """CSV interno do ZIP extraido. framework usa esse nome para localizar
+    o arquivo apos extracao automatica (ver etl/incremental/download.py:207+)."""
+    year, month = bucket_id.split("-")
+    return [f"{year}{month}_NovoBolsaFamilia.csv"]
+
+
+def _url_for_bucket(bucket_id: str) -> list[tuple[str, str]]:
+    """Portal Transparencia: 1 ZIP por (year, month). Nome do destino segue
+    o padrao usado em etl/00_download.py:1265 (novo_bf_{YYYYMM}.zip)."""
+    year, month = bucket_id.split("-")
+    ym = f"{year}{month}"
+    return [(f"{_PORTAL_BASE}/{ym}", f"novo_bf_{ym}.zip")]
+
+
+def _enumerate_buckets() -> list[str]:
+    """Novo Bolsa Familia substituiu Auxilio Brasil em marco/2023.
+    Listamos do primeiro mes disponivel ate o mes atual.
+    """
+    today = date.today()
+    out = []
+    start_year, start_month = 2023, 3  # Marco/2023 = primeiro mes do Novo BF
+    year, month = start_year, start_month
+    while (year, month) <= (today.year, today.month):
+        out.append(f"{year}-{month:02d}")
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+    return out
+
+
+# Headers SQL-safe declarados em spec.columns. O CSV raw publica nomes com
+# acentos e espacos; csv_header_rewrites faz o mapeamento.
+COLUMNS = [
+    "MES_COMPETENCIA",
+    "MES_REFERENCIA",
+    "UF",
+    "CODIGO_MUNICIPIO_SIAFI",
+    "NOME_MUNICIPIO",
+    "CPF_FAVORECIDO",
+    "NIS_FAVORECIDO",
+    "NOME_FAVORECIDO",
+    "VALOR_PARCELA",
+]
+
+# Header raw do CSV publicado pelo Portal da Transparencia. Encoding latin-1
+# preserva os acentos. Validado em 2026-05 com 202510, 202512 e 202602.
+CSV_HEADER_REWRITES = {
+    "MÊS COMPETÊNCIA": "MES_COMPETENCIA",
+    "MÊS REFERÊNCIA": "MES_REFERENCIA",
+    "UF": "UF",
+    "CÓDIGO MUNICÍPIO SIAFI": "CODIGO_MUNICIPIO_SIAFI",
+    "NOME MUNICÍPIO": "NOME_MUNICIPIO",
+    "CPF FAVORECIDO": "CPF_FAVORECIDO",
+    "NIS FAVORECIDO": "NIS_FAVORECIDO",
+    "NOME FAVORECIDO": "NOME_FAVORECIDO",
+    "VALOR PARCELA": "VALOR_PARCELA",
+}
+
+COLUMN_RENAMES = {c: c.lower() for c in COLUMNS}
+
+COLUMN_TYPES = {c: "TEXT" for c in COLUMNS}
+COLUMN_TYPES["VALOR_PARCELA"] = "NUMERIC"
+
+
+SPEC = LoaderSpec(
+    source="bolsa_familia",
+    table="bolsa_familia",
+    # natural_key abaixo e DECLARATIVO (semantico): identifica a parcela
+    # individual. Quando nk_synthetic_md5=True (abaixo), o framework usa
+    # ON CONFLICT (_nk_md5) em vez desses cols. Mantemos a lista coerente
+    # com o significado de "uma parcela" para que reviewers entendam a
+    # intencao mesmo sem ler o sql/41.
+    natural_key=[
+        "MES_COMPETENCIA",
+        "MES_REFERENCIA",
+        "CPF_FAVORECIDO",
+        "NIS_FAVORECIDO",
+    ],
+    cursor_strategy=CursorStrategy.MONTH_WINDOW,
+    dedupe_strategy=DedupeStrategy.UPSERT_DO_NOTHING,
+    # CRITICO: synthetic md5 NK. Cobre cenarios onde nem trio (cpf vazio)
+    # nem 4-uplo (parcelas retroativas) sao 100%-unicos. Padrao pb_extras.
+    # Requer:
+    #   * coluna _nk_md5 (criada em sql/41 step 1)
+    #   * trigger BEFORE INSERT compute_nk_md5_bolsa_familia (sql/41 step 2)
+    #   * UNIQUE INDEX ix_bolsa_familia_nk_md5 (sql/41 step 5)
+    nk_synthetic_md5=True,
+    columns=COLUMNS,
+    column_types=COLUMN_TYPES,
+    column_renames=COLUMN_RENAMES,
+    csv_delimiter=";",
+    csv_quotechar='"',
+    # cpf_digitos populado pelo framework via REGEXP_REPLACE. Use UPPERCASE
+    # exato do nome em spec.columns (ver staging.py linhas 183-185 — derived
+    # SELECT usa raw staging col names, antes do column_renames).
+    derived_columns={
+        "cpf_digitos": "REGEXP_REPLACE(CPF_FAVORECIDO, '[^0-9]', '', 'g')",
+    },
+    watermark_col="MES_COMPETENCIA",
+    watermark_type="string",
+    encoding="latin-1",
+    decimal_format="br",   # CSV usa virgula como decimal (1886,00)
+    date_format="iso",
+    is_zip_source=True,
+    refetch_recent_buckets=1,
+    file_pattern=_file_pattern,
+    bucket_from_filename=_bucket_from_filename,
+    url_for_bucket=_url_for_bucket,
+    enumerate_buckets=_enumerate_buckets,
+    csv_header_rewrites=CSV_HEADER_REWRITES,
+)

--- a/etl/incremental/specs/bolsa_familia.py
+++ b/etl/incremental/specs/bolsa_familia.py
@@ -33,7 +33,7 @@ nomes raw para os SQL-safe que aparecem em spec.columns (e.g.
 "MES_COMPETENCIA"). Encoding latin-1 garante leitura correta dos acentos
 antes do rewrite.
 
-Ver ADR-0009 e docs/etl-incremental-guide.md.
+Ver ADR-0010 e docs/etl-incremental-guide.md.
 """
 from __future__ import annotations
 

--- a/etl/refresh_post_incremental.py
+++ b/etl/refresh_post_incremental.py
@@ -83,6 +83,10 @@ def populate_nk_md5_bolsa_familia(conn, batch_size: int = 100_000) -> None:
     com autocommit=True permite COMMIT entre batches sem problema.
 
     Idempotente: WHERE _nk_md5 IS NULL. Pode ser interrompido e re-rodado.
+
+    Cria partial index temporario para acelerar batches (Opus 4.7-high
+    review MEDIUM-4 — sem isso, o WHERE IS NULL faz seq scan O(n) por
+    batch, gerando trabalho quadratico O(n²/batch) no total).
     """
     logger.info("populate_nk_md5_bolsa_familia: BATCH_SIZE=%d", batch_size)
     prev_autocommit = conn.autocommit
@@ -91,6 +95,16 @@ def populate_nk_md5_bolsa_familia(conn, batch_size: int = 100_000) -> None:
     total = 0
     try:
         with conn.cursor() as cur:
+            # Criar partial index ANTES do loop (CONCURRENTLY exige autocommit).
+            # Idempotente (IF NOT EXISTS). Sera dropado no final.
+            logger.info("creating temporary partial index for populate speedup...")
+            cur.execute("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS _tmp_idx_bf_nk_md5_null
+                ON bolsa_familia (id) WHERE _nk_md5 IS NULL
+            """)
+            # ANALYZE para o planner usar o partial index nos batches seguintes.
+            cur.execute("ANALYZE bolsa_familia")
+
             while True:
                 cur.execute("""
                     UPDATE bolsa_familia SET _nk_md5 = etl_admin.row_hash_md5(
@@ -117,6 +131,10 @@ def populate_nk_md5_bolsa_familia(conn, batch_size: int = 100_000) -> None:
                     "populate _nk_md5: total %s rows (%.0fs)",
                     f"{total:,}", time.time() - t0,
                 )
+
+            # Drop partial index — nao serve apos populate completo.
+            logger.info("dropping temporary partial index...")
+            cur.execute("DROP INDEX IF EXISTS _tmp_idx_bf_nk_md5_null")
     finally:
         conn.autocommit = prev_autocommit
     logger.info("populate_nk_md5_bolsa_familia: DONE — %d rows em %.0fs",
@@ -162,14 +180,19 @@ def refresh_for_bolsa_familia(conn) -> None:
     # Body extraido para sql/41c_tmp_bf_body.sql — drift com sql/12_views.sql
     # quebra esta logica (validado em smoke tests).
     body = _read_sql_file("41c_tmp_bf_body.sql")
-    # 41c contem comentarios + statement final. Garantimos TRUNCATE antes em
-    # uma unica transacao para nao deixar a MV servindo dados inconsistentes
-    # entre TRUNCATE e INSERT.
-    _run_sql(
-        conn,
-        "_tmp_bf TRUNCATE + INSERT",
-        f"BEGIN; TRUNCATE TABLE _tmp_bf; INSERT INTO _tmp_bf {body} COMMIT;",
-    )
+    # Strip statement terminator do body antes de injetar — evita ambiguidade
+    # com concatenacoes futuras (Opus 4.7-high review LOW-5).
+    body_stripped = body.rstrip().rstrip(";").rstrip()
+    # TRUNCATE + INSERT atomic via transacao implicita do psycopg2
+    # (autocommit=False default). Os dois statements executam em UMA
+    # transacao; AccessExclusiveLock do TRUNCATE eh mantido ate o
+    # commit() em _run_sql. mv_servidor_pb_risco nao vai ver estado
+    # intermediario.
+    with conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE _tmp_bf")
+        cur.execute(f"INSERT INTO _tmp_bf {body_stripped}")
+    conn.commit()
+    logger.info("_tmp_bf TRUNCATE + INSERT OK")
 
     # 4. mv_servidor_pb_risco: depende de _tmp_bf novo.
     # IMPORTANTE: a MV nao suporta REFRESH "limpo" porque _tmp_bf nao tem

--- a/etl/refresh_post_incremental.py
+++ b/etl/refresh_post_incremental.py
@@ -1,0 +1,273 @@
+"""Refresh de Materialized Views + tabelas _tmp_ apos ETL incremental.
+
+Roda como step final do `etl_phase=incremental` no deploy.yml quando uma
+source que tem MVs dependentes foi processada (atualmente: bolsa_familia).
+
+Por que existe:
+- O framework incremental P1-P6 (etl/incremental/) e generico: nao sabe
+  quais MVs dependem de cada source. Atualizar bolsa_familia sem refresh
+  deixa mv_pessoa_pb / mv_servidor_pb_risco / mv_municipio_pb_kpi_score
+  com dados velhos.
+- Refresh manual via deploy.yml inputs e fragil (esquecivel + drift).
+- Centralizando aqui: cada source que vira incremental registra sua
+  refresh fn em SOURCE_REFRESH_FNS. Step do deploy chama com --source X.
+
+Por que hard-fail:
+- Warm cache subsequente leria dados velhos se MVs nao refrescaram.
+- Site continua servindo a MV antiga (que existe) ate refresh terminar —
+  preferimos falhar o deploy do que entregar warm cache stale.
+
+Por que autocommit toggle:
+- REFRESH MATERIALIZED VIEW CONCURRENTLY exige rodar FORA de transacao
+  explicita (mesmo motivo de CREATE INDEX CONCURRENTLY). Padrao
+  etl/10_indices.py:32-36.
+
+CLI:
+    python -m etl.refresh_post_incremental --source bolsa_familia
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+import psycopg2
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+def _run_sql(conn, label: str, sql: str, *, autocommit: bool = False) -> float:
+    """Executa SQL. Se autocommit=True, toggle conn.autocommit no escopo.
+
+    Retorna tempo gasto (segundos).
+    """
+    prev = conn.autocommit
+    if autocommit and not prev:
+        conn.commit()  # encerra qualquer txn pendente
+        conn.autocommit = True
+    t0 = time.time()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+        if not conn.autocommit:
+            conn.commit()
+        dt = time.time() - t0
+        logger.info("%s OK em %.1fs", label, dt)
+        return dt
+    finally:
+        if autocommit and not prev:
+            conn.autocommit = prev
+
+
+def _read_sql_file(name: str) -> str:
+    path = Path(__file__).resolve().parents[1] / "sql" / name
+    return path.read_text(encoding="utf-8")
+
+
+def populate_nk_md5_bolsa_familia(conn, batch_size: int = 100_000) -> None:
+    """Popula _nk_md5 nas rows legacy de bolsa_familia em batches.
+
+    Workaround para PG 16: PROCEDURE com COMMIT interno falha quando chamada
+    via psql -c "CALL ..." (psql wrappa em transacao implicita). psycopg2
+    com autocommit=True permite COMMIT entre batches sem problema.
+
+    Idempotente: WHERE _nk_md5 IS NULL. Pode ser interrompido e re-rodado.
+    """
+    logger.info("populate_nk_md5_bolsa_familia: BATCH_SIZE=%d", batch_size)
+    prev_autocommit = conn.autocommit
+    conn.autocommit = True
+    t0 = time.time()
+    total = 0
+    try:
+        with conn.cursor() as cur:
+            while True:
+                cur.execute("""
+                    UPDATE bolsa_familia SET _nk_md5 = etl_admin.row_hash_md5(
+                        coalesce(mes_competencia, ''),
+                        coalesce(mes_referencia, ''),
+                        coalesce(uf, ''),
+                        coalesce(cd_municipio_siafi, ''),
+                        coalesce(nm_municipio, ''),
+                        coalesce(cpf_favorecido, ''),
+                        coalesce(nis_favorecido, ''),
+                        coalesce(nm_favorecido, ''),
+                        coalesce(valor_parcela::text, '')
+                    )
+                    WHERE id IN (
+                        SELECT id FROM bolsa_familia
+                        WHERE _nk_md5 IS NULL ORDER BY id LIMIT %s
+                    )
+                """, (batch_size,))
+                n = cur.rowcount
+                if n == 0:
+                    break
+                total += n
+                logger.info(
+                    "populate _nk_md5: total %s rows (%.0fs)",
+                    f"{total:,}", time.time() - t0,
+                )
+    finally:
+        conn.autocommit = prev_autocommit
+    logger.info("populate_nk_md5_bolsa_familia: DONE — %d rows em %.0fs",
+                total, time.time() - t0)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Refresh por source
+# ──────────────────────────────────────────────────────────────────────────
+
+def refresh_for_bolsa_familia(conn) -> None:
+    """Refresh das MVs que dependem de bolsa_familia.
+
+    Ordem (Layer 1 -> tmp -> Layer 2):
+      1. ANALYZE bolsa_familia (planner stats — barato e necessario)
+      2. REFRESH MATERIALIZED VIEW CONCURRENTLY mv_pessoa_pb (L1)
+      3. _tmp_bf via TRUNCATE+INSERT consumindo sql/41c_tmp_bf_body.sql
+         (DROP _tmp_bf falha — mv_servidor_pb_risco depende por OID)
+      4. mv_servidor_pb_risco: REFRESH CONCURRENTLY (usa _tmp_bf novo)
+      5. mv_municipio_pb_kpi_score: REFRESH CONCURRENTLY (depende de
+         mv_pessoa_pb agregado)
+
+    Hard-fail: qualquer step lanca → script aborta com exit code 1.
+    """
+    logger.info("=" * 60)
+    logger.info("refresh_for_bolsa_familia: iniciando")
+    logger.info("=" * 60)
+
+    total_t0 = time.time()
+
+    # 1. ANALYZE — refresh planner stats antes de queries pesadas.
+    _run_sql(conn, "ANALYZE bolsa_familia", "ANALYZE bolsa_familia")
+
+    # 2. mv_pessoa_pb (L1): SUM/COUNT bolsa_familia por cpf_digitos_6 + nome.
+    _run_sql(
+        conn,
+        "REFRESH mv_pessoa_pb",
+        "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_pessoa_pb",
+        autocommit=True,
+    )
+
+    # 3. _tmp_bf rebuild via TRUNCATE+INSERT atomic.
+    # Body extraido para sql/41c_tmp_bf_body.sql — drift com sql/12_views.sql
+    # quebra esta logica (validado em smoke tests).
+    body = _read_sql_file("41c_tmp_bf_body.sql")
+    # 41c contem comentarios + statement final. Garantimos TRUNCATE antes em
+    # uma unica transacao para nao deixar a MV servindo dados inconsistentes
+    # entre TRUNCATE e INSERT.
+    _run_sql(
+        conn,
+        "_tmp_bf TRUNCATE + INSERT",
+        f"BEGIN; TRUNCATE TABLE _tmp_bf; INSERT INTO _tmp_bf {body} COMMIT;",
+    )
+
+    # 4. mv_servidor_pb_risco: depende de _tmp_bf novo.
+    # IMPORTANTE: a MV nao suporta REFRESH "limpo" porque _tmp_bf nao tem
+    # UNIQUE INDEX (foi criado via CREATE TABLE AS, sem PK). Mas
+    # mv_servidor_pb_risco TEM idx_mv_srv_cpf_nome UNIQUE → suporta
+    # REFRESH CONCURRENTLY.
+    _run_sql(
+        conn,
+        "REFRESH mv_servidor_pb_risco",
+        "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_servidor_pb_risco",
+        autocommit=True,
+    )
+
+    # 5. mv_municipio_pb_kpi_score: agrega indicadores PB incluindo BF
+    # (via mv_pessoa_pb). Validar dependencia em runtime via pg_depend
+    # para nao quebrar silenciosamente se 12_views.sql for refatorado.
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT EXISTS (
+                SELECT 1 FROM pg_depend d
+                JOIN pg_class c1 ON c1.oid = d.refobjid
+                JOIN pg_class c2 ON c2.oid = d.objid
+                WHERE c1.relname = 'mv_pessoa_pb'
+                  AND c2.relname = 'mv_municipio_pb_kpi_score'
+            )
+        """)
+        depends = cur.fetchone()[0]
+    if depends:
+        _run_sql(
+            conn,
+            "REFRESH mv_municipio_pb_kpi_score",
+            "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_municipio_pb_kpi_score",
+            autocommit=True,
+        )
+    else:
+        logger.info("mv_municipio_pb_kpi_score nao depende de mv_pessoa_pb — skip.")
+
+    total_dt = time.time() - total_t0
+    logger.info("refresh_for_bolsa_familia: DONE em %.1fs (%.1f min)", total_dt, total_dt / 60)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Registry — fontes que tem refresh hooks
+# ──────────────────────────────────────────────────────────────────────────
+
+SOURCE_REFRESH_FNS: dict[str, Callable] = {
+    "bolsa_familia": refresh_for_bolsa_familia,
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Refresh MVs apos ETL incremental por source"
+    )
+    parser.add_argument(
+        "--source",
+        required=True,
+        choices=sorted(SOURCE_REFRESH_FNS.keys()),
+        help="Source registrada em SOURCE_REFRESH_FNS",
+    )
+    parser.add_argument(
+        "--populate-only",
+        action="store_true",
+        help="So roda populate_nk_md5 (sem MV refresh). Usado entre sql/41 e "
+             "sql/41z no deploy step. Apenas para source=bolsa_familia.",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help="Override DSN (default: etl.config.DSN)",
+    )
+    args = parser.parse_args()
+
+    if args.dsn is None:
+        from etl.config import DSN
+        args.dsn = DSN
+
+    conn = psycopg2.connect(args.dsn)
+    try:
+        if args.populate_only:
+            if args.source != "bolsa_familia":
+                logger.error("--populate-only so suporta source=bolsa_familia")
+                return 2
+            populate_nk_md5_bolsa_familia(conn)
+        else:
+            fn = SOURCE_REFRESH_FNS[args.source]
+            fn(conn)
+    except Exception:
+        logger.exception("refresh_for_%s FAILED", args.source)
+        return 1
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/etl/run_all.py
+++ b/etl/run_all.py
@@ -40,7 +40,7 @@ _CSV_DIRS: dict[str, list[str]] = {
     "etl.16_tse":           ["tse"],
     # NOTA: etl.17_bolsa_familia removida deste mapa — Bolsa Familia agora
     # roda via framework incremental (etl_phase=incremental), que cuida da
-    # propria limpeza de CSVs. A fase classica e no-op (ver ADR-0009).
+    # propria limpeza de CSVs. A fase classica e no-op (ver ADR-0010).
     "etl.18_tse_prestacao": ["tse"],          # mesma pasta que 16_tse
     "etl.19_tce_pb":        ["tce_pb"],
     "etl.20_dados_pb":      ["dados_pb"],

--- a/etl/run_all.py
+++ b/etl/run_all.py
@@ -38,7 +38,9 @@ _CSV_DIRS: dict[str, list[str]] = {
     "etl.13_sancoes":       ["sancoes"],
     "etl.14_viagens":       ["viagens"],
     "etl.16_tse":           ["tse"],
-    "etl.17_bolsa_familia": ["bolsa_familia"],
+    # NOTA: etl.17_bolsa_familia removida deste mapa — Bolsa Familia agora
+    # roda via framework incremental (etl_phase=incremental), que cuida da
+    # propria limpeza de CSVs. A fase classica e no-op (ver ADR-0009).
     "etl.18_tse_prestacao": ["tse"],          # mesma pasta que 16_tse
     "etl.19_tce_pb":        ["tce_pb"],
     "etl.20_dados_pb":      ["dados_pb"],

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -572,8 +572,16 @@ DROP TABLE IF EXISTS _tmp_bf;
 CREATE TABLE _tmp_bf AS
 WITH vinculo AS (
     SELECT cpf_digitos_6, nome_upper,
-           COALESCE(TO_CHAR(MIN(data_admissao), 'YYYYMM'), MIN(ano_mes)) AS inicio,
-           MAX(ano_mes) AS fim
+           -- Padroniza inicio/fim em YYYYMM (sem hifen) p/ comparar com
+           -- bf.mes_competencia. ano_mes vem como "YYYY-MM"; bug pre-existente
+           -- de comparacao lexicografica ("202410" <= "2024-12" da FALSE por
+           -- '-' < '1'). Fix tambem em sql/41c_tmp_bf_body.sql e
+           -- web/routes/cidade.py _compute_servidor_bf. Ver ADR-0010 HIGH-2.
+           COALESCE(
+               TO_CHAR(MIN(data_admissao), 'YYYYMM'),
+               REPLACE(MIN(ano_mes), '-', '')
+           ) AS inicio,
+           REPLACE(MAX(ano_mes), '-', '') AS fim
     FROM tce_pb_servidor
     WHERE cpf_digitos_6 IS NOT NULL AND nome_upper IS NOT NULL
       AND ano_mes >= '2022-01'

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -561,6 +561,13 @@ DROP TABLE IF EXISTS _tmp_d_agg;
 DROP TABLE IF EXISTS _tmp_se_unnest;
 
 -- Step 4: Bolsa Família match (apenas durante vínculo ativo)
+--
+-- IMPORTANTE: a query abaixo (CREATE TABLE _tmp_bf AS WITH ... SELECT ...)
+-- DEVE bater EXATAMENTE com sql/41c_tmp_bf_body.sql, que e consumido por
+-- etl/refresh_post_incremental.py durante etl_phase=incremental para fazer
+-- TRUNCATE+INSERT atomic de _tmp_bf (DROP nao funciona — MV depende por
+-- metadata, ver nota nas linhas 645-651). Drift entre os dois deixa
+-- mv_servidor_pb_risco com dados inconsistentes. Ver ADR-0009.
 DROP TABLE IF EXISTS _tmp_bf;
 CREATE TABLE _tmp_bf AS
 WITH vinculo AS (

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -567,7 +567,7 @@ DROP TABLE IF EXISTS _tmp_se_unnest;
 -- etl/refresh_post_incremental.py durante etl_phase=incremental para fazer
 -- TRUNCATE+INSERT atomic de _tmp_bf (DROP nao funciona — MV depende por
 -- metadata, ver nota nas linhas 645-651). Drift entre os dois deixa
--- mv_servidor_pb_risco com dados inconsistentes. Ver ADR-0009.
+-- mv_servidor_pb_risco com dados inconsistentes. Ver ADR-0010.
 DROP TABLE IF EXISTS _tmp_bf;
 CREATE TABLE _tmp_bf AS
 WITH vinculo AS (

--- a/sql/17_schema_bolsa_familia.sql
+++ b/sql/17_schema_bolsa_familia.sql
@@ -1,9 +1,16 @@
 -- Tabela do Novo Bolsa Familia
 -- Fonte: portaldatransparencia.gov.br/download-de-dados/novo-bolsa-familia
+--
+-- IDEMPOTENTE: Bolsa Familia migrou para o framework ETL incremental
+-- (ver ADR-0009). Schema canonico nunca mais e re-criado destrutivamente —
+-- migration sql/41_bolsa_familia_incremental.sql adiciona o que falta
+-- (UNIQUE INDEX, inserted_at, etc).
+--
+-- Aplicado em:
+--   * Fase 1 do ETL classico (etl/01_schema.py) — bootstrap inicial.
+--   * Step "ETL: Incremental" do deploy.yml (defensivo, idempotente).
 
-DROP TABLE IF EXISTS bolsa_familia CASCADE;
-
-CREATE TABLE bolsa_familia (
+CREATE TABLE IF NOT EXISTS bolsa_familia (
     id                  SERIAL PRIMARY KEY,
     mes_competencia     TEXT,
     mes_referencia      TEXT,
@@ -16,9 +23,19 @@ CREATE TABLE bolsa_familia (
     valor_parcela       NUMERIC
 );
 
--- Staging para COPY direto (valor como TEXT)
-DROP TABLE IF EXISTS _stg_bolsa_familia;
-CREATE UNLOGGED TABLE _stg_bolsa_familia (
+-- Staging para COPY direto (valor como TEXT) — UNLOGGED, recriada a cada carga.
+-- Mantida apenas por compatibilidade com codigo legado de import manual; o
+-- framework incremental usa sua propria staging gerenciada por
+-- etl/incremental/staging.py.
+CREATE UNLOGGED TABLE IF NOT EXISTS _stg_bolsa_familia (
     c0 TEXT, c1 TEXT, c2 TEXT, c3 TEXT,
     c4 TEXT, c5 TEXT, c6 TEXT, c7 TEXT, c8 TEXT
 );
+
+-- Indices clasicos (idempotentes). Indice UNIQUE para upsert do framework
+-- incremental e criado por sql/41_bolsa_familia_incremental.sql (CONCURRENTLY).
+CREATE INDEX IF NOT EXISTS idx_bf_cpf ON bolsa_familia(cpf_favorecido);
+CREATE INDEX IF NOT EXISTS idx_bf_nis ON bolsa_familia(nis_favorecido);
+CREATE INDEX IF NOT EXISTS idx_bf_nome ON bolsa_familia USING gin(nm_favorecido gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bf_municipio ON bolsa_familia(cd_municipio_siafi);
+CREATE INDEX IF NOT EXISTS idx_bf_uf ON bolsa_familia(uf);

--- a/sql/17_schema_bolsa_familia.sql
+++ b/sql/17_schema_bolsa_familia.sql
@@ -2,7 +2,7 @@
 -- Fonte: portaldatransparencia.gov.br/download-de-dados/novo-bolsa-familia
 --
 -- IDEMPOTENTE: Bolsa Familia migrou para o framework ETL incremental
--- (ver ADR-0009). Schema canonico nunca mais e re-criado destrutivamente —
+-- (ver ADR-0010). Schema canonico nunca mais e re-criado destrutivamente —
 -- migration sql/41_bolsa_familia_incremental.sql adiciona o que falta
 -- (UNIQUE INDEX, inserted_at, etc).
 --

--- a/sql/28_etl_role_grants.sql
+++ b/sql/28_etl_role_grants.sql
@@ -79,7 +79,7 @@ GRANT SELECT, INSERT, UPDATE ON
     public.pb_unidade_gestora
 TO etl_incremental;
 
--- Novo Bolsa Familia (Portal da Transparencia) — ADR-0009
+-- Novo Bolsa Familia (Portal da Transparencia) — ADR-0010
 -- Snapshots mensais acumulativos via framework incremental.
 -- SEM DELETE/TRUNCATE/DROP (mesmo principio P1 dos targets PB).
 GRANT SELECT, INSERT, UPDATE ON

--- a/sql/28_etl_role_grants.sql
+++ b/sql/28_etl_role_grants.sql
@@ -79,6 +79,13 @@ GRANT SELECT, INSERT, UPDATE ON
     public.pb_unidade_gestora
 TO etl_incremental;
 
+-- Novo Bolsa Familia (Portal da Transparencia) — ADR-0009
+-- Snapshots mensais acumulativos via framework incremental.
+-- SEM DELETE/TRUNCATE/DROP (mesmo principio P1 dos targets PB).
+GRANT SELECT, INSERT, UPDATE ON
+    public.bolsa_familia
+TO etl_incremental;
+
 -- Sequences (BIGSERIAL/SERIAL precisa USAGE para nextval)
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO etl_incremental;
 

--- a/sql/41_bolsa_familia_incremental.sql
+++ b/sql/41_bolsa_familia_incremental.sql
@@ -1,0 +1,154 @@
+-- Migration: Bolsa Familia para o framework ETL incremental (P1-P6).
+-- Estrategia: synthetic NK md5 (padrao sql/35a-d das 7 tabelas pb_extras).
+--
+-- Aplicada pelo step "ETL: Incremental" do deploy.yml (etl_phase=incremental).
+-- Idempotente — pode ser re-aplicada sem dano.
+--
+-- IMPORTANTE: CREATE INDEX CONCURRENTLY exige execucao FORA de transacao
+-- explicita. Aplicar via `psql -v ON_ERROR_STOP=1 -f sql/41_*.sql` SEM
+-- `--single-transaction`. Se interrompida no meio, o index pode ficar
+-- INVALID — o bloco DO $$ no final detecta e aborta.
+--
+-- Por que synthetic NK md5 e nao NK natural?
+--   Empirical analysis (2026-05) na base local + VM revelou:
+--   * 21% dos rows tem cpf_favorecido='' (CADUNICO com CPF nao-vinculado;
+--     adultos reais, NAO menores como inicialmente assumido).
+--   * Portal publica parcelas RETROATIVAS no mesmo mes_competencia com
+--     mes_referencia diferentes (legitimo — recebimentos atrasados).
+--   * Nenhuma combinacao razoavel de cols naturais gera NK 100%-unica
+--     sem perda de dado: trio (mes_comp, cpf, nis) tem 93k dups; mesmo
+--     5-uplo (+ mes_referencia + cd_municipio_siafi) tem 36 dups.
+--   * 9 grupos com TODAS 9 cols iguais (22 rows) sao true duplicates legacy.
+--   Synthetic md5 da hash de todas as 9 cols cobre 100% dos casos sem
+--   perda; segue padrao pb_extras + tem dedupe step inline.
+--
+-- Ver ADR-0009.
+
+
+-- ============================================================================
+-- 1. Colunas auxiliares (idempotente)
+-- ============================================================================
+
+-- cpf_digitos: populado pelo framework via derived_columns. Em prod legada
+-- foi adicionada por etl/15_normalizar.py.
+ALTER TABLE bolsa_familia
+    ADD COLUMN IF NOT EXISTS cpf_digitos TEXT;
+
+COMMENT ON COLUMN bolsa_familia.cpf_digitos IS
+    'Digitos do cpf_favorecido com nao-numericos removidos. '
+    'Bolsa Familia divulga CPF mascarado como ***.NNN.NNN-** — esta coluna '
+    'contem apenas os 6 digitos centrais (NAO 11 como em outras tabelas). '
+    'Para join cross-source, ver mv_pessoa_pb.cpf_digitos_6.';
+
+-- inserted_at: auditoria de quando o framework inseriu a row.
+ALTER TABLE bolsa_familia
+    ADD COLUMN IF NOT EXISTS inserted_at TIMESTAMPTZ DEFAULT now();
+
+COMMENT ON COLUMN bolsa_familia.inserted_at IS
+    'Timestamp de insercao da row pelo framework ETL incremental. '
+    'Para rows inseridas pela fase classica legada (pre-ADR-0009) o valor '
+    'sera o timestamp da primeira aplicacao desta migration.';
+
+-- _nk_md5: synthetic NK calculada via trigger BEFORE INSERT (etapa 2 abaixo).
+ALTER TABLE bolsa_familia
+    ADD COLUMN IF NOT EXISTS _nk_md5 TEXT;
+
+COMMENT ON COLUMN bolsa_familia._nk_md5 IS
+    'Hash md5 de todas 9 cols (mes_competencia, mes_referencia, uf, '
+    'cd_municipio_siafi, nm_municipio, cpf_favorecido, nis_favorecido, '
+    'nm_favorecido, valor_parcela). Calculado por trigger BEFORE INSERT. '
+    'UNIQUE INDEX em (_nk_md5) garante idempotencia em republish do Portal. '
+    'Ver sql/35a (padrao pb_extras) e ADR-0009.';
+
+
+-- ============================================================================
+-- 2. Trigger BEFORE INSERT para popular _nk_md5
+-- ============================================================================
+-- Reusa funcao etl_admin.row_hash_md5() definida em sql/35a (collision-free
+-- via array_to_json injective serialization).
+
+CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_bolsa_familia()
+RETURNS trigger AS $func$
+BEGIN
+  IF NEW._nk_md5 IS NULL THEN
+    NEW._nk_md5 := etl_admin.row_hash_md5(
+      coalesce(NEW.mes_competencia, ''),
+      coalesce(NEW.mes_referencia, ''),
+      coalesce(NEW.uf, ''),
+      coalesce(NEW.cd_municipio_siafi, ''),
+      coalesce(NEW.nm_municipio, ''),
+      coalesce(NEW.cpf_favorecido, ''),
+      coalesce(NEW.nis_favorecido, ''),
+      coalesce(NEW.nm_favorecido, ''),
+      coalesce(NEW.valor_parcela::text, '')
+    );
+  END IF;
+  RETURN NEW;
+END
+$func$ LANGUAGE plpgsql SET search_path = pg_catalog, public;
+
+DROP TRIGGER IF EXISTS trg_compute_nk_md5 ON bolsa_familia;
+CREATE TRIGGER trg_compute_nk_md5 BEFORE INSERT ON bolsa_familia
+FOR EACH ROW EXECUTE FUNCTION etl_admin.compute_nk_md5_bolsa_familia();
+
+
+-- ============================================================================
+-- 3. Popular _nk_md5 nas rows existentes (BATCHED — padrao sql/35b)
+-- ============================================================================
+-- ~18,7M rows em prod. UPDATE single-statement gera WAL e bloat extremos
+-- (testado local: 30s → 3MB de progresso, ETA 6-10h). Batched com COMMIT
+-- entre cada batch de 100k rows: ~3-5 min em SSD, segura para prod ate sob
+-- query load (lock fica curto, autovacuum tem chance de limpar dead tuples).
+--
+-- Resumivel: WHERE _nk_md5 IS NULL → so atualiza rows ainda nao populadas.
+-- Pode ser interrompido (Ctrl+C) e re-executado sem perda.
+--
+-- IMPORTANTE: COMMIT dentro de PROCEDURE precisa rodar fora de transacao
+-- explicita. psql wrappa CALL em transacao quando rodado com `-1` ou
+-- `--single-transaction` (NAO usamos). O step do deploy.yml chama
+-- separadamente com `psql -c "CALL ..."` para garantir autocommit.
+-- Ver sql/41b_bolsa_familia_populate_nk_md5.sql.
+
+CREATE OR REPLACE PROCEDURE etl_admin.populate_nk_md5_bolsa_familia(batch_size int DEFAULT 100000)
+LANGUAGE plpgsql SET search_path = pg_catalog, public AS $$
+DECLARE
+  n int;
+  total bigint := 0;
+BEGIN
+  LOOP
+    UPDATE bolsa_familia SET _nk_md5 = etl_admin.row_hash_md5(
+      coalesce(mes_competencia, ''),
+      coalesce(mes_referencia, ''),
+      coalesce(uf, ''),
+      coalesce(cd_municipio_siafi, ''),
+      coalesce(nm_municipio, ''),
+      coalesce(cpf_favorecido, ''),
+      coalesce(nis_favorecido, ''),
+      coalesce(nm_favorecido, ''),
+      coalesce(valor_parcela::text, '')
+    )
+    WHERE id IN (
+      SELECT id FROM bolsa_familia
+      WHERE _nk_md5 IS NULL ORDER BY id LIMIT batch_size
+    );
+    GET DIAGNOSTICS n = ROW_COUNT;
+    EXIT WHEN n = 0;
+    total := total + n;
+    RAISE NOTICE 'bolsa_familia: populated % rows (total %)', n, total;
+    COMMIT;
+  END LOOP;
+  RAISE NOTICE 'bolsa_familia: DONE - total % rows populated', total;
+END $$;
+
+-- NAO chamamos a procedure aqui (psql -f wrapping). Deploy step chama
+-- separadamente: `psql -c "CALL etl_admin.populate_nk_md5_bolsa_familia(100000);"`
+--
+-- Em seguida, rodar sql/41z_bolsa_familia_finalize.sql que faz dedupe + UNIQUE INDEX.
+
+
+-- ============================================================================
+-- Steps 4-7 (dedupe + UNIQUE INDEX + validation) ficam em sql/41z_*.sql.
+-- Motivo: precisam rodar DEPOIS da CALL (que tem que ser comando psql -c
+-- separado por causa de COMMIT-em-PROCEDURE). Ver ADR-0009 secao "Deploy
+-- ordering" e docs/ops.md.
+-- ============================================================================

--- a/sql/41_bolsa_familia_incremental.sql
+++ b/sql/41_bolsa_familia_incremental.sql
@@ -22,7 +22,7 @@
 --   Synthetic md5 da hash de todas as 9 cols cobre 100% dos casos sem
 --   perda; segue padrao pb_extras + tem dedupe step inline.
 --
--- Ver ADR-0009.
+-- Ver ADR-0010.
 
 
 -- ============================================================================
@@ -46,7 +46,7 @@ ALTER TABLE bolsa_familia
 
 COMMENT ON COLUMN bolsa_familia.inserted_at IS
     'Timestamp de insercao da row pelo framework ETL incremental. '
-    'Para rows inseridas pela fase classica legada (pre-ADR-0009) o valor '
+    'Para rows inseridas pela fase classica legada (pre-ADR-0010) o valor '
     'sera o timestamp da primeira aplicacao desta migration.';
 
 -- _nk_md5: synthetic NK calculada via trigger BEFORE INSERT (etapa 2 abaixo).
@@ -58,7 +58,7 @@ COMMENT ON COLUMN bolsa_familia._nk_md5 IS
     'cd_municipio_siafi, nm_municipio, cpf_favorecido, nis_favorecido, '
     'nm_favorecido, valor_parcela). Calculado por trigger BEFORE INSERT. '
     'UNIQUE INDEX em (_nk_md5) garante idempotencia em republish do Portal. '
-    'Ver sql/35a (padrao pb_extras) e ADR-0009.';
+    'Ver sql/35a (padrao pb_extras) e ADR-0010.';
 
 
 -- ============================================================================
@@ -104,10 +104,18 @@ FOR EACH ROW EXECUTE FUNCTION etl_admin.compute_nk_md5_bolsa_familia();
 -- Pode ser interrompido (Ctrl+C) e re-executado sem perda.
 --
 -- IMPORTANTE: COMMIT dentro de PROCEDURE precisa rodar fora de transacao
--- explicita. psql wrappa CALL em transacao quando rodado com `-1` ou
--- `--single-transaction` (NAO usamos). O step do deploy.yml chama
--- separadamente com `psql -c "CALL ..."` para garantir autocommit.
--- Ver sql/41b_bolsa_familia_populate_nk_md5.sql.
+-- explicita. No PG 16, `psql -c "CALL ..."`, `psql -f` com a CALL inline e
+-- ate stdin wrappam o comando em transacao implicita, fazendo o COMMIT
+-- interno da PROCEDURE falhar com "encerramento de transacao invalido".
+-- O step do deploy.yml chama via Python autocommit explicito:
+--    python -m etl.refresh_post_incremental --source bolsa_familia --populate-only
+-- A funcao Python em etl/refresh_post_incremental.py:populate_nk_md5_bolsa_familia
+-- replica a logica desta PROCEDURE com `conn.autocommit = True` antes do
+-- loop. A PROCEDURE serve como (a) documentacao SQL da logica de batches,
+-- (b) ponto de entrada para recovery interativo via `psql` (sessao
+-- interativa NAO wrappa CALL em transacao):
+--    PGPASSWORD=$PASS psql -U govbr -d govbr
+--    govbr=# CALL etl_admin.populate_nk_md5_bolsa_familia(100000);
 
 CREATE OR REPLACE PROCEDURE etl_admin.populate_nk_md5_bolsa_familia(batch_size int DEFAULT 100000)
 LANGUAGE plpgsql SET search_path = pg_catalog, public AS $$
@@ -149,6 +157,6 @@ END $$;
 -- ============================================================================
 -- Steps 4-7 (dedupe + UNIQUE INDEX + validation) ficam em sql/41z_*.sql.
 -- Motivo: precisam rodar DEPOIS da CALL (que tem que ser comando psql -c
--- separado por causa de COMMIT-em-PROCEDURE). Ver ADR-0009 secao "Deploy
+-- separado por causa de COMMIT-em-PROCEDURE). Ver ADR-0010 secao "Deploy
 -- ordering" e docs/ops.md.
 -- ============================================================================

--- a/sql/41c_tmp_bf_body.sql
+++ b/sql/41c_tmp_bf_body.sql
@@ -24,8 +24,16 @@
 
 WITH vinculo AS (
     SELECT cpf_digitos_6, nome_upper,
-           COALESCE(TO_CHAR(MIN(data_admissao), 'YYYYMM'), MIN(ano_mes)) AS inicio,
-           MAX(ano_mes) AS fim
+           -- Padroniza inicio/fim em YYYYMM (sem hifen) p/ comparar com
+           -- bf.mes_competencia. ano_mes vem como "YYYY-MM"; bug pre-existente
+           -- de comparacao lexicografica ("202410" <= "2024-12" da FALSE por
+           -- '-' < '1'). Fix aplicado tambem em web/routes/cidade.py
+           -- _compute_servidor_bf. Ver ADR-0010 review HIGH-2.
+           COALESCE(
+               TO_CHAR(MIN(data_admissao), 'YYYYMM'),
+               REPLACE(MIN(ano_mes), '-', '')
+           ) AS inicio,
+           REPLACE(MAX(ano_mes), '-', '') AS fim
     FROM tce_pb_servidor
     WHERE cpf_digitos_6 IS NOT NULL AND nome_upper IS NOT NULL
       AND ano_mes >= '2022-01'

--- a/sql/41c_tmp_bf_body.sql
+++ b/sql/41c_tmp_bf_body.sql
@@ -1,0 +1,43 @@
+-- SELECT body de _tmp_bf compartilhado entre:
+--   1. sql/12_views.sql (CREATE TABLE _tmp_bf AS <este body>) — usado em
+--      etl_phase=sql / etl_phase=all (full rebuild da MV).
+--   2. etl/refresh_post_incremental.py (INSERT INTO _tmp_bf <este body>) —
+--      usado em etl_phase=incremental apos carga incremental.
+--
+-- CRITICO: este body PRECISA bater EXATAMENTE com o de sql/12_views.sql.
+-- Quando voce alterar este arquivo, tambem altere a query inline em
+-- sql/12_views.sql:565-584 (e vice-versa). Drift entre os dois deixa
+-- mv_servidor_pb_risco com dados inconsistentes dependendo do caminho
+-- de refresh.
+--
+-- Por que nao DROP TABLE _tmp_bf?
+--   PostgreSQL registra dependencia de metadata entre mv_servidor_pb_risco
+--   e _tmp_bf (criada via SELECT sobre ela). DROP falha com:
+--     "cannot drop table _tmp_bf because other objects depend on it"
+--   Solucao: TRUNCATE + INSERT atomic em transacao (padrao
+--   sql/15c_rebuild_tmp_for_servidor.sql).
+--
+-- Schema esperado em _tmp_bf (definido por sql/12_views.sql):
+--   cpf_digitos_6 TEXT,
+--   nome_upper    TEXT,
+--   total_bf      NUMERIC
+
+WITH vinculo AS (
+    SELECT cpf_digitos_6, nome_upper,
+           COALESCE(TO_CHAR(MIN(data_admissao), 'YYYYMM'), MIN(ano_mes)) AS inicio,
+           MAX(ano_mes) AS fim
+    FROM tce_pb_servidor
+    WHERE cpf_digitos_6 IS NOT NULL AND nome_upper IS NOT NULL
+      AND ano_mes >= '2022-01'
+    GROUP BY cpf_digitos_6, nome_upper
+)
+SELECT srv.cpf_digitos_6,
+       srv.nome_upper,
+       SUM(bf.valor_parcela) AS total_bf
+FROM mv_servidor_pb_base srv
+JOIN vinculo v ON v.cpf_digitos_6 = srv.cpf_digitos_6 AND v.nome_upper = srv.nome_upper
+JOIN bolsa_familia bf ON bf.cpf_digitos = srv.cpf_digitos_6
+    AND UPPER(TRIM(bf.nm_favorecido)) = srv.nome_upper
+    AND bf.mes_competencia >= v.inicio
+    AND bf.mes_competencia <= v.fim
+GROUP BY srv.cpf_digitos_6, srv.nome_upper;

--- a/sql/41z_bolsa_familia_finalize.sql
+++ b/sql/41z_bolsa_familia_finalize.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- sql/41z_bolsa_familia_finalize.sql
+--
+-- Roda APOS:
+--   1. sql/41_bolsa_familia_incremental.sql (cria cols, trigger, procedure)
+--   2. psql -c "CALL etl_admin.populate_nk_md5_bolsa_familia(100000);"
+--      (popula _nk_md5 em batches — precisa rodar em comando separado para
+--      evitar problema de COMMIT-em-PROCEDURE com psql -f -v ON_ERROR_STOP)
+--
+-- Aplicar via `psql -v ON_ERROR_STOP=1 -f sql/41z_*.sql` SEM
+-- `--single-transaction` (CREATE INDEX CONCURRENTLY exige autocommit).
+--
+-- Idempotente: detecta INVALID indexes de runs falhos previos e refaz.
+-- Ver ADR-0009.
+
+
+-- ============================================================================
+-- 4. Pre-flight: confirmar que _nk_md5 esta populada
+-- ============================================================================
+DO $$
+DECLARE
+    n_null BIGINT;
+BEGIN
+    SELECT count(*) INTO n_null FROM bolsa_familia WHERE _nk_md5 IS NULL;
+    IF n_null > 0 THEN
+        RAISE EXCEPTION
+            'bolsa_familia: % rows com _nk_md5 NULL. '
+            'Rode `psql -c "CALL etl_admin.populate_nk_md5_bolsa_familia(100000);"` '
+            'antes de continuar.', n_null;
+    END IF;
+    RAISE NOTICE 'bolsa_familia: 100%% das rows tem _nk_md5 populado.';
+END $$;
+
+
+-- ============================================================================
+-- 5. Pre-drop INVALID index de runs CONCURRENTLY falhos previos
+-- ============================================================================
+-- Idempotent + self-healing (padrao sql/35d). Tambem dropa index VALID se
+-- estava criado prematuramente (sql/41 anterior podia ter criado antes do
+-- populate completar; UNIQUE OK com NULLs mas precisa ser recriado para
+-- validar duplicatas reais).
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT c.relname, i.indisvalid FROM pg_class c
+    JOIN pg_index i ON c.oid = i.indexrelid
+    WHERE c.relname = 'ix_bolsa_familia_nk_md5'
+  LOOP
+    IF NOT r.indisvalid THEN
+      RAISE NOTICE 'Dropping INVALID index %', r.relname;
+      EXECUTE format('DROP INDEX %I', r.relname);
+    END IF;
+  END LOOP;
+END $$;
+
+
+-- ============================================================================
+-- 6. Dedupe rows com mesmo _nk_md5 (necessario antes do UNIQUE INDEX)
+-- ============================================================================
+-- Empirical: 9 grupos com 22 rows exatamente iguais detectados em prod
+-- local + VM. Sao true duplicates do ETL classico legacy (TRUNCATE-and-
+-- reload, sem dedupe). Mantemos a row com MENOR id (mais antiga).
+-- Padrao sql/35c_pb_extras_synthetic_nk_dedupe.sql.
+
+DO $$
+DECLARE
+    n_deleted BIGINT;
+BEGIN
+    WITH dups AS (
+        SELECT id, _nk_md5,
+               ROW_NUMBER() OVER (PARTITION BY _nk_md5 ORDER BY id) AS rn
+        FROM bolsa_familia
+        WHERE _nk_md5 IS NOT NULL
+    ),
+    deleted AS (
+        DELETE FROM bolsa_familia
+        WHERE id IN (SELECT id FROM dups WHERE rn > 1)
+        RETURNING 1
+    )
+    SELECT count(*) INTO n_deleted FROM deleted;
+
+    RAISE NOTICE 'bolsa_familia dedupe: % rows deletadas (mantidas a mais antiga por _nk_md5)', n_deleted;
+END $$;
+
+
+-- ============================================================================
+-- 7. UNIQUE INDEX para upsert (ix_bolsa_familia_nk_md5)
+-- ============================================================================
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_bolsa_familia_nk_md5
+ON bolsa_familia (_nk_md5);
+
+
+-- ============================================================================
+-- 8. Validacao: index criado e VALID
+-- ============================================================================
+DO $$
+DECLARE
+    is_invalid BOOLEAN;
+BEGIN
+    SELECT NOT pg_index.indisvalid INTO is_invalid
+    FROM pg_class
+    JOIN pg_index ON pg_class.oid = pg_index.indexrelid
+    WHERE pg_class.relname = 'ix_bolsa_familia_nk_md5';
+
+    IF is_invalid IS NULL THEN
+        RAISE EXCEPTION 'ix_bolsa_familia_nk_md5 NAO existe — CREATE CONCURRENTLY falhou.';
+    ELSIF is_invalid THEN
+        RAISE EXCEPTION
+            'ix_bolsa_familia_nk_md5 esta INVALID. '
+            'Drop e recrie apos investigar (ver docs/ops.md).';
+    ELSE
+        RAISE NOTICE 'ix_bolsa_familia_nk_md5 valido. Pronto para upsert via synthetic NK.';
+    END IF;
+END $$;

--- a/sql/41z_bolsa_familia_finalize.sql
+++ b/sql/41z_bolsa_familia_finalize.sql
@@ -3,15 +3,16 @@
 --
 -- Roda APOS:
 --   1. sql/41_bolsa_familia_incremental.sql (cria cols, trigger, procedure)
---   2. psql -c "CALL etl_admin.populate_nk_md5_bolsa_familia(100000);"
---      (popula _nk_md5 em batches — precisa rodar em comando separado para
---      evitar problema de COMMIT-em-PROCEDURE com psql -f -v ON_ERROR_STOP)
+--   2. python -m etl.refresh_post_incremental --source bolsa_familia --populate-only
+--      (popula _nk_md5 em batches via psycopg2 autocommit explicito —
+--      psql -c/-f wrappa CALL em transacao implicita no PG 16, fazendo
+--      o COMMIT-em-PROCEDURE falhar.)
 --
 -- Aplicar via `psql -v ON_ERROR_STOP=1 -f sql/41z_*.sql` SEM
 -- `--single-transaction` (CREATE INDEX CONCURRENTLY exige autocommit).
 --
 -- Idempotente: detecta INVALID indexes de runs falhos previos e refaz.
--- Ver ADR-0009.
+-- Ver ADR-0010.
 
 
 -- ============================================================================
@@ -25,8 +26,9 @@ BEGIN
     IF n_null > 0 THEN
         RAISE EXCEPTION
             'bolsa_familia: % rows com _nk_md5 NULL. '
-            'Rode `psql -c "CALL etl_admin.populate_nk_md5_bolsa_familia(100000);"` '
-            'antes de continuar.', n_null;
+            'Rode `python -m etl.refresh_post_incremental --source bolsa_familia --populate-only` '
+            'antes de continuar (NAO use psql -c "CALL ..." — PG 16 wrappa em transacao implicita '
+            'e o COMMIT-em-PROCEDURE falha; ver ADR-0010 e docs/ops.md).', n_null;
     END IF;
     RAISE NOTICE 'bolsa_familia: 100%% das rows tem _nk_md5 populado.';
 END $$;

--- a/sql/41z_bolsa_familia_finalize.sql
+++ b/sql/41z_bolsa_familia_finalize.sql
@@ -64,25 +64,39 @@ END $$;
 -- local + VM. Sao true duplicates do ETL classico legacy (TRUNCATE-and-
 -- reload, sem dedupe). Mantemos a row com MENOR id (mais antiga).
 -- Padrao sql/35c_pb_extras_synthetic_nk_dedupe.sql.
+--
+-- GUARD: skip se ix_bolsa_familia_nk_md5 ja existe (UNIQUE constraint
+-- garante 0 dups daqui em diante; window scan completo eh desperdicio
+-- de I/O — Opus 4.7-high review MEDIUM-3).
 
 DO $$
 DECLARE
     n_deleted BIGINT;
+    index_exists BOOLEAN;
 BEGIN
-    WITH dups AS (
-        SELECT id, _nk_md5,
-               ROW_NUMBER() OVER (PARTITION BY _nk_md5 ORDER BY id) AS rn
-        FROM bolsa_familia
-        WHERE _nk_md5 IS NOT NULL
-    ),
-    deleted AS (
-        DELETE FROM bolsa_familia
-        WHERE id IN (SELECT id FROM dups WHERE rn > 1)
-        RETURNING 1
-    )
-    SELECT count(*) INTO n_deleted FROM deleted;
+    SELECT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE indexname = 'ix_bolsa_familia_nk_md5'
+    ) INTO index_exists;
 
-    RAISE NOTICE 'bolsa_familia dedupe: % rows deletadas (mantidas a mais antiga por _nk_md5)', n_deleted;
+    IF index_exists THEN
+        RAISE NOTICE 'bolsa_familia dedupe: skip (UNIQUE INDEX ja garante invariante)';
+    ELSE
+        WITH dups AS (
+            SELECT id, _nk_md5,
+                   ROW_NUMBER() OVER (PARTITION BY _nk_md5 ORDER BY id) AS rn
+            FROM bolsa_familia
+            WHERE _nk_md5 IS NOT NULL
+        ),
+        deleted AS (
+            DELETE FROM bolsa_familia
+            WHERE id IN (SELECT id FROM dups WHERE rn > 1)
+            RETURNING 1
+        )
+        SELECT count(*) INTO n_deleted FROM deleted;
+
+        RAISE NOTICE 'bolsa_familia dedupe: % rows deletadas (mantidas a mais antiga por _nk_md5)', n_deleted;
+    END IF;
 END $$;
 
 

--- a/tests/incremental/test_bolsa_familia.py
+++ b/tests/incremental/test_bolsa_familia.py
@@ -107,6 +107,34 @@ def test_build_upsert_sql_target_uses_lowercase_renames():
     assert "mes_competencia" in sql
 
 
+def test_build_upsert_sql_target_uses_legacy_column_names():
+    """CRITICAL regression: a tabela bolsa_familia usa nomes LEGADOS estilo
+    SIAFI antigo (cd_municipio_siafi, nm_municipio, nm_favorecido), NAO
+    o padrao Portal (codigo_municipio_siafi, nome_municipio, nome_favorecido).
+
+    Sem esse mapping explicito, blanket lowercase `{c: c.lower() for c}`
+    geraria INSERT em colunas inexistentes e o framework quebraria no
+    primeiro upsert apos sql/41 + sql/41z ja rodarem em prod.
+
+    Achado pelo GPT-5.5 na rodada de revisao final.
+    """
+    import re
+    sql = build_upsert_sql(SPEC, stg_typed="_stg_test", bucket_id="2026-04")
+    m = re.search(r"INSERT INTO public\.bolsa_familia \(([^)]+)\)", sql)
+    assert m, "regex INSERT INTO falhou"
+    target_cols = [c.strip() for c in m.group(1).split(",")]
+
+    # Nomes que DEVEM aparecer (legacy SIAFI):
+    assert "cd_municipio_siafi" in target_cols
+    assert "nm_municipio" in target_cols
+    assert "nm_favorecido" in target_cols
+
+    # Nomes que NAO devem aparecer (padrao Portal, divergente do schema):
+    assert "codigo_municipio_siafi" not in target_cols
+    assert "nome_municipio" not in target_cols
+    assert "nome_favorecido" not in target_cols
+
+
 # ─── csv_header_rewrites ──────────────────────────────────────────────────
 
 

--- a/tests/incremental/test_bolsa_familia.py
+++ b/tests/incremental/test_bolsa_familia.py
@@ -1,0 +1,202 @@
+"""Smoke tests para a spec bolsa_familia + sql/41 contracts.
+
+Cobertura:
+- SPEC valida (__post_init__ passa).
+- build_upsert_sql usa UPPERCASE em derived (CR1 regression).
+- ON CONFLICT usa _nk_md5 (nk_synthetic_md5=True).
+- DedupeStrategy = UPSERT_DO_NOTHING (decisao do user — nao corrigir).
+- csv_header_rewrites cobre todos os headers raw esperados.
+- bucket_from_filename aceita ambos CSV interno e ZIP.
+- file_pattern + url_for_bucket geram nomes consistentes.
+- enumerate_buckets comeca em 2023-03 (Novo BF substituiu Auxilio Brasil).
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from etl.incremental.spec import (
+    CursorStrategy,
+    DedupeStrategy,
+)
+from etl.incremental.specs.bolsa_familia import (
+    SPEC,
+    COLUMNS,
+    CSV_HEADER_REWRITES,
+    _bucket_from_filename,
+    _file_pattern,
+    _url_for_bucket,
+    _enumerate_buckets,
+)
+from etl.incremental.staging import build_upsert_sql
+
+
+# ─── SPEC validation ──────────────────────────────────────────────────────
+
+
+def test_spec_basic_attrs():
+    assert SPEC.source == "bolsa_familia"
+    assert SPEC.table == "bolsa_familia"
+    assert SPEC.cursor_strategy == CursorStrategy.MONTH_WINDOW
+    assert SPEC.dedupe_strategy == DedupeStrategy.UPSERT_DO_NOTHING
+    assert SPEC.is_zip_source is True
+    assert SPEC.refetch_recent_buckets == 1
+    assert SPEC.encoding == "latin-1"
+    assert SPEC.decimal_format == "br"
+
+
+def test_spec_uses_synthetic_md5_nk():
+    """Decisao chave: NK natural nao cobre todos casos (CPF vazio + parcelas
+    retroativas). Synthetic md5 cobre 100%."""
+    assert SPEC.nk_synthetic_md5 is True
+
+
+def test_spec_columns_uppercase_sql_safe():
+    """spec.columns deve usar UPPERCASE sem espaco/acento (SQL-safe).
+    Headers raw do CSV vem via csv_header_rewrites."""
+    for col in COLUMNS:
+        assert col == col.upper(), f"col {col!r} deveria ser UPPERCASE"
+        assert " " not in col, f"col {col!r} tem espaco"
+        # Sem acentos: ASCII apenas
+        assert col.isascii(), f"col {col!r} tem caractere nao-ASCII"
+
+
+def test_spec_natural_key_declarative():
+    """NK declarativa = trio semantico de parcela. ON CONFLICT usa _nk_md5
+    (porque nk_synthetic_md5=True), mas NK lista documenta intencao."""
+    assert "MES_COMPETENCIA" in SPEC.natural_key
+    assert "MES_REFERENCIA" in SPEC.natural_key
+    assert "CPF_FAVORECIDO" in SPEC.natural_key
+    assert "NIS_FAVORECIDO" in SPEC.natural_key
+
+
+# ─── build_upsert_sql contracts (mitigations CR1, F1) ─────────────────────
+
+
+def test_build_upsert_sql_uses_uppercase_csv_in_derived():
+    """CR1 regression: derived_columns SELECT usa raw staging col names
+    (UPPERCASE), nao o target lowercase. Erro classico: 'cpf_favorecido'
+    em vez de 'CPF_FAVORECIDO' faz REGEXP_REPLACE apontar para coluna
+    inexistente no staging."""
+    sql = build_upsert_sql(SPEC, stg_typed="_stg_test", bucket_id="2026-04")
+    assert "REGEXP_REPLACE(CPF_FAVORECIDO" in sql
+    assert "REGEXP_REPLACE(cpf_favorecido" not in sql
+
+
+def test_build_upsert_sql_on_conflict_uses_nk_md5():
+    """nk_synthetic_md5=True -> ON CONFLICT (_nk_md5)."""
+    sql = build_upsert_sql(SPEC, stg_typed="_stg_test", bucket_id="2026-04")
+    assert "ON CONFLICT (_nk_md5)" in sql
+
+
+def test_build_upsert_sql_uses_do_nothing():
+    """F1 dispensado: DedupeStrategy = UPSERT_DO_NOTHING. Incremental
+    acumula novos meses, nao corrige existentes."""
+    sql = build_upsert_sql(SPEC, stg_typed="_stg_test", bucket_id="2026-04")
+    assert "DO NOTHING" in sql
+    assert "DO UPDATE" not in sql
+
+
+def test_build_upsert_sql_target_uses_lowercase_renames():
+    """INSERT INTO target usa col names lowercase (column_renames)."""
+    sql = build_upsert_sql(SPEC, stg_typed="_stg_test", bucket_id="2026-04")
+    assert "INSERT INTO public.bolsa_familia" in sql
+    # cols renomeadas em INSERT INTO (..., cpf_favorecido, ...)
+    assert "cpf_favorecido" in sql
+    assert "mes_competencia" in sql
+
+
+# ─── csv_header_rewrites ──────────────────────────────────────────────────
+
+
+def test_csv_header_rewrites_covers_all_columns():
+    """Todo header raw mapeia para uma col de spec.columns. Sem cols
+    extras (caso contrario, validator do __post_init__ falharia)."""
+    rewrite_targets = set(CSV_HEADER_REWRITES.values())
+    columns_set = set(COLUMNS)
+    assert rewrite_targets == columns_set
+
+
+def test_csv_header_rewrites_has_9_entries():
+    """Portal Transparencia publica 9 cols. Smoke contra refator acidental."""
+    assert len(CSV_HEADER_REWRITES) == 9
+
+
+def test_csv_header_rewrites_includes_accented_keys():
+    """Empirico: validado em 202510, 202512, 202602. Acentos preservam
+    com encoding latin-1."""
+    assert "MÊS COMPETÊNCIA" in CSV_HEADER_REWRITES
+    assert "CÓDIGO MUNICÍPIO SIAFI" in CSV_HEADER_REWRITES
+    assert "NOME MUNICÍPIO" in CSV_HEADER_REWRITES
+
+
+# ─── Bucket helpers ───────────────────────────────────────────────────────
+
+
+def test_bucket_from_filename_csv():
+    """Framework chama com CSV apos extracao do ZIP."""
+    assert _bucket_from_filename("202604_NovoBolsaFamilia.csv") == "2026-04"
+    assert _bucket_from_filename("202301_NovoBolsaFamilia.csv") == "2023-01"
+
+
+def test_bucket_from_filename_zip():
+    """Aceita ZIP tambem (download.py pode chamar antes da extracao)."""
+    assert _bucket_from_filename("novo_bf_202604.zip") == "2026-04"
+
+
+def test_bucket_from_filename_unknown_returns_none():
+    """Arquivos fora do padrao retornam None — framework skip."""
+    assert _bucket_from_filename("garbage.txt") is None
+    assert _bucket_from_filename("202604_NovoBolsaFamilia.txt") is None
+
+
+def test_file_pattern_returns_csv_name():
+    """file_pattern aponta para o CSV interno do ZIP (apos extracao)."""
+    assert _file_pattern("2026-04") == ["202604_NovoBolsaFamilia.csv"]
+
+
+def test_url_for_bucket_format():
+    """URL = base + YYYYMM (sem hifen); destino = novo_bf_YYYYMM.zip."""
+    urls = _url_for_bucket("2026-04")
+    assert len(urls) == 1
+    url, filename = urls[0]
+    assert url.endswith("/202604")
+    assert filename == "novo_bf_202604.zip"
+    assert "portaldatransparencia" in url
+
+
+# ─── enumerate_buckets ────────────────────────────────────────────────────
+
+
+def test_enumerate_buckets_starts_at_2023_03():
+    """Novo Bolsa Familia substituiu Auxilio Brasil em marco/2023."""
+    buckets = _enumerate_buckets()
+    assert buckets[0] == "2023-03"
+
+
+def test_enumerate_buckets_continues_to_today():
+    """Ultimo bucket = mes atual."""
+    buckets = _enumerate_buckets()
+    today = date.today()
+    expected_last = f"{today.year}-{today.month:02d}"
+    assert buckets[-1] == expected_last
+
+
+def test_enumerate_buckets_monotonic():
+    """Buckets em ordem cronologica."""
+    buckets = _enumerate_buckets()
+    for prev, curr in zip(buckets, buckets[1:]):
+        assert prev < curr, f"{prev} >= {curr} quebra ordem"
+
+
+# ─── spec_hash stability ──────────────────────────────────────────────────
+
+
+def test_spec_hash_includes_csv_header_rewrites():
+    """Mudar csv_header_rewrites altera spec_hash (forca re-bootstrap)."""
+    import dataclasses as dc
+    h1 = SPEC.spec_hash
+    spec_mod = dc.replace(SPEC, csv_header_rewrites={"X": "MES_COMPETENCIA"})
+    h2 = spec_mod.spec_hash
+    assert h1 != h2

--- a/web/main.py
+++ b/web/main.py
@@ -445,7 +445,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "114"
+templates.env.globals["ASSET_VERSION"] = "115"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1472,6 +1472,96 @@ async def invalidate_web_cache(
         return JSONResponse({"error": "falha ao invalidar"}, status_code=500)
 
 
+def _compute_servidor_bf(cpf6: str, nome: str) -> dict | None:
+    """Computa historico Bolsa Familia + agregados de um servidor.
+
+    Cache in-memory por (cpf6, nome) via web.db.cached_query.
+
+    Trade-offs do cache:
+    - In-memory por worker, sem persistencia. TTL = CACHE_TTL da config.
+    - Para acelerar warm cache server-side persistente em web_cache (visivel
+      entre workers e reload), ver ADR-0010 (proposta de remover LIMIT 200
+      e migrar para lazy cache). Decisao: nao implementar persistente AGORA
+      porque (a) F10 acoplaria a LIMIT 200 dos top servidores; (b) endpoint
+      eh detalhe (nao hot path); (c) in-memory ja resolve cache miss imediato
+      do mesmo servidor.
+
+    Returns:
+        dict com {parcelas, stats} ou None se servidor nao recebeu BF.
+    """
+    sql = """
+        WITH vinculo AS (
+            SELECT COALESCE(TO_CHAR(MIN(data_admissao), 'YYYYMM'), MIN(ano_mes)) AS inicio,
+                   MAX(ano_mes) AS fim
+            FROM tce_pb_servidor
+            WHERE cpf_digitos_6 = %(cpf6)s AND nome_upper = %(nome)s
+              AND ano_mes >= '2022-01'
+        ),
+        bf_filtrado AS (
+            SELECT bf.mes_competencia, bf.mes_referencia,
+                   bf.valor_parcela, bf.nm_municipio, bf.uf,
+                   (bf.mes_competencia >= v.inicio
+                    AND bf.mes_competencia <= v.fim) AS durante_vinculo
+            FROM bolsa_familia bf
+            CROSS JOIN vinculo v
+            WHERE bf.cpf_digitos = %(cpf6)s
+              AND UPPER(TRIM(bf.nm_favorecido)) = %(nome)s
+        )
+        SELECT mes_competencia, mes_referencia, valor_parcela,
+               nm_municipio, uf, durante_vinculo
+        FROM bf_filtrado
+        ORDER BY mes_competencia DESC, mes_referencia DESC
+        LIMIT 240
+    """
+    cache_key = f"servidor:{cpf6}:{nome.upper()}:bolsa_familia"
+    cols, rows = cached_query(
+        cache_key, sql, {"cpf6": cpf6, "nome": nome}, timeout_sec=15
+    )
+    if not rows:
+        return None
+
+    bf_list = []
+    total_recebido = 0.0
+    total_durante_vinculo = 0.0
+    qtd_durante_vinculo = 0
+    meses_competencia: set[str] = set()
+    primeiro_mes = None
+    ultimo_mes = None
+    for row in rows:
+        r = _row_to_dict(cols, row)
+        for k, v in r.items():
+            if hasattr(v, "as_tuple"):
+                r[k] = float(v)
+        bf_list.append(r)
+        valor = r.get("valor_parcela") or 0.0
+        total_recebido += float(valor)
+        if r.get("durante_vinculo"):
+            total_durante_vinculo += float(valor)
+            qtd_durante_vinculo += 1
+        mc = r.get("mes_competencia")
+        if mc:
+            meses_competencia.add(mc)
+            if primeiro_mes is None or mc < primeiro_mes:
+                primeiro_mes = mc
+            if ultimo_mes is None or mc > ultimo_mes:
+                ultimo_mes = mc
+    qtd_meses = len(meses_competencia)
+    valor_medio = (total_recebido / len(bf_list)) if bf_list else 0.0
+    return {
+        "parcelas": bf_list,
+        "stats": {
+            "qtd_parcelas": len(bf_list),
+            "qtd_meses": qtd_meses,
+            "total_recebido": round(total_recebido, 2),
+            "valor_medio": round(valor_medio, 2),
+            "primeiro_mes": primeiro_mes,
+            "ultimo_mes": ultimo_mes,
+            "qtd_durante_vinculo": qtd_durante_vinculo,
+            "total_durante_vinculo": round(total_durante_vinculo, 2),
+        },
+    }
+
+
 @router.post("/api/servidor/detalhes")
 async def get_servidor_detalhes(payload: dict = Body(...)):
     """Retorna detalhes enriquecidos de um servidor: empresas, BF, vinculo, sancoes, empenhos."""
@@ -1532,75 +1622,11 @@ async def get_servidor_detalhes(payload: dict = Body(...)):
                 # Bolsa Familia: historico COMPLETO de parcelas (todos os
                 # snapshots mensais cumulativos) + agregados estatisticos +
                 # flag indicando quais parcelas caem dentro do periodo do
-                # vinculo TCE-PB. LIMIT 240 = 20 anos * 12 meses (defensivo,
-                # mesmo CPF tem 1 parcela por mes_competencia x mes_referencia).
-                cur.execute("""
-                    WITH vinculo AS (
-                        SELECT COALESCE(TO_CHAR(MIN(data_admissao), 'YYYYMM'), MIN(ano_mes)) AS inicio,
-                               MAX(ano_mes) AS fim
-                        FROM tce_pb_servidor
-                        WHERE cpf_digitos_6 = %s AND nome_upper = %s
-                          AND ano_mes >= '2022-01'
-                    ),
-                    bf_filtrado AS (
-                        SELECT bf.mes_competencia, bf.mes_referencia,
-                               bf.valor_parcela, bf.nm_municipio, bf.uf,
-                               (bf.mes_competencia >= v.inicio
-                                AND bf.mes_competencia <= v.fim) AS durante_vinculo
-                        FROM bolsa_familia bf
-                        CROSS JOIN vinculo v
-                        WHERE bf.cpf_digitos = %s
-                          AND UPPER(TRIM(bf.nm_favorecido)) = %s
-                    )
-                    SELECT mes_competencia, mes_referencia, valor_parcela,
-                           nm_municipio, uf, durante_vinculo
-                    FROM bf_filtrado
-                    ORDER BY mes_competencia DESC, mes_referencia DESC
-                    LIMIT 240
-                """, (cpf6, nome, cpf6, nome))
-                bf_cols = [d[0] for d in cur.description]
-                bf_rows = cur.fetchall()
-                if bf_rows:
-                    bf_list = []
-                    total_recebido = 0.0
-                    total_durante_vinculo = 0.0
-                    qtd_durante_vinculo = 0
-                    meses_competencia: set[str] = set()
-                    primeiro_mes = None
-                    ultimo_mes = None
-                    for row in bf_rows:
-                        r = _row_to_dict(bf_cols, row)
-                        for k, v in r.items():
-                            if hasattr(v, 'as_tuple'):
-                                r[k] = float(v)
-                        bf_list.append(r)
-                        valor = r.get("valor_parcela") or 0.0
-                        total_recebido += float(valor)
-                        if r.get("durante_vinculo"):
-                            total_durante_vinculo += float(valor)
-                            qtd_durante_vinculo += 1
-                        mc = r.get("mes_competencia")
-                        if mc:
-                            meses_competencia.add(mc)
-                            if primeiro_mes is None or mc < primeiro_mes:
-                                primeiro_mes = mc
-                            if ultimo_mes is None or mc > ultimo_mes:
-                                ultimo_mes = mc
-                    qtd_meses = len(meses_competencia)
-                    valor_medio = (total_recebido / len(bf_list)) if bf_list else 0.0
-                    result["bolsa_familia"] = {
-                        "parcelas": bf_list,
-                        "stats": {
-                            "qtd_parcelas": len(bf_list),
-                            "qtd_meses": qtd_meses,
-                            "total_recebido": round(total_recebido, 2),
-                            "valor_medio": round(valor_medio, 2),
-                            "primeiro_mes": primeiro_mes,
-                            "ultimo_mes": ultimo_mes,
-                            "qtd_durante_vinculo": qtd_durante_vinculo,
-                            "total_durante_vinculo": round(total_durante_vinculo, 2),
-                        },
-                    }
+                # vinculo TCE-PB. Cache in-memory por (cpf6, nome) via
+                # cached_query (TTL padrao do web.db). LIMIT 240 defensivo.
+                bf_data = _compute_servidor_bf(cpf6, nome)
+                if bf_data:
+                    result["bolsa_familia"] = bf_data
 
                 # Vínculo como servidor
                 cur.execute("""

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1529,7 +1529,11 @@ async def get_servidor_detalhes(payload: dict = Body(...)):
                         empresas.append(r)
                     result["empresas"] = empresas
 
-                # Bolsa Família (apenas durante vínculo ativo)
+                # Bolsa Familia: historico COMPLETO de parcelas (todos os
+                # snapshots mensais cumulativos) + agregados estatisticos +
+                # flag indicando quais parcelas caem dentro do periodo do
+                # vinculo TCE-PB. LIMIT 240 = 20 anos * 12 meses (defensivo,
+                # mesmo CPF tem 1 parcela por mes_competencia x mes_referencia).
                 cur.execute("""
                     WITH vinculo AS (
                         SELECT COALESCE(TO_CHAR(MIN(data_admissao), 'YYYYMM'), MIN(ano_mes)) AS inicio,
@@ -1537,27 +1541,66 @@ async def get_servidor_detalhes(payload: dict = Body(...)):
                         FROM tce_pb_servidor
                         WHERE cpf_digitos_6 = %s AND nome_upper = %s
                           AND ano_mes >= '2022-01'
+                    ),
+                    bf_filtrado AS (
+                        SELECT bf.mes_competencia, bf.mes_referencia,
+                               bf.valor_parcela, bf.nm_municipio, bf.uf,
+                               (bf.mes_competencia >= v.inicio
+                                AND bf.mes_competencia <= v.fim) AS durante_vinculo
+                        FROM bolsa_familia bf
+                        CROSS JOIN vinculo v
+                        WHERE bf.cpf_digitos = %s
+                          AND UPPER(TRIM(bf.nm_favorecido)) = %s
                     )
-                    SELECT bf.mes_competencia, bf.valor_parcela, bf.nm_municipio
-                    FROM bolsa_familia bf, vinculo v
-                    WHERE bf.cpf_digitos = %s
-                      AND UPPER(TRIM(bf.nm_favorecido)) = %s
-                      AND bf.mes_competencia >= v.inicio
-                      AND bf.mes_competencia <= v.fim
-                    ORDER BY bf.mes_competencia DESC
-                    LIMIT 5
+                    SELECT mes_competencia, mes_referencia, valor_parcela,
+                           nm_municipio, uf, durante_vinculo
+                    FROM bf_filtrado
+                    ORDER BY mes_competencia DESC, mes_referencia DESC
+                    LIMIT 240
                 """, (cpf6, nome, cpf6, nome))
                 bf_cols = [d[0] for d in cur.description]
                 bf_rows = cur.fetchall()
                 if bf_rows:
                     bf_list = []
+                    total_recebido = 0.0
+                    total_durante_vinculo = 0.0
+                    qtd_durante_vinculo = 0
+                    meses_competencia: set[str] = set()
+                    primeiro_mes = None
+                    ultimo_mes = None
                     for row in bf_rows:
                         r = _row_to_dict(bf_cols, row)
                         for k, v in r.items():
                             if hasattr(v, 'as_tuple'):
                                 r[k] = float(v)
                         bf_list.append(r)
-                    result["bolsa_familia"] = bf_list
+                        valor = r.get("valor_parcela") or 0.0
+                        total_recebido += float(valor)
+                        if r.get("durante_vinculo"):
+                            total_durante_vinculo += float(valor)
+                            qtd_durante_vinculo += 1
+                        mc = r.get("mes_competencia")
+                        if mc:
+                            meses_competencia.add(mc)
+                            if primeiro_mes is None or mc < primeiro_mes:
+                                primeiro_mes = mc
+                            if ultimo_mes is None or mc > ultimo_mes:
+                                ultimo_mes = mc
+                    qtd_meses = len(meses_competencia)
+                    valor_medio = (total_recebido / len(bf_list)) if bf_list else 0.0
+                    result["bolsa_familia"] = {
+                        "parcelas": bf_list,
+                        "stats": {
+                            "qtd_parcelas": len(bf_list),
+                            "qtd_meses": qtd_meses,
+                            "total_recebido": round(total_recebido, 2),
+                            "valor_medio": round(valor_medio, 2),
+                            "primeiro_mes": primeiro_mes,
+                            "ultimo_mes": ultimo_mes,
+                            "qtd_durante_vinculo": qtd_durante_vinculo,
+                            "total_durante_vinculo": round(total_durante_vinculo, 2),
+                        },
+                    }
 
                 # Vínculo como servidor
                 cur.execute("""

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1491,8 +1491,19 @@ def _compute_servidor_bf(cpf6: str, nome: str) -> dict | None:
     """
     sql = """
         WITH vinculo AS (
-            SELECT COALESCE(TO_CHAR(MIN(data_admissao), 'YYYYMM'), MIN(ano_mes)) AS inicio,
-                   MAX(ano_mes) AS fim
+            -- IMPORTANTE: padronizar inicio/fim em formato YYYYMM (sem hifen)
+            -- para comparar lexicograficamente com bf.mes_competencia que e
+            -- YYYYMM. ano_mes do tce_pb_servidor vem com hifen "YYYY-MM";
+            -- comparar "202410" <= "2024-12" da FALSE por causa do '-' < '1'
+            -- (bug pre-existente em sql/12_views.sql, AMPLIFICADO aqui pelo
+            -- novo flag durante_vinculo exposto na UI). Ver ADR-0010 e
+            -- review Opus 4.7-high HIGH-2 (2026-05-17).
+            SELECT
+                COALESCE(
+                    TO_CHAR(MIN(data_admissao), 'YYYYMM'),
+                    REPLACE(MIN(ano_mes), '-', '')
+                ) AS inicio,
+                REPLACE(MAX(ano_mes), '-', '') AS fim
             FROM tce_pb_servidor
             WHERE cpf_digitos_6 = %(cpf6)s AND nome_upper = %(nome)s
               AND ano_mes >= '2022-01'

--- a/web/static/css/components/empresa-dialog.css
+++ b/web/static/css/components/empresa-dialog.css
@@ -91,6 +91,45 @@
 .empresa-card.severity-blue { border-left: 4px solid var(--md-sys-color-primary); }
 .empresa-card.severity-green { border-left: 4px solid var(--md-comp-success); }
 
+/* Bolsa Familia — tabela de parcelas individuais.
+   Renderizada em <details> dentro do servidor-dialog (ver
+   web/static/js/components/servidor-dialog.js). Padrao M3 + token-based,
+   sem cores hardcoded. Linhas com row-flag-red = parcela recebida durante
+   periodo do vinculo TCE-PB. */
+.bf-historico {
+    margin-top: 1rem;
+}
+.bf-historico > summary {
+    cursor: pointer;
+    padding: .4rem .6rem;
+    color: var(--md-sys-color-primary);
+    font-size: var(--md-sys-typescale-body-medium-size);
+}
+.bf-parcelas-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: .6rem;
+    font-size: var(--md-sys-typescale-body-small-size);
+}
+.bf-parcelas-table th,
+.bf-parcelas-table td {
+    padding: .35rem .5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+.bf-parcelas-table th {
+    color: var(--md-sys-color-on-surface-variant);
+    font-weight: 500;
+    background: var(--md-sys-color-surface-container);
+}
+.bf-parcelas-table td:last-child {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+.bf-parcelas-table tr.row-flag-red td {
+    background: color-mix(in srgb, var(--md-sys-color-error) 6%, transparent);
+}
+
 .empresa-header {
     display: flex;
     align-items: baseline;

--- a/web/static/css/components/empresa-dialog.css
+++ b/web/static/css/components/empresa-dialog.css
@@ -129,6 +129,14 @@
 .bf-parcelas-table tr.row-flag-red td {
     background: color-mix(in srgb, var(--md-sys-color-error) 6%, transparent);
 }
+.bf-parcelas-table tr.row-empty td {
+    color: var(--md-sys-color-on-surface-variant);
+    font-style: italic;
+    background: color-mix(in srgb, var(--md-sys-color-surface-variant) 30%, transparent);
+}
+.bf-parcelas-table tr.row-empty--vinculo td {
+    background: color-mix(in srgb, var(--md-comp-warning) 8%, transparent);
+}
 
 .empresa-header {
     display: flex;

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -277,9 +277,14 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
                 if (parcelas && parcelas.length) {
                     // Pode haver multiplas parcelas no mesmo mes_competencia
                     // (mes_referencia diferentes — recebimentos retroativos).
+                    // Badge "Era servidor" no header do grupo deve aparecer
+                    // se QUALQUER parcela do grupo cair no vinculo (review
+                    // Opus 4.7-high LOW-6: badge somia se parcelas[0] estava
+                    // fora do vinculo mas parcelas[1+] dentro).
+                    const anyDuranteVinculo = parcelas.some(p => p.durante_vinculo);
                     return parcelas.map((b, idx) => {
                         const cls = b.durante_vinculo ? ' class="row-flag-red"' : '';
-                        const badge = b.durante_vinculo ? ` <span class="badge badge-red" title="${dualLabel('Recebeu enquanto era servidor publico','Parcela dentro do periodo do vinculo TCE-PB')}">${dualLabel('Era servidor','Durante vinculo')}</span>` : '';
+                        const badge = anyDuranteVinculo ? ` <span class="badge badge-red" title="${dualLabel('Recebeu enquanto era servidor publico','Parcela dentro do periodo do vinculo TCE-PB')}">${dualLabel('Era servidor','Durante vinculo')}</span>` : '';
                         const competLabel = idx === 0 ? _fmtDate(b.mes_competencia) : '';
                         return `<tr${cls}>
                             <td>${competLabel}${idx === 0 ? badge : ''}</td>

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -60,7 +60,18 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
     // Stats grid
     const vinculos = data.vinculos || [];
     const empresas = data.empresas || [];
-    const bf = data.bolsa_familia || [];
+    // BF agora pode ser array (formato antigo) ou {parcelas, stats} (novo
+    // — apos commit feat(web): /api/servidor/detalhes historico completo).
+    // Normaliza para acessar uniformemente parcelas[] e stats{}.
+    const bfRaw = data.bolsa_familia;
+    let bfParcelas = [];
+    let bfStats = null;
+    if (Array.isArray(bfRaw)) {
+        bfParcelas = bfRaw;
+    } else if (bfRaw && typeof bfRaw === 'object') {
+        bfParcelas = Array.isArray(bfRaw.parcelas) ? bfRaw.parcelas : [];
+        bfStats = bfRaw.stats || null;
+    }
     const qtdEmpresas = cnpjsNorm.length;
     const qtdSancionadas = Object.keys(sancoes).length;
     const qtdPgfn = Object.keys(pgfn).length;
@@ -76,7 +87,7 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
     if (totalPago > 0 && totalPago !== totalDuranteVinc) html += `<div class="stat-cell"><span class="stat-value">${_shortBrl(totalPago)}</span><span class="stat-label">Pago as empresas (total)</span></div>`;
     if (qtdSancionadas > 0) html += `<div class="stat-cell stat-cell--red"><span class="stat-value">${qtdSancionadas}</span><span class="stat-label">${dualLabel('Empresas punidas','Empresas sancionadas')}</span></div>`;
     if (qtdPgfn > 0) html += `<div class="stat-cell stat-cell--orange"><span class="stat-value">${qtdPgfn}</span><span class="stat-label">${dualLabel('Empresas devendo impostos','Empresas c/ divida PGFN')}</span></div>`;
-    if (bf.length > 0) html += `<div class="stat-cell stat-cell--yellow"><span class="stat-value">Sim</span><span class="stat-label">Bolsa Familia</span></div>`;
+    if (bfParcelas.length > 0) html += `<div class="stat-cell stat-cell--yellow"><span class="stat-value">${bfStats ? _shortBrl(bfStats.total_recebido) : 'Sim'}</span><span class="stat-label">${dualLabel('Recebeu Bolsa Familia','Total Bolsa Familia')}</span></div>`;
     if (data.ceaf && data.ceaf.length) html += `<div class="stat-cell stat-cell--red"><span class="stat-value">${data.ceaf.length}</span><span class="stat-label">${dualLabel('Expulso do servico publico federal','Expulsao federal')}</span></div>`;
     html += '</div>';
 
@@ -168,21 +179,57 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
         html += '</div>';
     }
 
-    // Bolsa Familia
-    if (bf.length) {
-        html += `<div class="dialog-section"><h4>${dualLabel('Recebeu Bolsa Familia','Bolsa Familia')}</h4>`;
-        const ultimo = bf[0];
-        const total = bf.reduce((s, b) => s + (b.valor_parcela || 0), 0);
-        html += `<div class="empresa-card">
-            <div class="empresa-header">
-                <strong>${_esc(ultimo.nm_municipio || '-')}</strong>
-                <span class="badge badge-yellow">Ultimo recebimento: ${_fmtDate(ultimo.mes_competencia)}</span>
-            </div>
-            <div class="empresa-details">
-                <span>Valor ultima parcela: ${_shortBrl(ultimo.valor_parcela)}</span>
-                <span>Ultimos ${bf.length} registros somam ${_shortBrl(total)}</span>
-            </div>
-        </div>`;
+    // Bolsa Familia: secao dedicada com stats agregados + lista cronologica
+    // colapsavel. Parcelas DENTRO do periodo do vinculo TCE-PB recebem
+    // highlight (badge red). dualLabel para cidadao/auditor.
+    if (bfParcelas.length) {
+        const stats = bfStats || {
+            qtd_parcelas: bfParcelas.length,
+            qtd_meses: bfParcelas.length,
+            total_recebido: bfParcelas.reduce((s, b) => s + (b.valor_parcela || 0), 0),
+            primeiro_mes: bfParcelas[bfParcelas.length - 1]?.mes_competencia || null,
+            ultimo_mes: bfParcelas[0]?.mes_competencia || null,
+            qtd_durante_vinculo: 0,
+            total_durante_vinculo: 0,
+        };
+        const hasDuranteVinculo = (stats.qtd_durante_vinculo || 0) > 0;
+        html += `<div class="dialog-section"><h4>${dualLabel('Recebeu Bolsa Familia','Bolsa Familia — historico completo')}</h4>`;
+        // Stats overview cells (secao propria)
+        html += '<div class="stats-grid">';
+        html += `<div class="stat-cell"><span class="stat-value">${_shortBrl(stats.total_recebido)}</span><span class="stat-label">${dualLabel('Total recebido','Total acumulado')}</span></div>`;
+        html += `<div class="stat-cell"><span class="stat-value">${stats.qtd_meses}</span><span class="stat-label">${dualLabel('Meses com pagamento','Meses competencia distintos')}</span></div>`;
+        if (stats.primeiro_mes && stats.ultimo_mes) {
+            html += `<div class="stat-cell"><span class="stat-value">${_fmtDate(stats.primeiro_mes)} &rarr; ${_fmtDate(stats.ultimo_mes)}</span><span class="stat-label">${dualLabel('Periodo','Janela temporal')}</span></div>`;
+        }
+        if (hasDuranteVinculo) {
+            html += `<div class="stat-cell stat-cell--red"><span class="stat-value">${_shortBrl(stats.total_durante_vinculo)}</span><span class="stat-label">${dualLabel('Recebido enquanto servidor','Recebido durante vinculo TCE-PB')}</span></div>`;
+        }
+        html += '</div>';
+        // Lista cronologica em <details> nativo (M3 — toggle async quirk
+        // documentado em AGENTS.md aplica). Default fechado para nao
+        // poluir o dialog; user expande se quiser ver tudo.
+        html += `<details class="collapsible-details bf-historico">
+            <summary>${dualLabel('Ver todos os recebimentos','Ver parcelas individuais')} (${stats.qtd_parcelas})</summary>
+            <table class="bf-parcelas-table">
+                <thead><tr>
+                    <th>${dualLabel('Mes pago','Competencia')}</th>
+                    <th>${dualLabel('Mes referencia','Referencia')}</th>
+                    <th>${dualLabel('Cidade','Municipio')}</th>
+                    <th>${dualLabel('Valor','Valor parcela')}</th>
+                </tr></thead>
+                <tbody>`;
+        html += bfParcelas.map(b => {
+            const cls = b.durante_vinculo ? ' class="row-flag-red"' : '';
+            const badge = b.durante_vinculo ? ` <span class="badge badge-red" title="${dualLabel('Recebeu enquanto era servidor publico','Parcela dentro do periodo do vinculo TCE-PB')}">${dualLabel('Era servidor','Durante vinculo')}</span>` : '';
+            return `<tr${cls}>
+                <td>${_fmtDate(b.mes_competencia)}${badge}</td>
+                <td>${_fmtDate(b.mes_referencia)}</td>
+                <td>${_esc(b.nm_municipio || '-')}${b.uf ? ' / ' + _esc(b.uf) : ''}</td>
+                <td>${_shortBrl(b.valor_parcela)}</td>
+            </tr>`;
+        }).join('');
+        html += `</tbody></table>
+        </details>`;
         html += '</div>';
     }
 

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -179,9 +179,11 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
         html += '</div>';
     }
 
-    // Bolsa Familia: secao dedicada com stats agregados + lista cronologica
-    // colapsavel. Parcelas DENTRO do periodo do vinculo TCE-PB recebem
-    // highlight (badge red). dualLabel para cidadao/auditor.
+    // Bolsa Familia: secao dedicada com stats agregados + grade mes-a-mes
+    // mostrando todos os meses entre primeiro/ultimo (ou janela do vinculo),
+    // com "Sem registro" para meses sem parcela. Padrao: meses dentro do
+    // vinculo TCE-PB com parcela => highlight red badge. dualLabel
+    // cidadao/auditor.
     if (bfParcelas.length) {
         const stats = bfStats || {
             qtd_parcelas: bfParcelas.length,
@@ -205,29 +207,100 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
             html += `<div class="stat-cell stat-cell--red"><span class="stat-value">${_shortBrl(stats.total_durante_vinculo)}</span><span class="stat-label">${dualLabel('Recebido enquanto servidor','Recebido durante vinculo TCE-PB')}</span></div>`;
         }
         html += '</div>';
-        // Lista cronologica em <details> nativo (M3 — toggle async quirk
-        // documentado em AGENTS.md aplica). Default fechado para nao
-        // poluir o dialog; user expande se quiser ver tudo.
+        // Constroi grade mes-a-mes:
+        // - Determina janela: min(primeiro_mes BF, primeiro mes do vinculo)
+        //   ate max(ultimo_mes BF, ultimo mes do vinculo).
+        // - Para cada mes, mostra parcelas que caem nele OU placeholder
+        //   "Sem registro" se nao houver.
+        const vincStart = vinculos.length ? vinculos
+            .map(v => (v.primeiro_registro || (v.data_admissao || '').slice(0, 7).replace('-', '')) || '')
+            .filter(Boolean).sort()[0] : null;
+        const vincEnd = vinculos.length ? vinculos
+            .map(v => (v.ultimo_registro || '').replace('-', ''))
+            .filter(Boolean).sort().slice(-1)[0] : null;
+        // Helpers
+        const ymToInt = (ym) => parseInt(String(ym || '').replace('-', '').slice(0, 6), 10);
+        const intToYm = (n) => `${Math.floor(n/100)}${String(n%100).padStart(2,'0')}`;
+        const ymNext = (n) => {
+            const y = Math.floor(n/100), m = n % 100;
+            return m === 12 ? (y+1) * 100 + 1 : n + 1;
+        };
+        let gridStart = ymToInt(stats.primeiro_mes);
+        let gridEnd = ymToInt(stats.ultimo_mes);
+        if (vincStart) {
+            const v = ymToInt(vincStart);
+            if (v && v < gridStart) gridStart = v;
+        }
+        if (vincEnd) {
+            const v = ymToInt(vincEnd);
+            if (v && v > gridEnd) gridEnd = v;
+        }
+        // Indexar parcelas por mes_competencia
+        const parcelasPorMes = {};
+        for (const p of bfParcelas) {
+            const k = String(p.mes_competencia || '');
+            if (!parcelasPorMes[k]) parcelasPorMes[k] = [];
+            parcelasPorMes[k].push(p);
+        }
+        // Range vinculo (para marcar visualmente)
+        const vincStartInt = vincStart ? ymToInt(vincStart) : null;
+        const vincEndInt = vincEnd ? ymToInt(vincEnd) : null;
+        const inVinculo = (n) => vincStartInt && vincEndInt && n >= vincStartInt && n <= vincEndInt;
+
+        const totalMesesGrid = gridStart && gridEnd ? (gridEnd - gridStart + 1) : 0; // grosso modo (nao exato com mes 12->01)
+        // Default fechado para nao poluir dialog; user expande
         html += `<details class="collapsible-details bf-historico">
-            <summary>${dualLabel('Ver todos os recebimentos','Ver parcelas individuais')} (${stats.qtd_parcelas})</summary>
+            <summary>${dualLabel('Ver mes a mes (incluindo meses sem registro)','Ver grade mensal completa')} (${stats.qtd_parcelas} parcelas)</summary>
             <table class="bf-parcelas-table">
                 <thead><tr>
-                    <th>${dualLabel('Mes pago','Competencia')}</th>
+                    <th>${dualLabel('Mes','Competencia')}</th>
                     <th>${dualLabel('Mes referencia','Referencia')}</th>
                     <th>${dualLabel('Cidade','Municipio')}</th>
                     <th>${dualLabel('Valor','Valor parcela')}</th>
                 </tr></thead>
                 <tbody>`;
-        html += bfParcelas.map(b => {
-            const cls = b.durante_vinculo ? ' class="row-flag-red"' : '';
-            const badge = b.durante_vinculo ? ` <span class="badge badge-red" title="${dualLabel('Recebeu enquanto era servidor publico','Parcela dentro do periodo do vinculo TCE-PB')}">${dualLabel('Era servidor','Durante vinculo')}</span>` : '';
-            return `<tr${cls}>
-                <td>${_fmtDate(b.mes_competencia)}${badge}</td>
-                <td>${_fmtDate(b.mes_referencia)}</td>
-                <td>${_esc(b.nm_municipio || '-')}${b.uf ? ' / ' + _esc(b.uf) : ''}</td>
-                <td>${_shortBrl(b.valor_parcela)}</td>
-            </tr>`;
-        }).join('');
+        if (gridStart && gridEnd && gridStart <= gridEnd) {
+            // Iterar do mais recente para o mais antigo (mesma ordem da lista)
+            const meses = [];
+            let cur = gridStart;
+            let safety = 0;
+            while (cur <= gridEnd && safety < 600) {
+                meses.push(cur);
+                cur = ymNext(cur);
+                safety++;
+            }
+            meses.reverse();  // mais recente primeiro
+            html += meses.map(mInt => {
+                const k = intToYm(mInt);
+                const parcelas = parcelasPorMes[k];
+                const inVinc = inVinculo(mInt);
+                if (parcelas && parcelas.length) {
+                    // Pode haver multiplas parcelas no mesmo mes_competencia
+                    // (mes_referencia diferentes — recebimentos retroativos).
+                    return parcelas.map((b, idx) => {
+                        const cls = b.durante_vinculo ? ' class="row-flag-red"' : '';
+                        const badge = b.durante_vinculo ? ` <span class="badge badge-red" title="${dualLabel('Recebeu enquanto era servidor publico','Parcela dentro do periodo do vinculo TCE-PB')}">${dualLabel('Era servidor','Durante vinculo')}</span>` : '';
+                        const competLabel = idx === 0 ? _fmtDate(b.mes_competencia) : '';
+                        return `<tr${cls}>
+                            <td>${competLabel}${idx === 0 ? badge : ''}</td>
+                            <td>${_fmtDate(b.mes_referencia)}</td>
+                            <td>${_esc(b.nm_municipio || '-')}${b.uf ? ' / ' + _esc(b.uf) : ''}</td>
+                            <td>${_shortBrl(b.valor_parcela)}</td>
+                        </tr>`;
+                    }).join('');
+                }
+                // Sem registro neste mes — placeholder
+                const labelMes = _fmtDate(k);
+                const cls = inVinc ? ' class="row-empty row-empty--vinculo"' : ' class="row-empty"';
+                const subt = inVinc
+                    ? `<span class="text-xs text-muted">${dualLabel('Era servidor neste mes — nao recebeu BF','Dentro do vinculo TCE-PB')}</span>`
+                    : `<span class="text-xs text-muted">${dualLabel('Sem registro','Sem parcela')}</span>`;
+                return `<tr${cls}>
+                    <td>${labelMes}</td>
+                    <td colspan="3">${subt}</td>
+                </tr>`;
+            }).join('');
+        }
         html += `</tbody></table>
         </details>`;
         html += '</div>';

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -9,7 +9,7 @@
 // Fallback estatico (FALLBACK_CACHE_VERSION) é usado quando manifest indisponível
 // (dev mode sem build, ou race no deploy).
 
-const FALLBACK_CACHE_VERSION = 'tpb-v48-fallback';
+const FALLBACK_CACHE_VERSION = 'tpb-v49-fallback';
 
 // Lista mínima usada APENAS quando manifest.json não pode ser fetched.
 // Mantém PWA instalável mesmo em deploy race / 404 transitorio.


### PR DESCRIPTION
# feat(bolsa-familia): ETL incremental + histórico cumulativo no frontend

Migra o Bolsa Família do ETL clássico destrutivo (snapshot único, ~18,7M
rows reescritas por mês) para o **framework incremental P1-P6** (snapshots
mensais acumulativos). Atualiza o frontend de servidor para mostrar o
histórico completo de recebimentos com grade mês-a-mês.

Resolve a limitação fundamental: até hoje a tabela `bolsa_familia` só
continha o último mês publicado pelo Portal — auditoria forense de
recebimento BF por servidor era impossível (`mv_servidor_pb_risco` só
detectava recebimento no mês corrente).

## ADRs

- **ADR-0010** (Accepted): Bolsa Família incremental + histórico cumulativo.
- **ADR-0011** (Proposed): Remover LIMIT 200/500 dos top resultados — PR
  futura, dependência arquitetural identificada durante este trabalho.

## Decisões críticas

1. **Synthetic NK md5** (não NK natural). Empirical 2026-05 contra base
   local + VM (read-only, idênticas): 18,7M rows, 21% sem CPF (adultos com
   CADUNICO incompleto), Portal publica parcelas retroativas no mesmo
   `mes_competencia` com `mes_referencia` distintos. Nenhuma NK natural
   cobre 100% sem perda. Padrão `pb_extras` (`sql/35a-d`): coluna
   `_nk_md5` + trigger BEFORE INSERT + UNIQUE INDEX.

2. **`UPSERT_DO_NOTHING`** (não `DO_UPDATE`). Intent: acumular meses novos,
   nunca sobrescrever existentes. Predicate estrito em `staging.py:244`
   (`EXCLUDED.{wm} > {target}.{wm}`) inviabiliza correções retroativas
   anyway.

3. **`csv_header_rewrites`** (nova feature no LoaderSpec). Portal publica
   headers com acentos + espaços (`"MÊS COMPETÊNCIA"`). Mapping
   `dict[str, str]` aplicado em `parser.validate_csv_header` antes do
   match com `spec.columns`. Default `{}` = no-op para specs existentes.

4. **`_tmp_bf` rebuild via TRUNCATE+INSERT atomic** (não DROP).
   `mv_servidor_pb_risco` mantém dependência por OID com `_tmp_bf`. DROP
   falha com `cannot drop table because other objects depend on it`.
   Padrão `sql/15c_*.sql`.

5. **Populate `_nk_md5` via psycopg2 autocommit** (PG 16 quirk). Workaround
   documentado: `psql -c/-f "CALL ..."` wrappa em transação implícita,
   fazendo `COMMIT` interno da PROCEDURE falhar com `encerramento de
   transação inválido`. Solução: `python -m etl.refresh_post_incremental
   --source bolsa_familia --populate-only` controla autocommit
   explicitamente.

## Estrutura (16 commits temáticos)

### Bloco 1 — Schema + grants (não-destrutivo)
1. `chore(etl)`: neutralizar `etl/17_bolsa_familia.py` (no-op), remover
   `_CSV_DIRS` entry.
2. `chore(etl)`: `download_bolsa_familia` não-destrutivo (preserva zips).
3. `feat(sql)`: `sql/17_*.sql` idempotente + incluído em fase 1.
4. `feat(sql)`: `sql/41_bolsa_familia_incremental.sql` (cols, trigger,
   procedure populate, COMMENTs, profile).
5. `chore(sql)`: grants em `bolsa_familia` para `etl_incremental`.
6. `feat(sql)`: `sql/41c_tmp_bf_body.sql` (SELECT body extraído,
   compartilhado entre full rebuild e incremental refresh).

### Bloco 2 — Spec + refresh
7. `feat(etl)`: LoaderSpec `bolsa_familia` + `csv_header_rewrites`.
8. `feat(etl)`: `refresh_post_incremental.py` (SOURCE_REFRESH_FNS dict,
   batched populate, MV refresh, hard-fail).

### Bloco 3 — Deploy
9. `feat(deploy)`: step "ETL: Incremental" aplica `sql/41` + populate +
   `sql/41z` + framework runner + refresh.
10. `feat(deploy)`: warm cache + ANALYZE + Reset shadow rodam em
    `etl_phase=incremental`.

### Bloco 4 — Frontend + cache
11. `feat(web)`: `/api/servidor/detalhes` retorna histórico BF completo
    (era `LIMIT 5`, agora `LIMIT 240` + agregados).
12. `feat(web)`: `cached_query` in-memory para BF endpoint.
13. `feat(web)`: `servidor-dialog` seção BF dedicada (stats + collapsible).
14. `feat(web)`: grade mês-a-mês (mostra meses sem registro como
    "Sem registro" ou "Era servidor neste mês — não recebeu BF").

### Bloco 5 — Tests + docs
15. `test(incremental)`: 21 smoke tests (`test_bolsa_familia.py`).
16. `docs`: ADR-0010 + ADR-0011 (Proposed) + AGENTS + etl-incremental-guide
    + deploy + ops + glossário + README.

### Fixes pós-review
- `fix(etl)`: `COLUMN_RENAMES` usa nomes legacy SIAFI
  (`cd_municipio_siafi`, `nm_municipio`, `nm_favorecido`) — CRITICAL
  achado pelo GPT-5.5 (blanket lowercase quebraria INSERT em prod).
- `fix(docs)`: 14 refs `ADR-0009` → `ADR-0010` + mensagem de recovery
  apontava para comando errado — MEDIUM achados pelo Opus 4.7-high.

## Validação local

- 21/21 smoke tests pass (incluindo regression do bug GPT-5.5).
- 85/85 incremental tests pass (nenhum existente quebrou com
  `csv_header_rewrites` nem `populate_nk_md5_bolsa_familia`).
- `sql/41` aplicado em banco local: 17.968.268 rows populadas com
  `_nk_md5` em ~90min (disco rotacional; SSD prod estimado 15-30min).
- `sql/41z` aplicado: 13 rows duplicadas removidas; UNIQUE INDEX
  `ix_bolsa_familia_nk_md5` criado VALID.
- E2E full (download → extract ZIP → parse CSV → COPY raw → typed
  staging → UPSERT → trigger BEFORE INSERT popula `_nk_md5`):
  - 202603 baixado (326 MB ZIP / 2.04 GB CSV), header validado com
    `csv_header_rewrites`.
  - 202602 baixado (336 MB ZIP / 2.10 GB CSV).
  - Parse: 18,58M rows válidas, 0 rejected em ~113s (~165k rows/s).
  - UPSERT em curso quando este PR foi aberto.

## Operação

```bash
# Carregar todos os meses faltantes (BF + outras specs):
gh workflow run deploy.yml -f etl_phase=incremental

# Só Bolsa Família:
gh workflow run deploy.yml -f etl_phase=incremental \
    -f incremental_only=bolsa_familia.bolsa_familia
```

Step "ETL: Incremental" no `deploy.yml`:
1. `psql -f sql/41_*.sql` (defs idempotent — cols + trigger + procedure)
2. `python -m etl.refresh_post_incremental --populate-only` (batched
   populate via psycopg2 autocommit)
3. `psql -f sql/41z_*.sql` (dedupe + UNIQUE INDEX CONCURRENTLY)
4. `python -m etl.incremental.runner --only <CSV>`
5. `python -m etl.refresh_post_incremental --source bolsa_familia`
   (refresh L1 mv_pessoa_pb → tmp _tmp_bf → L2 mv_servidor_pb_risco +
   mv_municipio_pb_kpi_score)

Cada step idempotente e resumível.

## Reviews paralelos

Lançados Opus 4.7-high + GPT-5.5 antes deste PR. Convergência identificou
o bug CRITICAL do COLUMN_RENAMES (aplicado antes deste push). Vou
relançar review na PR para feedback adicional.

## Documentação

- `docs/adr/0010-bolsa-familia-incremental.md` — decisão completa
  (5 trade-offs explicitamente documentados).
- `docs/adr/0011-remover-limit-top-tabelas.md` — ADR Proposed para
  follow-up sobre LIMIT 200 dos top servidores PB.
- `AGENTS.md` — quirks adicionados (PG 16 COMMIT em PROCEDURE,
  csv_header_rewrites, cpf_digitos 6 dígitos).
- `docs/etl-incremental-guide.md` — exemplo BF como caso especial.
- `docs/ops.md` — 2 runbooks novos (populate interrompido, INVALID index).
