### PR TITLE
fix(web): BF dialog 3 estados (snapshot+parcela / sem / sem snapshot) + agrupar retroativas

### DIFF
--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1647,6 +1647,33 @@ async def get_servidor_detalhes(payload: dict = Body(...)):
                         empresas.append(r)
                     result["empresas"] = empresas
 
+                # Vínculo como servidor (DEVE rodar ANTES de BF porque o
+                # bloco BF usa `vinculos` para decidir se servidor sem
+                # parcela ainda tem snapshots a reportar).
+                cur.execute("""
+                    SELECT municipio, descricao_cargo, data_admissao,
+                           MIN(ano_mes) AS primeiro_registro,
+                           MAX(ano_mes) AS ultimo_registro,
+                           MAX(valor_vantagem) AS maior_salario
+                    FROM tce_pb_servidor
+                    WHERE cpf_digitos_6 = %s AND nome_upper = %s
+                    GROUP BY municipio, descricao_cargo, data_admissao
+                    ORDER BY MAX(ano_mes) DESC
+                """, (cpf6, nome))
+                srv_cols = [d[0] for d in cur.description]
+                srv_rows = cur.fetchall()
+                vinculos = []
+                if srv_rows:
+                    for row in srv_rows:
+                        r = _row_to_dict(srv_cols, row)
+                        for k, v in r.items():
+                            if hasattr(v, 'as_tuple'):
+                                r[k] = float(v)
+                            elif hasattr(v, 'isoformat'):
+                                r[k] = v.isoformat()
+                        vinculos.append(r)
+                    result["vinculos"] = vinculos
+
                 # Bolsa Familia: historico COMPLETO de parcelas (todos os
                 # snapshots mensais cumulativos) + agregados estatisticos +
                 # flag indicando quais parcelas caem dentro do periodo do
@@ -1667,31 +1694,6 @@ async def get_servidor_detalhes(payload: dict = Body(...)):
                         "stats": None,
                         "meses_disponiveis": _get_bf_meses_disponiveis(),
                     }
-
-                # Vínculo como servidor
-                cur.execute("""
-                    SELECT municipio, descricao_cargo, data_admissao,
-                           MIN(ano_mes) AS primeiro_registro,
-                           MAX(ano_mes) AS ultimo_registro,
-                           MAX(valor_vantagem) AS maior_salario
-                    FROM tce_pb_servidor
-                    WHERE cpf_digitos_6 = %s AND nome_upper = %s
-                    GROUP BY municipio, descricao_cargo, data_admissao
-                    ORDER BY MAX(ano_mes) DESC
-                """, (cpf6, nome))
-                srv_cols = [d[0] for d in cur.description]
-                srv_rows = cur.fetchall()
-                if srv_rows:
-                    vinculos = []
-                    for row in srv_rows:
-                        r = _row_to_dict(srv_cols, row)
-                        for k, v in r.items():
-                            if hasattr(v, 'as_tuple'):
-                                r[k] = float(v)
-                            elif hasattr(v, 'isoformat'):
-                                r[k] = v.isoformat()
-                        vinculos.append(r)
-                    result["vinculos"] = vinculos
 
                 # Sancoes CEIS/CNEP das empresas vinculadas
                 if cnpjs:

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1573,6 +1573,23 @@ def _compute_servidor_bf(cpf6: str, nome: str) -> dict | None:
     }
 
 
+def _get_bf_meses_disponiveis() -> list[str]:
+    """Retorna lista de mes_competencia (YYYYMM) com snapshots BF carregados.
+
+    Cacheada in-memory (cached_query TTL CACHE_TTL) — global por instancia,
+    nao por servidor (independe de cpf6/nome). Permite ao frontend
+    distinguir 3 estados na grade mes-a-mes:
+      - Mes COM snapshot e SEM parcela do servidor: "Nao recebeu BF"
+      - Mes SEM snapshot: "Sem dados disponiveis ainda"
+      - Mes COM snapshot e COM parcela: linha normal
+    """
+    sql = "SELECT DISTINCT mes_competencia FROM bolsa_familia ORDER BY 1"
+    cols, rows = cached_query(
+        "bolsa_familia:meses_disponiveis", sql, None, timeout_sec=10
+    )
+    return [str(r[0]) for r in rows if r[0]]
+
+
 @router.post("/api/servidor/detalhes")
 async def get_servidor_detalhes(payload: dict = Body(...)):
     """Retorna detalhes enriquecidos de um servidor: empresas, BF, vinculo, sancoes, empenhos."""
@@ -1637,7 +1654,19 @@ async def get_servidor_detalhes(payload: dict = Body(...)):
                 # cached_query (TTL padrao do web.db). LIMIT 240 defensivo.
                 bf_data = _compute_servidor_bf(cpf6, nome)
                 if bf_data:
+                    # Adicionar lista global de meses com snapshots (cacheada
+                    # separadamente) para o frontend distinguir "sem snapshot"
+                    # de "snapshot existe mas servidor nao recebeu".
+                    bf_data["meses_disponiveis"] = _get_bf_meses_disponiveis()
                     result["bolsa_familia"] = bf_data
+                elif vinculos:
+                    # Servidor sem nenhuma parcela BF — mas ainda precisamos
+                    # avisar quais meses temos no banco.
+                    result["bolsa_familia"] = {
+                        "parcelas": [],
+                        "stats": None,
+                        "meses_disponiveis": _get_bf_meses_disponiveis(),
+                    }
 
                 # Vínculo como servidor
                 cur.execute("""

--- a/web/static/css/components/empresa-dialog.css
+++ b/web/static/css/components/empresa-dialog.css
@@ -137,6 +137,21 @@
 .bf-parcelas-table tr.row-empty--vinculo td {
     background: color-mix(in srgb, var(--md-comp-warning) 8%, transparent);
 }
+.bf-parcelas-table tr.row-empty--sem-snapshot td {
+    color: var(--md-sys-color-on-surface-variant);
+    font-style: italic;
+    opacity: 0.65;
+}
+.bf-parcelas-table tr.bf-mes-header td {
+    border-top: 1px solid var(--md-sys-color-outline-variant);
+    padding-top: .5rem;
+}
+.bf-parcelas-table tr.bf-mes-detail td {
+    border-bottom: none;
+    padding-top: .15rem;
+    padding-bottom: .15rem;
+    font-size: var(--md-sys-typescale-body-small-size);
+}
 
 .empresa-header {
     display: flex;

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -203,8 +203,9 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
     // incremental comecou a carregar a partir desse mes. Quando carregarmos
     // historico (e.g., 2023-03+), atualizar essa constante.
     const BF_GRID_MIN_YM = 202601;
-    if (bfParcelas.length) {
-        const stats = bfStats || {
+    if (bfParcelas.length || (bfRaw && Array.isArray(bfRaw.meses_disponiveis))) {
+        // bfStats pode ser null (caso "servidor sem parcela mas com vinculo")
+        const stats = bfStats || (bfParcelas.length ? {
             qtd_parcelas: bfParcelas.length,
             qtd_meses: bfParcelas.length,
             total_recebido: bfParcelas.reduce((s, b) => s + (b.valor_parcela || 0), 0),
@@ -212,7 +213,11 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
             ultimo_mes: bfParcelas[0]?.mes_competencia || null,
             qtd_durante_vinculo: 0,
             total_durante_vinculo: 0,
-        };
+        } : {
+            qtd_parcelas: 0, qtd_meses: 0, total_recebido: 0,
+            primeiro_mes: null, ultimo_mes: null,
+            qtd_durante_vinculo: 0, total_durante_vinculo: 0,
+        });
         const hasDuranteVinculo = (stats.qtd_durante_vinculo || 0) > 0;
         html += `<div class="dialog-section"><h4>${dualLabel('Recebeu Bolsa Familia','Bolsa Familia — historico completo')}</h4>`;
         // Stats overview cells (secao propria)
@@ -260,6 +265,21 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
             const v = ymToInt(vincEnd);
             if (v && v > gridEnd) gridEnd = v;
         }
+        // Set de meses_competencia com snapshot carregado (vem do endpoint).
+        // Permite distinguir 3 estados:
+        //   - Tem snapshot + tem parcela: linha normal
+        //   - Tem snapshot + sem parcela: "Nao recebeu BF" (afirma)
+        //   - Sem snapshot: "Sem dados disponiveis ainda"
+        const mesesDisponiveis = new Set(
+            (bfRaw && Array.isArray(bfRaw.meses_disponiveis))
+                ? bfRaw.meses_disponiveis.map(String) : []
+        );
+        // Estende gridEnd ate o ultimo snapshot disponivel (para mostrar
+        // meses recentes que ainda nao tem parcela mas TEMOS snapshot).
+        if (mesesDisponiveis.size) {
+            const maxDisponivelInt = Math.max(...[...mesesDisponiveis].map(ymToInt).filter(Boolean));
+            if (maxDisponivelInt > gridEnd) gridEnd = maxDisponivelInt;
+        }
         // Indexar parcelas por mes_competencia
         const parcelasPorMes = {};
         for (const p of bfParcelas) {
@@ -302,39 +322,57 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
                 const k = intToYm(mInt);
                 const parcelas = parcelasPorMes[k];
                 const inVinc = inVinculo(mInt);
+                const temSnapshot = mesesDisponiveis.has(k);
                 if (parcelas && parcelas.length) {
                     // Pode haver multiplas parcelas no mesmo mes_competencia
                     // (mes_referencia diferentes — recebimentos retroativos).
-                    // Badge "Era servidor" no header do grupo deve aparecer
-                    // se QUALQUER parcela do grupo cair no vinculo (review
-                    // Opus 4.7-high LOW-6: badge somia se parcelas[0] estava
-                    // fora do vinculo mas parcelas[1+] dentro).
+                    // Renderiza 1 linha "header" com mes_competencia + badge,
+                    // + linhas indentadas para cada (mes_referencia, valor)
+                    // distintos.
                     //
                     // IMPORTANTE: title= NAO pode conter dualLabel() porque
                     // este retorna HTML <span>; quebraria o attr. Usar
                     // texto plano + dualLabel APENAS no conteudo do badge.
                     const anyDuranteVinculo = parcelas.some(p => p.durante_vinculo);
                     const badgeTitle = "Parcela dentro do periodo do vinculo TCE-PB";
-                    return parcelas.map((b, idx) => {
-                        const cls = b.durante_vinculo ? ' class="row-flag-red"' : '';
-                        const badge = (anyDuranteVinculo && idx === 0)
-                            ? ` <span class="badge badge-red" title="${badgeTitle}">${dualLabel('Era servidor','Durante vinculo')}</span>`
-                            : '';
-                        const competLabel = idx === 0 ? _fmtDate(b.mes_competencia) : '';
-                        return `<tr${cls}>
-                            <td>${competLabel}${badge}</td>
-                            <td>${_fmtDate(b.mes_referencia)}</td>
-                            <td>${_esc(b.nm_municipio || '-')}${b.uf ? ' / ' + _esc(b.uf) : ''}</td>
-                            <td>${_shortBrl(b.valor_parcela)}</td>
-                        </tr>`;
-                    }).join('');
+                    const totalNoMes = parcelas.reduce((s, p) => s + (p.valor_parcela || 0), 0);
+                    const badge = anyDuranteVinculo
+                        ? ` <span class="badge badge-red" title="${badgeTitle}">${dualLabel('Era servidor','Durante vinculo')}</span>`
+                        : '';
+                    // Cabecalho do mes
+                    let html2 = `<tr class="bf-mes-header${anyDuranteVinculo ? ' row-flag-red' : ''}">
+                        <td><strong>${_fmtDate(k)}</strong>${badge}</td>
+                        <td class="text-sm text-muted">${parcelas.length > 1 ? parcelas.length + ' parcelas (retroativas)' : ''}</td>
+                        <td>${_esc(parcelas[0].nm_municipio || '-')}${parcelas[0].uf ? ' / ' + _esc(parcelas[0].uf) : ''}</td>
+                        <td><strong>${_shortBrl(totalNoMes)}</strong></td>
+                    </tr>`;
+                    // Linhas detalhe (so se mais de 1 parcela)
+                    if (parcelas.length > 1) {
+                        html2 += parcelas.map(b => {
+                            return `<tr class="bf-mes-detail">
+                                <td></td>
+                                <td class="text-sm text-muted">&hookrightarrow; ${dualLabel('referente a','ref.')} ${_fmtDate(b.mes_referencia)}</td>
+                                <td></td>
+                                <td>${_shortBrl(b.valor_parcela)}</td>
+                            </tr>`;
+                        }).join('');
+                    }
+                    return html2;
                 }
-                // Sem registro neste mes — placeholder
+                // Sem parcela neste mes — distinguir 3 estados
                 const labelMes = _fmtDate(k);
+                if (!temSnapshot) {
+                    // Sem dados disponiveis (snapshot nao carregado ainda)
+                    return `<tr class="row-empty row-empty--sem-snapshot">
+                        <td>${labelMes}</td>
+                        <td colspan="3"><span class="text-xs text-muted">${dualLabel('Sem dados disponiveis ainda','Snapshot BF nao carregado')}</span></td>
+                    </tr>`;
+                }
+                // Tem snapshot e nao recebeu — afirmar
                 const cls = inVinc ? ' class="row-empty row-empty--vinculo"' : ' class="row-empty"';
                 const subt = inVinc
-                    ? `<span class="text-xs text-muted">${dualLabel('Era servidor neste mes — nao recebeu BF','Dentro do vinculo TCE-PB')}</span>`
-                    : `<span class="text-xs text-muted">${dualLabel('Sem registro','Sem parcela')}</span>`;
+                    ? `<span class="text-xs text-muted">${dualLabel('Era servidor neste mes — nao recebeu BF','Dentro do vinculo TCE-PB — nao recebeu')}</span>`
+                    : `<span class="text-xs text-muted">${dualLabel('Nao recebeu BF neste mes','Sem parcela')}</span>`;
                 return `<tr${cls}>
                     <td>${labelMes}</td>
                     <td colspan="3">${subt}</td>


### PR DESCRIPTION
Hotfix UI: distinguir 'nao recebeu BF' (afirmativo, temos snapshot) de 'sem dados disponiveis ainda' (snapshot nao carregado). Agrupa parcelas retroativas em linha header + detalhes indentados pra evitar UX de 'linhas pra meses sem snapshot'.