### PR TITLE
fix(web): mescla 'Descricao+Valores' em 'Detalhes', renomeia 'Origem' -> 'Pagador' no empenho dialog + texto BF no servidor dialog

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -445,7 +445,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "115"
+templates.env.globals["ASSET_VERSION"] = "116"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/css/components/empresa-dialog.css
+++ b/web/static/css/components/empresa-dialog.css
@@ -111,6 +111,38 @@
     margin-top: .6rem;
     font-size: var(--md-sys-typescale-body-small-size);
 }
+
+/* Callout informativo sobre as regras do PBF dentro do servidor-dialog.
+   Inserido depois dos stats agregados (com o badge vermelho "Recebeu
+   enquanto servidor") pra contextualizar por que receber BF tendo
+   vinculo de servidor pode ser irregular. Usa secondary-container
+   (menos dominante que o .dialog-history-note primario) pra nao
+   competir visualmente com o callout azul no topo do dialog. */
+.bf-regras-info {
+    display: block;
+    margin: .85rem 0;
+    padding: .75rem .9rem;
+    border-radius: var(--md-sys-shape-corner-medium);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    font-size: var(--md-sys-typescale-body-small-size);
+    line-height: 1.5;
+}
+.bf-regras-info p { margin: 0 0 .55rem; }
+.bf-regras-info p:last-child { margin-bottom: 0; }
+.bf-regras-info ul.bf-regras-info__lista {
+    margin: .35rem 0 .55rem 1.1rem;
+    padding: 0;
+    list-style: disc;
+}
+.bf-regras-info ul.bf-regras-info__lista li { margin: .15rem 0; }
+.bf-regras-info .bf-regras-info__fonte {
+    color: var(--md-sys-color-on-surface-variant);
+    font-style: italic;
+    font-size: var(--md-sys-typescale-label-medium-size);
+    margin-top: .55rem;
+}
 .bf-parcelas-table th,
 .bf-parcelas-table td {
     padding: .35rem .5rem;

--- a/web/static/js/components/dialog-decorate.js
+++ b/web/static/js/components/dialog-decorate.js
@@ -22,9 +22,9 @@ function _dialogSectionNavLabel(rawText) {
     if (/despesas vinculadas|pagamentos desta licitacao/i.test(text)) return 'Despesas';
     if (/quem recebeu|^credor/i.test(text)) return 'Credor';
     if (/em que foi gasto|classificacao orcamentaria/i.test(text)) return 'Classificacao';
-    if (/de onde veio|^origem/i.test(text)) return 'Origem';
+    if (/de onde veio|^origem|quem pagou|orgao pagador/i.test(text)) return 'Pagador';
     if (/^valores$/i.test(text)) return 'Valores';
-    if (/^descricao$/i.test(text)) return 'Descricao';
+    if (/^descricao$|^detalhes$|o que diz o empenho/i.test(text)) return 'Detalhes';
     if (/pagamentos do governo as empresas|empenhos recebidos pelas empresas/i.test(text)) return 'Empenhos';
     return text.split(' ').slice(0, 2).join(' ');
 }

--- a/web/static/js/components/empenho-dialog.js
+++ b/web/static/js/components/empenho-dialog.js
@@ -41,17 +41,33 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     title.textContent = `Empenho ${data.numero_empenho}`;
     let html = _historyNote('Historico completo do empenho — este detalhamento nao muda com o filtro de periodo da pagina.');
 
-    // Descricao do empenho (historico livre escrito pelo orgao explicando
-    // o gasto). Primeiro bloco apos a nota de historico porque eh o texto
-    // que melhor responde "o que e este empenho?" pra usuario casual.
-    // Antes (PR #150) estava mesclada na secao final "Origem e descricao"
-    // mas usuario reportou que enterrar a descricao no fim do dialog
-    // confunde a leitura — descricao eh o "lede" do empenho.
+    // "Detalhes" — tab unica combinando descricao (historico livre do
+    // orgao) + valores (empenhado/liquidado/pago). Antes (PR #168) eram
+    // duas tabs separadas ("Descricao" e "Valores"), mas usuario reportou
+    // que fragmentava demais a leitura: a primeira tab do dialog deve
+    // responder de uma vez "o que e este empenho e quanto vale". A
+    // descricao continua sendo o "lede" (primeiro bloco visivel), seguida
+    // pelos valores. data-nav-label="Detalhes" sobrescreve o auto-derive
+    // do _dialogSectionNavLabel (que usaria o h4).
+    html += '<div class="dialog-section" data-nav-label="Detalhes"><h4>Detalhes</h4>';
     if (data.historico) {
-        html += `<div class="dialog-section"><h4>${dualLabel('O que diz o empenho','Descricao')}</h4>`;
-        html += `<p class="text-sm empenho-historico" style="line-height:1.6;margin:0">${_esc(data.historico)}</p>`;
-        html += '</div>';
+        html += `<p class="text-sm empenho-historico" style="line-height:1.6;margin:0 0 .85rem">${_esc(data.historico)}</p>`;
     }
+    html += `<div class="stats-grid" style="grid-template-columns:repeat(3,1fr)">
+        <div class="stat-cell">
+            <span class="stat-value">${_shortBrl(data.valor_empenhado)}</span>
+            <span class="stat-label">${dualLabel('Reservado','Empenhado')}</span>
+        </div>
+        <div class="stat-cell">
+            <span class="stat-value">${_shortBrl(data.valor_liquidado)}</span>
+            <span class="stat-label">${dualLabel('Servico entregue','Liquidado')}</span>
+        </div>
+        <div class="stat-cell">
+            <span class="stat-value">${_shortBrl(data.valor_pago)}</span>
+            <span class="stat-label">${dualLabel('Dinheiro saiu','Pago')}</span>
+        </div>
+    </div>`;
+    html += '</div>';
 
     // Licitacao vinculada — primeiro bloco logo apos descricao, pra dar
     // contexto imediato do empenho (qual processo originou o pagamento).
@@ -105,28 +121,9 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
         }
     }
 
-    // Historico do empenho movido para secao "Descricao" no topo do
-    // dialog (logo apos a nota de historico). Esta secao "Origem" agora
-    // contem apenas campos estruturais (UG, fonte, unidade, municipio,
-    // data) — o "de onde veio" o gasto.
-
-    // Valores
-    html += '<div class="dialog-section"><h4>Valores</h4>';
-    html += `<div class="stats-grid" style="grid-template-columns:repeat(3,1fr)">
-        <div class="stat-cell">
-            <span class="stat-value">${_shortBrl(data.valor_empenhado)}</span>
-            <span class="stat-label">${dualLabel('Reservado','Empenhado')}</span>
-        </div>
-        <div class="stat-cell">
-            <span class="stat-value">${_shortBrl(data.valor_liquidado)}</span>
-            <span class="stat-label">${dualLabel('Servico entregue','Liquidado')}</span>
-        </div>
-        <div class="stat-cell">
-            <span class="stat-value">${_shortBrl(data.valor_pago)}</span>
-            <span class="stat-label">${dualLabel('Dinheiro saiu','Pago')}</span>
-        </div>
-    </div>`;
-    html += '</div>';
+    // Descricao + Valores combinados na primeira secao "Detalhes" (acima).
+    // Manter ordem do dialog: Detalhes -> Licitacao -> Credor ->
+    // Classificacao -> Pagador.
 
     // Credor
     html += `<div class="dialog-section"><h4>${dualLabel('Quem recebeu','Credor')}</h4>`;
@@ -162,12 +159,17 @@ async function openEmpenhoDialog(empenhoId, options = {}) {
     html += '</div></div>';
     html += '</div>';
 
-    // Origem — campos estruturais do empenho (UG, fonte, unidade,
-    // municipio, data). Descricao livre fica na secao "Descricao" no
-    // topo do dialog (separada propositalmente apos feedback do usuario:
-    // misturar texto livre + campos estruturais no fim do dialog
-    // dificulta leitura).
-    html += `<div class="dialog-section"><h4>${dualLabel('De onde veio','Origem')}</h4>`;
+    // "Pagador" — campos estruturais do orgao publico que emitiu o
+    // empenho (UG, unidade orcamentaria, fonte do recurso, municipio,
+    // data). Antes chamava "Origem" mas o label era ambiguo (origem do
+    // que? do recurso? da licitacao?). Agora "Quem pagou / Orgao pagador"
+    // espelha o par "Quem recebeu / Credor" logo acima — citizen-mode
+    // pergunta-resposta simetrica. Descricao livre do empenho ficou em
+    // "Detalhes" (primeira tab), separada propositalmente apos feedback
+    // do usuario: misturar texto livre + campos estruturais no fim do
+    // dialog dificulta leitura. data-nav-label="Pagador" sobrescreve o
+    // auto-derive do _dialogSectionNavLabel.
+    html += `<div class="dialog-section" data-nav-label="Pagador"><h4>${dualLabel('Quem pagou','Orgao pagador')}</h4>`;
     html += '<div class="empresa-card"><div class="empresa-details">';
     html += `<span><strong>Data:</strong> ${_fmtDate(data.data_empenho)}</span>`;
     if (data.descricao_ug) html += `<span><strong>${dualLabel('Setor:','UG:')}</strong> ${_esc(data.descricao_ug)}</span>`;

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -238,6 +238,36 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
             html += `<div class="stat-cell stat-cell--red"><span class="stat-value">100%</span><span class="stat-label">${dualLabel('Recebeu enquanto servidor','Todo BF durante vinculo TCE-PB')}</span></div>`;
         }
         html += '</div>';
+
+        // Texto informativo sobre as regras do PBF (versao cidadao +
+        // auditor). Inserido logo apos os stats agregados — especialmente
+        // relevante quando o badge vermelho "Recebeu enquanto servidor"
+        // aparece, pois contextualiza por que ter emprego + BF eh
+        // potencialmente problematico. Fontes confirmadas: gov.br/mds
+        // (FAQ oficial e pagina principal do PBF) e Lei 14.601/2023.
+        // Importante: regra mudou em jul/2025 — agora sao 3 categorias
+        // (12m para renda instavel, 2m para renda fixa, 24m grandfathered).
+        // CadUnico recebe alimentacao automatica de renda formal via
+        // eSocial/RAIS/CAGED desde 2023, entao omissao eh detectada.
+        html += `<aside class="bf-regras-info" role="note" aria-label="Regras do Bolsa Familia">
+            <div class="citizen-only">
+                <p>O Bolsa Familia e para familias com renda baixa — ate <strong>R$ 218 por pessoa, por mes</strong>. Quando alguem da familia consegue emprego ou a renda aumenta, e obrigatorio atualizar o Cadastro Unico.</p>
+                <p>Se a renda por pessoa passar de R$ 218 mas ficar <strong>ate R$ 706</strong>, a familia entra na <strong>Regra de Protecao</strong>: continua recebendo <strong>metade</strong> do beneficio por <strong>ate 12 meses</strong> (caso tipico de emprego formal). Acima de R$ 706, o beneficio e cancelado.</p>
+                <p>Se mais tarde a renda cair de novo abaixo de R$ 218, a familia pode voltar ao programa com prioridade em ate <strong>3 anos</strong> (Retorno Garantido). <strong>Receber sem comunicar emprego ou renda extra da bloqueio, devolucao do dinheiro e pode virar processo por estelionato</strong> — o governo cruza automaticamente o CadUnico com eSocial, RAIS e CAGED.</p>
+                <p class="bf-regras-info__fonte">Regras do Programa Bolsa Familia (Lei 14.601/2023).</p>
+            </div>
+            <div class="auditor-only">
+                <p><strong>Programa Bolsa Familia (Lei 14.601, de 19/06/2023):</strong> renda per capita maxima de R$ 218/mes para elegibilidade.</p>
+                <p><strong>Regra de Protecao (vigente desde jul/2025 — 3 categorias):</strong> familia que ultrapassa R$ 218 mas fica ate R$ 706 per capita mantem 50% do beneficio por:</p>
+                <ul class="bf-regras-info__lista">
+                    <li><strong>12 meses</strong> — renda instavel (emprego formal, MEI, autonomo);</li>
+                    <li><strong>2 meses</strong> — renda fixa (aposentadoria, BPC, pensao);</li>
+                    <li><strong>24 meses</strong> com teto R$ 759 — direito adquirido para familias que ja estavam na regra ate jun/2025.</li>
+                </ul>
+                <p><strong>Retorno Garantido:</strong> reingresso prioritario em ate 3 anos se renda cair a &le; R$ 218.</p>
+                <p><strong>Cruzamentos automaticos</strong> alimentam o CadUnico com renda formal (eSocial/RAIS/CAGED, INSS, RFB). Deteccao de irregularidade pela Rede Federal de Fiscalizacao (art. 13, Lei 14.601/2023) implica cancelamento, devolucao dos valores e eventual responsabilizacao penal por estelionato (CP art. 171).</p>
+            </div>
+        </aside>`;
         // Constroi grade mes-a-mes:
         // - Janela: max(BF_GRID_MIN_YM, primeiro_mes BF) ate
         //   max(ultimo_mes BF, ultimo mes do vinculo).


### PR DESCRIPTION
# Empenho dialog — tabs simplificadas + texto informativo BF no servidor dialog

## Motivacao

1. **Empenho dialog** tinha duas tabs iniciais ("Descricao" + "Valores") que fragmentavam a leitura. A primeira tab deveria responder de uma vez "o que e este empenho e quanto vale". E a tab final "Origem" tinha label ambiguo (origem do recurso? da licitacao? do gasto?).

2. **Servidor dialog (secao Bolsa Familia)** mostra um badge vermelho "Recebeu enquanto servidor" quando o servidor publico recebeu BF durante o vinculo TCE-PB. Faltava contexto explicando _por que_ isso e potencialmente irregular: quem entra no PBF tem renda baixa, e arranjar emprego formal dispara obrigacao de comunicar.

## Mudancas

### Empenho dialog (`web/static/js/components/empenho-dialog.js`)

- **Tab 1 "Detalhes"** mescla a antiga "Descricao" (historico livre escrito pelo orgao) + "Valores" (empenhado/liquidado/pago) numa secao unica. Descricao continua sendo o lede (primeiro bloco visivel), seguida pelos 3 stat-cells.
- **Tab final renomeada de "Origem" para "Pagador"** com h4 `dualLabel('Quem pagou','Orgao pagador')` — espelha o par "Quem recebeu / Credor" logo acima.
- `data-nav-label` explicito em ambas as secoes; regex auto-derive em `dialog-decorate.js` atualizado por defesa em profundidade (caso o data-nav-label seja removido no futuro).

### Servidor dialog (`web/static/js/components/servidor-dialog.js`)

Novo callout `.bf-regras-info` logo apos os stats agregados (que contem o badge vermelho), antes da tabela de parcelas. Texto em duas versoes:

**Cidadao** explica em linguagem simples:
- Limite R$ 218 per capita;
- Regra de Protecao (50% por ate 12 meses ate R$ 706);
- Retorno Garantido (prioridade de reingresso em ate 3 anos);
- Sancoes (devolucao, possivel processo por estelionato);
- Cruzamento automatico do CadUnico com eSocial/RAIS/CAGED.

**Auditor** com precisao juridica:
- Cita Lei 14.601/2023 (alteracao de jul/2025 com 3 categorias — 12m renda instavel, 2m renda fixa, 24m direito adquirido grandfathered);
- Rede Federal de Fiscalizacao (art. 13, Lei 14.601/2023);
- Tipificacao penal possivel (Art. 171 CP — estelionato).

### Fontes oficiais consultadas

- gov.br/mds — pagina principal do PBF (`acoes-e-programas/bolsa-familia`)
- gov.br/mds — FAQ oficial do PBF (`bolsa-familia/perguntas-frequentes`) — confirmou as 3 categorias vigentes desde jul/2025
- gov.br/mds — Rede Federal de Fiscalizacao
- gov.br/mds — Nota de pagamento mai/2026

Pesquisa foi feita com sub-agent dedicado; descoberta importante: a regra de "24 meses + meio salario minimo" mudou em **julho/2025** — agora sao 3 categorias com teto fixo de R$ 706 e prazo de **12 meses** para emprego formal (caso mais comum).

### Outros

- `web/static/css/components/empresa-dialog.css`: estilo do callout `.bf-regras-info` (secondary-container, menos dominante que `.dialog-history-note` primary).
- `web/main.py`: `ASSET_VERSION` 115 → 116 (invalida cache do fallback dev `?v=NNN`).

## Como testar

1. `npm ci && npm run build` — gera bundle hashed.
2. `uvicorn web.main:app --port 8000` e abrir uma pagina cidade com empenhos:
   - Clicar num empenho qualquer → conferir tabs `Detalhes | Licitacao | Credor | Classificacao | Pagador`.
   - Verificar que valores aparecem na tab Detalhes (nao mais em tab propria).
3. Para o servidor dialog: abrir uma pagina cidade com servidores que receberam BF (e.g., Joao Pessoa) → clicar num servidor com badge vermelho "Recebeu enquanto servidor" → conferir callout informativo abaixo dos stats em ambos os modos (cidadao/auditor).

## Checklist

- [x] JS lint: `node --check` ok nos 3 arquivos tocados
- [x] Build: `npm run build` gera bundles validos
- [x] ASSET_VERSION bumpado
- [ ] README/docs — sem mudanca arquitetural; nao requer atualizacao
- [ ] ADR — sem mudanca arquitetural; nao requer ADR
- [x] PT-BR + convencao ASCII sem acentos em strings JS
- [x] Commit com `Co-authored-by: Copilot`

## Plano de deploy

Sera feito por SSH direto na VM (etl em andamento; nao queremos enfileirar deploy no runner single-slot). Apenas:
- `git pull` em `/home/govbr/govbr-project`
- `npm ci` se `package-lock.json` mudou (nao mudou neste PR)
- `node scripts/build-assets.mjs`
- `sudo systemctl restart cruza-web`

ETL/warm-cache nao tocados.
