### PR TITLE
hotfix(web): fix BF section timeout (pg_stats) + restore lost UX edits

### DIFF
--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -1573,21 +1573,52 @@ def _compute_servidor_bf(cpf6: str, nome: str) -> dict | None:
     }
 
 
+_BF_MESES_CACHE: tuple[float, list[str]] | None = None
+_BF_MESES_TTL = 3600  # 1h — mes_competencia novo so entra apos ETL incremental
+
+
 def _get_bf_meses_disponiveis() -> list[str]:
     """Retorna lista de mes_competencia (YYYYMM) com snapshots BF carregados.
 
-    Cacheada in-memory (cached_query TTL CACHE_TTL) — global por instancia,
-    nao por servidor (independe de cpf6/nome). Permite ao frontend
-    distinguir 3 estados na grade mes-a-mes:
+    Cache em modulo (1h TTL) — mes_competencia novo so entra com deploy
+    ETL incremental, refresh manual via restart eh aceitavel.
+
+    Performance: `SELECT DISTINCT mes_competencia FROM bolsa_familia`
+    em 18M+ linhas faz seq scan e estoura timeout (PR #175 regression).
+    Usa pg_stats most_common_vals (metadata do ANALYZE) — para coluna
+    de cardinality baixa (mes_competencia, ~12 valores), MCV cobre 100%
+    com folga. Query metadata-only, retorna em <1ms.
+
+    Permite ao frontend distinguir 3 estados na grade mes-a-mes:
       - Mes COM snapshot e SEM parcela do servidor: "Nao recebeu BF"
       - Mes SEM snapshot: "Sem dados disponiveis ainda"
       - Mes COM snapshot e COM parcela: linha normal
+
+    Fail-safe: qualquer erro retorna [] (frontend cai no comportamento
+    pre-PR #175 sem distincao de estados, mas o resto da API sobrevive).
     """
-    sql = "SELECT DISTINCT mes_competencia FROM bolsa_familia ORDER BY 1"
-    cols, rows = cached_query(
-        "bolsa_familia:meses_disponiveis", sql, None, timeout_sec=10
-    )
-    return [str(r[0]) for r in rows if r[0]]
+    import time as _time
+    global _BF_MESES_CACHE
+    now = _time.time()
+    if _BF_MESES_CACHE is not None:
+        ts, vals = _BF_MESES_CACHE
+        if now - ts < _BF_MESES_TTL:
+            return vals
+    sql = """
+        SELECT unnest(most_common_vals::text::text[])::text AS mes
+        FROM pg_stats
+        WHERE schemaname = 'public'
+          AND tablename = 'bolsa_familia'
+          AND attname = 'mes_competencia'
+        ORDER BY 1
+    """
+    try:
+        _, rows = execute_query(sql, None, timeout_sec=3)
+        vals = sorted(set(str(r[0]) for r in rows if r[0]))
+    except Exception:
+        vals = []
+    _BF_MESES_CACHE = (now, vals)
+    return vals
 
 
 @router.post("/api/servidor/detalhes")

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -231,11 +231,7 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
             // So mostra "Recebido enquanto servidor" se for diferente do total
             // (caso contrario, todos os meses estao no vinculo => stats
             // sao iguais e duplicar o valor confunde).
-            html += `<div class="stat-cell stat-cell--red"><span class="stat-value">${_shortBrl(stats.total_durante_vinculo)}</span><span class="stat-label">${dualLabel('Recebido enquanto servidor','Recebido durante vinculo TCE-PB')}</span></div>`;
-        } else if (hasDuranteVinculo) {
-            // Todos meses sao "durante vinculo" — destaca o total ja existente
-            // com badge red em vez de duplicar.
-            html += `<div class="stat-cell stat-cell--red"><span class="stat-value">100%</span><span class="stat-label">${dualLabel('Recebeu enquanto servidor','Todo BF durante vinculo TCE-PB')}</span></div>`;
+            html += `<div class="stat-cell stat-cell--red"><span class="stat-value">${_shortBrl(stats.total_durante_vinculo)}</span><span class="stat-label">${dualLabel('Recebido enquanto servidor','Recebido enquanto era servidor publico')}</span></div>`;
         }
         html += '</div>';
 
@@ -327,7 +323,7 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
         // via ETL incremental). Meses anteriores nao tem dado, por isso
         // nao mostramos linhas vazias para 2023-03..2025-12 — seria ruido.
         const coberturaLabel = `Cobertura: ${_fmtDate(String(BF_GRID_MIN_YM))} em diante. Meses anteriores nao estao disponiveis ainda.`;
-        const coberturaTec = `Snapshots BF acumulados desde ${_fmtDate(String(BF_GRID_MIN_YM))}. Historico anterior depende de novos deploys ETL incremental.`;
+        const coberturaTec = `Periodo coberto: ${_fmtDate(String(BF_GRID_MIN_YM))} em diante.`;
         html += `<p class="bf-cobertura text-xs text-muted"><span class="citizen-only">${coberturaLabel}</span><span class="auditor-only">${coberturaTec}</span></p>`;
         html += `<table class="bf-parcelas-table">
             <thead><tr>


### PR DESCRIPTION
## Resumo

Hotfix de 3 correções que foram aplicadas direto na VM em 18/05/2026 via SSH (sem bloquear o runner self-hosted durante warm cache do PR #174). Agora commitadas pra não serem efêmeras.

## Contexto

PR #175 introduziu `_get_bf_meses_disponiveis()` em `web/routes/cidade.py` com um `SELECT DISTINCT mes_competencia FROM bolsa_familia ORDER BY 1`. A tabela tem 18M+ linhas e a query estourava o `statement_timeout` em todo POST `/api/servidor/detalhes`, fazendo a aba **Bolsa Família** desaparecer no servidor dialog mesmo quando havia parcelas. Logs em produção mostravam:

```
ERROR:root:servidor detalhes failed
  File "web/routes/cidade.py", line 1695, in get_servidor_detalhes
psycopg2.errors.QueryCanceled: canceling statement due to statement timeout
```

Além disso, edições de UX já feitas localmente pelo maintainer foram revertidas por um `git reset --hard` durante o hotfix anterior (PR #176). Esse PR re-aplica essas edições.

## Mudanças

### 1. `web/routes/cidade.py` — Fix do timeout

Substituí `SELECT DISTINCT mes_competencia` (seq scan em 18M rows) por uma query **metadata-only** contra `pg_stats.most_common_vals`:

```sql
SELECT unnest(most_common_vals::text::text[])::text AS mes
FROM pg_stats
WHERE schemaname = 'public'
  AND tablename = 'bolsa_familia'
  AND attname = 'mes_competencia'
```

- `mes_competencia` tem cardinalidade baixíssima (~12 valores distintos), então o MCV do ANALYZE cobre **100%** dos valores com folga (`default_statistics_target=100`).
- Query roda em **<1ms** (lê metadata do catálogo, não a tabela).
- Cache de módulo com TTL de 1h (`mes_competencia` novo só entra com ETL incremental — refresh manual via restart é aceitável).
- **Fail-safe**: qualquer erro retorna `[]` — o frontend cai no comportamento pré-PR #175 (sem distinguir 3 estados), mas o resto da API sobrevive.

### 2. `servidor-dialog.js` — Remover card "Todo BF durante vinculo TCE-PB"

Removido o `else if (hasDuranteVinculo)` que renderizava um stat-cell vermelho `100% / Todo BF durante vinculo TCE-PB` quando todos os meses caem no vínculo. Era ruidoso e duplicava informação que já aparece nos badges row-by-row da tabela de parcelas.

### 3. `servidor-dialog.js` — Texto de cobertura mais conciso

Texto do auditor mudado:

- **Antes:** `Snapshots BF acumulados desde X. Historico anterior depende de novos deploys ETL incremental.`
- **Depois:** `Periodo coberto: X em diante.`

Mais conciso, evita expor detalhe operacional do pipeline.

### 4. `servidor-dialog.js` — Label mais auto-explicativo

Label auditor do stat-cell `Recebido enquanto servidor`:

- **Antes:** `Recebido durante vinculo TCE-PB`
- **Depois:** `Recebido enquanto era servidor publico`

## Testes

- `python -m compileall web -q` ✓
- `node --check web/static/js/components/servidor-dialog.js` ✓
- `node scripts/build-assets.mjs` ✓ → `core.710d3bd0.min.js`, manifest `tpb-bc57ebecad64`
- Já rodando em produção desde ~22:18 UTC (cruza-web restart pós-hotfix)

## Deploy

Sem necessidade de deploy adicional — já está em prod via SSH hotfix. Este PR apenas persiste as mudanças no repo.
