### PR TITLE
hotfix(web): regras BF colapsadas + evento Umami

### DIFF
--- a/web/static/css/components/empresa-dialog.css
+++ b/web/static/css/components/empresa-dialog.css
@@ -113,21 +113,64 @@
 }
 
 /* Callout informativo sobre as regras do PBF dentro do servidor-dialog.
-   Inserido depois dos stats agregados (com o badge vermelho "Recebeu
-   enquanto servidor") pra contextualizar por que receber BF tendo
-   vinculo de servidor pode ser irregular. Usa secondary-container
-   (menos dominante que o .dialog-history-note primario) pra nao
-   competir visualmente com o callout azul no topo do dialog. */
+   Renderizado como <details> colapsavel (default fechado) — user expande
+   pra ler. Inserido entre os stats agregados e a tabela de parcelas BF.
+   Tracking via Umami event 'secao-toggle' attached inline em
+   servidor-dialog.js (sem usar o global initCollapsibles pra evitar
+   duplo handler em re-init de dialog). */
 .bf-regras-info {
     display: block;
     margin: .85rem 0;
-    padding: .75rem .9rem;
+    padding: 0;
     border-radius: var(--md-sys-shape-corner-medium);
     border: 1px solid var(--md-sys-color-outline-variant);
     background: var(--md-sys-color-surface-container);
     color: var(--md-sys-color-on-surface);
     font-size: var(--md-sys-typescale-body-small-size);
     line-height: 1.5;
+    overflow: hidden;
+}
+.bf-regras-info__summary {
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    cursor: pointer;
+    padding: .65rem .9rem;
+    list-style: none;
+    user-select: none;
+    transition: background-color 120ms ease;
+}
+.bf-regras-info__summary::-webkit-details-marker { display: none; }
+.bf-regras-info__summary:hover,
+.bf-regras-info__summary:focus-visible {
+    background-color: color-mix(in oklab, var(--md-sys-color-on-surface) 5%, transparent);
+    outline: none;
+}
+.bf-regras-info__summary:focus-visible {
+    outline: 2px solid var(--md-sys-color-primary);
+    outline-offset: -2px;
+}
+.bf-regras-info__title {
+    flex: 1 1 auto;
+    font-weight: 600;
+    color: var(--md-sys-color-on-surface);
+}
+.bf-regras-info__chevron {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--md-sys-color-primary);
+    transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.bf-regras-info[open] > .bf-regras-info__summary .bf-regras-info__chevron {
+    transform: rotate(90deg);
+}
+.bf-regras-info__body {
+    padding: 0 .9rem .75rem;
 }
 .bf-regras-info p { margin: 0 0 .55rem; }
 .bf-regras-info p:last-child { margin-bottom: 0; }

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -245,25 +245,31 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
         // (12m para renda instavel, 2m para renda fixa, 24m grandfathered).
         // CadUnico recebe alimentacao automatica de renda formal via
         // eSocial/RAIS/CAGED desde 2023, entao omissao eh detectada.
-        html += `<aside class="bf-regras-info" role="note" aria-label="Regras do Bolsa Familia">
-            <div class="citizen-only">
-                <p>O Bolsa Familia e para familias com renda baixa — ate <strong>R$ 218 por pessoa, por mes</strong>. Quando alguem da familia consegue emprego ou a renda aumenta, e obrigatorio atualizar o Cadastro Unico.</p>
-                <p>Se a renda por pessoa passar de R$ 218 mas ficar <strong>ate R$ 706</strong>, a familia entra na <strong>Regra de Protecao</strong>: continua recebendo <strong>metade</strong> do beneficio por <strong>ate 12 meses</strong> (caso tipico de emprego formal). Acima de R$ 706, o beneficio e cancelado.</p>
-                <p>Se mais tarde a renda cair de novo abaixo de R$ 218, a familia pode voltar ao programa com prioridade em ate <strong>3 anos</strong> (Retorno Garantido). <strong>Receber sem comunicar emprego ou renda extra da bloqueio, devolucao do dinheiro e pode virar processo por estelionato</strong> — o governo cruza automaticamente o CadUnico com eSocial, RAIS e CAGED.</p>
-                <p class="bf-regras-info__fonte">Regras do Programa Bolsa Familia (Lei 14.601/2023).</p>
+        html += `<details class="bf-regras-info" data-bf-regras>
+            <summary class="bf-regras-info__summary">
+                <span class="bf-regras-info__title">Regras para recebimento do Bolsa Familia</span>
+                <span class="bf-regras-info__chevron" aria-hidden="true">›</span>
+            </summary>
+            <div class="bf-regras-info__body">
+                <div class="citizen-only">
+                    <p>O Bolsa Familia e para familias com renda baixa — ate <strong>R$ 218 por pessoa, por mes</strong>. Quando alguem da familia consegue emprego ou a renda aumenta, e obrigatorio atualizar o Cadastro Unico.</p>
+                    <p>Se a renda por pessoa passar de R$ 218 mas ficar <strong>ate R$ 706</strong>, a familia entra na <strong>Regra de Protecao</strong>: continua recebendo <strong>metade</strong> do beneficio por <strong>ate 12 meses</strong> (caso tipico de emprego formal). Acima de R$ 706, o beneficio e cancelado.</p>
+                    <p>Se mais tarde a renda cair de novo abaixo de R$ 218, a familia pode voltar ao programa com prioridade em ate <strong>3 anos</strong> (Retorno Garantido). <strong>Receber sem comunicar emprego ou renda extra da bloqueio, devolucao do dinheiro e pode virar processo por estelionato</strong> — o governo cruza automaticamente o CadUnico com eSocial, RAIS e CAGED.</p>
+                    <p class="bf-regras-info__fonte">Regras do Programa Bolsa Familia (Lei 14.601/2023).</p>
+                </div>
+                <div class="auditor-only">
+                    <p><strong>Programa Bolsa Familia (Lei 14.601, de 19/06/2023):</strong> renda per capita maxima de R$ 218/mes para elegibilidade.</p>
+                    <p><strong>Regra de Protecao (vigente desde jul/2025 — 3 categorias):</strong> familia que ultrapassa R$ 218 mas fica ate R$ 706 per capita mantem 50% do beneficio por:</p>
+                    <ul class="bf-regras-info__lista">
+                        <li><strong>12 meses</strong> — renda instavel (emprego formal, MEI, autonomo);</li>
+                        <li><strong>2 meses</strong> — renda fixa (aposentadoria, BPC, pensao);</li>
+                        <li><strong>24 meses</strong> com teto R$ 759 — direito adquirido para familias que ja estavam na regra ate jun/2025.</li>
+                    </ul>
+                    <p><strong>Retorno Garantido:</strong> reingresso prioritario em ate 3 anos se renda cair a &le; R$ 218.</p>
+                    <p><strong>Cruzamentos automaticos</strong> alimentam o CadUnico com renda formal (eSocial/RAIS/CAGED, INSS, RFB). Deteccao de irregularidade pela Rede Federal de Fiscalizacao (art. 13, Lei 14.601/2023) implica cancelamento, devolucao dos valores e eventual responsabilizacao penal por estelionato (CP art. 171).</p>
+                </div>
             </div>
-            <div class="auditor-only">
-                <p><strong>Programa Bolsa Familia (Lei 14.601, de 19/06/2023):</strong> renda per capita maxima de R$ 218/mes para elegibilidade.</p>
-                <p><strong>Regra de Protecao (vigente desde jul/2025 — 3 categorias):</strong> familia que ultrapassa R$ 218 mas fica ate R$ 706 per capita mantem 50% do beneficio por:</p>
-                <ul class="bf-regras-info__lista">
-                    <li><strong>12 meses</strong> — renda instavel (emprego formal, MEI, autonomo);</li>
-                    <li><strong>2 meses</strong> — renda fixa (aposentadoria, BPC, pensao);</li>
-                    <li><strong>24 meses</strong> com teto R$ 759 — direito adquirido para familias que ja estavam na regra ate jun/2025.</li>
-                </ul>
-                <p><strong>Retorno Garantido:</strong> reingresso prioritario em ate 3 anos se renda cair a &le; R$ 218.</p>
-                <p><strong>Cruzamentos automaticos</strong> alimentam o CadUnico com renda formal (eSocial/RAIS/CAGED, INSS, RFB). Deteccao de irregularidade pela Rede Federal de Fiscalizacao (art. 13, Lei 14.601/2023) implica cancelamento, devolucao dos valores e eventual responsabilizacao penal por estelionato (CP art. 171).</p>
-            </div>
-        </aside>`;
+        </details>`;
         // Constroi grade mes-a-mes:
         // - Janela: max(BF_GRID_MIN_YM, primeiro_mes BF) ate
         //   max(ultimo_mes BF, ultimo mes do vinculo).
@@ -503,5 +509,22 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
     body.innerHTML = html;
     _reattachDialogLinks(body);
     _decorateDialogBody(body);
+
+    // Umami tracking pro details colapsavel das regras do BF. Usa o mesmo
+    // event name 'secao-toggle' do components/collapsible.js (kebab-case,
+    // sem prefix de pagina) com {section: 'bf-regras', action}. Anexado
+    // inline porque o details eh dialog-rendered, sem data-collapsible-id
+    // — entao o global initCollapsibles() nao o pega (evita duplo handler).
+    const regrasDetails = body.querySelector('details.bf-regras-info[data-bf-regras]');
+    if (regrasDetails) {
+        regrasDetails.addEventListener('toggle', () => {
+            if (typeof trackEvent === 'function') {
+                trackEvent('secao-toggle', {
+                    section: 'bf-regras',
+                    action: regrasDetails.open ? 'open' : 'close',
+                });
+            }
+        });
+    }
 }
 


### PR DESCRIPTION
## Resumo

Converte o painel com **regras do Bolsa Familia** (Lei 14.601/2023) no servidor-dialog em um `<details>` colapsavel **default-fechado**, com summary clicavel `Regras para recebimento do Bolsa Familia` e chevron rotativo. Reduz scroll inicial do dialog, mantendo o texto integral disponivel pra quem quiser expandir.

Inclui tracking Umami via evento `secao-toggle` com `{section: 'bf-regras', action: 'open'|'close'}`  segue convencao kebab-case existente.

## Por que

O texto cidadao+auditor das regras BF (PR #176) ocupa muito espaco vertical, empurrando a tabela de parcelas pra fora da viewport inicial. Com o `<details>` fechado, o dialog abre limpo e o user expande ativamente se quiser ler.

## Detalhes tecnicos

- `servidor-dialog.js`: `<aside class="bf-regras-info">` -> `<details class="bf-regras-info" data-bf-regras>`. Toggle handler **inline** (nao via `initCollapsibles()`) pra evitar duplicidade  o details nao tem `data-collapsible-id`, entao o global handler do `components/collapsible.js` o ignora.
- `empresa-dialog.css`: adiciona `__summary`, `__title`, `__chevron` (gira 90deg quando `[open]`), `__body`. Mantem todos os estilos preexistentes de `p/ul/fonte`.
- Sem JS o `<details>` funciona (toggle nativo + chevron via CSS attribute selector).

## Deploy

Aplicado via SSH na VM (manifest `tpb-c173108ae4dc`) **sem reiniciar o warm_cache daemon** PID 28966  ETL ainda em andamento (run 26037222556). cruza-web restartado, smoke 200 OK.

## Checklist

- [x] `node --check` passa em servidor-dialog.js
- [x] Build local valida (`tpb-c173108ae4dc`)
- [x] Manifest VM bate com local
- [x] cruza-web `active` pos restart
- [x] warm_cache PID 28966 inalterado
- [x] Sem mudancas em README/docs/ADR (so JS/CSS, sem novo feature flag ou conceito arquitetural)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>