### PR TITLE
hotfix(web): mostra mes_referencia no header row do BF

### DIFF
--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -366,15 +366,27 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
                     // este retorna HTML <span>; quebraria o attr. Usar
                     // texto plano + dualLabel APENAS no conteudo do badge.
                     const anyDuranteVinculo = parcelas.some(p => p.durante_vinculo);
-                    const badgeTitle = "Parcela dentro do periodo do vinculo TCE-PB";
+                    const badgeTitle = "Parcela recebida enquanto era servidor publico";
                     const totalNoMes = parcelas.reduce((s, p) => s + (p.valor_parcela || 0), 0);
                     const badge = anyDuranteVinculo
                         ? ` <span class="badge badge-red" title="${badgeTitle}">${dualLabel('Era servidor','Durante vinculo')}</span>`
                         : '';
+                    // Coluna "Mes referencia" no header:
+                    //   - se ha varias parcelas no mes (retroativos), mostra "N parcelas
+                    //     (retroativas)" e os mes_referencia individuais vao nas detail rows;
+                    //   - se ha so 1 parcela, mostra direto o mes_referencia formatado dela
+                    //     (caso comum — sem isso a coluna ficaria sempre vazia).
+                    let refLabel;
+                    if (parcelas.length > 1) {
+                        refLabel = parcelas.length + ' parcelas (retroativas)';
+                    } else {
+                        const ref = parcelas[0].mes_referencia;
+                        refLabel = ref ? _fmtDate(ref) : '';
+                    }
                     // Cabecalho do mes
                     let html2 = `<tr class="bf-mes-header${anyDuranteVinculo ? ' row-flag-red' : ''}">
                         <td><strong>${_fmtDate(k)}</strong>${badge}</td>
-                        <td class="text-sm text-muted">${parcelas.length > 1 ? parcelas.length + ' parcelas (retroativas)' : ''}</td>
+                        <td class="text-sm text-muted">${refLabel}</td>
                         <td>${_esc(parcelas[0].nm_municipio || '-')}${parcelas[0].uf ? ' / ' + _esc(parcelas[0].uf) : ''}</td>
                         <td><strong>${_shortBrl(totalNoMes)}</strong></td>
                     </tr>`;


### PR DESCRIPTION
## Bug

Na tabela `bf-parcelas-table` (servidor-dialog), a coluna **Mes referencia** ficava vazia quando o `mes_competencia` tinha apenas 1 parcela  caso mais comum. O ternario inline soh emitia texto quando `parcelas.length > 1`:

`\\js
<td>\</td>
\\\

O mes_referencia individual aparecia apenas nas detail rows quando havia varios parcelamentos retroativos no mesmo mes.

## Fix

Substitui pelo bloco explicito que estava no build anterior do maintainer:

`\\js
let refLabel;
if (parcelas.length > 1) refLabel = parcelas.length + ' parcelas (retroativas)';
else { const ref = parcelas[0].mes_referencia; refLabel = ref ? _fmtDate(ref) : ''; }
\\\

Tambem restaura o `badgeTitle` para `"Parcela recebida enquanto era servidor publico"` (era `"Parcela dentro do periodo do vinculo TCE-PB"`  termo tecnico que nao ajuda o cidadao).

## Origem do regress

Ambas as mudancas tinham sido feitas localmente pelo maintainer e perderam-se no `git reset --hard` do hotfix anterior. Recuperadas via reverse engineering do `dist.prev3/core.8110f74e.min.js` na VM.

## Deploy

Aplicado via SSH (manifest `tpb-51e9d7224ef2`) sem reiniciar o warm_cache daemon PID 28966  ETL ainda em andamento (run 26037222556). cruza-web restartado, smoke 200 OK.

## Checklist

- [x] `node --check` ok
- [x] Build local valida (`tpb-51e9d7224ef2`)
- [x] Manifest VM bate com local
- [x] cruza-web `active` pos restart
- [x] warm_cache PID 28966 inalterado

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>