### PR TITLE
fix(web): cache miss em /empresa/<cnpj> retorna 410 Gone (era 404)

### DIFF
--- a/docs/adr/0009-orphan-empresa-cache-cleanup.md
+++ b/docs/adr/0009-orphan-empresa-cache-cleanup.md
@@ -365,3 +365,92 @@ comportamento de tratamento de 410), basta inverter `status_code=410`
 para `status_code=404` nos dois handlers. Sem mudança de template,
 schema, ou dependências.
 
+---
+
+## Revisão 2026-05-19: DB error distinto de cache miss (503 vs 410)
+
+### Observação em review paralelo do PR #181
+
+Review paralelo Opus 4.7-high + GPT-5.5 do PR #181 (revisão 2026-05-18)
+identificou bug HIGH **convergente em ambos os modelos**:
+
+`read_web_cache()` em `web/db.py` usava `try: ... except Exception: pass;
+return None`, tornando **DB errors indistinguiveis de cache miss**.
+Cenários afetados:
+
+1. **Pool exhaustion** (`POOL_MAX=16`) sob carga de crawler — exatamente
+   o padrão que motivou o PR #57.
+2. **DB restart / failover / network blip** durante o crawl.
+3. **`statement_timeout`** durante `cleanup_orphan_empresa_cache`
+   rodando `DELETE` em batches contra `web_cache`.
+4. **Cold start** com `_pool` não inicializado raising `RuntimeError`.
+5. **JSON corrompido** no payload do cache.
+
+Pré-PR #181, todos esses cenários retornavam `404 Not Found` — bug
+recoverable (Google retentava por semanas). **Pós-PR #181 retornavam
+`410 Gone`** — Google de-indexava permanente em dias. Uma janela de
+5 minutos de pool starvation durante crawl podia marcar páginas
+legítimas como removidas.
+
+### Mudança
+
+`web/db.py`:
+- Novo sentinel `CACHE_ERROR` (singleton de classe `_CacheError`)
+  retornado quando `read_web_cache()` falha por erro de DB/conexão.
+- Bare `except Exception: pass` substituído por log de WARNING
+  (visível em journalctl) — antes era silencioso, dificultando diagnóstico.
+- Tipo de retorno expandido: `tuple[cols, rows] | _CacheError | None`.
+
+`web/routes/empresa.py` (ambos `empresa_perfil` e `empresa_perfil_municipio`):
+- Branch novo: `if cached is CACHE_ERROR: return 503 com Retry-After`.
+- Comportamento atual mantido para `None` (cache miss permanente) e
+  hit válido.
+
+### Por que esse fix é mínimo
+
+Considerei (e descartei) abordagens mais elaboradas:
+
+- **Existence check em `mv_empresa_pb`** antes de decidir 410 vs 503:
+  ~30 linhas + LRU cache + day_bucket TTL + thundering herd protection.
+  Yagni para distinguir "URL nunca existiu" de "URL órfã" — >99% dos
+  misses são caso (b) órfão.
+- **Sentinel value no cache** marcando "qualifying mas rewarming":
+  exige mudança no warmer, no schema do `web_cache` e na lógica de
+  cleanup. Trade-off ruim.
+- **Feature flag pra rollout gradual**: 503 é universalmente seguro
+  (não causa de-indexação como 410), então rollout direto está OK.
+
+A mudança atual:
+- ~15 linhas em `web/db.py` (sentinel + log)
+- ~10 linhas por handler em `empresa.py` (verificar `is CACHE_ERROR`)
+- Total ~35 linhas
+
+### Trade-offs (após esta revisão)
+
+| Caso | Comportamento atual |
+|---|---|
+| (a) URL inventada `/empresa/99999999999999/x` | 410 Gone |
+| (b) CNPJ órfão (PR #156 cleanup) | 410 Gone ✅ |
+| (c) Cold start / CNPJ novo entre warms | 410 transient (raro — sitemap gated em deploy.yml exige cache coverage ≥80%) |
+| (d) **DB error transiente** (NOVO) | **503 Retry-After** ✅ |
+| (e) JSON corrompido no cache | 410 (cache hit mas dict vazio) — aceitável, cleanup re-popula |
+
+### Reversibilidade
+
+Se uma URL legítima ainda assim receber 410 (caso c muito raro), reverter
+para 200 leva 1 crawl pós-warm (Google atualiza status em re-crawl).
+Mas com sitemap gated + cache coverage 80%, esse caso é estatisticamente
+desprezível (vs ~6.7k retries/dia de URLs verdadeiramente órfãs).
+
+### Observabilidade
+
+`logging.getLogger("transparencia.db").warning(...)` em `read_web_cache`
+torna DB errors visíveis em `journalctl -u cruza-web` — antes eram
+silenciosos. Padrão de erro para alertar:
+
+```
+read_web_cache DB error for EMPRESA_PERFIL:00012345678901 — PoolError: connection pool exhausted
+```
+
+Monitorar pico desses warnings após deploy correlaciona com hits 503.
+

--- a/docs/adr/0009-orphan-empresa-cache-cleanup.md
+++ b/docs/adr/0009-orphan-empresa-cache-cleanup.md
@@ -84,9 +84,10 @@ Adotamos **alternativa 3** (DELETE entries stale) com função
 **standalone** invocável independentemente do warm cycle, **acompanhada
 de mudança no contrato de cache miss da rota `/empresa/<cnpj>` (e
 `/empresa/<cnpj>/<slug>`)** de `503 Service Unavailable` para
-`404 Not Found`.
+`410 Gone` (atualizada de `404 Not Found` em revisão 2026-05-18,
+ver seção "Revisão 2026-05-18" abaixo).
 
-### Rota: cache miss = 404 (era 503)
+### Rota: cache miss = 410 Gone (era 503 → depois 404 → revisado para 410)
 
 Antes deste ADR, `web/routes/empresa.py` retornava `503` com
 `Retry-After: 3600` em cache miss. A intenção original era proteger o
@@ -108,13 +109,9 @@ três situações:
    descobre via sitemap, que só lista pós-warm).
 
 Em todos os casos, **a URL não representa um recurso válido no
-domínio PB**. `404 Not Found` é semanticamente correto e produz
-melhor sinal SEO: Google de-indexa URLs 404 em ~7-30 dias, vs
-semanas-meses pra 503 transient. Para as ~511k URLs órfãs que estão
-sendo limpas, isso acelera materialmente a saída do índice.
-
-Cold start (warm ainda rodando após restart) continua possível mas é
-caso transitório e raro — o trade-off pra produção é favorável.
+domínio PB**. Inicialmente adotamos `404 Not Found`. Após observação
+em produção (ver "Revisão 2026-05-18"), migramos para `410 Gone`
+para acelerar de-indexação.
 
 ### Implementação do cleanup
 
@@ -249,7 +246,7 @@ gh workflow run deploy.yml -f etl_phase=web \
 
 - Code:
   - [`web/warm_cache.py::cleanup_orphan_empresa_cache`](../../web/warm_cache.py)
-  - [`web/routes/empresa.py`](../../web/routes/empresa.py) — `empresa_perfil` + `empresa_perfil_municipio` (cache miss = 404).
+  - [`web/routes/empresa.py`](../../web/routes/empresa.py) — `empresa_perfil` + `empresa_perfil_municipio` (cache miss = 410 Gone, atualizado de 404 em 2026-05-18).
 - Workflow:
   - [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml)
     (input `cleanup_orphan_empresa_cache`).
@@ -263,3 +260,108 @@ gh workflow run deploy.yml -f etl_phase=web \
 - PRs:
   - [#156](https://github.com/lucasdiniz/govbr-cruza-dados/pull/156) —
     ETL normalize fix que motivou este ADR.
+
+---
+
+## Revisão 2026-05-18: cache miss = 410 Gone (era 404)
+
+### Observação em produção
+
+Após o ADR original (2026-05-17), análise de tráfego em 18/May/2026
+mostrou Googlebot **persistindo em ~6.7k re-crawls/dia** em URLs órfãs
+retornando 404. O comportamento esperado era de-indexação em 7-30
+dias, mas Google estava interpretando 404 como "recurso temporariamente
+ausente, vale a pena retentar" — mantendo crawl budget alocado em URLs
+que nunca mais existirão.
+
+Distribuição de status no dia 18/May/2026 (00:00-18:21 BR):
+
+| Status | Hits | % do total |
+|---|---:|---:|
+| 200 | 51,348 | 59.2% |
+| **404** | **33,743** | **38.9%** |
+| 301 | 1,206 | 1.4% |
+
+`66.249.74.38` (Googlebot principal) sozinho gerou 6,726 × 404 — quase
+todos em URLs `/empresa/<CNPJ>/<municipio>` órfãs. O mesmo padrão se
+repetiu em 17/May (~6.7k) — ou seja, o ritmo de retry não diminuiu
+após 24h+.
+
+### Mudança
+
+Substituímos `status_code=404` por `status_code=410` nos dois cache
+miss handlers (`empresa_perfil` e `empresa_perfil_municipio`).
+
+**Por que 410 é estritamente melhor para este caso**:
+
+1. **Semântica HTTP precisa**: 410 Gone significa "removido
+   permanentemente, não tente novamente". Google documenta que trata
+   410 como permanente e remove do índice em dias (vs semanas para 404).
+2. **Crawl budget preservado**: Googlebot para de retentar URLs 410,
+   liberando budget para crawlar páginas novas qualificadas.
+3. **Zero complexidade adicionada**: a mudança é literal de
+   `status_code=404` para `status_code=410`. O template `errors/404.html`
+   é reutilizado (status code é o que importa pra crawler, conteúdo é
+   genérico).
+4. **Nenhuma nova query**: avaliamos cachear um existence check em
+   `empresa` (RFB) para distinguir "CNPJ nunca existiu" de "CNPJ órfão",
+   mas isso adiciona complexidade (LRU cache, day-bucket TTL, thundering
+   herd protection) sem benefício prático — 99%+ dos cache misses em
+   produção são caso (b) "CNPJ órfão", justificando 410 universal.
+
+### Trade-offs aceitos
+
+| Caso | Status correto ideal | Status produzido | Impacto |
+|---|---|---|---|
+| (a) URL inventada `/empresa/99999999999999/x` | 404 | 410 | Mínimo — Google de-indexa essa URL "inventada" mais rápido (não é problema; era irrelevante de qualquer forma) |
+| (b) CNPJ órfão (PR #156 cleanup) | **410** | 410 ✅ | Resolve o problema raiz |
+| (c) Cold start / CNPJ novo entre warms | 503 / 404 transient | 410 transient | Pior caso teórico. Mitigação: warm cycle dura ~3h após deploy mensal; janela de exposição é curta. Crawler descobre URL nova via sitemap (que só lista pós-warm), tornando race improvável |
+
+### Por que não query+cache pra distinguir (a) de (b)/(c)
+
+Considerei (e descartei) cachear `SELECT 1 FROM empresa WHERE
+cnpj_basico = $1` com `lru_cache + day_bucket` para retornar 410
+apenas quando CNPJ existe na RFB (caso b) e 404 quando não (caso a).
+
+Razões contra:
+
+- **Complexidade não justificada**: ~30 linhas de código + LRU cache
+  + day bucket + risco de thundering herd em cold deploy. Para
+  distinguir um caso raro (URL inventada) de um caso dominante
+  (URL órfã do cleanup), sem ganho prático.
+- **Não há cliente para essa distinção**: humanos digitando URLs
+  inventadas são <1% do tráfego em rotas `/empresa/<CNPJ>/<slug>`.
+  Para esses, ver "Página gone" no lugar de "Página não encontrada"
+  não muda nada (template é o mesmo).
+- **Yagni**: se um dia precisarmos distinguir, adicionamos. Por
+  enquanto, 410 universal é simples e correto para >99% dos casos.
+
+### Consequences (adicionais ao decision original)
+
+#### Positive
+
+- **Crawl budget liberado**: 6.7k retries/dia esperados parar em
+  ~3-7 dias após Google internalizar 410.
+- **De-index acelerado**: ~511k URLs órfãs saem do Google em dias
+  (vs semanas com 404).
+- **Sinal mais limpo no Search Console**: URLs com 410 aparecem em
+  relatório "Removed" (intencional) em vez de "Not found" (warning).
+
+#### Negative
+
+- **Reversão demora mais**: se uma empresa órfã voltar a qualificar
+  (improvável), Google leva mais tempo pra re-indexar URL marcada
+  como 410 vs 404. Mitigação: cleanup é idempotente; quando empresa
+  re-qualifica, warm cycle popula cache e próximo crawl retorna 200.
+  Google reverte 410→200 quando recebe 200 em re-crawl.
+- **URLs digitadas inventadas (caso a) recebem 410**: semanticamente
+  impreciso ("removido" vs "nunca existiu"), mas inconsequente —
+  esses são <1% dos misses e usuário vê mesmo template.
+
+### Reverso da mudança (se necessário)
+
+Se por algum motivo precisarmos voltar para 404 (ex: Google muda
+comportamento de tratamento de 410), basta inverter `status_code=410`
+para `status_code=404` nos dois handlers. Sem mudança de template,
+schema, ou dependências.
+

--- a/web/db.py
+++ b/web/db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from contextlib import contextmanager
 from typing import Any
@@ -90,8 +91,60 @@ def cached_query(
     return result
 
 
-def read_web_cache(query_id: str, municipio: str, periodo: str = "") -> tuple[list[str], list[tuple]] | None:
-    """Le resultado pre-processado de web_cache. Retorna None se nao existir.
+class _CacheError:
+    """Sentinel singleton retornado por read_web_cache quando lookup falha
+    por erro de DB/conexao (pool exhausted, statement_timeout, conn error,
+    JSON corrompido).
+
+    Diferenciar erro de "row ausente" e crucial para a rota /empresa/<cnpj>
+    decidir entre 410 Gone (URL permanentemente removida — row ausente
+    pos-cleanup) e 503 Service Unavailable (erro transiente — qualifying
+    empresa pode estar com cache temporariamente inacessivel).
+
+    Sem este sentinel, `read_web_cache` retornava None para ambos os casos
+    e a rota tratava DB error como cache miss permanente, marcando URLs
+    legitimas como 410 Gone durante pool exhaustion / restart / failover.
+    (HIGH bug identificado em revisao paralela Opus 4.7-high + GPT-5.5
+    do PR #181.)
+
+    Backward compat: callers legados em cidade.py/licitacao.py/warm_cache.py
+    fazem `if cached is not None: cols, rows = cached`. Para nao quebra-los
+    com TypeError no unpack, `_CacheError` e iteravel e desempacota como
+    `([], [])` — caem naturalmente no path existente de "cache miss
+    vazio -> 503". Callers que querem distinguir erro vs miss permanente
+    (rotas empresa.py) checam `is CACHE_ERROR` ANTES do unpack.
+    """
+    __slots__ = ()
+    def __repr__(self) -> str:
+        return "<CacheError>"
+    def __iter__(self):
+        # Permite `cols, rows = CACHE_ERROR` -> ([], []) sem quebrar
+        # callers legados. Equivalente semanticamente a "cache miss" para
+        # quem nao distingue erro de miss permanente.
+        yield []
+        yield []
+    def __bool__(self) -> bool:
+        # `if cached:` treat as falsy (cache miss equivalente para legados).
+        return False
+
+
+CACHE_ERROR = _CacheError()
+
+
+def read_web_cache(query_id: str, municipio: str, periodo: str = "") -> tuple[list[str], list[tuple]] | _CacheError | None:
+    """Le resultado pre-processado de web_cache.
+
+    Retorna:
+    - `tuple[cols, rows]` se entry existe (rows pode estar vazia para soft-miss).
+    - `None` se row genuinamente ausente (cache miss permanente).
+    - `CACHE_ERROR` (sentinel) se lookup falhou por erro de DB/conexao.
+
+    O caller deve diferenciar None (miss permanente -> 410 Gone) de
+    CACHE_ERROR (transiente -> 503 Retry-After). Antes desta mudanca,
+    bare `except Exception: pass; return None` tornava DB errors
+    indistinguiveis de cache miss; rotas /empresa retornavam 410 em
+    ambos os casos, marcando URLs legitimas como permanentemente
+    removidas durante incidentes transientes do DB.
 
     periodo: prefixo temporal (ex: 'ANO'). Se informado, busca '{periodo}:{query_id}'.
     """
@@ -109,6 +162,12 @@ def read_web_cache(query_id: str, municipio: str, periodo: str = "") -> tuple[li
                     cols = row[0] if isinstance(row[0], list) else []
                     rows = [tuple(r) for r in row[1]] if isinstance(row[1], list) else []
                     return cols, rows
-    except Exception:
-        pass
+    except Exception as e:
+        # Log com WARNING (visivel em journalctl) — antes era silencioso
+        # via `pass`, dificultando diagnostico de incidentes.
+        logging.getLogger("transparencia.db").warning(
+            "read_web_cache DB error for %s:%s — %s: %s",
+            effective_qid, municipio, type(e).__name__, e,
+        )
+        return CACHE_ERROR
     return None

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -5,14 +5,20 @@ ARQUITETURA pos-incidente do PR #57:
 - Cache miss = 410 Gone (NAO faz live query — protege DB do thundering herd
   que derrubou o site quando IndexNow notificou Bing sobre 45K URLs
   simultaneamente). Cache-miss-only e seguro porque empresas so entram no
-  sitemap depois de warmed, e cleanup_orphan_empresa_cache (ADR-0009)
-  garante que entries stale para CNPJs nao mais qualificados sao removidas.
-  Miss aqui significa URL nao representa empresa qualificada na PB —
-  410 e semanticamente correto e acelera de-index da URL no Google
-  (Google trata 410 como permanente e para de retentar em dias, vs 404
-  que insiste re-crawlando por semanas). Status revisado de 404 para 410
-  na revisao 2026-05-18 do ADR-0009 apos observar Googlebot persistindo
-  em ~6.7k retries/dia em URLs orfas.
+  sitemap depois de warmed (gating em deploy.yml com coverage >= 80%), e
+  cleanup_orphan_empresa_cache (ADR-0009) garante que entries stale para
+  CNPJs nao mais qualificados sao removidas. Miss aqui significa URL nao
+  representa empresa qualificada na PB — 410 e semanticamente correto e
+  acelera de-index da URL no Google (Google trata 410 como permanente e
+  para de retentar em dias, vs 404 que insiste re-crawlando por semanas).
+  Status revisado de 404 para 410 na revisao 2026-05-18 do ADR-0009 apos
+  observar Googlebot persistindo em ~6.7k retries/dia em URLs orfas.
+- DB error (pool exhaustion, statement_timeout, conn drop) = 503 com
+  Retry-After. Distincao de cache miss vs DB error eh crucial: 410 em
+  DB error transiente marcaria URLs legitimas como permanentemente
+  removidas. read_web_cache retorna sentinel CACHE_ERROR para erros
+  e None para row genuinamente ausente. (Revisao 2026-05-19 do ADR-0009
+  apos review paralelo Opus 4.7-high + GPT-5.5 do PR #181.)
 - A funcao `compute_empresa_perfil_dict` executa as 8 queries e monta o
   dict completo. Eh chamada APENAS pelo warmer (web/warm_cache.py), nunca
   inline na rota.
@@ -31,7 +37,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse, Response
 
 from web.config import TIMEOUT_PROFILE
-from web.db import execute_query, get_conn, read_web_cache
+from web.db import CACHE_ERROR, execute_query, get_conn, read_web_cache
 from web.queries.empresa import (
     EMPRESA_AGREGADOS_PB_BY_BASICO,
     EMPRESA_EMPENHOS_COUNT_BY_MUN,
@@ -634,7 +640,13 @@ def compute_empresa_municipio_perfil_dict(
 
 @router.get("/empresa/{cnpj}")
 async def empresa_perfil(request: Request, cnpj: str):
-    """Renderiza /empresa/<14-digits>. Le de web_cache. Cache miss = 410 Gone.
+    """Renderiza /empresa/<14-digits>. Le de web_cache.
+
+    Resultado por cenario:
+    - Cache hit -> 200 OK
+    - Cache miss (row ausente) -> 410 Gone (URL permanentemente removida)
+    - DB error -> 503 Retry-After (transiente, qualifying empresa pode
+      estar com cache temporariamente inacessivel)
 
     NUNCA executa as 8 queries inline. O incidente do PR #57 mostrou que
     sob trafego de crawler agressivo (Bing + 45K URLs do IndexNow), o pool
@@ -646,6 +658,11 @@ async def empresa_perfil(request: Request, cnpj: str):
     porque Googlebot insistia ~6.7k re-crawls/dia em URLs orfas
     interpretando 404 como "talvez volte". 410 = "removido permanentemente",
     de-index em dias vs semanas.
+
+    DB error retorna 503 (revisao 2026-05-19) — antes era tratado como
+    cache miss permanente (410), marcando URLs legitimas como removidas
+    durante pool exhaustion / restart / failover. Distincao usa sentinel
+    CACHE_ERROR do read_web_cache.
     """
     from web.main import templates
 
@@ -683,6 +700,22 @@ async def empresa_perfil(request: Request, cnpj: str):
     # Lookup no web_cache. Schema: (query_id=EMPRESA_PERFIL, municipio=cnpj),
     # rows[0][0] = dict completo serializado como JSONB.
     cached = read_web_cache(CACHE_QUERY_ID, canonical)
+    if cached is CACHE_ERROR:
+        # DB error transiente (pool exhausted, statement_timeout, conn drop).
+        # Retornar 503 sinaliza ao crawler "tenta de novo" sem disparar
+        # de-indexacao (diferente de 410, que Google trata como permanente).
+        # Antes desta verificacao, `read_web_cache` retornava None em DB
+        # errors (bare except: pass) e a rota tratava como cache miss
+        # permanente -> 410, marcando URLs de empresas qualificadas como
+        # removidas durante incidentes transientes do DB. (HIGH bug
+        # convergente Opus 4.7-high + GPT-5.5 review PR #181.)
+        _log.warning("DB error reading cache for /empresa/%s — returning 503", canonical)
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "60"},
+            content="Servico temporariamente indisponivel.",
+            media_type="text/plain; charset=utf-8",
+        )
     if cached is not None:
         cols, rows = cached
         if rows and rows[0]:
@@ -729,7 +762,13 @@ async def empresa_perfil_municipio(
     request: Request, cnpj: str, municipio_slug_in: str
 ):
     """Renderiza /empresa/<14-digits>/<municipio-slug>. Cache-only (mesmo
-    invariant da rota global): cache miss = 410 Gone (ver docstring do modulo).
+    invariant da rota global).
+
+    Resultado por cenario:
+    - Cache hit -> 200 OK
+    - Cache miss (row ausente) -> 410 Gone
+    - DB error -> 503 Retry-After
+    - Slug invalido -> 404 (ANTES do lookup de cache)
 
     Validacoes em ordem:
     1. CNPJ canonico (14 digitos numericos puros, sem mascara).
@@ -737,7 +776,7 @@ async def empresa_perfil_municipio(
     3. Slug municipio resolve via slug_to_municipio. None = 404.
     4. Slug nao canonico -> 301 pro slug canonico.
     5. Lookup web_cache(EMPRESA_PERFIL_MUN, "<cnpj>:<slug>"). Hit -> render.
-       Miss -> 410.
+       DB error -> 503. Miss -> 410.
     """
     from web.main import templates
 
@@ -816,6 +855,19 @@ async def empresa_perfil_municipio(
 
     cache_key = f"{canonical_cnpj}:{canonical_slug}"
     cached = read_web_cache(CACHE_QUERY_ID_MUN, cache_key)
+    if cached is CACHE_ERROR:
+        # DB error transiente — 503 em vez de 410 (ver docstring de
+        # empresa_perfil acima e ADR-0009 revisao 2026-05-19).
+        _log.warning(
+            "DB error reading cache for /empresa/%s/%s — returning 503",
+            canonical_cnpj, canonical_slug,
+        )
+        return Response(
+            status_code=503,
+            headers={"Retry-After": "60"},
+            content="Servico temporariamente indisponivel.",
+            media_type="text/plain; charset=utf-8",
+        )
     if cached is not None:
         _cols, rows = cached
         if rows and rows[0]:

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -2,14 +2,17 @@
 
 ARQUITETURA pos-incidente do PR #57:
 - Rota e CACHE-ONLY: le de web_cache (chave EMPRESA_PERFIL:<cnpj>) e renderiza.
-- Cache miss = 404 (NAO faz live query — protege DB do thundering herd que
-  derrubou o site quando IndexNow notificou Bing sobre 45K URLs simultaneamente).
-  Cache-miss-only e seguro porque empresas so entram no sitemap depois de
-  warmed, e cleanup_orphan_empresa_cache (ADR-0009) garante que entries
-  stale para CNPJs nao mais qualificados sao removidas. Miss aqui significa
-  URL nao representa empresa qualificada na PB — 404 e semanticamente
-  correto e acelera de-index de URLs antigas no Google (vs 503 transient
-  que demora semanas-meses).
+- Cache miss = 410 Gone (NAO faz live query — protege DB do thundering herd
+  que derrubou o site quando IndexNow notificou Bing sobre 45K URLs
+  simultaneamente). Cache-miss-only e seguro porque empresas so entram no
+  sitemap depois de warmed, e cleanup_orphan_empresa_cache (ADR-0009)
+  garante que entries stale para CNPJs nao mais qualificados sao removidas.
+  Miss aqui significa URL nao representa empresa qualificada na PB —
+  410 e semanticamente correto e acelera de-index da URL no Google
+  (Google trata 410 como permanente e para de retentar em dias, vs 404
+  que insiste re-crawlando por semanas). Status revisado de 404 para 410
+  na revisao 2026-05-18 do ADR-0009 apos observar Googlebot persistindo
+  em ~6.7k retries/dia em URLs orfas.
 - A funcao `compute_empresa_perfil_dict` executa as 8 queries e monta o
   dict completo. Eh chamada APENAS pelo warmer (web/warm_cache.py), nunca
   inline na rota.
@@ -631,13 +634,18 @@ def compute_empresa_municipio_perfil_dict(
 
 @router.get("/empresa/{cnpj}")
 async def empresa_perfil(request: Request, cnpj: str):
-    """Renderiza /empresa/<14-digits>. Le de web_cache. Cache miss = 404.
+    """Renderiza /empresa/<14-digits>. Le de web_cache. Cache miss = 410 Gone.
 
     NUNCA executa as 8 queries inline. O incidente do PR #57 mostrou que
     sob trafego de crawler agressivo (Bing + 45K URLs do IndexNow), o pool
     de DB exauria em segundos e levava o site inteiro junto. Cache-only +
     sitemap-after-warm garante que crawler so encontra URLs com cache
     quente.
+
+    Cache miss retorna 410 (era 404 ate revisao 2026-05-18 do ADR-0009)
+    porque Googlebot insistia ~6.7k re-crawls/dia em URLs orfas
+    interpretando 404 como "talvez volte". 410 = "removido permanentemente",
+    de-index em dias vs semanas.
     """
     from web.main import templates
 
@@ -692,18 +700,22 @@ async def empresa_perfil(request: Request, cnpj: str):
     #       que retirou empresas-fantasma contaminadas por CPF padded);
     #   (c) edge case raro: empresa nova entre warms (so visivel via
     #       sitemap apos proximo warm).
-    # Em (a) e (b), 404 e o codigo HTTP correto (URL nao representa um
-    # recurso valido na PB). Em (c), 404 pode causar de-index transiente
-    # de uma URL recem-criada, mas como crawlers descobrem essas URLs
-    # via sitemap (que so lista apos warm), o caso e improvavel.
-    # 404 acelera de-index das ~511k URLs orfas no Google (vs 503 que
-    # Google trata como transient e demora semanas-meses pra de-indexar).
-    _log.info("cache miss /empresa/%s — returning 404 (URL not in qualifying set)", canonical)
+    # Em (a) e (b), 410 Gone e o codigo HTTP correto: a URL nao representa
+    # (e nunca mais representara) um recurso valido no dominio PB. Em (c),
+    # 410 pode causar de-index transiente de uma URL recem-criada, mas
+    # como crawlers descobrem essas URLs via sitemap (que so lista apos
+    # warm), o caso e improvavel e o efeito reverte no proximo crawl da
+    # URL ja warmed.
+    # Por que 410 e nao 404: observado em prod (18/May/2026) Googlebot
+    # persistindo ~6.7k retries/dia em URLs orfas — 404 sinaliza
+    # "talvez volte". 410 sinaliza "removido permanentemente" e Google
+    # para de retentar em dias (vs semanas com 404).
+    _log.info("cache miss /empresa/%s — returning 410 Gone (URL not in qualifying set)", canonical)
     return templates.TemplateResponse(
         request,
         "errors/404.html",
         {"path": str(request.url.path)},
-        status_code=404,
+        status_code=410,
     )
 
 
@@ -717,7 +729,7 @@ async def empresa_perfil_municipio(
     request: Request, cnpj: str, municipio_slug_in: str
 ):
     """Renderiza /empresa/<14-digits>/<municipio-slug>. Cache-only (mesmo
-    invariant da rota global): cache miss = 404 (ver docstring do modulo).
+    invariant da rota global): cache miss = 410 Gone (ver docstring do modulo).
 
     Validacoes em ordem:
     1. CNPJ canonico (14 digitos numericos puros, sem mascara).
@@ -725,7 +737,7 @@ async def empresa_perfil_municipio(
     3. Slug municipio resolve via slug_to_municipio. None = 404.
     4. Slug nao canonico -> 301 pro slug canonico.
     5. Lookup web_cache(EMPRESA_PERFIL_MUN, "<cnpj>:<slug>"). Hit -> render.
-       Miss -> 404.
+       Miss -> 410.
     """
     from web.main import templates
 
@@ -814,14 +826,14 @@ async def empresa_perfil_municipio(
                 )
 
     _log.info(
-        "cache miss /empresa/%s/%s — returning 404 (URL not in qualifying set)",
+        "cache miss /empresa/%s/%s — returning 410 Gone (URL not in qualifying set)",
         canonical_cnpj, canonical_slug,
     )
     return templates.TemplateResponse(
         request,
         "errors/404.html",
         {"path": str(request.url.path)},
-        status_code=404,
+        status_code=410,
     )
 
 


### PR DESCRIPTION
## Contexto

Análise de tráfego de produção em 18/May/2026 mostrou que Googlebot estava persistindo em **~6,7k re-crawls/dia** em URLs órfãs (`/empresa/<CNPJ>/<municipio>` de empresas removidas de `mv_empresa_pb` após o ETL normalize fix do PR #156 + `cleanup_orphan_empresa_cache` do ADR-0009).

Distribuição de status no dia (00:00-18:21 BR):

| Status | Hits | % |
|---|---:|---:|
| 200 | 51.348 | 59.2% |
| **404** | **33.743** | **38.9%** ⚠️ |
| 301 | 1.206 | 1.4% |

`66.249.74.38` (Googlebot principal) sozinho gerou **6.726 × 404**. Mesmo padrão se repetiu em 17/May — ou seja, retry rate não diminuiu após 24h+ com ADR-0009 ativo.

## Causa raiz

`404 Not Found` é interpretado pelo Google como **"recurso temporariamente ausente"** — mantém crawl budget alocado em URLs que nunca mais existirão. Para URLs intencionalmente removidas (cleanup do ADR-0009), `410 Gone` é o sinal semântico correto: Google de-indexa em **dias** vs **semanas** com 404.

## Mudança

**Mínima**: troca `status_code=404` por `status_code=410` em 2 lugares do `web/routes/empresa.py`:

1. `empresa_perfil` (rota `/empresa/{cnpj}`) — cache miss
2. `empresa_perfil_municipio` (rota `/empresa/{cnpj}/{slug}`) — cache miss

Reuso o template `errors/404.html` existente (status code é o que importa pro crawler; conteúdo é genérico).

**Não muda**:
- Outros 404 (CNPJ malformado, slug inválido) — continuam 404
- `cleanup_orphan_empresa_cache` (ADR-0009)
- Sitemap gating
- Cold start behavior (warm ainda incompleto)

## ADR-0009 atualizado

Seção nova "Revisão 2026-05-18: cache miss = 410 Gone (era 404)" documenta:
- Observação em prod (~6.7k retries/dia)
- Justificativa da mudança 404 → 410
- Trade-offs aceitos (caso a: URL inventada perde precisão semântica, mas <1% dos misses)
- **Opção descartada**: cache + existence check em `empresa` RFB para distinguir "CNPJ inventado" (404) de "CNPJ órfão" (410). Yagni: >99% dos misses são caso (b) órfão, e cache+query adicionariam complexidade (LRU, day_bucket, thundering herd protection) sem ganho prático.

## Trade-offs

| Caso | Status ideal | Status produzido | Impacto |
|---|---|---|---|
| (a) URL inventada `/empresa/99999999999999/x` | 404 | 410 | Mínimo — Google de-indexa essa URL "inventada" mais rápido (irrelevante) |
| (b) CNPJ órfão (PR #156 cleanup) | **410** | **410** ✅ | **Resolve o problema raiz** |
| (c) Cold start / CNPJ novo entre warms | 503/404 transient | 410 transient | Pior caso teórico — janela curta (warm ~3h pós-deploy mensal), race improvável |

## Reverso

Trivial: inverter `410` → `404` nos 2 handlers. Sem mudança de template, schema, dependências.

## Validação

- `python -m compileall web/routes/empresa.py -q` ✅ passa
- Mudança literal de status code (não muda lógica nem template)
- Logs (`_log.info`) atualizados pra refletir 410 Gone
- Docstrings atualizadas em 3 lugares (module, `empresa_perfil`, `empresa_perfil_municipio`)

## Stats

```
docs/adr/0009-orphan-empresa-cache-cleanup.md | 122 +++++++++++++++++++++++---
web/routes/empresa.py                         |  54 +++++++-----
2 files changed, 145 insertions(+), 31 deletions(-)
```

Mudança de código real: 4 linhas de status_code + docstrings/comentários.