### PR TITLE
fix(warm_cache): add missing 'import math' for sitemap sharded scopes

### DIFF
--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import sys
 import threading


### PR DESCRIPTION
Hotfix de bug exposto pelo PR #85 quando o warmer rodou pos-merge.

Log do deploy 26128807031:

\\\
fail  contar empresas: name 'math' is not defined (pruning de empresas-shard: pulado)
fail  contar empresas-municipios: name 'math' is not defined (pruning pulado)
fail  contar licitacoes: name 'math' is not defined (pruning pulado)
\\\

\_warm_sitemaps_phase\ usa \math.ceil(total / SHARD_SIZE)\ em 3 scopes (empresas, empresas-municipios, licitacoes) mas o modulo nunca importava \math\. Erro foi mascarado pelo \xcept Exception\ (que adiciona \skip_prune_prefixes\ — bom!) mas os shards **nunca foram gerados em L2** pelo warmer, defeitando o ponto principal do PR #85.

\cidades-urlset\ e \cidade-resumo-urlset\ nao usam \math.ceil\ (single-shard) — por isso foram OK no log.

Fix: \import math\ no topo (1 linha).

Como nao foi pego no review: nenhum dos 5 rounds de review rodou o codigo. Compileall passou (compile catch syntax, nao NameError em runtime). Lesson learned.