### PR TITLE
feat(web): paginar+filtrar empenhos no dialog e pagina de licitacao

### DIFF
--- a/web/queries/licitacao.py
+++ b/web/queries/licitacao.py
@@ -141,8 +141,115 @@ LICITACAO_EMPENHOS_VINCULADOS = """
                   AND e.natureza_juridica NOT LIKE '1%%'
     JOIN estabelecimento est ON est.cnpj_basico = dp.cnpj_basico
                             AND est.cnpj_ordem = '0001'
-    ORDER BY dp.valor_pago DESC NULLS LAST
+    ORDER BY dp.data_empenho DESC NULLS LAST, dp.id DESC
     LIMIT 50
+"""
+
+# ─────────────────────────────────────────────────────────────────────────
+# Empenhos paginados — versao filtravel + paginada da query acima. Mesmas
+# regras de PJ-only + canonical-mod-match + year window. Usada pelo endpoint
+# /api/licitacao/empenhos pra:
+#   - pagina /licitacao/<...> (paginas 2+ e filtros)
+#   - dialog de licitacao aberto via /cidade
+#
+# Parametros (todos via psycopg2 %(...)s):
+#   municipio (str), codigo_ug (str | ''), numero_despesa (str — formato
+#   digit-only do tce_pb_despesa, ex '000282025'), modalidade (str —
+#   formato livre, normalizado via canonical-match), ano (int),
+#   data_inicio (str ISO | None), data_fim (str ISO | None),
+#   q (str | None), q_pat (str ILIKE pattern | None), limit (int),
+#   offset (int).
+#
+# ORDER BY data_empenho DESC pra alinhar com a primeira pagina warmed
+# (compute_licitacao_dict tambem usa data_empenho DESC) — sem flicker
+# quando o controller faz fetch live ao mount.
+LICITACAO_EMPENHOS_PAGINATED = """
+    WITH despesas_pj AS MATERIALIZED (
+        SELECT
+            d.id, d.numero_empenho, d.data_empenho, d.elemento_despesa,
+            d.valor_empenhado, d.valor_pago, d.cpf_cnpj, d.nome_credor,
+            d.cnpj_basico::bpchar(8) AS cnpj_basico
+        FROM tce_pb_despesa d
+        WHERE d.municipio = %(municipio)s
+          AND (%(codigo_ug)s = '' OR d.codigo_ug = %(codigo_ug)s)
+          AND d.numero_licitacao = %(numero_despesa)s
+          AND (
+              %(modalidade)s = '' OR
+              LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                    d.modalidade_licitacao,
+                    '\\s*-?\\s*\\([^)]*\\).*$', ''))))
+                = LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                    %(modalidade)s,
+                    '\\s*-?\\s*\\([^)]*\\).*$', ''))))
+          )
+          AND (%(ano)s = 0 OR
+               EXTRACT(YEAR FROM d.data_empenho) BETWEEN %(ano)s - 1 AND %(ano)s + 5)
+          AND d.valor_pago > 0
+          AND d.cnpj_basico IS NOT NULL
+          AND (%(data_inicio)s IS NULL OR d.data_empenho >= %(data_inicio)s::date)
+          AND (%(data_fim)s IS NULL OR d.data_empenho <= %(data_fim)s::date)
+          AND (
+              %(q)s IS NULL OR (
+                  d.numero_empenho ILIKE %(q_pat)s
+                  OR d.elemento_despesa ILIKE %(q_pat)s
+                  OR COALESCE(d.historico, '') ILIKE %(q_pat)s
+                  OR COALESCE(d.nome_credor, '') ILIKE %(q_pat)s
+              )
+          )
+    )
+    SELECT
+        dp.id, dp.numero_empenho, dp.data_empenho, dp.elemento_despesa,
+        dp.valor_empenhado, dp.valor_pago,
+        dp.cpf_cnpj AS cnpj_clean,
+        COALESCE(NULLIF(e.razao_social, ''), dp.nome_credor) AS razao_social,
+        dp.nome_credor,
+        est.cnpj_completo
+    FROM despesas_pj dp
+    JOIN empresa e ON e.cnpj_basico = dp.cnpj_basico
+                  AND e.natureza_juridica NOT LIKE '1%%'
+    JOIN estabelecimento est ON est.cnpj_basico = dp.cnpj_basico
+                            AND est.cnpj_ordem = '0001'
+    ORDER BY dp.data_empenho DESC NULLS LAST, dp.id DESC
+    LIMIT %(limit)s OFFSET %(offset)s
+"""
+
+LICITACAO_EMPENHOS_COUNT = """
+    WITH despesas_pj AS MATERIALIZED (
+        SELECT d.id, d.cnpj_basico::bpchar(8) AS cnpj_basico
+        FROM tce_pb_despesa d
+        WHERE d.municipio = %(municipio)s
+          AND (%(codigo_ug)s = '' OR d.codigo_ug = %(codigo_ug)s)
+          AND d.numero_licitacao = %(numero_despesa)s
+          AND (
+              %(modalidade)s = '' OR
+              LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                    d.modalidade_licitacao,
+                    '\\s*-?\\s*\\([^)]*\\).*$', ''))))
+                = LOWER(unaccent(BTRIM(REGEXP_REPLACE(
+                    %(modalidade)s,
+                    '\\s*-?\\s*\\([^)]*\\).*$', ''))))
+          )
+          AND (%(ano)s = 0 OR
+               EXTRACT(YEAR FROM d.data_empenho) BETWEEN %(ano)s - 1 AND %(ano)s + 5)
+          AND d.valor_pago > 0
+          AND d.cnpj_basico IS NOT NULL
+          AND (%(data_inicio)s IS NULL OR d.data_empenho >= %(data_inicio)s::date)
+          AND (%(data_fim)s IS NULL OR d.data_empenho <= %(data_fim)s::date)
+          AND (
+              %(q)s IS NULL OR (
+                  d.numero_empenho ILIKE %(q_pat)s
+                  OR d.elemento_despesa ILIKE %(q_pat)s
+                  OR COALESCE(d.historico, '') ILIKE %(q_pat)s
+                  OR COALESCE(d.nome_credor, '') ILIKE %(q_pat)s
+              )
+          )
+    )
+    SELECT COUNT(*)
+    FROM despesas_pj dp
+    JOIN empresa e ON e.cnpj_basico = dp.cnpj_basico
+                  AND e.natureza_juridica NOT LIKE '1%%'
+    JOIN estabelecimento est ON est.cnpj_basico = dp.cnpj_basico
+                            AND est.cnpj_ordem = '0001'
 """
 
 # Outras licitacoes do mesmo orgao no mesmo ano (sidebar/related).

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -55,6 +55,10 @@ from web.queries.empresa import (
     EMPRESA_SANCOES_CNEP_BY_CNPJ,
     EMPRESA_SOCIOS_BY_BASICO,
 )
+from web.queries.licitacao import (
+    LICITACAO_EMPENHOS_COUNT,
+    LICITACAO_EMPENHOS_PAGINATED,
+)
 from web.queries.registry import CIDADE_QUERIES, get_categories
 from web.kpis.cidade import compute_cidade_kpis
 
@@ -2553,33 +2557,186 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
                 rows = cur.fetchall()
                 result["proponentes"] = [_convert(_row_to_dict(cols, r)) for r in rows]
 
-                # Despesas vinculadas. Filtra por modalidade canonical + codigo_ug
-                # pra nao misturar empenhos de licitacoes diferentes que
-                # compartilham numero_licitacao no mesmo municipio (ex: Cruz
-                # do Espirito Santo tem 7 licitacoes distintas com '00003/2025',
-                # uma por modalidade x UG).
-                cur.execute(f"""
-                    SELECT id, nome_credor, cpf_cnpj, data_empenho,
-                           elemento_despesa, valor_empenhado, valor_pago
-                    FROM tce_pb_despesa
-                    WHERE numero_licitacao = %s AND municipio = %s
-                      AND valor_pago > 0
-                      AND (%s = '' OR codigo_ug = %s)
-                      AND (%s = '' OR {_CANON_MOD.format(col='modalidade_licitacao')}
-                                    = {_CANON_MOD.format(col='%s')})
-                    ORDER BY data_empenho DESC
-                    LIMIT 50
-                """, (numero_despesa, municipio,
-                      codigo_ug, codigo_ug,
-                      modalidade, modalidade))
+                # Despesas vinculadas. Usa LICITACAO_EMPENHOS_PAGINATED
+                # (mesma SQL do endpoint /api/licitacao/empenhos e da pagina
+                # /licitacao/<...>) — PJ-only via JOIN com empresa+
+                # estabelecimento. Garante paridade exata entre dialog e
+                # pagina (user-facing: mesmas linhas de empenho, mesmo total).
+                _lic_params = {
+                    "municipio": municipio,
+                    "codigo_ug": codigo_ug,
+                    "numero_despesa": numero_despesa,
+                    "modalidade": modalidade,
+                    "ano": int(ano or 0),
+                    "data_inicio": None,
+                    "data_fim": None,
+                    "q": None,
+                    "q_pat": None,
+                    "limit": 50,
+                    "offset": 0,
+                }
+                cur.execute(LICITACAO_EMPENHOS_PAGINATED, _lic_params)
                 cols = [d[0] for d in cur.description]
                 rows = cur.fetchall()
                 result["despesas"] = [_convert(_row_to_dict(cols, r)) for r in rows]
+
+                # Total pra render imediato da paginacao no dialog (controller
+                # com totalKnown=1 evita fetch live ao mount).
+                cur.execute(LICITACAO_EMPENHOS_COUNT, _lic_params)
+                _cnt_row = cur.fetchone()
+                result["despesas_total"] = int(_cnt_row[0]) if _cnt_row else 0
 
         return JSONResponse(result, headers={"Cache-Control": "public, max-age=3600"})
     except Exception:
         import logging; logging.exception("licitacao detalhes failed")
         return JSONResponse({})
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# /api/licitacao/empenhos — paginate + filtra empenhos de uma licitacao
+# especifica (4-tupla canonica: municipio + codigo_ug + modalidade + numero).
+# Espelha /api/fornecedor/empenhos: usado pela tabela paginada na pagina
+# /licitacao/<...> e no dialog de licitacao (aberto via /cidade).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_EMP_LIC_PAGE_SIZE = 50
+_EMP_LIC_TIMEOUT_SEC = 10
+
+
+@router.post("/api/licitacao/empenhos")
+async def get_licitacao_empenhos(payload: dict = Body(...)):
+    """Lista paginada de empenhos vinculados a uma licitacao.
+
+    Body:
+        numero_licitacao (str): formato livre — tce_pb_licitacao
+            ('00028/2025') ou tce_pb_despesa ('000282025'). Normalizado
+            pra digit-only internamente.
+        municipio (str): nome canonico do municipio. Obrigatorio.
+        ano_licitacao (int | str, opcional): se 0/vazio, derivado do
+            numero quando este tem 9 digits.
+        modalidade (str, opcional): formato livre. Canonical-match
+            (lowercase + unaccent + strip suffix). Vazio = nao filtra.
+        codigo_ug (str, opcional): vazio = nao filtra UG.
+        q, data_inicio, data_fim, page: idem outros endpoints de empenhos.
+
+    Returns: {empenhos, total, page, total_pages, page_size}
+    """
+    numero = str(payload.get("numero_licitacao", "") or "").strip()
+    municipio = (payload.get("municipio") or "").strip()
+    if not numero or not municipio:
+        return JSONResponse(
+            {"error": "numero_licitacao e municipio obrigatorios"},
+            status_code=400,
+        )
+
+    # Normaliza numero pro formato de tce_pb_despesa (digit-only) e deriva
+    # ano se nao veio. Mesmo padrao de /api/licitacao/detalhes.
+    import re as _re
+    numero_despesa = _re.sub(r"\D", "", numero)
+    try:
+        ano = int(payload.get("ano_licitacao") or 0)
+    except (TypeError, ValueError):
+        ano = 0
+    if ano == 0 and len(numero_despesa) == 9 and numero_despesa.isdigit():
+        year_part = numero_despesa[5:]
+        try:
+            yp = int(year_part)
+            if 2000 <= yp <= 2099:
+                ano = yp
+        except ValueError:
+            pass
+
+    modalidade = str(payload.get("modalidade", "") or "")
+    codigo_ug = str(payload.get("codigo_ug", "") or "")
+
+    data_inicio = _empforn_parse_iso_date(payload.get("data_inicio"))
+    data_fim = _empforn_parse_iso_date(payload.get("data_fim"))
+    q_clean, q_pat = _empforn_parse_q(payload.get("q"))
+
+    try:
+        page = int(payload.get("page") or 1)
+    except (TypeError, ValueError):
+        page = 1
+    if page < 1:
+        page = 1
+    offset = (page - 1) * _EMP_LIC_PAGE_SIZE
+
+    params = {
+        "municipio": municipio,
+        "codigo_ug": codigo_ug,
+        "numero_despesa": numero_despesa,
+        "modalidade": modalidade,
+        "ano": ano,
+        "data_inicio": data_inicio,
+        "data_fim": data_fim,
+        "q": q_clean,
+        "q_pat": q_pat,
+        "limit": _EMP_LIC_PAGE_SIZE,
+        "offset": offset,
+    }
+
+    try:
+        from psycopg2.errors import QueryCanceled
+        from web.db import get_conn
+        with get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SET statement_timeout = '{_EMP_LIC_TIMEOUT_SEC * 1000}'"
+                )
+                try:
+                    cur.execute(LICITACAO_EMPENHOS_PAGINATED, params)
+                    cols = [d[0] for d in cur.description]
+                    empenhos = []
+                    for row in cur.fetchall():
+                        d = _row_to_dict(cols, row)
+                        for k, v in d.items():
+                            if hasattr(v, "as_tuple"):
+                                d[k] = float(v)
+                            elif hasattr(v, "isoformat"):
+                                d[k] = v.isoformat()
+                        empenhos.append(d)
+
+                    count_params = {k: v for k, v in params.items()
+                                    if k not in ("limit", "offset")}
+                    cur.execute(LICITACAO_EMPENHOS_COUNT, count_params)
+                    cnt = cur.fetchone()
+                    total = int(cnt[0]) if cnt else 0
+                finally:
+                    try:
+                        cur.execute("RESET statement_timeout")
+                    except Exception:
+                        pass
+    except QueryCanceled:
+        return JSONResponse(
+            {
+                "error": "timeout",
+                "message": (
+                    "A busca demorou muito. Use filtros (data ou texto) "
+                    "para refinar."
+                ),
+            },
+            status_code=504,
+        )
+    except Exception:
+        import logging; logging.exception("licitacao empenhos failed")
+        return JSONResponse(
+            {"error": "internal", "message": "Erro ao buscar empenhos."},
+            status_code=500,
+        )
+
+    total_pages = (
+        (total + _EMP_LIC_PAGE_SIZE - 1) // _EMP_LIC_PAGE_SIZE
+        if total > 0 else 0
+    )
+    return {
+        "empenhos": empenhos,
+        "total": total,
+        "page": page,
+        "total_pages": total_pages,
+        "page_size": _EMP_LIC_PAGE_SIZE,
+    }
 
 
 @router.get("/api/export/{query_id}")

--- a/web/routes/licitacao.py
+++ b/web/routes/licitacao.py
@@ -37,6 +37,7 @@ from web.config import TIMEOUT_PROFILE, TIMEOUT_PROFILE_WARM
 from web.db import execute_query, get_conn, read_web_cache
 from web.queries.licitacao import (
     LICITACAO_DETAIL,
+    LICITACAO_EMPENHOS_COUNT,
     LICITACAO_EMPENHOS_VINCULADOS,
     LICITACAO_OUTRAS_MESMA_MODALIDADE,
     LICITACAO_OUTRAS_MESMO_ORGAO,
@@ -93,6 +94,13 @@ def _build_mod_num_slug(modalidade: str, numero_licitacao: str) -> str:
     mod = numero_slug(modalidade) or "lic"
     num = numero_slug(numero_licitacao) or "0"
     return f"{mod}-{num}"
+
+
+def _numero_to_despesa_format(numero_licitacao: str) -> str:
+    """Converte numero_licitacao do formato tce_pb_licitacao ('00028/2025')
+    pro formato digit-only de tce_pb_despesa ('000282025').
+    Reuso interno + exposto pra rota /api/licitacao/empenhos."""
+    return re.sub(r"\D", "", numero_licitacao or "")
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -188,12 +196,31 @@ def compute_licitacao_dict(
                         f"Licitacao sem proponente PJ qualificado: {numero_licitacao}/{ano}"
                     )
 
-                # 3. Empenhos vinculados (top 50, PJ only)
+                # 3. Empenhos vinculados (top 50, PJ only). Mesma query
+                # paginada usada pelo endpoint /api/licitacao/empenhos com
+                # filtros default (sem q, sem data) — primeira pagina warmed
+                # bate com a page 1 que o controller fetches no mount.
                 cur.execute(LICITACAO_EMPENHOS_VINCULADOS, params)
                 emp_cols = [d[0] for d in cur.description]
                 empenhos = [
                     _convert_row(_row_to_dict(emp_cols, r)) for r in cur.fetchall()
                 ]
+
+                # 3b. Count total de empenhos (PJ-only) — propagado pro
+                # template como `empenhos_total` pra render imediato da
+                # paginacao sem fetch live ao mount (totalKnown=1).
+                # Parametros base + filtros default (sem q/data).
+                _cnt_params = {
+                    **params,
+                    "numero_despesa": _numero_to_despesa_format(numero_licitacao),
+                    "data_inicio": None,
+                    "data_fim": None,
+                    "q": None,
+                    "q_pat": None,
+                }
+                cur.execute(LICITACAO_EMPENHOS_COUNT, _cnt_params)
+                _cnt_row = cur.fetchone()
+                empenhos_total = int(_cnt_row[0]) if _cnt_row else 0
 
                 # 4. Outras licitacoes do mesmo orgao (sidebar)
                 cur.execute(LICITACAO_OUTRAS_MESMO_ORGAO, params)
@@ -258,6 +285,7 @@ def compute_licitacao_dict(
         "detail": detail,
         "proponentes": proponentes,
         "empenhos": empenhos,
+        "empenhos_total": empenhos_total,
         "outras_orgao": outras_orgao,
         "outras_modalidade": outras_modalidade,
         # KPIs derivados

--- a/web/static/js/components/empenhos-controller.js
+++ b/web/static/js/components/empenhos-controller.js
@@ -41,6 +41,14 @@ class EmpenhosController {
         this.cnpj = mount.dataset.empenhosCnpj || '';
         this.cpfCnpj = mount.dataset.empenhosCpfCnpj || '';
         this.municipio = mount.dataset.empenhosMunicipio || '';
+        // Licitacao-specific identifiers (scope='licitacao'). Quando
+        // setados, sao enviados no body junto com o filtro padrao
+        // pra que o endpoint /api/licitacao/empenhos resolva a 4-tupla
+        // canonica (municipio + codigo_ug + modalidade + numero).
+        this.licNumero = mount.dataset.empenhosLicNumero || '';
+        this.licAno = mount.dataset.empenhosLicAno || '';
+        this.licModalidade = mount.dataset.empenhosLicModalidade || '';
+        this.licCodigoUg = mount.dataset.empenhosLicCodigoUg || '';
         this.total = parseInt(mount.dataset.empenhosTotal || '0', 10) || 0;
         this.hasInitial = mount.dataset.empenhosInitial === '1';
         // Flag: total acima eh autoritativo (warmer novo) ou eh um proxy
@@ -325,6 +333,10 @@ class EmpenhosController {
         if (this.cnpj) body.cnpj = this.cnpj;
         if (this.cpfCnpj) body.cpf_cnpj = this.cpfCnpj;
         if (this.municipio) body.municipio = this.municipio;
+        if (this.licNumero) body.numero_licitacao = this.licNumero;
+        if (this.licAno) body.ano_licitacao = this.licAno;
+        if (this.licModalidade) body.modalidade = this.licModalidade;
+        if (this.licCodigoUg) body.codigo_ug = this.licCodigoUg;
         if (this.filters.q) body.q = this.filters.q;
         if (this.filters.dateInicio) body.data_inicio = this.filters.dateInicio;
         if (this.filters.dateFim) body.data_fim = this.filters.dateFim;
@@ -398,21 +410,36 @@ class EmpenhosController {
                 'Nenhum empenho encontrado.</p>';
             return;
         }
+        const isLicitacao = this.scope === 'licitacao';
         const showMun = this.scope === 'global';
-        const rows = empenhos.map((e) => _empRenderRow(e, showMun)).join('');
+        const rows = empenhos
+            .map((e) => isLicitacao
+                ? _empRenderRowLicitacao(e)
+                : _empRenderRow(e, showMun))
+            .join('');
         const munTh = showMun ? '<th>Municipio</th>' : '';
+        const headHtml = isLicitacao
+            ? '<thead><tr>' +
+              '<th>Data</th>' +
+              '<th>Numero</th>' +
+              '<th>Credor</th>' +
+              '<th>Elemento de despesa</th>' +
+              '<th class="text-right">Empenhado</th>' +
+              '<th class="text-right">Pago</th>' +
+              '</tr></thead>'
+            : '<thead><tr>' +
+              '<th>Data</th>' +
+              '<th>Numero</th>' +
+              munTh +
+              '<th>Elemento de despesa</th>' +
+              '<th>Modalidade / Licitacao</th>' +
+              '<th class="text-right">Empenhado</th>' +
+              '<th class="text-right">Pago</th>' +
+              '</tr></thead>';
         this.tableContainer.innerHTML =
             '<div class="tbl-wrap">' +
             '<table class="stack-mobile data-table empresa-empenhos-table">' +
-            '<thead><tr>' +
-            '<th>Data</th>' +
-            '<th>Numero</th>' +
-            munTh +
-            '<th>Elemento de despesa</th>' +
-            '<th>Modalidade / Licitacao</th>' +
-            '<th class="text-right">Empenhado</th>' +
-            '<th class="text-right">Pago</th>' +
-            '</tr></thead>' +
+            headHtml +
             `<tbody>${rows}</tbody>` +
             '</table></div>';
         if (typeof initClickableRows === 'function') {
@@ -453,6 +480,31 @@ function _empEsc(s) {
     return String(s)
         .replace(/&/g, '&amp;').replace(/</g, '&lt;')
         .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// Renderiza row pra scope='licitacao': sem Municipio (todas mesma mun),
+// sem Modalidade/Licitacao (todas mesma licitacao), com Credor clicavel
+// (abre fornecedor-dialog via dialog-links.js — mesmo padrao do
+// proponentes table no licitacao-dialog).
+function _empRenderRowLicitacao(e) {
+    const cnpjRaw = String(e.cnpj_clean || e.cpf_cnpj || '').replace(/\D/g, '');
+    const cnpjB = cnpjRaw.slice(0, 8);
+    const isClickable = cnpjB.length === 8
+        && /^\d{8}$/.test(cnpjB)
+        && cnpjRaw.length >= 14;
+    const nome = _empEsc(e.razao_social || e.nome_credor || '—');
+    const credorCell = isClickable
+        ? `<a href="#" class="dialog-link" data-forn-cnpj="${cnpjB}" data-forn-cpf-cnpj="${cnpjRaw}" data-forn-nome="${nome}" data-forn-nome-credor="${_empEsc(e.nome_credor || '')}">${nome}</a>`
+        : nome;
+    const empenhoIdAttr = e.id ? ` data-empenho-id="${_empEsc(String(e.id))}"` : '';
+    return `<tr class="clickable-row"${empenhoIdAttr}>
+        <td data-label="Data">${_empFmtDate(e.data_empenho)}</td>
+        <td data-label="Numero"><code>${_empEsc(e.numero_empenho || '—')}</code></td>
+        <td data-label="Credor" class="stack-title">${credorCell}</td>
+        <td data-label="Elemento">${_empEsc(e.elemento_despesa || '—')}</td>
+        <td data-label="Empenhado" class="text-right num">${_empBrl(e.valor_empenhado)}</td>
+        <td data-label="Pago" class="text-right num"><strong>${_empBrl(e.valor_pago)}</strong></td>
+    </tr>`;
 }
 
 function _empFmtDate(iso) {

--- a/web/static/js/components/licitacao-dialog.js
+++ b/web/static/js/components/licitacao-dialog.js
@@ -151,36 +151,107 @@ async function openLicitacaoDialog(numeroLicitacao, anoLicitacao, municipio, lab
         html += '</div>';
     }
 
-    // Despesas vinculadas
-    if (data.despesas && data.despesas.length) {
-        html += `<div class="dialog-section"><h4>${dualLabel('Pagamentos desta licitacao','Despesas vinculadas')}</h4>`;
-        const despRows = data.despesas.map(d => {
-            const cnpjRaw = String(d.cpf_cnpj || '').replace(/\D/g, '');
-            const cnpjB = cnpjRaw.slice(0, 8);
-            const isClickable = cnpjB.length === 8 && /^\d{8}$/.test(cnpjB) && cnpjRaw.length >= 14;
-            const nome = _esc(d.nome_credor || '-');
-            const nomeCell = isClickable
-                ? `<a href="#" class="dialog-link" data-forn-cnpj="${cnpjB}" data-forn-cpf-cnpj="${cnpjRaw}" data-forn-nome="${nome}" data-forn-nome-credor="${nome}">${nome}</a>`
-                : nome;
-            return `<tr class="clickable-row" data-empenho-id="${d.id}">
-                <td data-label="Credor" class="stack-title">${nomeCell}</td>
-                <td data-label="Data" class="stack-meta">${_fmtDate(d.data_empenho)}</td>
-                <td data-label="Tipo de gasto" class="stack-meta">${_esc(d.elemento_despesa || '-')}</td>
-                <td data-label="Reservado" class="text-right num">${_shortBrl(d.valor_empenhado)}</td>
-                <td data-label="Pago" class="text-right num">${_shortBrl(d.valor_pago)}</td>
-            </tr>`;
-        }).join('');
-        html += `<div class="tbl-wrap"><table class="dialog-table stack-mobile">
-            <thead><tr><th>${dualLabel('Empresa','Credor')}</th><th>Data</th><th>${dualLabel('Tipo de gasto','Elemento')}</th><th class="text-right">${dualLabel('Reservado','Empenhado')}</th><th class="text-right">Pago</th></tr></thead>
-            <tbody>${despRows}</tbody>
-        </table></div>`;
-        if (data.despesas.length >= 50) {
-            html += '<p class="text-sm text-muted">Mostrando as 50 despesas mais recentes.</p>';
+    // Despesas vinculadas. Renderiza como mount do empenhos-controller
+    // (paginado + filtravel — paridade exata com a pagina /licitacao/<...>).
+    // Initial table = data.despesas (top 50 do /api/licitacao/detalhes,
+    // ja PJ-filtered). Paginas 2+ / filtros fetcham /api/licitacao/empenhos.
+    const despTotal = parseInt(data.despesas_total || 0, 10) || 0;
+    if ((data.despesas && data.despesas.length) || despTotal > 0) {
+        html += `<div class="dialog-section" id="lic-empenhos" data-nav-label="Empenhos"><h4>${dualLabel('Pagamentos desta licitacao','Empenhos vinculados')}</h4>`;
+        // Container montado pelo empenhos-controller. Total conhecido
+        // (totalKnown=1) — controller nao faz fetch live ao mount.
+        const totalKnown = (typeof data.despesas_total === 'number') ? '1' : '0';
+        html += `<section
+            class="empenhos-section empenhos-section-dialog"
+            data-empenhos-mount
+            data-empenhos-endpoint="/api/licitacao/empenhos"
+            data-empenhos-scope="licitacao"
+            data-empenhos-lic-numero="${_esc(String(numeroLicitacao || ''))}"
+            data-empenhos-lic-ano="${_esc(String(anoLicitacao || ''))}"
+            data-empenhos-lic-modalidade="${_esc(String(modalidade || ''))}"
+            data-empenhos-lic-codigo-ug="${_esc(String(codigoUg || ''))}"
+            data-empenhos-total="${despTotal || (data.despesas ? data.despesas.length : 0)}"
+            data-empenhos-total-known="${totalKnown}"
+            data-empenhos-initial="${data.despesas && data.despesas.length ? '1' : '0'}">
+            <p class="text-sm text-muted" data-empenhos-summary>
+                ${despTotal > 0 ? despTotal.toLocaleString('pt-BR') + ' empenhos encontrados.' : 'Clique em uma linha para ver os detalhes.'}
+            </p>`;
+        // Filter bar (sub-template inline pra evitar dependencia de Jinja
+        // no dialog que eh montado client-side).
+        html += `<details class="date-filter-bar empenhos-filter-bar">
+            <summary class="date-filter-summary">
+                <span class="date-filter-current" data-empenhos-filter-summary>Periodo: todo o historico</span>
+                <span class="date-filter-action">Filtrar empenhos</span>
+            </summary>
+            <div class="date-filter-panel" role="group" aria-label="Filtros de empenhos">
+                <div class="empenhos-search-row">
+                    <label class="date-field empenhos-search-field"><span>Buscar</span>
+                        <input type="search" data-empenhos-q placeholder="Numero, elemento, historico, credor..." inputmode="search" maxlength="100" autocomplete="off">
+                    </label>
+                </div>
+                <div class="date-filter-inputs">
+                    <label class="date-field"><span>De</span>
+                        <input type="text" data-empenhos-date-inicio inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off">
+                    </label>
+                    <label class="date-field"><span>Ate</span>
+                        <input type="text" data-empenhos-date-fim inputmode="numeric" placeholder="DD/MM/AAAA" maxlength="10" autocomplete="off">
+                    </label>
+                    <md-filled-button data-empenhos-apply class="date-filter-submit">Aplicar</md-filled-button>
+                    <p class="date-filter-status text-sm text-muted" data-empenhos-status aria-live="polite"></p>
+                </div>
+                <div class="date-filter-presets" role="group" aria-label="Atalhos de periodo">
+                    <md-filter-chip label="Tudo" data-empenhos-preset="all" selected></md-filter-chip>
+                    <md-filter-chip label="Ano atual" data-empenhos-preset="current-year"></md-filter-chip>
+                    <md-filter-chip label="12 meses" data-empenhos-preset="last-12m"></md-filter-chip>
+                    <md-text-button data-empenhos-clear style="display:none">Limpar filtros</md-text-button>
+                </div>
+            </div>
+        </details>`;
+        // Tabela inicial: data.despesas do payload (se houver). Senao
+        // placeholder pro controller fetch live page 1.
+        if (data.despesas && data.despesas.length) {
+            const despRows = data.despesas.map(d => {
+                const cnpjRaw = String(d.cnpj_clean || d.cpf_cnpj || '').replace(/\D/g, '');
+                const cnpjB = cnpjRaw.slice(0, 8);
+                const isClickable = cnpjB.length === 8 && /^\d{8}$/.test(cnpjB) && cnpjRaw.length >= 14;
+                const nome = _esc(d.razao_social || d.nome_credor || '-');
+                const nomeCell = isClickable
+                    ? `<a href="#" class="dialog-link" data-forn-cnpj="${cnpjB}" data-forn-cpf-cnpj="${cnpjRaw}" data-forn-nome="${nome}" data-forn-nome-credor="${_esc(d.nome_credor || '')}">${nome}</a>`
+                    : nome;
+                return `<tr class="clickable-row" data-empenho-id="${d.id}">
+                    <td data-label="Data">${_fmtDate(d.data_empenho)}</td>
+                    <td data-label="Numero"><code>${_esc(d.numero_empenho || '-')}</code></td>
+                    <td data-label="Credor" class="stack-title">${nomeCell}</td>
+                    <td data-label="Elemento">${_esc(d.elemento_despesa || '-')}</td>
+                    <td data-label="Empenhado" class="text-right num">${_shortBrl(d.valor_empenhado)}</td>
+                    <td data-label="Pago" class="text-right num"><strong>${_shortBrl(d.valor_pago)}</strong></td>
+                </tr>`;
+            }).join('');
+            html += `<div data-empenhos-table><div class="tbl-wrap"><table class="stack-mobile data-table empresa-empenhos-table">
+                <thead><tr><th>Data</th><th>Numero</th><th>Credor</th><th>Elemento de despesa</th><th class="text-right">Empenhado</th><th class="text-right">Pago</th></tr></thead>
+                <tbody>${despRows}</tbody>
+            </table></div></div>`;
+        } else {
+            html += '<div data-empenhos-table><p class="text-sm text-muted empenhos-loading-placeholder">Carregando empenhos...</p></div>';
         }
+        // Pagination footer
+        html += `<nav class="empenhos-pagination" data-empenhos-pagination aria-label="Paginacao de empenhos" hidden>
+            <md-text-button data-empenhos-prev disabled aria-label="Pagina anterior">
+                <md-icon slot="icon">chevron_left</md-icon>Anterior
+            </md-text-button>
+            <span class="empenhos-page-info" data-empenhos-page-info aria-live="polite">Pagina 1</span>
+            <md-text-button data-empenhos-next aria-label="Proxima pagina">
+                Proxima<md-icon slot="icon">chevron_right</md-icon>
+            </md-text-button>
+        </nav>`;
+        html += '</section>';
         html += '</div>';
     }
     body.innerHTML = html;
     _reattachDialogLinks(body);
     _decorateDialogBody(body);
+    if (typeof initEmpenhosControllers === 'function') {
+        initEmpenhosControllers(body);
+    }
 }
 

--- a/web/templates/partials/empresa/_empenhos.html
+++ b/web/templates/partials/empresa/_empenhos.html
@@ -5,13 +5,22 @@
        empenhos_total: int. Count total. None/0 = pagina renderiza
            sem footer ate primeiro fetch live (fallback p/ payloads
            cacheados pre-PR de paginacao).
-       empenhos_endpoint: '/api/empresa/empenhos' (default) ou
-           '/api/fornecedor/empenhos'.
-       empenhos_scope: 'global' ou 'municipio' (afeta colunas
-           exibidas — global mostra coluna Municipio).
+       empenhos_endpoint: '/api/empresa/empenhos' (default),
+           '/api/fornecedor/empenhos' ou '/api/licitacao/empenhos'.
+       empenhos_scope: 'global', 'municipio' ou 'licitacao' (afeta
+           colunas exibidas — global mostra Municipio; licitacao
+           mostra Credor sem Modalidade/Licitacao).
        empenhos_cnpj: 14 digitos canonicos (passado pro endpoint
-           via JS no body).
+           via JS no body). Usado quando scope!='licitacao'.
        empenhos_municipio: nome canonico OU None (None = global).
+
+   Scope='licitacao' (pagina /licitacao/<...> + dialog de licitacao):
+       empenhos_lic_numero: numero_licitacao (qualquer formato).
+       empenhos_lic_ano: ano_licitacao (int).
+       empenhos_lic_modalidade: modalidade (formato livre — canonical-
+           match no SQL).
+       empenhos_lic_codigo_ug: codigo_ug (str, opcional).
+       empenhos_cnpj nao usado.
 
    Usa o macro `collapsible` (partials/_collapsible.html) via section_attrs
    pra colocar TODOS os data-attrs no <section> wrapper, que eh onde
@@ -40,6 +49,10 @@
     'data-empenhos-cnpj': empenhos_cnpj or cnpj or '',
     'data-empenhos-municipio': empenhos_municipio or none,
     'data-empenhos-cpf-cnpj': empenhos_cpf_cnpj or none,
+    'data-empenhos-lic-numero': empenhos_lic_numero or none,
+    'data-empenhos-lic-ano': (empenhos_lic_ano|string) if empenhos_lic_ano is defined and empenhos_lic_ano else none,
+    'data-empenhos-lic-modalidade': empenhos_lic_modalidade or none,
+    'data-empenhos-lic-codigo-ug': empenhos_lic_codigo_ug or none,
     'data-empenhos-total': _empenhos_total,
     'data-empenhos-total-known': '1' if _empenhos_total_known else '0',
     'data-empenhos-initial': '1' if empenhos else '0',
@@ -73,8 +86,9 @@
                         <th>Data</th>
                         <th>Numero</th>
                         {% if _show_municipio_col %}<th>Municipio</th>{% endif %}
+                        {% if _empenhos_scope == 'licitacao' %}<th>Credor</th>{% endif %}
                         <th>Elemento de despesa</th>
-                        <th>Modalidade / Licitacao</th>
+                        {% if _empenhos_scope != 'licitacao' %}<th>Modalidade / Licitacao</th>{% endif %}
                         <th class="text-right">Empenhado</th>
                         <th class="text-right">Pago</th>
                     </tr>
@@ -88,7 +102,18 @@
                         {% if _show_municipio_col %}
                         <td data-label="Municipio">{{ e.municipio|clean_text or '—' }}</td>
                         {% endif %}
+                        {% if _empenhos_scope == 'licitacao' %}
+                        {% set _cnpj_raw = (e.cnpj_clean or e.cpf_cnpj or '')|string %}
+                        {% set _cnpj_b = _cnpj_raw[:8] %}
+                        {% set _nome = (e.razao_social or e.nome_credor or '—')|clean_text %}
+                        <td data-label="Credor" class="stack-title">
+                            {% if _cnpj_b and _cnpj_b.isdigit() and _cnpj_raw|length >= 14 %}
+                            <a href="#" class="dialog-link" data-forn-cnpj="{{ _cnpj_b }}" data-forn-cpf-cnpj="{{ _cnpj_raw }}" data-forn-nome="{{ _nome }}" data-forn-nome-credor="{{ (e.nome_credor or '')|clean_text }}">{{ _nome }}</a>
+                            {% else %}{{ _nome }}{% endif %}
+                        </td>
+                        {% endif %}
                         <td data-label="Elemento">{{ e.elemento_despesa|clean_text or '—' }}</td>
+                        {% if _empenhos_scope != 'licitacao' %}
                         <td data-label="Modalidade">
                             {% if sem_lic %}
                                 <span class="badge badge-yellow" title="Empenho sem licitacao identificada">Sem licitacao</span>
@@ -99,6 +124,7 @@
                                 {% endif %}
                             {% endif %}
                         </td>
+                        {% endif %}
                         <td data-label="Empenhado" class="text-right num">{{ e.valor_empenhado|short_brl }}</td>
                         <td data-label="Pago" class="text-right num"><strong>{{ e.valor_pago|short_brl }}</strong></td>
                     </tr>

--- a/web/templates/results/licitacao.html
+++ b/web/templates/results/licitacao.html
@@ -126,41 +126,21 @@
     </section>
     {% endif %}
 
-    {% if empenhos %}
-    <section class="empresa-section" id="empenhos">
-        <h2>Empenhos vinculados ({{ empenhos|length }})</h2>
-        <p class="text-sm text-muted">Pagamentos efetuados pelo orgao referentes a esta licitacao. Top 50 por valor pago.</p>
-        <div class="tbl-wrap">
-            <table class="dialog-table stack-mobile">
-                <thead>
-                    <tr>
-                        <th>Data</th>
-                        <th>Empenho</th>
-                        <th>Credor</th>
-                        <th>Elemento</th>
-                        <th class="text-right">Pago</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for e in empenhos %}
-                    <tr{% if e.id %} class="clickable-row" data-empenho-id="{{ e.id }}"{% endif %}>
-                        <td data-label="Data" class="stack-meta">{% if e.data_empenho %}{{ e.data_empenho[8:10] }}/{{ e.data_empenho[5:7] }}/{{ e.data_empenho[0:4] }}{% else %}-{% endif %}</td>
-                        <td data-label="Empenho" class="stack-meta"><code>{{ e.numero_empenho|clean_text or "-" }}</code></td>
-                        <td data-label="Credor" class="stack-title">
-                            {% if e.cnpj_completo %}
-                                <a href="/empresa/{{ e.cnpj_completo }}">{{ e.razao_social|clean_text }}</a>
-                            {% else %}
-                                {{ e.razao_social|clean_text }}
-                            {% endif %}
-                        </td>
-                        <td data-label="Elemento" class="stack-meta">{{ e.elemento_despesa|clean_text or "-" }}</td>
-                        <td data-label="Pago" class="text-right num">{{ e.valor_pago | short_brl }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </section>
+    {% if empenhos or empenhos_total %}
+    {# Empenhos vinculados com paginacao + filtros (data + busca).
+       Mesma infra de /empresa/<cnpj>/<municipio> via empenhos-controller.
+       Filtra por 4-tupla canonica (municipio + codigo_ug + canonical
+       modalidade + numero_licitacao). #}
+    {% with
+       empenhos_endpoint = '/api/licitacao/empenhos',
+       empenhos_scope = 'licitacao',
+       empenhos_lic_numero = numero_licitacao,
+       empenhos_lic_ano = ano,
+       empenhos_lic_modalidade = modalidade,
+       empenhos_lic_codigo_ug = codigo_ug
+    %}
+        {% include "partials/empresa/_empenhos.html" %}
+    {% endwith %}
     {% endif %}
 
     {% if outras_orgao %}


### PR DESCRIPTION
## Problema

Reportado pelo usuario:

1. **Dialog de licitacao** (aberto via /cidade/<slug>) NAO mostrava lista
   de empenhos como a pagina dedicada /licitacao/<...> ja mostrava.
2. **Pagina /licitacao/<...>** NAO tinha filtro de data nos empenhos —
   essa superficie ficou de fora do PR #65 que adicionou paginacao+filtros
   pras outras tabelas de empenhos (empresa-municipio, empresa-global,
   fornecedor-dialog).

Investigando o codigo descobri tambem que o dialog usava uma query mais
permissiva que a pagina (sem o filtro PJ-only via JOIN empresa+
estabelecimento), o que explicava muitos casos em que o dialog mostrava
empenhos diferentes dos da pagina pra mesma licitacao.

## Solucao

Estende a infra de paginacao+filtros de empenhos pra **quarta superficie**
(licitacao), seguindo exatamente o mesmo pattern de PR #65.

### Backend
- Novas queries em `web/queries/licitacao.py`:
  `LICITACAO_EMPENHOS_PAGINATED` + `LICITACAO_EMPENHOS_COUNT`
  (PJ-only, q+date filters, canonical-match em modalidade, year window
  como safety perf).
- `LICITACAO_EMPENHOS_VINCULADOS` muda ORDER BY pra `data_empenho DESC, id DESC`
  (consistencia com page 1 do endpoint paginado).
- `compute_licitacao_dict` agora calcula `empenhos_total` via COUNT.
- **Novo endpoint** `POST /api/licitacao/empenhos` espelhando shape de
  `/api/fornecedor/empenhos`: aceita `numero_licitacao`, `ano_licitacao`,
  `municipio`, `modalidade`, `codigo_ug`, `q`, `data_inicio`,
  `data_fim`, `page`. Retorna `{empenhos, total, page, total_pages, page_size}`.
- `/api/licitacao/detalhes` agora usa `LICITACAO_EMPENHOS_PAGINATED`
  (PJ-only) — paridade com a pagina; tambem retorna `despesas_total`.

### Frontend
- `empenhos-controller.js`: novo scope `'licitacao'` que le
  `data-empenhos-lic-{numero,ano,modalidade,codigo-ug}` e renderiza
  colunas Data | Numero | Credor | Elemento | Empenhado | Pago (Credor
  clicavel via fornecedor-dialog quando `cnpj_basico` valido).
- `_empenhos.html` partial: aceita novos vars `empenhos_lic_*` e
  renderiza coluna Credor no SSR table quando `scope='licitacao'`.
- `results/licitacao.html`: substitui `<section id='empenhos'>`
  estatica por include do partial com `scope='licitacao'`.
- `licitacao-dialog.js`: secao "Despesas vinculadas" agora monta o
  empenhos-controller (filter bar inline + initial table com
  `data.despesas` + paginacao footer).

## Cache compat

Entries cacheadas pre-PR nao tem `empenhos_total` no payload. O partial
`_empenhos.html` ja trata esse caso: `data-empenhos-total-known=0`
faz o controller fetch live ao mount pra descobrir o total real. Nao
quebra nada — so adiciona um fetch transient por primeira visualizacao.

**Recomendado** rodar shadow rewarm de `LICITACAO_PERFIL:*` apos
deploy pra ja popular o total e evitar o fetch extra:

`rewarm_cache_keys=LICITACAO_PERFIL:*`

(Per memoria pinada: NUNCA dropar cache inteiro quando se sabe quais
keys foram afetadas — usar shadow rewarm seletivo.)

## Validacao local

- `python -m compileall web -q`: OK
- `node --check` em `empenhos-controller.js` + `licitacao-dialog.js`: OK
- `npm run build` (esbuild concat+minify, manifest hash): OK — core
  166 KB
- Jinja smoke render do partial `_empenhos.html` nos 3 scopes
  (municipio, global, licitacao) + `results/licitacao.html` end-to-end
  com base stub: OK

## Telas afetadas

- `/licitacao/<municipio>/<ano>/<ug>/<mod-numero>` — agora com filtro
  de data + paginacao nos empenhos.
- Dialog de licitacao (clicar em "ver detalhes" em qualquer card de
  licitacao no /cidade/<slug>) — agora mostra lista completa de empenhos
  com filtro de data + paginacao.

## Follow-ups

- [ ] (Opcional) Shadow rewarm `LICITACAO_PERFIL:*` apos deploy.
- [ ] Considerar drill-in inverso: link do empenho-dialog pra licitacao
      pode passar pre-filtros (ja funciona, so vale documentar).

Fixes reportado pelo usuario.

🤖 Generated with [Copilot CLI](https://github.com/cli/cli)