### PR TITLE
fix(web): formatar valores monetarios e datas BR nas tabelas da pagina cidade

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -241,14 +241,22 @@ COLUMN_META: dict[str, dict[str, Any]] = {
     "capital_social":       {"citizen": "Capital social",      "auditor": "Capital Social"},
     "maior_salario":        {"citizen": "Maior salario",       "auditor": "Maior Salario"},
     "salario":              {"citizen": "Salario",             "auditor": "Salario"},
+    # Monetarios sem prefixo valor_/total_ — usados em queries Q67/Q69/Q77/Q61/Q86.
+    "divida_pgfn":          {"citizen": "Divida na PGFN",      "auditor": "Divida PGFN"},
+    "maior_valor":          {"citizen": "Maior valor",         "auditor": "Maior Valor"},
+    "maior_empenho":        {"citizen": "Maior empenho",       "auditor": "Maior Empenho"},
+    "diferenca":            {"citizen": "Diferenca",           "auditor": "Diferenca"},
+    "empenhado_dezembro":   {"citizen": "Reservado em dezembro", "auditor": "Empenhado Dezembro"},
 
     # Contadores e percentuais
     "qtd_empenhos":         {"citizen": "Qtd pagamentos",      "auditor": "Qtd Empenhos", "auditor_only": True},
     "qtd_contratos":        {"citizen": "Qtd contratos",       "auditor": "Qtd Contratos"},
     "qtd_empresas_socio":   {"citizen": "Empresas onde e socio", "auditor": "Qtd Empresas Socio"},
+    "qtd_vencedores":       {"citizen": "Qtd vencedores",      "auditor": "Qtd Vencedores"},
     "pct_sem_licitacao":    {"citizen": "% sem concorrencia",  "auditor": "Pct Sem Licitacao"},
     "pct_dezembro":         {"citizen": "% em dezembro",       "auditor": "Pct Dezembro"},
     "pct_proponente_unico": {"citizen": "% com um so proponente", "auditor": "Pct Proponente Unico"},
+    "pct_nao_pago":         {"citizen": "% nao pago",          "auditor": "Pct Nao Pago"},
 
     # Classificacoes / descritores
     "modalidade":           {"citizen": "Tipo de licitacao",   "auditor": "Modalidade"},
@@ -268,6 +276,9 @@ COLUMN_META: dict[str, dict[str, Any]] = {
     "dt_inicio_sancao":     {"citizen": "Inicio da punicao",   "auditor": "Dt Inicio Sancao"},
     "dt_final_sancao":      {"citizen": "Fim da punicao",      "auditor": "Dt Final Sancao"},
     "data_abertura":        {"citizen": "Abertura",            "auditor": "Data Abertura"},
+    "data_homologacao":     {"citizen": "Homologada em",       "auditor": "Data Homologacao"},
+    "primeiro_empenho_no_filtro": {"citizen": "1o pagamento",  "auditor": "Primeiro Empenho No Filtro"},
+    "ultimo_empenho_no_filtro":   {"citizen": "Ultimo pagamento", "auditor": "Ultimo Empenho No Filtro"},
     "ano":                  {"citizen": "Ano",                 "auditor": "Ano"},
     "mes":                  {"citizen": "Mes",                 "auditor": "Mes"},
 
@@ -296,9 +307,50 @@ def column_is_auditor_only(col: str) -> bool:
     return bool(COLUMN_META.get(col, {}).get("auditor_only"))
 
 
+# ── Heuristicas de tipo para formatacao em result_table.html ─────────
+# Colunas monetarias sem prefixo `valor_`/`total_` que precisam de
+# short_brl (Q67 PGFN, Q69 todas licitacoes, Q77 fracionamento, Q61
+# divergencia empenhado/pago, Q86 sazonalidade dezembro, cruzamento PNCP).
+# Detectado por nome ao inves do tipo Python: valores cacheados em
+# web_cache vem como string (json.dumps default=str serializa Decimal
+# como string), entao `value is number` em Jinja2 falha para entries
+# cacheadas. Os filters short_brl/date_br ja aceitam string OU
+# Decimal/date — usar checagem por nome torna a formatacao consistente
+# entre live e cached.
+_MONETARY_COLUMN_NAMES: frozenset[str] = frozenset({
+    "capital_social", "maior_salario", "salario",
+    "divida_pgfn", "maior_valor", "maior_empenho",
+    "diferenca", "empenhado_dezembro",
+})
+
+_DATE_COLUMN_NAMES: frozenset[str] = frozenset({
+    "primeiro_empenho_no_filtro", "ultimo_empenho_no_filtro",
+})
+
+
+def column_is_monetary(col: str) -> bool:
+    """True se a coluna deve ser formatada com short_brl."""
+    if not col:
+        return False
+    if col in _MONETARY_COLUMN_NAMES:
+        return True
+    return col.startswith("valor_") or col.startswith("total_") or col in {"valor", "total"}
+
+
+def column_is_date(col: str) -> bool:
+    """True se a coluna deve ser formatada com date_br (DD/MM/AAAA)."""
+    if not col:
+        return False
+    if col in _DATE_COLUMN_NAMES:
+        return True
+    return col.startswith("data_") or col.startswith("dt_")
+
+
 templates.env.globals["COLUMN_META"] = COLUMN_META
 templates.env.globals["column_label"] = column_label
 templates.env.globals["column_is_auditor_only"] = column_is_auditor_only
+templates.env.globals["column_is_monetary"] = column_is_monetary
+templates.env.globals["column_is_date"] = column_is_date
 
 # Data de refresh dos dados (Fase 8 - badge de credibilidade).
 # Lida de env DATA_REFRESH_DATE (formato YYYY-MM-DD); se ausente, usa mes/ano atuais.

--- a/web/templates/partials/result_table.html
+++ b/web/templates/partials/result_table.html
@@ -109,8 +109,10 @@
                                 <span class="badge badge-red">Sim</span>
                             {% elif value is sameas false %}
                                 <span class="badge badge-gray">Nao</span>
-                            {% elif value is number and (col.startswith("valor") or col.startswith("total") or col == "capital_social" or col == "maior_salario" or col == "salario") %}
+                            {% elif column_is_monetary(col) and value is not none and value != '' %}
                                 {{ value|short_brl }}
+                            {% elif column_is_date(col) and value is not none and value != '' %}
+                                {{ value|date_br }}
                             {% elif value is number and col.startswith("pct") %}
                                 <span class="{% if value >= 70 %}color-red{% elif value >= 30 %}color-yellow{% else %}color-green{% endif %}">
                                     {{ "{:,.1f}".format(value) }}%


### PR DESCRIPTION
## Problema

Reportado pelo usuario: tabelas de fornecedores irregulares na pagina /cidade/<slug> nao formatavam valores monetarios e datas no padrao BR:

- **Fornecedores com divida PGFN** (Q67): coluna divida_pgfn aparecia como numero cru (1234567.89 em vez de R\$ 1.2 mi).
- **Fornecedor sancionado** (Q65): datas de primeiro/ultimo empenho e inicio/fim de sancao apareciam em ISO 2025-01-15 em vez de 15/01/2025.
- **Todas as licitacoes do municipio** (Q69): coluna maior_valor sem formatacao monetaria; data_homologacao sem formato BR.
- **Fracionamento de despesa** (Q77): coluna maior_empenho sem formatacao.

## Root cause

Template generico web/templates/partials/result_table.html (usado por **todos** os deep-dives da cidade via _render_result_table) tem 3 problemas:

1. **Predicato monetario hardcoded** por prefix alor/	otal + nomes especificos (capital_social, maior_salario, salario). Nao cobre divida_pgfn, maior_valor, maior_empenho, diferenca, empenhado_dezembro.

2. **Sem ramo para datas** — colunas data_* / dt_* caiam no else generico e apareciam como ISO.

3. **Check alue is number** so funciona pra Decimal/float (live query). Entries cacheadas vem como string (json.dumps(default=str) em _upsert serializa Decimal e date como string). Isso significa que mesmo 	otal_pago na verdade nao formatava quando renderizado de cache — so em live.

## Fix

### web/main.py
Novos helpers expostos como globals do Jinja:

\\\python
def column_is_monetary(col: str) -> bool:
    \"\"\"True se a coluna deve ser formatada com short_brl.\"\"\"
    if col in _MONETARY_COLUMN_NAMES:
        return True
    return col.startswith(\"valor_\") or col.startswith(\"total_\") or col in {\"valor\", \"total\"}

def column_is_date(col: str) -> bool:
    \"\"\"True se a coluna deve ser formatada com date_br (DD/MM/AAAA).\"\"\"
    if col in _DATE_COLUMN_NAMES:
        return True
    return col.startswith(\"data_\") or col.startswith(\"dt_\")
\\\

Funcionam para **live (Decimal/date) e cached (string)** porque short_brl e date_br ja aceitam ambos.

Tambem novas entries de COLUMN_META (labels cidadao/auditor):
- divida_pgfn, maior_valor, maior_empenho, diferenca, empenhado_dezembro
- data_homologacao, primeiro_empenho_no_filtro, ultimo_empenho_no_filtro
- qtd_vencedores, pct_nao_pago

### web/templates/partials/result_table.html
Substitui condicional hardcoded por:

\\\jinja
{% elif column_is_monetary(col) and value is not none and value != '' %}
    {{ value|short_brl }}
{% elif column_is_date(col) and value is not none and value != '' %}
    {{ value|date_br }}
\\\

Guarda alue is not none and value != '' mantem None/vazio caindo no fallback -.

## Cache compat
**Nenhuma rewarm necessaria** — mudanca puramente de rendering, dados cacheados continuam validos. Beneficio adicional: tabelas que ja usam 	otal_pago agora formatam corretamente tambem em rendering de cache (antes so live).

## Validacao
- \python -m compileall web -q\: OK
- Smoke render com mocks live (Decimal/date) e cached (string) — 9 colunas validadas, todas formatadas corretamente em ambos casos:

\\\
=== LIVE ===
  OK: divida_pgfn em short_brl -> R\$ 1.2 mi
  OK: total_pago em short_brl -> R\$ 98.8 mil
  OK: maior_valor em short_brl -> R\$ 500.0 mil
  OK: maior_empenho em short_brl -> R\$ 50.0 mil
  OK: data_homologacao em date_br -> 15/01/2025
  OK: primeiro_empenho_no_filtro em date_br -> 10/03/2024
  ...

=== CACHED ===
  OK: divida_pgfn em short_brl -> R\$ 1.2 mi
  ... (mesmo resultado pra cached strings)
\\\

## Surfaces afetadas
Todas as Q## queries que passam por _render_result_table na pagina /cidade/<slug> agora formatam consistentemente. Bonus: outras tabelas pelo mesmo partial tambem ficam consistentes.

🤖 Generated with [Copilot CLI](https://github.com/cli/cli)