### PR TITLE
fix(warm-cache): TOP_SERVIDORES_RISCO_DATED EXISTS em vez de CTE bf_periodo (deploy 186 timeout fix)

### DIFF
--- a/tests/test_cidade_kpis.py
+++ b/tests/test_cidade_kpis.py
@@ -86,9 +86,24 @@ def test_top_servidores_dated_filtra_pagamentos_bf_e_salario_pelo_periodo():
     assert TOP_SERVIDORES_RISCO_DATED.count("d.data_empenho >= %(data_inicio)s") >= 2
     assert TOP_SERVIDORES_RISCO_DATED.count("d.data_empenho <= %(data_fim)s") >= 2
     assert "_periodo._maior_salario AS maior_salario" in TOP_SERVIDORES_RISCO_DATED
-    assert "bf_periodo" in TOP_SERVIDORES_RISCO_DATED
+    # `flag_bolsa_familia` recortada pelo periodo. Usa EXISTS correlacionado
+    # com bolsa_familia (apelido bf_periodo) em vez de CTE materializada,
+    # porque mes_competencia nao tem indice e o DISTINCT da janela inteira
+    # estourava o statement_timeout (deploy run 186, todas as 223 munis PB).
+    assert "FROM bolsa_familia bf_periodo" in TOP_SERVIDORES_RISCO_DATED
     assert (
-        "COALESCE(bf_periodo.cpf_digitos_6 IS NOT NULL, FALSE) AS flag_bolsa_familia"
+        "bf_periodo.cpf_digitos = mv_servidor_pb_risco.cpf_digitos_6"
         in TOP_SERVIDORES_RISCO_DATED
     )
+    assert (
+        "bf_periodo.mes_competencia >= REPLACE(%(ano_mes_inicio)s, '-', '')"
+        in TOP_SERVIDORES_RISCO_DATED
+    )
+    assert (
+        "bf_periodo.mes_competencia <= REPLACE(%(ano_mes_fim)s, '-', '')"
+        in TOP_SERVIDORES_RISCO_DATED
+    )
+    assert ") AS flag_bolsa_familia" in TOP_SERVIDORES_RISCO_DATED
+    # Garante que NAO voltou para CTE materializada (regressao do bug).
+    assert "bf_periodo AS (" not in TOP_SERVIDORES_RISCO_DATED
     assert "%(data_inicio)s" not in TOP_SERVIDORES_RISCO

--- a/web/queries/cidade.py
+++ b/web/queries/cidade.py
@@ -844,26 +844,31 @@ ORDER BY flag_ceaf_expulso DESC, flag_socio_inidoneidade DESC, flag_socio_sancio
 LIMIT 200
 """
 
+# Flag Bolsa Familia recortada pelo periodo do filtro. Usa EXISTS correlacionado
+# em vez de CTE materializada (`bf_periodo`) porque a tabela `bolsa_familia` nao
+# tem indice em `mes_competencia` — materializar um DISTINCT da janela inteira
+# forca seq scan de dezenas de milhoes de linhas por muni e estoura o
+# statement_timeout (PR #183 -> deploy run 186 timed out 223/223 munis em 600s
+# cada). O EXISTS abaixo bate em `idx_bf_cpf_digitos` (sql/19_indices_queries.sql)
+# e roda em O(servidores_do_muni * linhas_por_cpf), apos `_periodo` ja ter
+# reduzido o conjunto para algumas centenas de servidores.
+_FLAG_BF_PERIODO_EXISTS = """COALESCE(
+           EXISTS (
+               SELECT 1 FROM bolsa_familia bf_periodo
+               WHERE bf_periodo.cpf_digitos = mv_servidor_pb_risco.cpf_digitos_6
+                 AND UPPER(TRIM(bf_periodo.nm_favorecido)) = mv_servidor_pb_risco.nome_upper
+                 AND bf_periodo.mes_competencia >= REPLACE(%(ano_mes_inicio)s, '-', '')
+                 AND bf_periodo.mes_competencia <= REPLACE(%(ano_mes_fim)s, '-', '')
+           ),
+           FALSE
+       ) AS flag_bolsa_familia"""
+
+
 TOP_SERVIDORES_RISCO_DATED = TOP_SERVIDORES_RISCO.replace(
     "WHERE d.municipio = %(municipio)s AND d.valor_pago > 0",
     """WHERE d.municipio = %(municipio)s AND d.valor_pago > 0
       AND d.data_empenho >= %(data_inicio)s
       AND d.data_empenho <= %(data_fim)s""",
-    1,
-).replace(
-    "    GROUP BY cpf_digitos_6, nome_upper\n)\nSELECT",
-    """    GROUP BY cpf_digitos_6, nome_upper
-),
-bf_periodo AS (
-    SELECT DISTINCT cpf_digitos AS cpf_digitos_6,
-           UPPER(TRIM(nm_favorecido)) AS nome_upper
-    FROM bolsa_familia
-    WHERE cpf_digitos IS NOT NULL
-      AND nm_favorecido IS NOT NULL
-      AND mes_competencia >= REPLACE(%(ano_mes_inicio)s, '-', '')
-      AND mes_competencia <= REPLACE(%(ano_mes_fim)s, '-', '')
-)
-SELECT""",
     1,
 ).replace(
     "SELECT cpf_digitos_6, nome_upper, nome_servidor,",
@@ -875,7 +880,7 @@ SELECT""",
     1,
 ).replace(
     "       flag_bolsa_familia, flag_duplo_vinculo_estado,",
-    "       COALESCE(bf_periodo.cpf_digitos_6 IS NOT NULL, FALSE) AS flag_bolsa_familia, flag_duplo_vinculo_estado,",
+    f"       {_FLAG_BF_PERIODO_EXISTS}, flag_duplo_vinculo_estado,",
     1,
 ).replace(
     "WHERE d.data_empenho >= vd.dt_ini AND d.data_empenho <= vd.dt_fim",
@@ -885,9 +890,7 @@ SELECT""",
     1,
 ).replace(
     "WHERE %(municipio)s = ANY(municipios)",
-    """LEFT JOIN bf_periodo ON bf_periodo.cpf_digitos_6 = mv_servidor_pb_risco.cpf_digitos_6
-            AND bf_periodo.nome_upper = mv_servidor_pb_risco.nome_upper
-JOIN (
+    """JOIN (
       SELECT s.cpf_digitos_6 AS _cpf6,
              s.nome_upper AS _nome,
              MAX(s.valor_vantagem) AS _maior_salario


### PR DESCRIPTION
## Problema

Deploy run **#186** foi cancelado pelo usuario apos 10h+ no warm cache porque o ciclo `ANO` (atual: 2026) timeout em **223/223 munis PB** na fase `TOP_SERVIDORES`:

```
[journal] May 20 10:04:00 ANO:TOP_SERVIDORES [SHADOW]: 0/223 ok, 223 fail (33600s, 0.0/s)
[journal] May 20 10:04:00     FAIL ANO:TOP_SERVIDORES Cabedelo: canceling statement due to statement timeout
[journal] May 20 10:04:00     FAIL ANO:TOP_SERVIDORES Santa Rita: canceling statement due to statement timeout
... +213 outras falhas
[journal] May 20 10:04:00 ANO:KPI_SUMMARY [SHADOW]: 0/223 ok, 223 fail (0s)
```

`KPI_SUMMARY` falhou em cascata porque `TOP_SERVIDORES` esta no `CACHE_DEPENDENCY_GRAPH` e o design strict-no-fallback (ADR-0003) recusa derivar de shadow incompleto.

## Causa raiz

PR #183 (commit `4c4d855`) introduziu uma CTE `bf_periodo` em `TOP_SERVIDORES_RISCO_DATED`:

```sql
bf_periodo AS (
    SELECT DISTINCT cpf_digitos AS cpf_digitos_6,
           UPPER(TRIM(nm_favorecido)) AS nome_upper
    FROM bolsa_familia
    WHERE cpf_digitos IS NOT NULL
      AND nm_favorecido IS NOT NULL
      AND mes_competencia >= REPLACE(%(ano_mes_inicio)s, '-', '')
      AND mes_competencia <= REPLACE(%(ano_mes_fim)s, '-', '')
)
```

E joinou via `LEFT JOIN bf_periodo` pra computar `flag_bolsa_familia` no recorte do periodo.

Problema: **`bolsa_familia` nao tem indice em `mes_competencia`** (ver `sql/19_indices_queries.sql`). A CTE forca seq scan da tabela inteira (dezenas de milhoes de linhas) + DISTINCT em hash, **PARA CADA muni** (PG nao reusa CTE entre queries). Cada execucao bateu nos 600s de `TIMEOUT_TOP_SERV` e nada foi cacheado.

## Fix

Trocar a CTE materializada por **EXISTS correlacionado** no SELECT:

```sql
COALESCE(
    EXISTS (
        SELECT 1 FROM bolsa_familia bf_periodo
        WHERE bf_periodo.cpf_digitos = mv_servidor_pb_risco.cpf_digitos_6
          AND UPPER(TRIM(bf_periodo.nm_favorecido)) = mv_servidor_pb_risco.nome_upper
          AND bf_periodo.mes_competencia >= REPLACE(%(ano_mes_inicio)s, '-', '')
          AND bf_periodo.mes_competencia <= REPLACE(%(ano_mes_fim)s, '-', '')
    ),
    FALSE
) AS flag_bolsa_familia
```

**Semantica**: identica — `TRUE` sse existe parcela do mesmo (CPF6, nome) dentro da janela.

**Performance**: depois que `_periodo` (JOIN ja existente filtrando por `s.municipio = %(municipio)s`) reduz o conjunto pra algumas centenas/milhares de servidores, o EXISTS bate em `idx_bf_cpf_digitos` (lookup O(log N)) e filtra `mes_competencia` + `nome_upper` em memoria sobre <50 linhas tipicas por CPF. Resultado: milisegundos vs 600s+.

## Validacao

- 91/91 testes verdes (`tests/test_cidade_kpis.py` + `tests/incremental/`).
- Regressao guard: novo `assert "bf_periodo AS (" not in TOP_SERVIDORES_RISCO_DATED` impede que a CTE materializada volte.
- SQL render manual conferido (`python -c "from web.queries.cidade import TOP_SERVIDORES_RISCO_DATED; print(...)"`).

## Pos-merge

Apos merge + deploy `etl_phase=web` (ou similar que ative warm), o ciclo deve completar em ~5-10min por fase de TOP_SERVIDORES (vs 9h+ antes). `KPI_SUMMARY` ira computar normalmente porque as dependencias completarao com `fail == 0`.

## Checklist

- [x] Tests: `pytest tests/` (91/91 verdes)
- [x] Documentado no codigo (comentario explicativo acima do `_FLAG_BF_PERIODO_EXISTS`)
- [x] Regressao guard nos asserts
- [x] Sem mudancas em schema/MV
- [ ] N/A — ADR (fix de performance, sem decisao arquitetural nova)
- [ ] N/A — README/docs (comportamento user-facing inalterado)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
