### PR TITLE
fix(web): dialog de licitacao mostra empenhos para rows em formato canonical

### DIFF
--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -2480,15 +2480,30 @@ async def get_licitacao_detalhes(payload: dict = Body(...)):
     if not numero or not municipio:
         return JSONResponse({})
 
-    # Despesa stores as '000282025' (9 digits), licitacao as '00028/2025'
-    numero_despesa = numero  # keep original for tce_pb_despesa
+    # numero_licitacao chega em 2 formatos dependendo da query de origem
+    # no /cidade/<slug> que produziu a row clicada:
+    #   - tce_pb_licitacao (Q68, Q69, etc): canonical '00028/2025'
+    #   - tce_pb_despesa  (HEATMAP_MES_EMPENHOS, etc): digit-only '000282025'
+    # Normaliza AMBOS sempre: `numero_despesa` digit-only pra queries em
+    # tce_pb_despesa (LICITACAO_EMPENHOS_PAGINATED/COUNT) e `numero`
+    # canonical pra queries em tce_pb_licitacao (metadata + proponentes).
+    # Antes, `numero_despesa = numero` deixava o formato canonical passar
+    # cru pra query de despesas (que compara com '000282025'), retornando
+    # 0 empenhos quando o user clicava em row vinda de Q68/Q69 (#188).
+    import re as _re
+    numero_despesa = _re.sub(r"\D", "", numero)  # always digit-only
+    if not ano and len(numero_despesa) == 9:
+        try:
+            yp = int(numero_despesa[5:])
+            if 2000 <= yp <= 2099:
+                ano = yp
+        except ValueError:
+            pass
     if len(numero) == 9 and numero.isdigit() and '/' not in numero:
         year_part = numero[5:]
         num_part = numero[:5]
         if 2000 <= int(year_part) <= 2099:
             numero = f"{num_part}/{year_part}"
-            if not ano:
-                ano = int(year_part)
     # Match canonico de modalidade — formatos divergem entre tce_pb_licitacao
     # ('Pregao (Lei No 14.133/2021)') e tce_pb_despesa ('Pregao (Lei 14.133/21)').
     # Normalizacao: strip " (...)" suffix + lower + unaccent.


### PR DESCRIPTION
## Problema

Reportado pelo usuario apos o PR #186:

> "the licitacao dialog that opens from the city page doesn't list the empenhos
> related to that licitacao like the licitacao page. lets have the exact same
> listing as the licitacao page with filters and all"

O dialog de licitacao aberto via `/cidade/<slug>` **nao listava nenhum empenho**
quando o user clicava em uma row vinda de queries que selecionam de
`tce_pb_licitacao` (Q68 — proponente unico, Q69 — todas as licitacoes, etc).

A pagina dedicada `/licitacao/<...>` da mesma licitacao mostrava 44 empenhos
normalmente. Discrepancia confusa pro user.

## Causa raiz

`numero_licitacao` chega no dialog em **2 formatos diferentes** dependendo
da query de origem que gerou a row clicada:

| Origem | Formato | Exemplo |
|---|---|---|
| `tce_pb_licitacao` (Q68, Q69, Q67_DATED, etc) | canonical | `'00017/2018'` |
| `tce_pb_despesa` (HEATMAP_MES_EMPENHOS, etc) | digit-only | `'000172018'` |

O endpoint `POST /api/licitacao/detalhes` (chamado pelo `licitacao-dialog`)
fazia:

```python
numero_despesa = numero  # keep original for tce_pb_despesa
```

— sem normalizar. Quando `numero` vinha em formato canonical, a query
`LICITACAO_EMPENHOS_PAGINATED` comparava
`d.numero_licitacao = '00017/2018'` contra valores armazenados como
`'000172018'`. **Nunca casava**, retornava 0 despesas.

E como `licitacao-dialog.js` so renderiza a secao "Empenhos vinculados" quando
`data.despesas.length > 0` OR `data.despesas_total > 0`, o user via:

- Dialog abre OK
- Mostra proponentes corretamente
- **Secao de empenhos some completamente** (sem placeholder, sem mensagem)

## Validacao em prod

Mesma licitacao, mesmo endpoint, dois formatos de input:

| Input `numero_licitacao` | `despesas_total` | `despesas.length` |
|---|---|---|
| `"00017/2018"` (canonical — vinha de Q68/Q69) | **0** ❌ | **0** |
| `"000172018"` (digit-only — vinha de HEATMAP)  | **44** ✅ | **44** |
| Pagina dedicada `/licitacao/joao-pessoa/2018/...` | **44** ✅ | **44** |

Apos esse PR, ambos formatos retornam `despesas_total=44`.

## Fix

`web/routes/cidade.py` `/api/licitacao/detalhes`:

```python
import re as _re
numero_despesa = _re.sub(r"\D", "", numero)  # always digit-only
if not ano and len(numero_despesa) == 9:
    try:
        yp = int(numero_despesa[5:])
        if 2000 <= yp <= 2099:
            ano = yp
    except ValueError:
        pass
if len(numero) == 9 and numero.isdigit() and '/' not in numero:
    year_part = numero[5:]
    num_part = numero[:5]
    if 2000 <= int(year_part) <= 2099:
        numero = f"{num_part}/{year_part}"
```

Mesmo padrao ja usado no endpoint irmao `/api/licitacao/empenhos` (que ja
normalizava corretamente — so o `/detalhes` ficou desincronizado).

Tambem deriva `ano` a partir do digit-only quando nao veio no payload —
defesa-em-profundidade pros 2 formatos.

## Regressao

Introduzida por #186 ao trocar a query do dialog pra
`LICITACAO_EMPENHOS_PAGINATED` (que exige `numero_despesa` digit-only).
Antes do #186 o dialog usava uma query com LIKE que tolerava ambos os
formatos por acaso.

## Validacao local

- [x] `python -m compileall web -q` → OK
- [x] `npm run build` → OK (sem mudancas em JS/CSS)
- [x] Teste manual em prod com ambos os formatos (tabela acima)

## Cache compat

`_cachedPost` (`web/static/js/lib/api.js`) e cache **em memoria por pagina**
— sem persistencia em localStorage. Cache do dialog reseta no proximo reload.
Sem necessidade de shadow rewarm de `LICITACAO_PERFIL:*` (essa entry nao
foi alterada).

## Telas afetadas

- Dialog de licitacao aberto via `/cidade/<slug>` quando user clica em row
  vinda de **Q68** (proponente unico), **Q69** (todas licitacoes), **Q67**
  (sancao em licitacao), ou qualquer query que `SELECT numero_licitacao FROM
  tce_pb_licitacao`.
- Dialog continua funcionando para rows vindas de queries que selecionam de
  `tce_pb_despesa` (HEATMAP_MES_EMPENHOS, etc) — esses ja estavam em formato
  digit-only e nao eram afetados pelo bug.

Fixes user feedback reported after #186.

🤖 Generated with [Copilot CLI](https://github.com/cli/cli)
