### PR TITLE
hotfix(web): remove referencias publicas ao repositorio na pagina sobre

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -83,9 +83,6 @@
           "logo": "{{ _origin }}/static/icon-512.png",
           "description": "Plataforma cidadã de cruzamento de dados públicos abertos da Paraíba",
           "foundingDate": "2025",
-          "sameAs": [
-            "https://github.com/lucasdiniz/govbr-cruza-dados"
-          ],
           "publishingPrinciples": "{{ _origin }}/sobre",
           "knowsAbout": [
             "Transparência pública",

--- a/web/templates/partials/seo/_faq_sobre.html
+++ b/web/templates/partials/seo/_faq_sobre.html
@@ -53,14 +53,6 @@
         ],
     },
     {
-        'q': 'O codigo eh aberto?',
-        'a': 'Sim. O codigo-fonte do TransparenciaPB e publico no GitHub. Documentamos metodologia, queries e estrutura de dados.',
-        'links': [
-            {'label': 'Repositorio no GitHub', 'href': 'https://github.com/lucasdiniz/govbr-cruza-dados', 'external': True},
-            {'label': 'Glossario', 'href': '/glossario'},
-        ],
-    },
-    {
         'q': 'Por que so prefeituras paraibanas?',
         'a': 'O TCE-PB publica dados unitarios de despesa por empenho desde 2003 — uma cobertura unica no Brasil. Aplicar essa metodologia em outros estados depende de cada TCE liberar a mesma granularidade de dados. Hoje, e a Paraiba.',
         'links': [

--- a/web/templates/sobre.html
+++ b/web/templates/sobre.html
@@ -144,15 +144,11 @@
   </section>
 
   <section class="sobre-section" id="contato">
-    <h2>Contato e c&oacute;digo aberto</h2>
+    <h2>Contato</h2>
     <p>
       Encontrou um bug, dado errado ou sugest&atilde;o? Use a
       <a href="/contato">p&aacute;gina de contato</a>. Toda devolutiva
       &eacute; lida e respondida.
-    </p>
-    <p>
-      O c&oacute;digo deste projeto est&aacute; em
-      <a href="https://github.com/lucasdiniz/govbr-cruza-dados" target="_blank" rel="noopener">github.com/lucasdiniz/govbr-cruza-dados</a>.
     </p>
   </section>
 


### PR DESCRIPTION
Remove o link/URL do repositorio GitHub das superficies publicas:

- web/templates/sobre.html: secao 'Contato e codigo aberto' vira 'Contato', removido paragrafo com link.
- web/templates/partials/seo/_faq_sobre.html: removida pergunta 'O codigo eh aberto?'.
- web/templates/base.html: removido entry 'sameAs' do JSON-LD Organization.

Hotfix solicitado pelo mantenedor.