### PR TITLE
feat(web): sinalizar vínculo federal de servidores

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ A fase 17 (`etl/15_normalizar.py`) cria colunas indexadas `cpf_digitos` e `cpf_c
 
 Match por **nome normalizado + 6 dígitos centrais** entre fontes distintas (sócio × servidor × Bolsa Família) reduz falsos positivos mesmo com CPFs mascarados. Quando uma fonte tem CPF completo (CEIS, dados.pb pagamento), o cruzamento usa os 11 dígitos diretamente.
 
+O frontend também sinaliza vínculos **municipal + federal** na lista de servidores ao cruzar `tce_pb_servidor` com SIAPE (`siape_cadastro`) por nome normalizado + 6 dígitos centrais do CPF. Esse badge é triagem: acumulação pode ser legal em hipóteses como saúde e magistério.
+
 ### Identificação de fornecedores
 
 Use `cpf_cnpj` completo (14 dígitos) — não `cnpj_basico` (8 dígitos), que sofre colisão com CPFs que coincidem no prefixo. Filtre com `EXISTS (SELECT 1 FROM estabelecimento WHERE cpf_cnpj = ...)` para excluir falsos positivos. Desde PR feat/etl-cnpj-basico-fix, o ETL aplica esse guard preventivamente em `tce_pb_despesa` + 9 tabelas `pb_*`, e a coluna nova `cpf_digitos` (11 dígitos extraídos via DV check matemático módulo 11) viabiliza queries de pessoa física (ex: `/empenho-pf/<cpf>`). Ver [ADR-0007](docs/adr/0007-etl-normalize-fix.md).

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -169,7 +169,7 @@ Use **após** `run_normalize_fix=true` + `refresh_mvs=mv_empresa_pb` (que remove
 A receita operacional canônica (mudou SQL de uma query → quero atualizar cache sem downtime):
 
 1. PR com a nova SQL.
-2. Após merge, dispare `deploy.yml` com `rewarm_cache_keys=Q65,PERFIL` (vírgula separa múltiplas).
+2. Após merge, dispare `deploy.yml` com `rewarm_cache_keys=Q65,PERFIL` (vírgula separa múltiplas). Para mudanças no painel de servidores, use `rewarm_cache_keys=TOP_SERVIDORES`; a auto-expansão inclui `KPI_SUMMARY`. Se o deploy também precisar de `etl_phase=sql` mas só uma key conhecida mudou, passe `warm_skip_hours=-1` para evitar rebuild live completo e deixar só o shadow rewarm recalcular a key.
 3. Workflow:
    - Sincroniza código.
    - Reseta shadow rows (`DELETE WHERE query_id LIKE '%__pending'`).

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -177,6 +177,20 @@ rewarm_cache_keys: Q65,PERFIL
 
 Isso força B4/Premium, configura `WARM_REWARM_KEYS`, roda warm em shadow e mantém live antigo até swap seguro ([linhas 972-1001](../.github/workflows/deploy.yml)).
 
+### Badge em `mv_servidor_pb_risco` + painel de servidores
+
+Quando a mudança altera a definição de `mv_servidor_pb_risco` e a shape de `TOP_SERVIDORES` (ex.: novo badge em servidores), use:
+
+```yaml
+etl_phase: sql
+rewarm_cache_keys: TOP_SERVIDORES
+warm_skip_hours: "-1"
+drop_cache: false
+invalidate_cache_keys: ""
+```
+
+`etl_phase=sql` recria as MVs via `etl.21_views` sem recarregar dados brutos. `rewarm_cache_keys=TOP_SERVIDORES` faz shadow rewarm zero-downtime das variantes `TOP_SERVIDORES`, `ANO:TOP_SERVIDORES` e `12M:TOP_SERVIDORES`; pela auto-expansão do cache, `KPI_SUMMARY` entra no mesmo shadow. `warm_skip_hours=-1` é importante aqui: como `etl_phase=sql` normalmente força rebuild completo, esse opt-out mantém as demais keys live e recalcula apenas as keys em shadow.
+
 ### MV atomic swap (zero-downtime)
 
 Pra atualizar UMA MV (ex: corrigir definição) sem mexer nas outras nem fazer resize de VM:

--- a/docs/glossario.md
+++ b/docs/glossario.md
@@ -230,6 +230,8 @@ Mantém a base oficial de CNPJs (~58GB raw), cadastros de empresas, sócios, est
 Folha de pagamento do Executivo federal. Dados publicados no Portal da Transparência.
 
 - **Tabelas**: `siape_cadastro`, `siape_remuneracao`
+- **Onde aparece**: badge "vínculo municipal + federal (SIAPE)" em servidores; aba "Vínculos" do dialog de servidor
+- **Match key**: `cpf_digitos` (6 dígitos centrais) + nome normalizado; não usar nome aproximado
 
 ### CGU — Controladoria-Geral da União
 
@@ -434,6 +436,14 @@ Bens declarados pelo candidato no momento da candidatura. Evolução entre candi
 Situação em que interesse privado de servidor público entra em conflito com sua função. Pode ser legal (servidor público com empresa privada em outro setor) ou ilegal (servidor que decide compra contrata empresa onde é sócio).
 
 - **Caveat investigativo central** do projeto — atravessa servidor × empresa × empenho × Bolsa Família × CEAF
+
+### Acumulação de vínculos públicos
+
+Servidor que aparece em mais de um vínculo público ao mesmo tempo, por exemplo municipal (TCE-PB) + federal (SIAPE). Não é automaticamente irregular: a Constituição Federal, art. 37, XVI, admite acumulação em hipóteses específicas (magistério, saúde e alguns cargos técnicos/científicos), desde que haja compatibilidade de horários.
+
+- **Tabelas**: `tce_pb_servidor`, `siape_cadastro`, `siape_remuneracao`
+- **Onde aparece**: badge amarelo "Vínculo municipal + federal (SIAPE)" e aba "Vínculos" do dialog de servidor
+- **Caveat**: sinal de triagem; revisar cargo, jornada, datas de ingresso/afastamento e autorizações antes de concluir irregularidade
 
 ### Porta giratória
 

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -610,6 +610,26 @@ JOIN pb_pagamento pp ON pp.cpf_digitos_6 = srv.cpf_digitos_6
     AND LENGTH(pp.cpfcnpj_credor) = 11
 GROUP BY srv.cpf_digitos_6, srv.nome_upper;
 
+-- Step 5b: Duplo vínculo federal (servidor municipal + SIAPE)
+-- Materializar aqui evita calcular o join contra SIAPE em cada request/warm de
+-- TOP_SERVIDORES. Medido localmente: ~0,65s para criar 2.024 matches sobre
+-- 353k servidores base, contra ~105s se calculado inline em Joao Pessoa.
+DROP TABLE IF EXISTS _tmp_siape_federal;
+CREATE TABLE _tmp_siape_federal AS
+SELECT DISTINCT srv.cpf_digitos_6, srv.nome_upper
+FROM mv_servidor_pb_base srv
+JOIN siape_cadastro sf ON sf.cpf_digitos = srv.cpf_digitos_6
+    AND UPPER(TRIM(sf.nome)) = srv.nome_upper
+WHERE srv.cpf_digitos_6 IS NOT NULL
+  AND srv.cpf_digitos_6 != ''
+  AND srv.cpf_digitos_6 != '000000'
+  AND sf.cpf_digitos IS NOT NULL
+  AND sf.cpf_digitos != ''
+  AND sf.cpf_digitos != '000000';
+
+CREATE UNIQUE INDEX idx_tmp_siape_federal_cpf_nome
+    ON _tmp_siape_federal(cpf_digitos_6, nome_upper);
+
 -- Step 6: Montar MV final a partir das tabelas intermediárias
 CREATE MATERIALIZED VIEW mv_servidor_pb_risco AS
 SELECT
@@ -637,6 +657,7 @@ SELECT
     (se.qtd_empresas >= 3) AS flag_multi_empresa,
     (bf.cpf_digitos_6 IS NOT NULL) AS flag_bolsa_familia,
     (de.cpf_digitos_6 IS NOT NULL) AS flag_duplo_vinculo_estado,
+    (sf.cpf_digitos_6 IS NOT NULL) AS flag_duplo_vinculo_federal,
     (srv.maior_salario > 20000 AND se.qtd_empresas > 0) AS flag_alto_salario_socio,
     -- Score (0-100)
     (
@@ -651,13 +672,14 @@ LEFT JOIN _tmp_socio_empresas se ON se.cpf_digitos_6 = srv.cpf_digitos_6 AND se.
 LEFT JOIN _tmp_fornecedor_gov fg ON fg.cpf_digitos_6 = srv.cpf_digitos_6 AND fg.nome_upper = srv.nome_upper
 LEFT JOIN _tmp_conflito conf ON conf.cpf_digitos_6 = srv.cpf_digitos_6 AND conf.nome_upper = srv.nome_upper
 LEFT JOIN _tmp_bf bf ON bf.cpf_digitos_6 = srv.cpf_digitos_6 AND bf.nome_upper = srv.nome_upper
-LEFT JOIN _tmp_duplo de ON de.cpf_digitos_6 = srv.cpf_digitos_6 AND de.nome_upper = srv.nome_upper;
+LEFT JOIN _tmp_duplo de ON de.cpf_digitos_6 = srv.cpf_digitos_6 AND de.nome_upper = srv.nome_upper
+LEFT JOIN _tmp_siape_federal sf ON sf.cpf_digitos_6 = srv.cpf_digitos_6 AND sf.nome_upper = srv.nome_upper;
 
 CREATE UNIQUE INDEX idx_mv_srv_cpf_nome ON mv_servidor_pb_risco(cpf_digitos_6, nome_upper);
 CREATE INDEX idx_mv_srv_conflito ON mv_servidor_pb_risco(cpf_digitos_6) WHERE flag_conflito_interesses;
 CREATE INDEX idx_mv_srv_risco ON mv_servidor_pb_risco(risco_score DESC) WHERE risco_score > 0;
 
--- Nota: _tmp_socio_empresas, _tmp_fornecedor_gov, _tmp_conflito, _tmp_bf, _tmp_duplo
+-- Nota: _tmp_socio_empresas, _tmp_fornecedor_gov, _tmp_conflito, _tmp_bf, _tmp_duplo, _tmp_siape_federal
 -- não podem ser dropadas aqui. O PostgreSQL registra dependência de metadata entre
 -- mv_servidor_pb_risco e essas tabelas (porque a MV foi criada via SELECT sobre elas),
 -- e recusa o DROP com "cannot drop table X because other objects depend on it".

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -664,7 +664,7 @@ SELECT
         CASE WHEN conf.cpf_digitos_6 IS NOT NULL THEN 40 ELSE 0 END
       + CASE WHEN srv.maior_salario > 20000 AND se.qtd_empresas > 0 THEN 20 ELSE 0 END
       + CASE WHEN bf.cpf_digitos_6 IS NOT NULL THEN 15 ELSE 0 END
-      + CASE WHEN de.cpf_digitos_6 IS NOT NULL THEN 15 ELSE 0 END
+      + CASE WHEN sf.cpf_digitos_6 IS NOT NULL THEN 15 ELSE 0 END
       + CASE WHEN se.qtd_empresas >= 3 THEN 10 ELSE 0 END
     )::SMALLINT AS risco_score
 FROM mv_servidor_pb_base srv
@@ -1413,7 +1413,7 @@ SELECT
         CASE WHEN srv.flag_conflito_interesses THEN 'CONFLITO_INTERESSES' END,
         CASE WHEN srv.flag_multi_empresa THEN 'MULTI_EMPRESA' END,
         CASE WHEN srv.flag_bolsa_familia THEN 'BOLSA_FAMILIA' END,
-        CASE WHEN srv.flag_duplo_vinculo_estado THEN 'DUPLO_VINCULO' END,
+        CASE WHEN srv.flag_duplo_vinculo_federal THEN 'VINCULO_FEDERAL' END,
         CASE WHEN srv.flag_alto_salario_socio THEN 'ALTO_SALARIO_SOCIO' END
     ], NULL) AS flags,
     srv.maior_salario

--- a/web/main.py
+++ b/web/main.py
@@ -289,6 +289,7 @@ COLUMN_META: dict[str, dict[str, Any]] = {
     "flag_inativa":         {"citizen": "Empresa inativa",     "auditor": "Flag Inativa",        "auditor_only": True},
     "flag_inativa_irregular": {"citizen": "Recebeu apos baixa", "auditor": "Recebeu Pos-Inativa", "auditor_only": True},
     "flag_inidoneidade":    {"citizen": "Proibida contratar",  "auditor": "Flag Inidoneidade",   "auditor_only": True},
+    "flag_duplo_vinculo_federal": {"citizen": "Cadastro federal", "auditor": "Flag Vinculo Federal", "auditor_only": True},
     "flag_acordo_leniencia": {"citizen": "Acordo leniencia",   "auditor": "Flag Acordo Leniencia", "auditor_only": True},
 }
 

--- a/web/queries/cidade.py
+++ b/web/queries/cidade.py
@@ -775,7 +775,7 @@ ceaf_expulsos AS (
     FROM ceaf_expulsao
     WHERE LENGTH(cpf_cnpj_norm) = 6
 ),
-empresa_pagamentos AS (
+empresa_pagamentos AS MATERIALIZED (
     SELECT d.cnpj_basico, SUM(d.valor_pago) AS total_pago
     FROM tce_pb_despesa d
     WHERE d.municipio = %(municipio)s AND d.valor_pago > 0
@@ -801,7 +801,7 @@ SELECT cpf_digitos_6, nome_upper, nome_servidor,
        municipios, maior_salario, cargo,
        qtd_empresas_socio, cnpjs_socio,
        flag_conflito_interesses, flag_multi_empresa,
-       flag_bolsa_familia, flag_duplo_vinculo_estado,
+       flag_bolsa_familia, flag_duplo_vinculo_federal,
        flag_alto_salario_socio,
        risco_score,
        EXISTS(
@@ -837,10 +837,10 @@ SELECT cpf_digitos_6, nome_upper, nome_servidor,
            JOIN vinculo_datas vd ON vd.cpf_digitos_6 = mv_servidor_pb_risco.cpf_digitos_6
                AND vd.nome_upper = mv_servidor_pb_risco.nome_upper
            WHERE d.data_empenho >= vd.dt_ini AND d.data_empenho <= vd.dt_fim
-       ), 0) AS total_pago_durante_vinculo
-FROM mv_servidor_pb_risco
-WHERE %(municipio)s = ANY(municipios)
-ORDER BY flag_ceaf_expulso DESC, flag_socio_inidoneidade DESC, flag_socio_sancionado DESC, flag_bolsa_familia DESC, risco_score DESC
+        ), 0) AS total_pago_durante_vinculo
+  FROM mv_servidor_pb_risco
+ WHERE %(municipio)s = ANY(municipios)
+ ORDER BY flag_ceaf_expulso DESC, flag_socio_inidoneidade DESC, flag_socio_sancionado DESC, flag_duplo_vinculo_federal DESC, flag_bolsa_familia DESC, risco_score DESC
 LIMIT 200
 """
 
@@ -859,7 +859,7 @@ TOP_SERVIDORES_RISCO_DATED = TOP_SERVIDORES_RISCO.replace(
     "       municipios, _periodo._maior_salario AS maior_salario, cargo,",
     1,
 ).replace(
-    "       flag_bolsa_familia, flag_duplo_vinculo_estado,",
+    "       flag_bolsa_familia, flag_duplo_vinculo_federal,",
     """       EXISTS (
            SELECT 1
            FROM bolsa_familia bf
@@ -867,7 +867,7 @@ TOP_SERVIDORES_RISCO_DATED = TOP_SERVIDORES_RISCO.replace(
              AND UPPER(TRIM(bf.nm_favorecido)) = mv_servidor_pb_risco.nome_upper
              AND bf.mes_competencia >= REPLACE(%(ano_mes_inicio)s, '-', '')
              AND bf.mes_competencia <= REPLACE(%(ano_mes_fim)s, '-', '')
-       ) AS flag_bolsa_familia, flag_duplo_vinculo_estado,""",
+       ) AS flag_bolsa_familia, flag_duplo_vinculo_federal,""",
     1,
 ).replace(
     "WHERE d.data_empenho >= vd.dt_ini AND d.data_empenho <= vd.dt_fim",

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -261,7 +261,7 @@ def _empty_top_servidores():
         "municipios", "maior_salario", "cargo",
         "qtd_empresas_socio", "cnpjs_socio",
         "flag_conflito_interesses", "flag_multi_empresa",
-        "flag_bolsa_familia", "flag_duplo_vinculo_estado",
+        "flag_bolsa_familia", "flag_duplo_vinculo_federal",
         "flag_alto_salario_socio", "risco_score",
     ], []
 
@@ -591,7 +591,11 @@ def _servidor_severity_key(s: dict) -> tuple:
         or _num(s.get('total_pago_durante_vinculo')) > 0
         or s.get('flag_socio_inidoneidade')
     )
-    is_yellow = bool(s.get('flag_socio_sancionado') or s.get('flag_bolsa_familia'))
+    is_yellow = bool(
+        s.get('flag_socio_sancionado')
+        or s.get('flag_bolsa_familia')
+        or s.get('flag_duplo_vinculo_federal')
+    )
     severity = 0 if is_red else (1 if is_yellow else 2)
     salary = -_num(s.get('maior_salario'))
     return (severity, salary)
@@ -1708,6 +1712,54 @@ async def get_servidor_detalhes(payload: dict = Body(...)):
                                 r[k] = v.isoformat()
                         vinculos.append(r)
                     result["vinculos"] = vinculos
+
+                cur.execute("""
+                    SELECT sf.id_servidor_portal, sf.descricao_cargo, sf.funcao,
+                           sf.atividade, sf.org_lotacao, sf.org_exercicio, sf.orgsup_exercicio,
+                           sf.uorg_exercicio, sf.uf_exercicio, sf.tipo_vinculo,
+                           sf.situacao_vinculo, sf.regime_juridico,
+                           sf.jornada_trabalho, sf.dt_ingresso_orgao,
+                           sf.dt_ingresso_cargofuncao, sf.dt_inicio_afastamento,
+                           sf.dt_termino_afastamento,
+                           rem.ano AS remuneracao_ano,
+                           rem.mes AS remuneracao_mes,
+                           rem.remuneracao_basica_bruta,
+                           rem.remuneracao_apos_deducoes,
+                           rem.total_verbas_indenizatorias
+                    FROM siape_cadastro sf
+                    LEFT JOIN LATERAL (
+                        SELECT ano, mes, remuneracao_basica_bruta,
+                               remuneracao_apos_deducoes,
+                               total_verbas_indenizatorias
+                        FROM siape_remuneracao sr
+                        WHERE sr.id_servidor_portal = sf.id_servidor_portal
+                        ORDER BY ano DESC NULLS LAST, mes DESC NULLS LAST
+                        LIMIT 1
+                    ) rem ON TRUE
+                    WHERE sf.cpf_digitos = %s
+                      AND UPPER(TRIM(sf.nome)) = %s
+                      AND sf.cpf_digitos IS NOT NULL
+                      AND sf.cpf_digitos != ''
+                      AND sf.cpf_digitos != '000000'
+                    ORDER BY (sf.uf_exercicio = 'PB') DESC,
+                             sf.org_exercicio NULLS LAST,
+                             sf.descricao_cargo NULLS LAST,
+                             sf.id_servidor_portal
+                    LIMIT 20
+                """, (cpf6, nome))
+                sf_cols = [d[0] for d in cur.description]
+                sf_rows = cur.fetchall()
+                if sf_rows:
+                    vinculos_federais = []
+                    for row in sf_rows:
+                        r = _row_to_dict(sf_cols, row)
+                        for k, v in r.items():
+                            if hasattr(v, 'as_tuple'):
+                                r[k] = float(v)
+                            elif hasattr(v, 'isoformat'):
+                                r[k] = v.isoformat()
+                        vinculos_federais.append(r)
+                    result["vinculos_federais"] = vinculos_federais
 
                 # Bolsa Familia: historico COMPLETO de parcelas (todos os
                 # snapshots mensais cumulativos) + agregados estatisticos +

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -266,6 +266,21 @@ def _empty_top_servidores():
     ], []
 
 
+def _sanitize_top_servidores_cache(cols: list, rows: list) -> tuple[list, list]:
+    """Remove colunas legadas que nao devem mais ser surfaciadas no painel."""
+    if not cols or "flag_duplo_vinculo_estado" not in cols:
+        return cols, rows
+    keep = [i for i, col in enumerate(cols) if col != "flag_duplo_vinculo_estado"]
+    clean_cols = [cols[i] for i in keep]
+    clean_rows = []
+    for row in rows:
+        if isinstance(row, dict):
+            clean_rows.append({k: v for k, v in row.items() if k != "flag_duplo_vinculo_estado"})
+        else:
+            clean_rows.append([row[i] for i in keep])
+    return clean_cols, clean_rows
+
+
 def _get_query_def(query_id: str):
     query_def = CIDADE_QUERIES.get(query_id.upper())
     if query_def is None:
@@ -944,6 +959,7 @@ async def _render_cidade(request: Request, municipio: str):
                 serv_cached = read_web_cache("TOP_SERVIDORES", canonical_mun)
                 if serv_cached:
                     scols, srows = serv_cached
+                    scols, srows = _sanitize_top_servidores_cache(scols, srows)
                     servidores_dicts = [_row_to_dict(scols, r) for r in srows]
         except Exception:
             pass
@@ -1105,6 +1121,7 @@ async def top_servidores(request: Request, payload: MunicipioPayload):
             cols, rows = cached
         else:
             cols, rows = _load_top_servidores(municipio)
+    cols, rows = _sanitize_top_servidores_cache(cols, rows)
     servidores = [_row_to_dict(cols, row) for row in rows]
     servidores.sort(key=_servidor_severity_key)
     response = _render_partial(
@@ -1137,9 +1154,16 @@ async def batch_cache(municipio_path: str, periodo: str = ""):
                 prefix = f"{periodo}:" if periodo else ""
                 for row in cur.fetchall():
                     qid, cols, rows_data, count = row
+                    response_cols = cols if isinstance(cols, list) else []
+                    response_rows = rows_data if isinstance(rows_data, list) else []
+                    base_qid_for_shape = qid.split(":", 1)[-1]
+                    if base_qid_for_shape == "TOP_SERVIDORES":
+                        response_cols, response_rows = _sanitize_top_servidores_cache(
+                            response_cols, response_rows,
+                        )
                     entry = {
-                        "columns": cols if isinstance(cols, list) else [],
-                        "rows": rows_data if isinstance(rows_data, list) else [],
+                        "columns": response_cols,
+                        "rows": response_rows,
                         "row_count": count or 0,
                     }
                     if periodo and qid.startswith(prefix):
@@ -1239,6 +1263,7 @@ def _load_servidores_for_kpis(municipio: str, payload: MunicipioPayload, periodo
                 cols, rows = _load_top_servidores(municipio)
             except Exception:
                 pass
+    cols, rows = _sanitize_top_servidores_cache(cols, rows)
     return [_row_to_json_dict(cols, r) for r in rows]
 
 

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -59,6 +59,7 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
 
     // Stats grid
     const vinculos = data.vinculos || [];
+    const vinculosFederais = data.vinculos_federais || [];
     const empresas = data.empresas || [];
     // BF agora pode ser array (formato antigo) ou {parcelas, stats} (novo
     // — apos commit feat(web): /api/servidor/detalhes historico completo).
@@ -87,6 +88,7 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
     if (totalPago > 0 && totalPago !== totalDuranteVinc) html += `<div class="stat-cell"><span class="stat-value">${_shortBrl(totalPago)}</span><span class="stat-label">Pago as empresas (total)</span></div>`;
     if (qtdSancionadas > 0) html += `<div class="stat-cell stat-cell--red"><span class="stat-value">${qtdSancionadas}</span><span class="stat-label">${dualLabel('Empresas punidas','Empresas sancionadas')}</span></div>`;
     if (qtdPgfn > 0) html += `<div class="stat-cell stat-cell--orange"><span class="stat-value">${qtdPgfn}</span><span class="stat-label">${dualLabel('Empresas devendo impostos','Empresas c/ divida PGFN')}</span></div>`;
+    if (vinculosFederais.length) html += `<div class="stat-cell stat-cell--yellow"><span class="stat-value">${vinculosFederais.length}</span><span class="stat-label">${dualLabel('Cadastro federal','Vinculos SIAPE')}</span></div>`;
     // Stat BF no overview:
     //   - qtd_meses = quantos meses distintos tem registro de pagamento
     //   - maior_valor = maior parcela individual recebida
@@ -104,26 +106,58 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
     html += '</div>';
 
     // Vinculos como servidor (first)
-    if (vinculos.length) {
+    if (vinculos.length || vinculosFederais.length) {
         html += `<div class="dialog-section"><h4>${dualLabel('Empregos publicos','Vinculos como servidor')}</h4>`;
-        html += vinculos.map(v => {
-            const admissao = _fmtDate(v.data_admissao);
-            const ultimo = _fmtDate(v.ultimo_registro);
-            const salario = v.maior_salario ? _shortBrl(v.maior_salario) : '-';
-            const cargoRaw = v.descricao_cargo || '';
-            const cargoStripped = _stripCodePrefix(cargoRaw) || '-';
-            return `<div class="empresa-card">
-                <div class="empresa-header">
-                    <strong>${_esc(v.municipio)}</strong>
-                    <span class="text-sm text-muted"><span class="citizen-only">${_esc(cargoStripped)}</span><span class="auditor-only">${_esc(cargoRaw || '-')}</span></span>
-                </div>
-                <div class="empresa-details">
-                    <span>${dualLabel('Entrada:','Admissao:')} ${admissao}</span>
-                    <span>${dualLabel('Ultimo registro:','Ultimo registro:')} ${ultimo}</span>
-                    <span>${dualLabel('Maior salario:','Maior salario:')} ${salario}</span>
-                </div>
-            </div>`;
-        }).join('');
+        if (vinculos.length) {
+            html += `<p class="text-xs text-muted" style="margin:.2rem 0 .5rem">${dualLabel('Vinculos municipais informados ao TCE-PB.','Vinculos municipais — TCE-PB')}</p>`;
+            html += vinculos.map(v => {
+                const admissao = _fmtDate(v.data_admissao);
+                const ultimo = _fmtDate(v.ultimo_registro);
+                const salario = v.maior_salario ? _shortBrl(v.maior_salario) : '-';
+                const cargoRaw = v.descricao_cargo || '';
+                const cargoStripped = _stripCodePrefix(cargoRaw) || '-';
+                return `<div class="empresa-card">
+                    <div class="empresa-header">
+                        <strong>${_esc(v.municipio)}</strong>
+                        <span class="text-sm text-muted"><span class="citizen-only">${_esc(cargoStripped)}</span><span class="auditor-only">${_esc(cargoRaw || '-')}</span></span>
+                    </div>
+                    <div class="empresa-details">
+                        <span>${dualLabel('Entrada:','Admissao:')} ${admissao}</span>
+                        <span>${dualLabel('Ultimo registro:','Ultimo registro:')} ${ultimo}</span>
+                        <span>${dualLabel('Maior salario:','Maior salario:')} ${salario}</span>
+                    </div>
+                </div>`;
+            }).join('');
+        }
+        if (vinculosFederais.length) {
+            html += `<p class="text-xs text-muted" style="margin:.75rem 0 .5rem">${dualLabel('Tambem aparece no cadastro federal SIAPE. Acumulacao pode ser permitida em alguns casos.','Vinculos federais — SIAPE/Portal da Transparencia')}</p>`;
+            html += vinculosFederais.map(v => {
+                const cargoRaw = v.descricao_cargo || v.funcao || v.atividade || '';
+                const cargoStripped = _stripCodePrefix(cargoRaw) || '-';
+                const org = v.org_exercicio || v.org_lotacao || v.orgsup_exercicio || 'SIAPE';
+                const remun = v.remuneracao_apos_deducoes || v.remuneracao_basica_bruta || 0;
+                const competencia = (v.remuneracao_ano && v.remuneracao_mes)
+                    ? `${String(v.remuneracao_mes).padStart(2, '0')}/${v.remuneracao_ano}`
+                    : '';
+                return `<div class="empresa-card severity-yellow">
+                    <div class="empresa-header">
+                        <strong>${_esc(org)}</strong>
+                        <span class="badge badge-yellow">SIAPE</span>
+                    </div>
+                    <div class="empresa-details">
+                        <span><span class="citizen-only">${_esc(cargoStripped)}</span><span class="auditor-only">${_esc(cargoRaw || '-')}</span></span>
+                        ${v.uorg_exercicio ? `<span>${dualLabel('Unidade:','UORG exercicio:')} ${_esc(v.uorg_exercicio)}</span>` : ''}
+                        ${v.uf_exercicio ? `<span>UF exercicio: ${_esc(v.uf_exercicio)}</span>` : ''}
+                        ${v.tipo_vinculo ? `<span>${dualLabel('Tipo de vinculo:','Tipo vinculo:')} ${_esc(v.tipo_vinculo)}</span>` : ''}
+                        ${v.situacao_vinculo ? `<span>${dualLabel('Situacao:','Situacao vinculo:')} ${_esc(v.situacao_vinculo)}</span>` : ''}
+                        ${v.regime_juridico ? `<span class="auditor-only">Regime: ${_esc(v.regime_juridico)}</span>` : ''}
+                        ${v.jornada_trabalho ? `<span class="auditor-only">Jornada: ${_esc(v.jornada_trabalho)}</span>` : ''}
+                        ${v.dt_ingresso_orgao ? `<span>${dualLabel('Entrada no orgao:','Ingresso orgao:')} ${_fmtDate(v.dt_ingresso_orgao)}</span>` : ''}
+                        ${remun ? `<span>${dualLabel('Remuneracao federal:','Remuneracao SIAPE:')} ${_shortBrl(remun)}${competencia ? ` (${competencia})` : ''}</span>` : ''}
+                    </div>
+                </div>`;
+            }).join('');
+        }
         html += '</div>';
     } else {
         const cargoFallback = servidorFallback.cargo ? _stripCodePrefix(servidorFallback.cargo) : '';

--- a/web/static/js/components/top-servidores.js
+++ b/web/static/js/components/top-servidores.js
@@ -6,8 +6,8 @@ function buildServidoresPanel(data) {
     const sortedRows = [...data.rows].sort((a, b) => {
         const aRed = _val(a, cols, 'flag_ceaf_expulso') || _val(a, cols, 'total_pago_durante_vinculo') > 0 || _val(a, cols, 'flag_socio_inidoneidade');
         const bRed = _val(b, cols, 'flag_ceaf_expulso') || _val(b, cols, 'total_pago_durante_vinculo') > 0 || _val(b, cols, 'flag_socio_inidoneidade');
-        const aYellow = !aRed && (_val(a, cols, 'flag_socio_sancionado') || _val(a, cols, 'flag_bolsa_familia'));
-        const bYellow = !bRed && (_val(b, cols, 'flag_socio_sancionado') || _val(b, cols, 'flag_bolsa_familia'));
+        const aYellow = !aRed && (_val(a, cols, 'flag_socio_sancionado') || _val(a, cols, 'flag_bolsa_familia') || _val(a, cols, 'flag_duplo_vinculo_federal'));
+        const bYellow = !bRed && (_val(b, cols, 'flag_socio_sancionado') || _val(b, cols, 'flag_bolsa_familia') || _val(b, cols, 'flag_duplo_vinculo_federal'));
         const aScore = aRed ? 0 : aYellow ? 1 : 2;
         const bScore = bRed ? 0 : bYellow ? 1 : 2;
         return aScore - bScore;
@@ -27,7 +27,7 @@ function buildServidoresPanel(data) {
         if (totalDuranteVinculo > 0) {
             badges += `<span class="badge badge-red">${dualLabel(`Empresa ligada a ele recebeu ${_shortBrl(totalDuranteVinculo)} enquanto era servidor`, `Empresa recebeu ${_shortBrl(totalDuranteVinculo)} durante vinculo`)}</span>`;
         }
-        if (_val(r, cols, 'flag_duplo_vinculo_estado')) badges += `<span class="badge badge-red">${dualLabel('Recebe salario em dois governos ao mesmo tempo','Tambem recebe pagamentos do governo estadual')}</span>`;
+        if (_val(r, cols, 'flag_duplo_vinculo_federal')) badges += `<span class="badge badge-yellow" title="${dualLabel('Sinal de revisao: a Constituicao permite acumulacao em alguns casos, como saude e magisterio.', 'Sinal de revisao: checar hipoteses permitidas pelo art. 37, XVI.')}">${dualLabel('Tambem aparece no cadastro federal','Vinculo municipal + federal (SIAPE)')}</span>`;
         if (_val(r, cols, 'flag_multi_empresa')) badges += `<span class="badge badge-yellow">${dualLabel(`Socio de ${qtdEmpresas || 'varias'} empresas`, `Socio de ${qtdEmpresas || 'varias'} empresas`)}</span>`;
         if (_val(r, cols, 'flag_bolsa_familia')) badges += `<span class="badge badge-yellow">${dualLabel('Recebe Bolsa Familia sendo servidor','Bolsa Familia durante vinculo')}</span>`;
         if (_val(r, cols, 'flag_alto_salario_socio')) badges += `<span class="badge badge-yellow">${dualLabel('Salario alto + socio de empresa','Salario alto + vinculo societario')}</span>`;
@@ -43,26 +43,27 @@ function buildServidoresPanel(data) {
         const detailAttrs = hasDetail ? ` data-cpf6="${cpf6}" data-nome-upper="${nomeUpper}" data-cnpjs='${JSON.stringify(cnpjs)}' data-nome="${nome}"` : '';
         const totalPagoRow = _val(r, cols, 'total_pago_durante_vinculo') > 0;
         const bolsaFamilia = _val(r, cols, 'flag_bolsa_familia');
-        const rowClass = (ceafExpulso || totalPagoRow || socioInidoneidade) ? 'clickable-row row-sancao' : (socioSancionado || bolsaFamilia) ? 'clickable-row row-sancao-leve' : 'clickable-row';
+        const vinculoFederal = _val(r, cols, 'flag_duplo_vinculo_federal');
+        const rowClass = (ceafExpulso || totalPagoRow || socioInidoneidade) ? 'clickable-row row-sancao' : (socioSancionado || bolsaFamilia || vinculoFederal) ? 'clickable-row row-sancao-leve' : 'clickable-row';
         const cpfFmt = cpf6.length === 6 ? `***.${cpf6.slice(0,3)}.${cpf6.slice(3,6)}-**` : '';
         return `<tr data-cargo="${_esc(String(cargoRaw).toLowerCase())}" ${hasDetail ? `class="${rowClass}"` : ''}${detailAttrs}><td data-label="Servidor" class="stack-title">${nome}</td><td data-label="CPF" class="auditor-only stack-meta"><code class="text-sm">${cpfFmt}</code></td><td data-label="Cargo" class="stack-meta">${cargo}</td><td data-label="Maior salario" class="text-right num">${salario}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
     }).join('');
 
     const _ldot = (bg) => `<span class="color-legend-dot" style="background:${bg}"></span>`;
     const hasRedServ = data.rows.some(r => _val(r, data.columns, 'flag_ceaf_expulso') || _val(r, data.columns, 'total_pago_durante_vinculo') > 0 || _val(r, data.columns, 'flag_socio_inidoneidade'));
-    const hasYellowServ = data.rows.some(r => (_val(r, data.columns, 'flag_socio_sancionado') && !_val(r, data.columns, 'flag_socio_inidoneidade')) || _val(r, data.columns, 'flag_bolsa_familia'));
+    const hasYellowServ = data.rows.some(r => (_val(r, data.columns, 'flag_socio_sancionado') && !_val(r, data.columns, 'flag_socio_inidoneidade')) || _val(r, data.columns, 'flag_bolsa_familia') || _val(r, data.columns, 'flag_duplo_vinculo_federal'));
     let servLegend = '';
     if (hasRedServ || hasYellowServ) {
         let items = [];
         if (hasRedServ) items.push(`<span class="color-legend-item">${_ldot('#ef4444')} Expulso da adm. federal, empresa recebeu empenhos durante vinculo ou socio de empresa com Inidoneidade</span>`);
-        if (hasYellowServ) items.push(`<span class="color-legend-item">${_ldot('#f59e0b')} Socio de empresa com Impedimento/CNEP ou Bolsa Familia durante vinculo</span>`);
+        if (hasYellowServ) items.push(`<span class="color-legend-item">${_ldot('#f59e0b')} Socio de empresa com Impedimento/CNEP, Bolsa Familia durante vinculo ou vinculo federal SIAPE</span>`);
         servLegend = `<div class="color-legend">${items.join('')}</div>`;
     }
 
     return `<section class="result-block">
         <div class="result-toolbar"><div>
             <h3 class="card-title title-with-action"><span class="title-text">${dualLabel('Servidores com sinais de atencao', 'Servidores com sinais de atencao')}</span> ${mobileDescToggleHtml()}</h3>
-            <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, salario em mais de um governo, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos para profissionais de saude.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, duplo vinculo com o estado, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite acumulacao para profissionais de saude.</span></p>
+            <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, cadastro federal, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos em alguns casos, como saude e magisterio.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, vinculo municipal + federal, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite algumas acumulacoes.</span></p>
             ${servLegend}
         </div></div>
         <div class="table-shell js-data-table" data-page-size="10">

--- a/web/templates/partials/seo/_faq_cidade.html
+++ b/web/templates/partials/seo/_faq_cidade.html
@@ -28,7 +28,7 @@
     },
     {
         'q': 'Quantos servidores trabalham na prefeitura de ' ~ _mun_nome ~ '?',
-        'a': 'A secao "Servidores" lista os trabalhadores publicos registrados no TCE-PB (ultimos 2 anos), com cargo e maior salario observado. Voce pode clicar pra ver historico do servidor e eventuais vinculos com empresas que recebem da propria prefeitura — sinal de atencao para conflitos de interesse.',
+        'a': 'A secao "Servidores" lista os trabalhadores publicos registrados no TCE-PB (ultimos 2 anos), com cargo e maior salario observado. Voce pode clicar pra ver historico do servidor e sinais como vinculos com empresas que recebem da prefeitura ou aparicao no cadastro federal SIAPE. Esses sinais sao triagem, nao acusacao.',
         'links': [
             {'label': 'Servidores', 'href': '#servidores'},
             {'label': 'Relatorio completo', 'href': '#relatorio'},
@@ -44,7 +44,7 @@
     },
     {
         'q': 'Os dados de ' ~ _mun_nome ~ ' sao oficiais?',
-        'a': 'Sim. Despesas, licitacoes, servidores e receitas vem do TCE-PB. Cadastro CNPJ vem da Receita Federal. Sancoes vem da CGU. Atualizamos periodicamente; sempre indicamos a data do ultimo snapshot.',
+        'a': 'Sim. Despesas, licitacoes, servidores e receitas vem do TCE-PB. Cadastro CNPJ vem da Receita Federal. Sancoes vem da CGU e vinculos federais vem do SIAPE/Portal da Transparencia. Atualizamos periodicamente; sempre indicamos a data do ultimo snapshot.',
         'links': [
             {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},
             {'label': 'Receita Federal', 'href': 'https://www.gov.br/receitafederal', 'external': True},

--- a/web/templates/partials/seo/_faq_sobre.html
+++ b/web/templates/partials/seo/_faq_sobre.html
@@ -36,7 +36,7 @@
     },
     {
         'q': 'Posso usar para fazer denuncia?',
-        'a': 'Os dados aqui sao um ponto de partida, nao conclusao. Para denuncias formais, recomendamos confirmar nas fontes oficiais, reunir contexto adicional, e acionar Ministerio Publico, TCU, TCE ou Controladoria. As sinais de atencao nao implicam ilicito — sao informacoes objetivas pra triagem.',
+        'a': 'Os dados aqui sao um ponto de partida, nao conclusao. Para denuncias formais, recomendamos confirmar nas fontes oficiais, reunir contexto adicional, e acionar Ministerio Publico, TCU, TCE ou Controladoria. Sinais como vinculo municipal + federal podem ser legais em casos permitidos pela Constituicao; servem para triagem, nao como acusacao.',
         'links': [
             {'label': 'MP-PB', 'href': 'https://www.mppb.mp.br/', 'external': True},
             {'label': 'TCE-PB', 'href': 'https://tce.pb.gov.br/', 'external': True},

--- a/web/templates/partials/top_servidores.html
+++ b/web/templates/partials/top_servidores.html
@@ -2,11 +2,11 @@
 <section class="result-block">
     <div class="table-shell js-data-table" data-page-size="10">
         {% set has_red_serv = servidores|selectattr('flag_ceaf_expulso')|list or servidores|selectattr('flag_socio_inidoneidade')|list or servidores|selectattr('total_pago_durante_vinculo')|list %}
-        {% set has_yellow_serv = servidores|selectattr('flag_socio_sancionado')|list or servidores|selectattr('flag_bolsa_familia')|list %}
+        {% set has_yellow_serv = servidores|selectattr('flag_socio_sancionado')|list or servidores|selectattr('flag_bolsa_familia')|list or servidores|selectattr('flag_duplo_vinculo_federal')|list %}
         {% if has_red_serv or has_yellow_serv %}
         <div class="table-shell-legend">
             {% if has_red_serv %}<span class="color-legend-item"><span class="color-legend-dot" style="background:#ef4444"></span> <span class="citizen-only">Expulso do servi&ccedil;o federal, s&oacute;cio de empresa proibida de contratar, ou empresa recebeu pagamentos durante o v&iacute;nculo</span><span class="auditor-only">Expulso da adm. federal, empresa recebeu empenhos durante vinculo ou socio de empresa com Inidoneidade</span></span>{% endif %}
-            {% if has_yellow_serv %}<span class="color-legend-item"><span class="color-legend-dot" style="background:#f59e0b"></span> <span class="citizen-only">S&oacute;cio de empresa sancionada, ou recebendo Bolsa Fam&iacute;lia durante v&iacute;nculo</span><span class="auditor-only">Socio de empresa com Impedimento/CNEP ou Bolsa Familia durante vinculo</span></span>{% endif %}
+            {% if has_yellow_serv %}<span class="color-legend-item"><span class="color-legend-dot" style="background:#f59e0b"></span> <span class="citizen-only">S&oacute;cio de empresa sancionada, recebendo Bolsa Fam&iacute;lia durante v&iacute;nculo, ou tamb&eacute;m no cadastro federal</span><span class="auditor-only">Socio de empresa com Impedimento/CNEP, Bolsa Familia durante vinculo ou vinculo federal SIAPE</span></span>{% endif %}
         </div>
         {% endif %}
         <div class="table-actions">
@@ -42,7 +42,7 @@
                     {% set nome_up = s.nome_upper|default('')|string %}
                     {% set cnpjs_json = s.cnpjs_socio|default([])|tojson %}
                     {% if cpf6 and nome_up %}
-                    <tr class="clickable-row{% if s.flag_ceaf_expulso or (s.total_pago_durante_vinculo|default(0)|float > 0) or s.flag_socio_inidoneidade %} row-sancao{% elif s.flag_socio_sancionado or s.flag_bolsa_familia %} row-sancao-leve{% endif %}" data-cargo="{{ cargo|lower }}" data-cpf6="{{ cpf6 }}" data-nome-upper="{{ nome_up }}" data-nome="{{ s.nome_servidor|default(nome_up)|clean_text }}" data-cnpjs='{{ cnpjs_json }}'>
+                    <tr class="clickable-row{% if s.flag_ceaf_expulso or (s.total_pago_durante_vinculo|default(0)|float > 0) or s.flag_socio_inidoneidade %} row-sancao{% elif s.flag_socio_sancionado or s.flag_bolsa_familia or s.flag_duplo_vinculo_federal %} row-sancao-leve{% endif %}" data-cargo="{{ cargo|lower }}" data-cpf6="{{ cpf6 }}" data-nome-upper="{{ nome_up }}" data-nome="{{ s.nome_servidor|default(nome_up)|clean_text }}" data-cnpjs='{{ cnpjs_json }}'>
                     {% else %}
                     <tr data-cargo="{{ cargo|lower }}">
                     {% endif %}
@@ -55,7 +55,7 @@
                             {% if s.total_pago_durante_vinculo|default(0)|float > 0 %}
                                 <span class="badge badge-red"><span class="citizen-only">Empresa ligada a ele recebeu {{ s.total_pago_durante_vinculo|short_brl }} enquanto era servidor</span><span class="auditor-only">Empresa recebeu {{ s.total_pago_durante_vinculo|short_brl }} durante vinculo</span></span>
                             {% endif %}
-                            {% if s.flag_duplo_vinculo_estado %}<span class="badge badge-red"><span class="citizen-only">Recebe sal&aacute;rio em dois governos ao mesmo tempo</span><span class="auditor-only">Tambem recebe pagamentos do governo estadual</span></span>{% endif %}
+                            {% if s.flag_duplo_vinculo_federal %}<span class="badge badge-yellow" title="Sinal de revis&atilde;o: a Constitui&ccedil;&atilde;o admite acumula&ccedil;&atilde;o em alguns casos, como sa&uacute;de e magist&eacute;rio."><span class="citizen-only">Tamb&eacute;m aparece no cadastro federal</span><span class="auditor-only">Vinculo municipal + federal (SIAPE)</span></span>{% endif %}
                             {% if s.flag_multi_empresa %}
                                 <span class="badge badge-yellow"><span class="citizen-only">S&oacute;cio de {{ s.qtd_empresas_socio|default('v&aacute;rias') }} empresas</span><span class="auditor-only">Socio de {{ s.qtd_empresas_socio|default('varias') }} empresas</span></span>
                             {% endif %}
@@ -63,7 +63,7 @@
                             {% if s.flag_alto_salario_socio %}<span class="badge badge-yellow"><span class="citizen-only">Sal&aacute;rio alto + s&oacute;cio de empresa</span><span class="auditor-only">Salario alto + vinculo societario</span></span>{% endif %}
                             {% if s.flag_socio_inidoneidade %}<span class="badge badge-red"><span class="citizen-only">S&oacute;cio de empresa proibida de contratar com o governo</span><span class="auditor-only">Socio de empresa com Inidoneidade (CEIS)</span></span>
                             {% elif s.flag_socio_sancionado %}<span class="badge badge-orange"><span class="citizen-only">S&oacute;cio de empresa sancionada pelo governo</span><span class="auditor-only">Socio de empresa sancionada (CEIS/CNEP)</span></span>{% endif %}
-                            {% if not s.flag_ceaf_expulso and not s.flag_conflito_interesses and not s.flag_multi_empresa and not s.flag_bolsa_familia and not s.flag_duplo_vinculo_estado and not s.flag_alto_salario_socio and not s.flag_socio_sancionado and not s.flag_socio_inidoneidade and not (s.total_pago_durante_vinculo|default(0)|float > 0) %}
+                            {% if not s.flag_ceaf_expulso and not s.flag_conflito_interesses and not s.flag_multi_empresa and not s.flag_bolsa_familia and not s.flag_duplo_vinculo_federal and not s.flag_alto_salario_socio and not s.flag_socio_sancionado and not s.flag_socio_inidoneidade and not (s.total_pago_durante_vinculo|default(0)|float > 0) %}
                                 <span class="text-sm text-muted"><span class="citizen-only">Sem sinais espec&iacute;ficos detectados</span><span class="auditor-only">Sem sinal automatico</span></span>
                             {% endif %}
                         </td>

--- a/web/templates/results/cidade.html
+++ b/web/templates/results/cidade.html
@@ -339,9 +339,9 @@ Panorama de transparencia de {{ municipio }} - PB.
                     <span class="auditor-only">Servidores que merecem verifica&ccedil;&atilde;o adicional</span>
                 </h2>
                 <p class="text-muted mobile-duplicate-desc">
-                    <span class="citizen-only">Servidores da prefeitura com ind&iacute;cios cruzados — por exemplo, <span class="term" data-tip="Quando o servidor aparece como s&oacute;cio ou administrador de empresa, algo que a lei restringe.">v&iacute;nculo com empresas</span>, sal&aacute;rio em mais de um governo ao mesmo tempo, ou outro sinal incomum.</span>
+                    <span class="citizen-only">Servidores da prefeitura com ind&iacute;cios cruzados — por exemplo, <span class="term" data-tip="Quando o servidor aparece como s&oacute;cio ou administrador de empresa, algo que a lei restringe.">v&iacute;nculo com empresas</span>, cadastro federal SIAPE, ou outro sinal incomum.</span>
                     <span class="auditor-only">Servidores municipais com sinais nos cruzamentos automaticos — vinculos societarios,
-                    pagamentos estaduais simultaneos, beneficios sociais ou acumulacao atipica de indicadores.
+                    vinculo federal SIAPE, beneficios sociais ou acumulacao atipica de indicadores.
                     Clique em um servidor para ver detalhes.</span>
                 </p>
             </div>

--- a/web/templates/sobre.html
+++ b/web/templates/sobre.html
@@ -65,7 +65,8 @@
       problemas (san&ccedil;&otilde;es, d&iacute;vidas, situa&ccedil;&atilde;o
       cadastral irregular), conflitos de interesse (servidores que s&atilde;o
       s&oacute;cios de quem recebe da prefeitura), compras sem licita&ccedil;&atilde;o,
-      concentra&ccedil;&atilde;o de gastos em poucos fornecedores e mais.
+      concentra&ccedil;&atilde;o de gastos em poucos fornecedores e v&iacute;nculos
+      municipais + federais no SIAPE.
     </p>
   </section>
 
@@ -77,6 +78,8 @@
       mascarado, CNPJ b&aacute;sico ou completo &mdash; normalizamos antes de
       qualquer compara&ccedil;&atilde;o. Joins s&atilde;o sempre por <em>igualdade</em>
       sobre os d&iacute;gitos normalizados (n&atilde;o por nome aproximado).
+      No badge municipal + federal, cruzamos servidores municipais do TCE-PB
+      com o SIAPE por nome normalizado e 6 d&iacute;gitos centrais do CPF.
     </p>
     <h3>Score de aten&ccedil;&atilde;o (0-100)</h3>
     <p>
@@ -114,6 +117,13 @@
         mascara 6 d&iacute;gitos do meio e o dados.pb.gov.br mascara o
         in&iacute;cio e o fim. Quando cruzamos masked com aberto, indicamos
         explicitamente.
+      </li>
+      <li>
+        <strong>Duplo v&iacute;nculo n&atilde;o &eacute; automaticamente irregular.</strong>
+        A Constitui&ccedil;&atilde;o permite acumula&ccedil;&atilde;o em alguns casos
+        (por exemplo sa&uacute;de e magist&eacute;rio). O badge municipal + federal
+        &eacute; um sinal de triagem para verificar compatibilidade de cargos,
+        jornada e autoriza&ccedil;&otilde;es.
       </li>
       <li>
         <strong>Dados podem ter erro de origem.</strong> Erros de digita&ccedil;&atilde;o


### PR DESCRIPTION
## Resumo
- Adiciona badge amarelo de v?nculo municipal + federal (SIAPE) na lista de servidores.
- Mostra os v?nculos federais SIAPE na aba **V?nculos** do dialog de servidor.
- Materializa `flag_duplo_vinculo_federal` em `mv_servidor_pb_risco` para evitar join SIAPE em cada request/warm.
- Atualiza `/sobre`, FAQ, README, gloss?rio, cache/deploy docs.

## Estrat?gia de deploy
Usar `deploy.yml` com:

```yaml
etl_phase: sql
rewarm_cache_keys: TOP_SERVIDORES
warm_skip_hours: "-1"
drop_cache: false
invalidate_cache_keys: ""
```

Motivo: `etl_phase=sql` recria `mv_servidor_pb_risco` com a nova coluna; `rewarm_cache_keys=TOP_SERVIDORES` reaquece `TOP_SERVIDORES`, `ANO:TOP_SERVIDORES`, `12M:TOP_SERVIDORES` e auto-expande `KPI_SUMMARY`; `warm_skip_hours=-1` evita rebuild live completo das demais keys.

## Valida??o local
- `python -m compileall web etl -q`
- `npm run build`
- `npm run build:check`
- Simula??o local da MV nova + `TOP_SERVIDORES_RISCO`/`TOP_SERVIDORES_RISCO_DATED` para Jo?o Pessoa:
  - all-time: 200 rows, 195 com `flag_duplo_vinculo_federal`, ~4.4s
  - dated 2025: 200 rows, 196 com `flag_duplo_vinculo_federal`, ~12.3s
- `/api/servidor/detalhes` retorna `vinculos_federais` com ?rg?o, cargo, v?nculo, situa??o e remunera??o SIAPE mais recente.

## Notas para review
- N?o surfaciar pagamento estadual como duplo v?nculo; o painel/API `TOP_SERVIDORES` usa apenas SIAPE federal para esse novo sinal.
- Conferir especialmente a estrat?gia de deploy/cache acima.
