### PR TITLE
docs: reforcar mv_swap como default para mudancas de UMA MV

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,19 @@ add a `REFRESH MATERIALIZED VIEW CONCURRENTLY` line in the footer comment
 treat `sql/12_views.sql` as the source of truth. Detail:
 [`docs/mv-guide.md`](docs/mv-guide.md) and [ADR-0002](docs/adr/0002-mv-layered.md).
 
+**Updating ONE existing MV: use atomic swap, NOT `etl_phase=sql`.** For a
+single-MV change (new column, fix a CTE, change a join), the default deploy
+path is `mv_swap=<mv_name>` + `deploy/mv_updates/<mv_name>.sql` (framework
+in [`etl/mv_swap.py`](etl/mv_swap.py), ADR-0006). That swaps the MV in
+**~1s** while serving the old MV from live traffic during the parallel
+build. `etl_phase=sql` is destructive: `sql/12_views.sql` starts with
+`DROP MATERIALIZED VIEW ... CASCADE` for every MV, so `pg_matviews` is
+empty for the full ~1–2h recreate window, **and the deploy cannot be
+safely cancelled** once `etl.21_views` started. Reserve `etl_phase=sql`
+for cases where multiple inter-dependent MVs change at once. Always
+update both `sql/12_views.sql` (source of truth for next full rebuild)
+and `deploy/mv_updates/<mv>.sql` (the swap definition).
+
 **Web app** (`web/`): FastAPI + Jinja2, **no ORM** — raw SQL via `web/db.py`
 pool. Two query flavours per cidade query are registered in
 `web/queries/registry.py`: `sql_full` (all time) and optional `sql_full_dated`
@@ -236,6 +249,17 @@ before editing the relevant area.
   at the top, recreates L1 → L2 → views. Adding a new MV requires updating
   both blocks **and** the `REFRESH MATERIALIZED VIEW CONCURRENTLY` footer.
   `REFRESH CONCURRENTLY` needs a UNIQUE INDEX on the MV.
+- **`etl_phase=sql` is destructive and non-cancellable.** It runs
+  `etl.21_views`, which executes `sql/12_views.sql` whose first ~12 statements
+  are `DROP MATERIALIZED VIEW ... CASCADE` for every MV. From that point
+  on, `pg_matviews` is empty until the full L1→L2→views recreate finishes
+  (~1–2h). Cancelling the deploy mid-flight leaves the DB with no MVs and
+  the site partially broken. **For changes to a single MV, prefer
+  `mv_swap=<mv_name>` + `deploy/mv_updates/<mv>.sql`** (ADR-0006), which
+  has ~1s downtime and keeps the live MV serving until the swap. Reserve
+  `etl_phase=sql` for multi-MV refactors that must rebuild together.
+  See [`docs/mv-guide.md`](docs/mv-guide.md#atualizando-uma-mv-existente-atomic-swap-zero-downtime)
+  and the "MV atomic swap (zero-downtime)" cenário em [`docs/deploy.md`](docs/deploy.md).
 - **`_tmp_bf` rebuild via TRUNCATE+INSERT** (ADR-0010): `DROP TABLE _tmp_bf`
   falha porque `mv_servidor_pb_risco` mantém dependência por OID
   (sql/12_views.sql:645-651). SELECT body extraído para

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Auto-expansão: shadow de `PERFIL`/`TOP_FORN`/`TOP_SERV` propaga para `KPI_SUMMA
 
 ### MV atomic swap (zero-downtime)
 
-`etl/mv_swap.py` permite atualizar UMA `MATERIALIZED VIEW` (incluindo schema/colunas novas) com downtime de ~1s, sem dropar as outras. Comparado a `etl_phase=sql` que faz `DROP CASCADE` de todas as MVs em `sql/12_views.sql` (1-2h + VM resize), o swap usa a VM atual e mantém o tráfego servindo a MV antiga durante o build.
+`etl/mv_swap.py` permite atualizar UMA `MATERIALIZED VIEW` (incluindo schema/colunas novas) com downtime de ~1s, sem dropar as outras. **É o caminho default para qualquer mudança de definição de UMA MV.** Comparado a `etl_phase=sql` que faz `DROP CASCADE` de todas as MVs em `sql/12_views.sql` (1-2h + VM resize, e não-cancelável mid-flight), o swap usa a VM atual e mantém o tráfego servindo a MV antiga durante o build.
 
 Mecânica:
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -140,12 +140,14 @@ skip_download: false
 
 ### Recriar índices/MVs sem reload
 
+> ⚠️ **Destrutivo e não-cancelável.** `etl_phase=sql` roda `etl.21_views`, que executa `sql/12_views.sql` cujo topo é `DROP MATERIALIZED VIEW ... CASCADE` pra **todas** as MVs. Durante ~1-2h do recreate, `pg_matviews` fica vazio e cancelar deixa o banco sem MVs. **Para mudar UMA MV, use [MV atomic swap](#mv-atomic-swap-zero-downtime) (~1s) em vez disso.**
+
 ```yaml
 etl_phase: sql
 warm_cache: true
 ```
 
-`sql` roda índices/normalização/views/MV sitemap, sem schema base destrutivo ([linhas 610-635](../.github/workflows/deploy.yml)).
+`sql` roda índices/normalização/views/MV sitemap, sem schema base destrutivo ([linhas 610-635](../.github/workflows/deploy.yml)). Use só quando múltiplas MVs inter-dependentes precisam ser recriadas juntas (ex: refactor de coluna em L1 que propaga pra várias L2).
 
 ### Retomar fase específica
 
@@ -179,7 +181,19 @@ Isso força B4/Premium, configura `WARM_REWARM_KEYS`, roda warm em shadow e mant
 
 ### Badge em `mv_servidor_pb_risco` + painel de servidores
 
-Quando a mudança altera a definição de `mv_servidor_pb_risco` e a shape de `TOP_SERVIDORES` (ex.: novo badge em servidores), use:
+> ⚠️ **Default recomendado: atomic swap.** Adicionar/remover coluna em UMA MV (`mv_servidor_pb_risco`) e atualizar shape do painel é o caso clássico do `mv_swap` (~1s downtime). Use `etl_phase=sql` **apenas** se a mudança altera múltiplas MVs inter-dependentes (ex: nova coluna em L1 que várias L2 consomem).
+
+**Caminho recomendado** (single MV change):
+
+```yaml
+etl_phase: web
+mv_swap: mv_servidor_pb_risco
+rewarm_cache_keys: TOP_SERVIDORES
+```
+
+Requer `deploy/mv_updates/mv_servidor_pb_risco.sql` com sufixo `_swap` em todos os identifiers (ver [`mv-guide.md`](mv-guide.md#atualizando-uma-mv-existente-atomic-swap-zero-downtime)). O swap acontece após o code sync e antes do warm; `rewarm_cache_keys=TOP_SERVIDORES` faz shadow rewarm zero-downtime das variantes `TOP_SERVIDORES`/`ANO:TOP_SERVIDORES`/`12M:TOP_SERVIDORES` (e `KPI_SUMMARY` por auto-expansão).
+
+**Caminho fallback** (apenas se mudança envolve várias MVs):
 
 ```yaml
 etl_phase: sql
@@ -189,7 +203,7 @@ drop_cache: false
 invalidate_cache_keys: ""
 ```
 
-`etl_phase=sql` recria as MVs via `etl.21_views` sem recarregar dados brutos. `rewarm_cache_keys=TOP_SERVIDORES` faz shadow rewarm zero-downtime das variantes `TOP_SERVIDORES`, `ANO:TOP_SERVIDORES` e `12M:TOP_SERVIDORES`; pela auto-expansão do cache, `KPI_SUMMARY` entra no mesmo shadow. `warm_skip_hours=-1` é importante aqui: como `etl_phase=sql` normalmente força rebuild completo, esse opt-out mantém as demais keys live e recalcula apenas as keys em shadow.
+`etl_phase=sql` recria todas as MVs via `etl.21_views` (~1-2h, `pg_matviews` vazio nesse intervalo). `warm_skip_hours=-1` é importante: como `etl_phase=sql` normalmente força rebuild completo, esse opt-out mantém as demais keys live e recalcula apenas as keys em shadow rewarm.
 
 ### MV atomic swap (zero-downtime)
 

--- a/docs/mv-guide.md
+++ b/docs/mv-guide.md
@@ -85,6 +85,8 @@ flowchart TD
 
 ## Atualizando UMA MV existente (atomic swap zero-downtime)
 
+> 🟢 **Default para qualquer mudança de definição de UMA MV.** Use `mv_swap` em vez de `etl_phase=sql`. A diferença prática é ~1s vs ~1-2h de downtime parcial, e `etl_phase=sql` é não-cancelável uma vez que o `DROP CASCADE` rodou (ver "Quando NÃO usar" abaixo).
+
 `etl/mv_swap.py` permite atualizar a definição de UMA MV (incluindo schema/colunas novas) com **downtime de ~1s**, sem dropar as outras MVs do `sql/12_views.sql`. Reutilizável pra qualquer MV.
 
 **Quando usar:**
@@ -94,7 +96,9 @@ flowchart TD
 
 **Quando NÃO usar:**
 - Refresh periódico de dados (use `REFRESH MATERIALIZED VIEW CONCURRENTLY`).
-- Mudanças em múltiplas MVs simultaneamente que se referenciam (use `etl_phase=sql`).
+- Mudanças em múltiplas MVs simultaneamente que se referenciam (use `etl_phase=sql` — único caso legítimo).
+
+> ⚠️ **`etl_phase=sql` é destrutivo e não-cancelável.** O `etl.21_views` executa `sql/12_views.sql`, cujos primeiros ~12 statements são `DROP MATERIALIZED VIEW ... CASCADE` pra **todas** as MVs. Durante ~1-2h, `pg_matviews` fica vazio; cancelar o deploy nesse intervalo deixa o banco sem MVs e o site quebra em paths que dependem delas. Sempre prefira `mv_swap` pra mudanças pontuais.
 
 **Mecânica** (detalhes em [`../etl/mv_swap.py`](../etl/mv_swap.py)):
 


### PR DESCRIPTION
Aprendizado do PR #192 (badge vinculo federal): usamos `etl_phase=sql` para uma mudanca em UMA MV (`mv_servidor_pb_risco`), expondo o site a ~1-2h de degradacao com `pg_matviews` vazio durante o recreate de `sql/12_views.sql`. O `mv_swap` (ADR-0006) ja existia e teria custado ~1s.

Esta PR reforca docs/AGENTS pra evitar a mesma escolha errada:

- `AGENTS.md`: nova subsecao na descricao de Materialized Views + quirk em `SQL / Materialized Views` cobrindo o caminho destrutivo + nao-cancelavel de `etl_phase=sql`.
- `docs/deploy.md`: warning no cenario `Recriar indices/MVs sem reload` e refraseamento completo do `Badge em mv_servidor_pb_risco` com `mv_swap` como caminho recomendado e `etl_phase=sql` como fallback.
- `docs/mv-guide.md`: callout no topo da secao de atomic swap e nota explicita sobre nao-cancelabilidade do `etl_phase=sql`.
- `README.md`: pequeno toque mencionando nao-cancelabilidade.

Nenhum codigo alterado.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>