### PR TITLE
feat(mapa): persistir cache do mapa PB em web_cache + warm cycle

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS web_cache (
 - **Q##** literal (ex: `Q65`) — variante all-time.
 - **Prefixo temporal** (ex: `ANO:Q65`, `12M:Q65`) — variantes datadas.
 - **Sufixo `__pending`** durante shadow rewarm (ver abaixo).
-- **Keys especiais:** `PERFIL`, `TOP_FORNECEDORES`, `TOP_SERVIDORES`, `HEATMAP`, `KPI_SUMMARY`, `EMPRESA_PERFIL`.
+- **Keys especiais:** `PERFIL`, `TOP_FORNECEDORES`, `TOP_SERVIDORES`, `HEATMAP`, `KPI_SUMMARY`, `EMPRESA_PERFIL`, `MAPA_PB` (mapa coropletico da homepage, `municipio=""`).
 
 ## Warm cycle
 

--- a/web/routes/mapa.py
+++ b/web/routes/mapa.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import json
+import logging
+
+import psycopg2
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from etl.config import DSN
 from web.db import cached_query
 from web.config import CACHE_TTL
 
 router = APIRouter()
+
+log = logging.getLogger(__name__)
 
 MAPA_SQL = """
 SELECT municipio, risco_score, pct_sem_licitacao, pct_irregulares,
@@ -17,6 +24,10 @@ FROM mv_municipio_pb_mapa
 WHERE municipio IS NOT NULL
 """
 
+# query_id usado em web_cache (warm_cache.py escreve, rota le como fallback
+# persistente). municipio = "" porque a query nao eh per-muni.
+MAPA_QID = "MAPA_PB"
+
 # TCE-PB usa nomes antigos; GeoJSON IBGE usa nomes oficiais atuais.
 # Mapa aplicado no endpoint para que o frontend case pelo nome atual.
 MUNICIPIO_ALIASES = {
@@ -24,6 +35,36 @@ MUNICIPIO_ALIASES = {
     "São Vicente do Seridó": "Seridó",
     "Tacima": "Campo de Santana",
 }
+
+
+def _read_mapa_from_web_cache() -> tuple[list[str], list[tuple]] | None:
+    """Le mapa:pb do web_cache (persistente, sobrevive restart do cruza-web).
+
+    Retorna (cols, rows) ou None em miss/erro. Erro nao propaga: rota cai
+    no fallback live SQL.
+    """
+    try:
+        conn = psycopg2.connect(DSN)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT columns, rows FROM web_cache WHERE query_id=%s AND municipio=%s",
+                    (MAPA_QID, ""),
+                )
+                row = cur.fetchone()
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.warning("mapa:pb web_cache read failed: %s", exc)
+        return None
+    if not row:
+        return None
+    cols, rows = row
+    if isinstance(cols, str):
+        cols = json.loads(cols)
+    if isinstance(rows, str):
+        rows = json.loads(rows)
+    return cols, rows
 
 
 def _municipio_total_pb() -> int:
@@ -56,12 +97,20 @@ async def mapa_pb_trailing(request: Request):
 
 @router.get("/api/mapa/pb")
 async def api_mapa_pb():
-    cols, rows = cached_query(
-        "mapa:pb",
-        MAPA_SQL,
-        timeout_sec=10,
-        ttl=CACHE_TTL,
-    )
+    # 1) Tenta web_cache persistente (warm_cache popula via warm_mapa_pb).
+    #    Sobrevive restart do cruza-web e blackout temporario da MV
+    #    (ex: durante etl_phase=sql que dropa+recria todas as MVs).
+    cached = _read_mapa_from_web_cache()
+    if cached is not None:
+        cols, rows = cached
+    else:
+        # 2) Miss → live SQL com cache in-memory por TTL (per-worker).
+        cols, rows = cached_query(
+            MAPA_QID,
+            MAPA_SQL,
+            timeout_sec=10,
+            ttl=CACHE_TTL,
+        )
     data = {}
     for r in rows:
         d = dict(zip(cols, r))

--- a/web/routes/mapa.py
+++ b/web/routes/mapa.py
@@ -2,20 +2,13 @@
 
 from __future__ import annotations
 
-import json
-import logging
-
-import psycopg2
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
-from etl.config import DSN
-from web.db import cached_query
+from web.db import CACHE_ERROR, cached_query, read_web_cache
 from web.config import CACHE_TTL
 
 router = APIRouter()
-
-log = logging.getLogger(__name__)
 
 MAPA_SQL = """
 SELECT municipio, risco_score, pct_sem_licitacao, pct_irregulares,
@@ -35,36 +28,6 @@ MUNICIPIO_ALIASES = {
     "São Vicente do Seridó": "Seridó",
     "Tacima": "Campo de Santana",
 }
-
-
-def _read_mapa_from_web_cache() -> tuple[list[str], list[tuple]] | None:
-    """Le mapa:pb do web_cache (persistente, sobrevive restart do cruza-web).
-
-    Retorna (cols, rows) ou None em miss/erro. Erro nao propaga: rota cai
-    no fallback live SQL.
-    """
-    try:
-        conn = psycopg2.connect(DSN)
-        try:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT columns, rows FROM web_cache WHERE query_id=%s AND municipio=%s",
-                    (MAPA_QID, ""),
-                )
-                row = cur.fetchone()
-        finally:
-            conn.close()
-    except Exception as exc:
-        log.warning("mapa:pb web_cache read failed: %s", exc)
-        return None
-    if not row:
-        return None
-    cols, rows = row
-    if isinstance(cols, str):
-        cols = json.loads(cols)
-    if isinstance(rows, str):
-        rows = json.loads(rows)
-    return cols, rows
 
 
 def _municipio_total_pb() -> int:
@@ -97,14 +60,15 @@ async def mapa_pb_trailing(request: Request):
 
 @router.get("/api/mapa/pb")
 async def api_mapa_pb():
-    # 1) Tenta web_cache persistente (warm_cache popula via warm_mapa_pb).
+    # 1) Tenta web_cache persistente (warm_cache popula via _warm_mapa_pb).
     #    Sobrevive restart do cruza-web e blackout temporario da MV
     #    (ex: durante etl_phase=sql que dropa+recria todas as MVs).
-    cached = _read_mapa_from_web_cache()
-    if cached is not None:
+    #    read_web_cache usa o pool de conexoes ja existente.
+    cached = read_web_cache(MAPA_QID, "")
+    if cached is not None and cached is not CACHE_ERROR:
         cols, rows = cached
     else:
-        # 2) Miss → live SQL com cache in-memory por TTL (per-worker).
+        # 2) Miss/erro -> live SQL com cache in-memory por TTL (per-worker).
         cols, rows = cached_query(
             MAPA_QID,
             MAPA_SQL,

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -1153,32 +1153,49 @@ def warm_cycle_pb(municipios: list[str], verbose: bool = True):
 
 
 def _warm_mapa_pb(verbose: bool = True) -> tuple[int, int]:
-    """Computa /api/mapa/pb e armazena em web_cache (qid=mapa:pb, municipio='').
+    """Computa /api/mapa/pb e armazena em web_cache (qid=MAPA_PB, municipio='').
 
-    Retorna (ok, fail). Falha nao quebra o ciclo — proxima execucao tenta de novo.
+    Honra shadow rewarm: se REWARM_KEYS casa MAPA_PB, escreve em
+    MAPA_PB__pending e _swap_all_pending_shadows() promove para live no fim
+    do ciclo. Caso contrario, escreve direto em live.
+
+    Retorna (ok, fail). Conexao aberta DENTRO do try pra que falha transiente
+    de connect retorne (0, 1) ao inves de propagar e abortar o ciclo inteiro
+    (impedindo o swap das outras shadow keys).
     """
     from web.routes.mapa import MAPA_QID, MAPA_SQL
-    conn = psycopg2.connect(DSN)
-    conn.autocommit = False
+    conn = None
     try:
+        conn = psycopg2.connect(DSN)
+        conn.autocommit = False
         with conn.cursor() as cur:
-            cur.execute(f"SET statement_timeout = '30s'")
+            cur.execute("SET statement_timeout = '30s'")
             cur.execute(f"SET work_mem = '{WARM_WORK_MEM}'")
             cur.execute(MAPA_SQL)
             cols = [d[0] for d in cur.description]
             rows = cur.fetchall()
-            _upsert(cur, MAPA_QID, "", cols, rows)
+            _upsert(cur, _effective_qid(MAPA_QID), "", cols, rows)
         conn.commit()
+        _record_shadow_result(MAPA_QID, 1, 0)
         if verbose:
-            print(f"[warm] mapa:pb OK ({len(rows)} rows)")
+            print(f"[warm] {_effective_qid(MAPA_QID)} OK ({len(rows)} rows)")
         return 1, 0
     except Exception as exc:
-        conn.rollback()
+        if conn is not None:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+        _record_shadow_result(MAPA_QID, 0, 1)
         if verbose:
-            print(f"[warm] mapa:pb FAIL: {exc}")
+            print(f"[warm] {MAPA_QID} FAIL: {exc}")
         return 0, 1
     finally:
-        conn.close()
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/warm_cache.py
+++ b/web/warm_cache.py
@@ -1144,7 +1144,41 @@ def warm_cycle_pb(municipios: list[str], verbose: bool = True):
         "", municipios, all_queries, None, verbose,
     )
 
-    return ano_ok + m12_ok + all_ok, ano_fail + m12_fail + all_fail
+    # Mapa coropletico da homepage (1 query global, ~223 rows).
+    # Persistir no web_cache evita mapa cinza durante restart do cruza-web
+    # e durante blackout temporario da MV (ex: etl_phase=sql drop+recria).
+    mapa_ok, mapa_fail = _warm_mapa_pb(verbose)
+
+    return ano_ok + m12_ok + all_ok + mapa_ok, ano_fail + m12_fail + all_fail + mapa_fail
+
+
+def _warm_mapa_pb(verbose: bool = True) -> tuple[int, int]:
+    """Computa /api/mapa/pb e armazena em web_cache (qid=mapa:pb, municipio='').
+
+    Retorna (ok, fail). Falha nao quebra o ciclo — proxima execucao tenta de novo.
+    """
+    from web.routes.mapa import MAPA_QID, MAPA_SQL
+    conn = psycopg2.connect(DSN)
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SET statement_timeout = '30s'")
+            cur.execute(f"SET work_mem = '{WARM_WORK_MEM}'")
+            cur.execute(MAPA_SQL)
+            cols = [d[0] for d in cur.description]
+            rows = cur.fetchall()
+            _upsert(cur, MAPA_QID, "", cols, rows)
+        conn.commit()
+        if verbose:
+            print(f"[warm] mapa:pb OK ({len(rows)} rows)")
+        return 1, 0
+    except Exception as exc:
+        conn.rollback()
+        if verbose:
+            print(f"[warm] mapa:pb FAIL: {exc}")
+        return 0, 1
+    finally:
+        conn.close()
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Problema

O endpoint `/api/mapa/pb` usava apenas cache **in-memory** (`cached_query` em `web/db.py`): dict per-worker com TTL 1h, perdido em restart do `cruza-web` e nunca escrito em disk.

Resultado observado hoje (deploy run 26181465216, `etl_phase=sql`): mapa cinza na homepage durante a janela de:
1. Restart do `cruza-web` (wipa in-memory).
2. Blackout temporário de `mv_municipio_pb_mapa` (DROP CASCADE -> recreate leva ~1-2h em `etl_phase=sql`).

## Solução

Cache persistente em `web_cache` table com fallback live:

- **`web/routes/mapa.py`** — nova qid `MAPA_PB`. Endpoint lê primeiro do `web_cache` (sobrevive restart + blackout de MV) e cai em live SQL na miss (preservando o `cached_query` in-memory como segunda camada).
- **`web/warm_cache.py`** — nova função `_warm_mapa_pb` chamada no fim de `warm_cycle_pb`. Custo desprezível (~1s: 1 query global, ~223 rows). qid=`MAPA_PB`, municipio=`""`.
- **`docs/cache.md`** — adiciona `MAPA_PB` na lista de keys especiais.

## Deploy

- `etl_phase=web` é suficiente para o code change. O warm cycle subsequente popula `web_cache(MAPA_PB, "")`.
- A partir daí o mapa sobrevive restarts e blackouts de MV.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
