### PR TITLE
feat(web): servidores sem LIMIT + filtros por flag + regras de duplo vinculo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1007,29 +1007,15 @@ jobs:
           sudo bash deploy/setup-umami.sh \
             || echo "WARNING: setup-umami.sh falhou (non-fatal — analytics admin)."
 
-          # Build frontend assets RIGHT BEFORE cruza-web restart pra evitar
-          # a janela onde nginx serve novo dist/ enquanto workers velhos
-          # geram HTML com URLs antigas (404 nos hashed assets).
-          # build-assets.mjs eh atomic (dist.new -> mv -T dist), entao se
-          # falhar, dist/ fica como esta. ASSETS_STRICT=1 (cruza-web.service)
-          # garante que cruza-web crashe loud se manifest sumir.
-          if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
-            curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-          fi
-          node --version
-          npm --version
-          LOCK_HASH_FILE=".node_modules.lockhash"
-          NEW_HASH=$(sha256sum package-lock.json | awk '{print $1}')
-          OLD_HASH=$(cat "$LOCK_HASH_FILE" 2>/dev/null || echo "")
-          if [ ! -d "node_modules" ] || [ "$NEW_HASH" != "$OLD_HASH" ]; then
-            echo "[build-assets] reinstalando node_modules..."
-            npm ci --no-audit --no-fund
-            echo "$NEW_HASH" > "$LOCK_HASH_FILE"
-          fi
-          node scripts/build-assets.mjs
-          echo "=== Asset build OK ==="
-          ls -la web/static/dist/
+          # NOTA: build de assets (node scripts/build-assets.mjs) acontece no
+          # step "Restart cruza-web (after warm)" abaixo, IMEDIATAMENTE antes
+          # do restart. Motivo: build-assets.mjs faz `mv -T dist.new dist` e
+          # deleta `dist.old`, entao se buildarmos aqui (horas antes do
+          # restart), workers velhos continuam servindo HTML com hashes do
+          # manifest ANTIGO (carregado em memoria em web/main.py:574), mas
+          # nginx ja serve `dist/` NOVO -> 404 nos assets hashed durante toda
+          # a janela do warm cache (pode ser 12-18h). Solucao: build + restart
+          # no mesmo step, sem janela vulneravel.
 
           # Install systemd services. cruza-warm-cache eh oneshot (sem [Install]):
           # apenas o arquivo eh copiado, sem enable/start. Disparado pelo step
@@ -1046,19 +1032,23 @@ jobs:
           # processo OLD continua servindo OLD cache; quando o warm termina o
           # restart faz cruza-web pegar codigo NOVO + cache JA QUENTE.
           #
-          # Mas no PRIMEIRO deploy (cruza-web ainda nao rodando), precisamos
-          # subir alguma coisa pra o resto da pipeline (SEO IndexNow, smoke
-          # tests) ter cruza-web up. `systemctl start` eh no-op se ja ativo.
-          if ! systemctl is-active --quiet cruza-web; then
-            echo "cruza-web nao estava ativo — starting (primeiro deploy?)"
-            sudo systemctl start cruza-web
+          # PRIMEIRO deploy (cruza-web nao existe): tambem fica adiado pro step
+          # de restart, que faz build de assets + systemctl restart no mesmo
+          # passo. Steps intermediarios (ANALYZE, warm cache) so usam Postgres,
+          # nao precisam de cruza-web HTTP up.
+          if systemctl is-active --quiet cruza-web; then
+            echo "cruza-web ja ativo — restart adiado pra apos o warm (codigo OLD + cache OLD ate la)"
           else
-            echo "cruza-web ja ativo — restart adiado pra apos o warm"
+            echo "cruza-web NAO ativo — start tambem adiado pro step pre-restart (build de assets + start no mesmo step)"
           fi
 
           echo "=== Web services deployed (cruza-web restart adiado pra apos warm) ==="
           systemctl is-active nginx && echo "nginx: RUNNING" || echo "nginx: FAILED"
-          systemctl is-active cruza-web && echo "cruza-web: RUNNING (codigo OLD ate restart pos-warm)" || echo "cruza-web: FAILED"
+          if systemctl is-active --quiet cruza-web; then
+            echo "cruza-web: RUNNING (codigo OLD ate restart pos-warm)"
+          else
+            echo "cruza-web: NOT ACTIVE (primeiro deploy — start no step pre-restart)"
+          fi
           systemctl is-active cruza-umami >/dev/null 2>&1 && echo "cruza-umami: RUNNING" || echo "cruza-umami: not active (admin-only, OK)"
           echo "cruza-warm-cache: oneshot instalado (executado sob demanda)"
 
@@ -1435,7 +1425,36 @@ jobs:
         if: success()
         run: |
           set -euo pipefail
-          echo "=== Restart cruza-web (codigo NOVO + cache QUENTE) ==="
+          cd ${{ env.PROJECT_DIR }}
+          echo "=== Build de assets + Restart cruza-web (codigo NOVO + cache QUENTE) ==="
+
+          # Build de assets IMEDIATAMENTE antes do restart pra eliminar a janela
+          # onde nginx serve `dist/` NOVO mas workers velhos geram HTML com
+          # hashes do manifest ANTIGO (carregado em memoria em web/main.py:574,
+          # nao re-lido por request). build-assets.mjs deleta `dist.old` apos
+          # promote (scripts/build-assets.mjs:362-369), entao manter o build
+          # aqui garante que o promote acontece <1s antes do restart -- workers
+          # NOVOS ja sobem com o manifest correspondente ao `dist/` no disco.
+          # ASSETS_STRICT=1 (cruza-web.service) faz crashe loud se manifest
+          # sumir, blindando contra build parcial.
+          if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+            curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+          fi
+          node --version
+          npm --version
+          LOCK_HASH_FILE=".node_modules.lockhash"
+          NEW_HASH=$(sha256sum package-lock.json | awk '{print $1}')
+          OLD_HASH=$(cat "$LOCK_HASH_FILE" 2>/dev/null || echo "")
+          if [ ! -d "node_modules" ] || [ "$NEW_HASH" != "$OLD_HASH" ]; then
+            echo "[build-assets] reinstalando node_modules..."
+            npm ci --no-audit --no-fund
+            echo "$NEW_HASH" > "$LOCK_HASH_FILE"
+          fi
+          node scripts/build-assets.mjs
+          echo "=== Asset build OK ==="
+          ls -la web/static/dist/
+
           # restart funciona em servico ativo OU inativo (alias de stop+start).
           sudo systemctl restart cruza-web
           # Aguarda port 8000 responder (workers spawnam em ~3-5s).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,23 @@ Before opening or merging a PR, verify:
   changes, `python -m compileall etl -q` is the minimum baseline.
 - [ ] **Audit scripts** — touched `relatorios/` or report identifiers? Run
   `python scripts/audit_report_identifiers.py --strict`.
+- [ ] **Mobile-first UI/UX review** — touched anything in `web/static/` or
+  `web/templates/`? **The site is mobile-first.** Review at viewport
+  360-414px (touch): touch targets ≥44×44px (Apple HIG) / 48dp (Material),
+  no horizontal scroll, contrast WCAG AA in both light + dark mode, no main-
+  thread freezes on weak CPUs, `aria-pressed`/`aria-expanded` correct for
+  toggles. Always have a parallel reviewer assess mobile UX explicitly — do
+  not assume desktop validation transfers.
+- [ ] **Deploy strategy** — every PR that ships to production must include a
+  **Deploy** section in the PR body specifying:
+  - `etl_phase` (`web` / `sql` / `incremental` / `all` / `N`)
+  - `mv_swap` value (use atomic swap whenever a single MV changed — never
+    let `etl_phase=sql` drop all MVs CASCADE if a targeted swap works)
+  - `rewarm_cache_keys` (specific qids affected — base match like
+    `TOP_SERVIDORES` already covers `ANO:` and `12M:` variants; never drop
+    the whole cache when shadow rewarm of known-affected keys works)
+  - Zero-downtime guarantee statement (shadow rewarm vs blue-green vs
+    rolling) and how active users are served during the deploy window.
 - [ ] **Commit trailer** — every commit has
   `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,29 @@ documentação acompanhada:
   para mudanças one-off, `python -m compileall etl -q` é o baseline mínimo.
 - [ ] **Audit scripts** — mexeu em `relatorios/` ou identificadores? Rode
   `python scripts/audit_report_identifiers.py --strict` (offline) antes do PR.
+- [ ] **Review UI/UX mobile-first** — mexeu em `web/static/` ou `web/templates/`?
+  **O site é mobile-first.** Revise no viewport 360-414px (touch):
+  - Touch targets ≥44×44px (Apple HIG) / 48dp (Material).
+  - Sem scroll horizontal acidental; chips/labels longos não estouram.
+  - Contraste WCAG AA em light **e** dark mode (cego pra cor / OLED).
+  - Sem travas de main thread em CPUs fracas (filtros sobre datasets grandes,
+    render de muitas rows).
+  - `aria-pressed` / `aria-expanded` corretos para toggles e expandables;
+    `TalkBack`/`VoiceOver` anunciam estado.
+  - Sempre peça review paralelo focado em mobile UX — validação desktop
+    não transfere automaticamente.
+- [ ] **Estratégia de deploy** — todo PR que vai pra produção precisa de uma
+  seção **Deploy** no body do PR descrevendo:
+  - `etl_phase` (`web` / `sql` / `incremental` / `all` / `N`).
+  - `mv_swap` — use atomic swap (`deploy/mv_updates/MV.sql` + input `mv_swap`)
+    sempre que **uma única MV** mudou. Nunca deixe `etl_phase=sql` dropar
+    todas as MVs CASCADE se um swap pontual resolve (~1s downtime vs horas).
+  - `rewarm_cache_keys` — qids específicos afetados pela mudança. Base match
+    em `warm_cache.py` já cobre prefixos (`TOP_SERVIDORES` cobre
+    `TOP_SERVIDORES`, `ANO:TOP_SERVIDORES`, `12M:TOP_SERVIDORES`). **Nunca
+    dropar o cache inteiro** quando shadow rewarm seletivo resolve.
+  - Garantia de zero-downtime: shadow rewarm preserva cache antigo até swap
+    atômico — descreva o caminho do usuário ativo durante a janela.
 - [ ] **Trailer Copilot** em todo commit:
   `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
 

--- a/docs/adr/0011-remover-limit-top-tabelas.md
+++ b/docs/adr/0011-remover-limit-top-tabelas.md
@@ -2,10 +2,12 @@
 
 ## Status
 
-Accepted (parcial) — implementado para `TOP_SERVIDORES_RISCO`/`_DATED` em
-2026-05-20 (PR feat/servidores-sem-limit-filtros). Demais LIMITs (queries
-Q##, outras top-tabelas) continuam Proposed e serão tratados em PRs
-subsequentes.
+Accepted (parcial) — implementado **apenas para `TOP_SERVIDORES_RISCO` /
+`TOP_SERVIDORES_RISCO_DATED`** em 2026-05-20 ([PR #195][pr195]). Demais
+LIMITs (queries Q## em `registry.py` e outras top-tabelas em `cidade.py`)
+continuam **Proposed** e serão tratados em PRs subsequentes, caso-a-caso.
+
+[pr195]: https://github.com/lucasdiniz/govbr-cruza-dados/pull/195
 
 ## Date
 
@@ -90,9 +92,9 @@ Remover progressivamente os LIMITs hardcoded, começando por
 
 ## Status
 
-`Proposed` — depende de decisão arquitetural sobre warm cache strategy
-e implementação de paginação real no frontend. Não bloqueia o ETL
-incremental BF (ADR-0010).
+`Proposed` (para os escopos não implementados — Q## em `registry.py` e
+outras top-tabelas em `cidade.py`). Ver "Implementação parcial" abaixo
+para o que já foi aceito em [PR #195][pr195].
 
 ## Quando implementar
 
@@ -131,7 +133,12 @@ Quando alguma das condições se materializar:
 
 ## Implementação parcial (2026-05-20) — TOP_SERVIDORES_RISCO
 
-PR `feat(web): servidores sem LIMIT + filtros por flag`:
+**Escopo aceito**: apenas `TOP_SERVIDORES_RISCO` e `TOP_SERVIDORES_RISCO_DATED`
+em `web/queries/cidade.py:805`. Os demais LIMITs listados na tabela acima
+**continuam em vigor** e serão tratados em PRs separadas, caso-a-caso,
+quando houver demanda concreta de produto.
+
+Entregue em [PR #195 — feat(web): servidores sem LIMIT + filtros][pr195]:
 
 - **LIMIT removido** de `TOP_SERVIDORES_RISCO` em `web/queries/cidade.py`.
   Variante `_DATED` herda automaticamente via `.replace()`.
@@ -186,9 +193,15 @@ PR `feat(web): servidores sem LIMIT + filtros por flag`:
   prod ainda — follow-up se warm cycle aumentar significativamente.
   Não muda CACHE_DEPENDENCY_GRAPH.
 
-### Próximos passos (continuam Proposed)
+### Próximos passos (continuam Proposed — não entregues no PR #195)
 
-- LIMITs em `cidade.py:289`, `:393`, `:512`, `:614` (outras agregações).
-- LIMIT 500 nas ~30 queries Q## de `registry.py`.
-- Aplicar mesmo padrão de chips em top-fornecedores e demais top-tables.
-- Considerar virtual scroll se mobile Lighthouse regredir > 10%.
+Nada abaixo foi implementado ainda. PRs futuras devem revisitar este ADR:
+
+- LIMITs em `cidade.py:289`, `:393`, `:512`, `:614` (outras agregações de
+  top-tabelas, ainda com `LIMIT 200` hardcoded).
+- LIMIT 500 nas ~30 queries Q## em `web/queries/registry.py`
+  (linhas 169-849).
+- Aplicar o mesmo padrão de chips de filtro + ordenação por sinais reais
+  em top-fornecedores e demais top-tables.
+- Considerar virtual scroll se mobile Lighthouse regredir > 10% após PR
+  #195 estar em produção.

--- a/docs/adr/0011-remover-limit-top-tabelas.md
+++ b/docs/adr/0011-remover-limit-top-tabelas.md
@@ -2,11 +2,15 @@
 
 ## Status
 
-Proposed
+Accepted (parcial) — implementado para `TOP_SERVIDORES_RISCO`/`_DATED` em
+2026-05-20 (PR feat/servidores-sem-limit-filtros). Demais LIMITs (queries
+Q##, outras top-tabelas) continuam Proposed e serão tratados em PRs
+subsequentes.
 
 ## Date
 
-2026-05-17
+2026-05-17 (proposta original)
+2026-05-20 (aceitação parcial — servidores)
 
 ## Context
 
@@ -124,3 +128,67 @@ Quando alguma das condições se materializar:
 - Memória sessão 2026-05-17: usuário pediu "incluir nessa plano um ADR
   para uma proxima PR para tirar esse LIMIT de servidores e possivelmente
   de outras tabelas tambem".
+
+## Implementação parcial (2026-05-20) — TOP_SERVIDORES_RISCO
+
+PR `feat(web): servidores sem LIMIT + filtros por flag`:
+
+- **LIMIT removido** de `TOP_SERVIDORES_RISCO` em `web/queries/cidade.py`.
+  Variante `_DATED` herda automaticamente via `.replace()`.
+- **Sizing real** (medido na VM em 2026-05-20, não 13k como estimado):
+  - João Pessoa: **51.573 servidores** (~30MB de HTML SSR sem limit).
+  - Campina Grande: 32.035; Santa Rita: 12.360; Bayeux: 9.978.
+  - Mediana das 223 munis PB: 855 servidores.
+  - `mv_servidor_pb_risco` total: 358.651 rows.
+- **Decisão "sem LIMIT mesmo assim"**: usuário priorizou completude.
+  Paginação client-side existente (`data-table.js`, 10/pag) absorve o volume
+  visual; cliente paga em download/parse. Virtual scroll fica como
+  follow-up se Lighthouse/mobile reportar regressão.
+- **Sort reescrito** (em vez de só `risco_score DESC`):
+  1. `flag_ceaf_expulso` (vermelho — expulsão administrativa federal)
+  2. `flag_socio_inidoneidade` (vermelho — sócio CEIS Inidoneidade)
+  3. `total_pago_durante_vinculo > 0` (vermelho — empresa do servidor
+     recebeu durante vínculo)
+  4. `flag_bolsa_familia` (amarelo)
+  5. `flag_socio_sancionado` (laranja)
+  6. `flag_multi_empresa` (amarelo)
+  7. `risco_score` (peso composto da MV)
+  8. `flag_duplo_vinculo_federal` (apenas tie-breaker — Constituição
+     permite acumulação em alguns casos; não é "fraude" por si só).
+
+  Motivação: João Pessoa estava com 20 páginas dominadas por médicos
+  com duplo vínculo (saúde + município), enterrando sinais de fraude
+  reais (CEAF, sócio sancionado, pagamentos durante vínculo).
+
+- **Filtros por flag** (chips): UI permite ao usuário fatiar livremente.
+  Chips disponíveis: CEAF, Inidoneidade, "Empresa recebeu durante vínculo",
+  Bolsa Família, Sócio sancionado, Multi-empresa, Salário alto + sócio,
+  Vínculo SIAPE. Semantica **OR** dentro do grupo (row visível se
+  combina ≥1 chip ativo). Chip `duplo_vinculo_estadual` foi
+  explicitamente excluído (decisão de UX: não enfatizar o sinal de
+  duplo vínculo, que tem hipóteses constitucionais permitidas).
+
+- **Eventos Umami**: `servidores-filtro-toggle` ({flag, action, ativos,
+  qtd_ativos, visiveis, total}) + `servidores-filtro-limpar`. Padrão
+  kebab-case sem prefixo de página, alinhado com memory de Umami event
+  naming. Permite medir adoção dos filtros e quais flags os usuários
+  efetivamente usam.
+
+- **Expandable de regras de acumulação**: servidor-dialog agora renderiza
+  `details[data-duplo-vinculo-regras]` quando há vínculo municipal +
+  federal SIAPE, com dual-mode citizen/auditor citando CF/88 Art. 37 XI
+  e XVI, EC 19/98, EC 34/2001, Lei 8.112/90 Art. 132 e teto do STF (MP
+  1.230/2024). Reusa CSS `.bf-regras-info` e padrão de evento Umami
+  `secao-toggle` com `section='duplo-vinculo-regras'`.
+
+- **Warm cache impact**: TOP_SERVIDORES_RISCO já era warm; sem LIMIT
+  o tamanho do payload por key cresce ~250× em JP. Não foi medido em
+  prod ainda — follow-up se warm cycle aumentar significativamente.
+  Não muda CACHE_DEPENDENCY_GRAPH.
+
+### Próximos passos (continuam Proposed)
+
+- LIMITs em `cidade.py:289`, `:393`, `:512`, `:614` (outras agregações).
+- LIMIT 500 nas ~30 queries Q## de `registry.py`.
+- Aplicar mesmo padrão de chips em top-fornecedores e demais top-tables.
+- Considerar virtual scroll se mobile Lighthouse regredir > 10%.

--- a/web/main.py
+++ b/web/main.py
@@ -493,12 +493,13 @@ JS_FILES: list[str] = [
     "components/report-sections.js",
     "lib/run-limited.js",
     "components/data-table.js",
+    "components/servidores-filter-chips.js",
     "components/clickable-rows.js",
     "components/empenhos-controller.js",
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "116"
+templates.env.globals["ASSET_VERSION"] = "117"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/main.py
+++ b/web/main.py
@@ -499,7 +499,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "117"
+templates.env.globals["ASSET_VERSION"] = "118"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/queries/cidade.py
+++ b/web/queries/cidade.py
@@ -840,8 +840,14 @@ SELECT cpf_digitos_6, nome_upper, nome_servidor,
         ), 0) AS total_pago_durante_vinculo
   FROM mv_servidor_pb_risco
  WHERE %(municipio)s = ANY(municipios)
- ORDER BY flag_ceaf_expulso DESC, flag_socio_inidoneidade DESC, flag_socio_sancionado DESC, flag_duplo_vinculo_federal DESC, flag_bolsa_familia DESC, risco_score DESC
-LIMIT 200
+ ORDER BY flag_ceaf_expulso DESC,
+          flag_socio_inidoneidade DESC,
+          (total_pago_durante_vinculo > 0) DESC,
+          flag_bolsa_familia DESC,
+          flag_socio_sancionado DESC,
+          flag_multi_empresa DESC,
+          risco_score DESC,
+          flag_duplo_vinculo_federal DESC
 """
 
 TOP_SERVIDORES_RISCO_DATED = TOP_SERVIDORES_RISCO.replace(

--- a/web/queries/cidade.py
+++ b/web/queries/cidade.py
@@ -840,6 +840,14 @@ SELECT cpf_digitos_6, nome_upper, nome_servidor,
         ), 0) AS total_pago_durante_vinculo
   FROM mv_servidor_pb_risco
  WHERE %(municipio)s = ANY(municipios)
+"""
+
+# Wrap em outer SELECT pra poder usar o alias total_pago_durante_vinculo dentro
+# de uma expressao no ORDER BY. PG nao resolve aliases dentro de expressoes em
+# ORDER BY do mesmo SELECT (ex.: "ORDER BY (alias > 0)" falha com "column does
+# not exist") — so resolve quando o alias eh o ORDER BY inteiro. Validado na
+# VM em 2026-05-20 (PG 16).
+_TOP_SERVIDORES_RISCO_ORDER_BY = """
  ORDER BY flag_ceaf_expulso DESC,
           flag_socio_inidoneidade DESC,
           (total_pago_durante_vinculo > 0) DESC,
@@ -849,6 +857,10 @@ SELECT cpf_digitos_6, nome_upper, nome_servidor,
           risco_score DESC,
           flag_duplo_vinculo_federal DESC
 """
+TOP_SERVIDORES_RISCO = (
+    "SELECT * FROM (\n" + TOP_SERVIDORES_RISCO + "\n) _ranked"
+    + _TOP_SERVIDORES_RISCO_ORDER_BY
+)
 
 TOP_SERVIDORES_RISCO_DATED = TOP_SERVIDORES_RISCO.replace(
     "WHERE d.municipio = %(municipio)s AND d.valor_pago > 0",

--- a/web/static/css/components/_dark-overrides.css
+++ b/web/static/css/components/_dark-overrides.css
@@ -167,6 +167,38 @@ body.dark-page .table-filter {
     border-color: var(--line);
 }
 body.dark-page input::placeholder { color: #64748b; }
+body.dark-page .table-filter-chips {
+    border-color: var(--line);
+}
+body.dark-page .filter-chip {
+    background: rgba(15, 23, 42, 0.7);
+    color: var(--text);
+    border-color: var(--line);
+}
+body.dark-page .filter-chip:hover { background: rgba(59, 130, 246, 0.18); }
+body.dark-page .filter-chip__count {
+    background: rgba(71, 85, 105, 0.5);
+    color: #cbd5e1;
+}
+body.dark-page .filter-chip--red.filter-chip--active {
+    background: rgba(220, 38, 38, 0.28);
+    border-color: #ef4444;
+    color: #fecaca;
+}
+body.dark-page .filter-chip--orange.filter-chip--active {
+    background: rgba(249, 115, 22, 0.28);
+    border-color: #f97316;
+    color: #fed7aa;
+}
+body.dark-page .filter-chip--yellow.filter-chip--active {
+    background: rgba(234, 179, 8, 0.28);
+    border-color: #f59e0b;
+    color: #fde68a;
+}
+body.dark-page .filter-chip--active .filter-chip__count {
+    background: rgba(0, 0, 0, 0.35);
+    color: #fff;
+}
 body.dark-page input[type="date"]::-webkit-calendar-picker-indicator { filter: invert(0.8); }
 body.dark-page .btn-outline {
     background: rgba(15, 23, 42, 0.6);

--- a/web/static/css/components/data-table.css
+++ b/web/static/css/components/data-table.css
@@ -103,6 +103,85 @@ tr:hover {
     border-color: var(--md-sys-color-primary);
 }
 
+/* Chips de filtro por flag (top servidores).
+   Bloco renderizado acima de .table-actions; cada chip toggle-able dispara
+   evento Umami 'servidores-filtro-toggle' e re-filtra via _refilter. */
+.table-filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    padding: 0.7rem 0.95rem;
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+    align-items: center;
+}
+.table-filter-chips__label {
+    margin-right: 0.25rem;
+    align-self: center;
+}
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: 999px;
+    background: var(--md-sys-color-surface);
+    color: var(--md-sys-color-on-surface);
+    font-size: var(--md-sys-typescale-label-medium-size, 0.85rem);
+    font-family: inherit;
+    cursor: pointer;
+    line-height: 1.2;
+    transition: background-color .12s ease, border-color .12s ease, color .12s ease;
+}
+.filter-chip:hover {
+    background: var(--md-sys-color-surface-container-high);
+}
+.filter-chip:focus-visible {
+    outline: 2px solid var(--md-sys-color-primary);
+    outline-offset: 2px;
+}
+.filter-chip__count {
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface-variant);
+    padding: 0.05rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.78em;
+    font-weight: 600;
+}
+.filter-chip--active {
+    background: var(--md-sys-color-secondary-container);
+    border-color: var(--md-sys-color-secondary);
+    color: var(--md-sys-color-on-secondary-container);
+}
+.filter-chip--active .filter-chip__count {
+    background: var(--md-sys-color-secondary);
+    color: var(--md-sys-color-on-secondary);
+}
+.filter-chip--red.filter-chip--active {
+    background: #fee2e2;
+    border-color: #ef4444;
+    color: #7f1d1d;
+}
+.filter-chip--orange.filter-chip--active {
+    background: #ffedd5;
+    border-color: #f97316;
+    color: #7c2d12;
+}
+.filter-chip--yellow.filter-chip--active {
+    background: #fef3c7;
+    border-color: #f59e0b;
+    color: #78350f;
+}
+.filter-chip--clear {
+    margin-left: auto;
+    color: var(--md-sys-color-primary);
+    border-color: transparent;
+    background: transparent;
+}
+.filter-chip--clear:hover {
+    background: var(--md-sys-color-surface-container);
+}
+
 /* Clickable rows.
    Affordance: indicador visual PERMANENTE de que a linha eh interativa.
    - chevron `›` no fim da linha (desktop e mobile)

--- a/web/static/css/components/data-table.css
+++ b/web/static/css/components/data-table.css
@@ -39,6 +39,14 @@ tr:hover {
 
 .compact-table table { font-size: var(--md-sys-typescale-body-small-size); }
 
+/* Filter feedback: enquanto _refilter roda em datasets grandes (51k rows
+   em municipios grandes apos ADR-0011), tbody recebe .is-filtering pra
+   dar feedback visual e usuario nao crer que o tap foi perdido. */
+.js-data-table[aria-busy="true"] tbody {
+    opacity: 0.6;
+    transition: opacity .12s ease;
+}
+
 /* Table shell: chassi unificado que agrupa legenda + filtro + tabela +
    paginacao em um unico bloco MD3 (surface-container-low + 12dp shape). */
 .table-shell {
@@ -123,6 +131,7 @@ tr:hover {
     align-items: center;
     gap: 0.3rem;
     padding: 0.3rem 0.7rem;
+    min-height: 32px;
     border: 1px solid var(--md-sys-color-outline);
     border-radius: 999px;
     background: var(--md-sys-color-surface);
@@ -132,6 +141,23 @@ tr:hover {
     cursor: pointer;
     line-height: 1.2;
     transition: background-color .12s ease, border-color .12s ease, color .12s ease;
+}
+/* Mobile touch targets: ≥44px (Apple HIG) / 48dp (Material).
+   Tambem aumenta gap entre chips pra reduzir mis-tap. */
+@media (max-width: 480px), (pointer: coarse) {
+    .filter-chip {
+        min-height: 44px;
+        padding: 0.55rem 0.9rem;
+    }
+    .table-filter-chips {
+        gap: 0.5rem;
+    }
+    /* Em mobile, mantemos o Clear inline (sem margin-left:auto) — com
+       wrap, margin-left:auto empurra Clear pra ultima linha do flex,
+       isolado, na zona de pegada do polegar (mis-tap ao rolar). */
+    .filter-chip--clear {
+        margin-left: 0;
+    }
 }
 .filter-chip:hover {
     background: var(--md-sys-color-surface-container-high);

--- a/web/static/js/components/data-table.js
+++ b/web/static/js/components/data-table.js
@@ -42,12 +42,16 @@ function initDataTables(root = document) {
             if (pager) pager.hidden = totalPages <= 1;
         };
 
-        // Expose refilter for external toggles
+        // Expose refilter for external toggles. Retorna o numero de rows que
+        // passaram pelos filtros (NAO o numero de rows visiveis na pagina —
+        // renderPage so mostra pageSize por vez). Usado por componentes como
+        // servidores-filter-chips.js pra reportar metrica de filtro correta.
         tableShell._refilter = (filterFn) => {
             externalFilter = filterFn;
             applyFilters();
             page = 1;
             renderPage();
+            return filteredRows.length;
         };
 
         // Column sorting

--- a/web/static/js/components/data-table.js
+++ b/web/static/js/components/data-table.js
@@ -24,14 +24,22 @@ function initDataTables(root = document) {
             });
         };
 
+        // Optimizacao: em datasets grandes (ate 51k rows apos ADR-0011),
+        // iterar todas as rows e setar style.display gera N style recalc.
+        // Em vez disso, marcamos qualquer row visivel com data-page-row=""
+        // (na hora) e usamos CSS pra esconder o resto. Mas pra simplicidade
+        // e zero-mudanca em outras tabelas pequenas, mantemos o forEach
+        // mas dentro de requestAnimationFrame agrupado.
+        let renderRaf = 0;
         const renderPage = () => {
             const totalPages = Math.max(1, Math.ceil(filteredRows.length / pageSize));
             if (page > totalPages) page = totalPages;
             const start = (page - 1) * pageSize;
             const pageRows = filteredRows.slice(start, start + pageSize);
+            const visible = new Set(pageRows);
 
             rows.forEach((row) => {
-                row.style.display = pageRows.includes(row) ? '' : 'none';
+                row.style.display = visible.has(row) ? '' : 'none';
             });
 
             if (meta) meta.textContent = `${filteredRows.length} registro(s) encontrados`;
@@ -46,11 +54,30 @@ function initDataTables(root = document) {
         // passaram pelos filtros (NAO o numero de rows visiveis na pagina —
         // renderPage so mostra pageSize por vez). Usado por componentes como
         // servidores-filter-chips.js pra reportar metrica de filtro correta.
+        //
+        // Em datasets grandes (ate 51k rows apos ADR-0011), aplicamos
+        // aria-busy + defer via requestAnimationFrame pra browser repintar
+        // o estado pressed do chip antes do reflow pesado. Sem isso, o
+        // usuario toca o chip e UI freeza ~500-1500ms em mid-tier mobile
+        // sem feedback — leva a toggle duplicado por re-tap.
         tableShell._refilter = (filterFn) => {
             externalFilter = filterFn;
             applyFilters();
             page = 1;
-            renderPage();
+
+            // Defer apenas pra datasets grandes (>1k); pequenos seguem sync
+            // pra evitar flicker desnecessario.
+            if (rows.length > 1000) {
+                tableShell.setAttribute('aria-busy', 'true');
+                if (renderRaf) cancelAnimationFrame(renderRaf);
+                renderRaf = requestAnimationFrame(() => {
+                    renderPage();
+                    tableShell.removeAttribute('aria-busy');
+                    renderRaf = 0;
+                });
+            } else {
+                renderPage();
+            }
             return filteredRows.length;
         };
 

--- a/web/static/js/components/servidor-dialog.js
+++ b/web/static/js/components/servidor-dialog.js
@@ -158,6 +158,44 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
                 </div>`;
             }).join('');
         }
+        // Expandable com regras de acumulacao de cargos publicos. So renderiza
+        // quando ha duplo vinculo de fato (municipal + federal SIAPE). Reutiliza
+        // o estilo .bf-regras-info (generico apesar do prefixo) e dispara o
+        // mesmo evento Umami 'secao-toggle' com section='duplo-vinculo-regras'.
+        if (vinculos.length && vinculosFederais.length) {
+            html += `<details class="bf-regras-info" data-duplo-vinculo-regras>
+                <summary class="bf-regras-info__summary">
+                    <span class="bf-regras-info__title">${dualLabel('Pode acumular dois cargos publicos?','Regras de acumulacao de cargos publicos')}</span>
+                    <span class="bf-regras-info__chevron" aria-hidden="true">›</span>
+                </summary>
+                <div class="bf-regras-info__body">
+                    <div class="citizen-only">
+                        <p>A regra geral da Constituicao e que <strong>nao pode acumular dois empregos publicos</strong> — municipal, estadual, federal, autarquia, empresa publica ou estatal. Quem entra em dois cargos sem se enquadrar em uma das excecoes pode ser <strong>demitido por improbidade</strong> e tem que devolver o que recebeu a mais.</p>
+                        <p><strong>Excecoes permitidas</strong> (somente nestes casos, com horarios comprovadamente compativeis e <strong>respeitando o teto do STF</strong>: R$ 46.366,19 em 2024):</p>
+                        <ul class="bf-regras-info__lista">
+                            <li><strong>Dois cargos de professor</strong>.</li>
+                            <li><strong>Um cargo de professor + um cargo tecnico ou cientifico</strong>.</li>
+                            <li><strong>Dois cargos privativos da area da saude</strong> com profissoes regulamentadas (medico, enfermeiro, dentista, farmaceutico, psicologo etc).</li>
+                        </ul>
+                        <p>Mesmo nas excecoes, a soma das remuneracoes <strong>nao pode ultrapassar o teto do STF</strong>. Quem ja recebe acima do teto so pode acumular se devolver o que excede. Acumular fora das excecoes da <strong>demissao + ressarcimento + acao por improbidade</strong>.</p>
+                        <p class="bf-regras-info__fonte">Constituicao Federal, Art. 37, incisos XI e XVI.</p>
+                    </div>
+                    <div class="auditor-only">
+                        <p><strong>Regra geral (CF/88 Art. 37, XVI):</strong> vedada a acumulacao remunerada de cargos publicos. Aplica-se a empregos e funcoes publicas, abrangendo autarquias, fundacoes, empresas publicas, sociedades de economia mista e subsidiarias da Uniao, Estados, DF e Municipios.</p>
+                        <p><strong>Excecoes (havendo compatibilidade de horarios):</strong></p>
+                        <ul class="bf-regras-info__lista">
+                            <li>Dois cargos de <strong>professor</strong> (alinea a).</li>
+                            <li>Um cargo de <strong>professor + um tecnico ou cientifico</strong> (alinea b).</li>
+                            <li>Dois cargos privativos de <strong>profissionais de saude</strong> com profissoes regulamentadas (alinea c, EC 34/2001).</li>
+                        </ul>
+                        <p><strong>Teto remuneratorio (CF/88 Art. 37, XI):</strong> subsidio mensal dos Ministros do STF (R$ 46.366,19 desde fev/2024, MP 1.230/2024). Aplica-se a soma de todas as remuneracoes acumulaveis, incluindo proventos de inatividade.</p>
+                        <p><strong>Compatibilidade de horarios:</strong> jornadas semanais devem permitir o exercicio efetivo dos dois cargos. STF (RE 1.176.440, Tema 1.072) afastou limite generico de 60h/sem — analise caso a caso, mas jornadas que comprovadamente impossibilitem o exercicio sao causa de demissao.</p>
+                        <p><strong>Sancao em caso de acumulacao ilicita:</strong> demissao por improbidade administrativa (Lei 8.112/90, Art. 132, XII; Lei 8.429/92, Art. 11). Servidor notificado pode optar por um dos cargos em ate 10 dias; opcao pos-prazo implica demissao do mais recente + ressarcimento ao erario.</p>
+                        <p class="bf-regras-info__fonte">CF/88 Art. 37, XI e XVI; Lei 8.112/90 Art. 118-120 e 132; Sumula 246/TCU; EC 19/98 e EC 34/2001.</p>
+                    </div>
+                </div>
+            </details>`;
+        }
         html += '</div>';
     } else {
         const cargoFallback = servidorFallback.cargo ? _stripCodePrefix(servidorFallback.cargo) : '';
@@ -565,6 +603,18 @@ async function openServidorDialog(cpf6, nome, cnpjs, servidorNome, servidorFallb
                 trackEvent('secao-toggle', {
                     section: 'bf-regras',
                     action: regrasDetails.open ? 'open' : 'close',
+                });
+            }
+        });
+    }
+
+    const duploRegrasDetails = body.querySelector('details.bf-regras-info[data-duplo-vinculo-regras]');
+    if (duploRegrasDetails) {
+        duploRegrasDetails.addEventListener('toggle', () => {
+            if (typeof trackEvent === 'function') {
+                trackEvent('secao-toggle', {
+                    section: 'duplo-vinculo-regras',
+                    action: duploRegrasDetails.open ? 'open' : 'close',
                 });
             }
         });

--- a/web/static/js/components/servidores-filter-chips.js
+++ b/web/static/js/components/servidores-filter-chips.js
@@ -1,0 +1,86 @@
+// === components/servidores-filter-chips.js ===
+// Filtros de chips por flag pra tabela de servidores. Plugga no _refilter
+// exposto pelo data-table.js. Semantica OR: row visivel se tem >=1 dos flags
+// ativos (ou se nenhum chip ativo).
+//
+// Umami: dispara 'servidores-filtro-toggle' (kebab-case, sem prefix de pagina)
+// com {flag, action: 'on'|'off', ativos: csv ordenado, qtd_ativos, visiveis,
+// total} e 'servidores-filtro-limpar' no botao Limpar. Convencao alinhada com
+// store_memory de eventos Umami.
+
+function initServidoresFilterChips(root = document) {
+    root.querySelectorAll('[data-servidores-filter-chips]').forEach((chipsEl) => {
+        if (chipsEl.dataset.enhanced === 'true') return;
+        chipsEl.dataset.enhanced = 'true';
+
+        const tableShell = chipsEl.closest('.js-data-table');
+        if (!tableShell || typeof tableShell._refilter !== 'function') return;
+
+        const chips = Array.from(chipsEl.querySelectorAll('.filter-chip[data-flag]'));
+        const clearBtn = chipsEl.querySelector('[data-clear]');
+        const active = new Set(); // flags ativos
+
+        const flagToAttr = (flag) => `data-flag-${flag.replace(/_/g, '-')}`;
+
+        const apply = () => {
+            if (!active.size) {
+                tableShell._refilter(null);
+                if (clearBtn) clearBtn.hidden = true;
+                return;
+            }
+            const attrs = Array.from(active).map(flagToAttr);
+            tableShell._refilter((row) => attrs.some((a) => row.hasAttribute(a)));
+            if (clearBtn) clearBtn.hidden = false;
+        };
+
+        const trackToggle = (flag, on) => {
+            if (typeof trackEvent !== 'function') return;
+            const ativos = Array.from(active).sort().join(',');
+            // qtd_visiveis: aproximado pelas rows nao-display:none apos apply().
+            const visiveis = Array.from(tableShell.querySelectorAll('tbody tr')).filter(
+                (r) => r.style.display !== 'none'
+            ).length;
+            const total = tableShell.querySelectorAll('tbody tr').length;
+            trackEvent('servidores-filtro-toggle', {
+                flag,
+                action: on ? 'on' : 'off',
+                ativos,
+                qtd_ativos: active.size,
+                visiveis,
+                total,
+            });
+        };
+
+        chips.forEach((chip) => {
+            chip.addEventListener('click', () => {
+                const flag = chip.dataset.flag;
+                const willActivate = !active.has(flag);
+                if (willActivate) active.add(flag);
+                else active.delete(flag);
+                chip.classList.toggle('filter-chip--active', willActivate);
+                chip.setAttribute('aria-pressed', String(willActivate));
+                apply();
+                trackToggle(flag, willActivate);
+            });
+        });
+
+        if (clearBtn) {
+            clearBtn.addEventListener('click', () => {
+                const ativosPrev = Array.from(active).sort().join(',');
+                const qtdPrev = active.size;
+                active.clear();
+                chips.forEach((c) => {
+                    c.classList.remove('filter-chip--active');
+                    c.setAttribute('aria-pressed', 'false');
+                });
+                apply();
+                if (typeof trackEvent === 'function') {
+                    trackEvent('servidores-filtro-limpar', {
+                        ativos_anteriores: ativosPrev,
+                        qtd_ativos_anteriores: qtdPrev,
+                    });
+                }
+            });
+        }
+    });
+}

--- a/web/static/js/components/servidores-filter-chips.js
+++ b/web/static/js/components/servidores-filter-chips.js
@@ -24,22 +24,19 @@ function initServidoresFilterChips(root = document) {
 
         const apply = () => {
             if (!active.size) {
-                tableShell._refilter(null);
+                const total = tableShell._refilter(null);
                 if (clearBtn) clearBtn.hidden = true;
-                return;
+                return total;
             }
             const attrs = Array.from(active).map(flagToAttr);
-            tableShell._refilter((row) => attrs.some((a) => row.hasAttribute(a)));
+            const matched = tableShell._refilter((row) => attrs.some((a) => row.hasAttribute(a)));
             if (clearBtn) clearBtn.hidden = false;
+            return matched;
         };
 
-        const trackToggle = (flag, on) => {
+        const trackToggle = (flag, on, visiveis) => {
             if (typeof trackEvent !== 'function') return;
             const ativos = Array.from(active).sort().join(',');
-            // qtd_visiveis: aproximado pelas rows nao-display:none apos apply().
-            const visiveis = Array.from(tableShell.querySelectorAll('tbody tr')).filter(
-                (r) => r.style.display !== 'none'
-            ).length;
             const total = tableShell.querySelectorAll('tbody tr').length;
             trackEvent('servidores-filtro-toggle', {
                 flag,
@@ -59,8 +56,8 @@ function initServidoresFilterChips(root = document) {
                 else active.delete(flag);
                 chip.classList.toggle('filter-chip--active', willActivate);
                 chip.setAttribute('aria-pressed', String(willActivate));
-                apply();
-                trackToggle(flag, willActivate);
+                const matched = apply();
+                trackToggle(flag, willActivate, matched);
             });
         });
 
@@ -73,11 +70,12 @@ function initServidoresFilterChips(root = document) {
                     c.classList.remove('filter-chip--active');
                     c.setAttribute('aria-pressed', 'false');
                 });
-                apply();
+                const matched = apply();
                 if (typeof trackEvent === 'function') {
                     trackEvent('servidores-filtro-limpar', {
                         ativos_anteriores: ativosPrev,
                         qtd_ativos_anteriores: qtdPrev,
+                        visiveis: matched,
                     });
                 }
             });

--- a/web/static/js/components/top-servidores.js
+++ b/web/static/js/components/top-servidores.js
@@ -44,10 +44,56 @@ function buildServidoresPanel(data) {
         const totalPagoRow = _val(r, cols, 'total_pago_durante_vinculo') > 0;
         const bolsaFamilia = _val(r, cols, 'flag_bolsa_familia');
         const vinculoFederal = _val(r, cols, 'flag_duplo_vinculo_federal');
+        const multiEmpresa = _val(r, cols, 'flag_multi_empresa');
+        const altoSalario = _val(r, cols, 'flag_alto_salario_socio');
+        const flagAttrs = [
+            ceafExpulso && 'data-flag-ceaf-expulso="1"',
+            socioInidoneidade && 'data-flag-socio-inidoneidade="1"',
+            totalPagoRow && 'data-flag-durante-vinculo="1"',
+            bolsaFamilia && 'data-flag-bolsa-familia="1"',
+            socioSancionado && 'data-flag-socio-sancionado="1"',
+            multiEmpresa && 'data-flag-multi-empresa="1"',
+            altoSalario && 'data-flag-alto-salario-socio="1"',
+            vinculoFederal && 'data-flag-duplo-vinculo-federal="1"',
+        ].filter(Boolean).join(' ');
         const rowClass = (ceafExpulso || totalPagoRow || socioInidoneidade) ? 'clickable-row row-sancao' : (socioSancionado || bolsaFamilia || vinculoFederal) ? 'clickable-row row-sancao-leve' : 'clickable-row';
         const cpfFmt = cpf6.length === 6 ? `***.${cpf6.slice(0,3)}.${cpf6.slice(3,6)}-**` : '';
-        return `<tr data-cargo="${_esc(String(cargoRaw).toLowerCase())}" ${hasDetail ? `class="${rowClass}"` : ''}${detailAttrs}><td data-label="Servidor" class="stack-title">${nome}</td><td data-label="CPF" class="auditor-only stack-meta"><code class="text-sm">${cpfFmt}</code></td><td data-label="Cargo" class="stack-meta">${cargo}</td><td data-label="Maior salario" class="text-right num">${salario}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
+        return `<tr data-cargo="${_esc(String(cargoRaw).toLowerCase())}" ${hasDetail ? `class="${rowClass}"` : ''}${detailAttrs} ${flagAttrs}><td data-label="Servidor" class="stack-title">${nome}</td><td data-label="CPF" class="auditor-only stack-meta"><code class="text-sm">${cpfFmt}</code></td><td data-label="Cargo" class="stack-meta">${cargo}</td><td data-label="Maior salario" class="text-right num">${salario}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
     }).join('');
+
+    // Contagens por flag para os chips
+    const _count = (flag, pred) => data.rows.filter(r => pred(r)).length;
+    const cnt = {
+        ceaf_expulso: _count('ceaf', r => _val(r, cols, 'flag_ceaf_expulso')),
+        socio_inidoneidade: _count('inid', r => _val(r, cols, 'flag_socio_inidoneidade')),
+        durante_vinculo: _count('durante', r => _val(r, cols, 'total_pago_durante_vinculo') > 0),
+        bolsa_familia: _count('bf', r => _val(r, cols, 'flag_bolsa_familia')),
+        socio_sancionado: _count('sanc', r => _val(r, cols, 'flag_socio_sancionado')),
+        multi_empresa: _count('multi', r => _val(r, cols, 'flag_multi_empresa')),
+        alto_salario_socio: _count('alto', r => _val(r, cols, 'flag_alto_salario_socio')),
+        duplo_vinculo_federal: _count('fed', r => _val(r, cols, 'flag_duplo_vinculo_federal')),
+    };
+    const chipHtml = (flag, severity, citizenLabel, auditorLabel) => {
+        if (!cnt[flag]) return '';
+        return `<button type="button" class="filter-chip filter-chip--${severity}" data-flag="${flag}" aria-pressed="false"><span class="citizen-only">${citizenLabel}</span><span class="auditor-only">${auditorLabel}</span> <span class="filter-chip__count">${cnt[flag]}</span></button>`;
+    };
+    const chips = [
+        chipHtml('ceaf_expulso', 'red', 'Expulso federal', 'CEAF'),
+        chipHtml('socio_inidoneidade', 'red', 'Socio inidoneo', 'CEIS inidoneidade'),
+        chipHtml('durante_vinculo', 'red', 'Empresa recebeu durante vinculo', 'Pago durante vinculo'),
+        chipHtml('bolsa_familia', 'yellow', 'Recebe Bolsa Familia', 'Bolsa Familia'),
+        chipHtml('socio_sancionado', 'orange', 'Socio de sancionada', 'CEIS/CNEP'),
+        chipHtml('multi_empresa', 'yellow', 'Socio de varias empresas', 'Multi-empresa'),
+        chipHtml('alto_salario_socio', 'yellow', 'Salario alto + socio', 'Salario alto + socio'),
+        chipHtml('duplo_vinculo_federal', 'yellow', 'Tambem no cadastro federal', 'Vinculo SIAPE'),
+    ].join('');
+    const chipsBlock = chips
+        ? `<div class="table-filter-chips" data-servidores-filter-chips role="group" aria-label="Filtrar servidores por sinal">
+            <span class="table-filter-chips__label text-sm text-muted">${dualLabel('Filtrar por sinal:','Filtros por flag:')}</span>
+            ${chips}
+            <button type="button" class="filter-chip filter-chip--clear" data-clear hidden>${dualLabel('Limpar filtros','Limpar')}</button>
+        </div>`
+        : '';
 
     const _ldot = (bg) => `<span class="color-legend-dot" style="background:${bg}"></span>`;
     const hasRedServ = data.rows.some(r => _val(r, data.columns, 'flag_ceaf_expulso') || _val(r, data.columns, 'total_pago_durante_vinculo') > 0 || _val(r, data.columns, 'flag_socio_inidoneidade'));
@@ -67,6 +113,7 @@ function buildServidoresPanel(data) {
             ${servLegend}
         </div></div>
         <div class="table-shell js-data-table" data-page-size="10">
+            ${chipsBlock}
             <div class="table-actions">
                 <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar servidores">
                 <p class="table-meta text-sm text-muted" data-table-meta></p>

--- a/web/static/js/pages/cidade-async-panels.js
+++ b/web/static/js/pages/cidade-async-panels.js
@@ -26,6 +26,7 @@ async function loadAsyncPanel(panelName, municipio, uf) {
         panel.innerHTML = await response.text();
         panel.setAttribute('aria-busy', 'false');
         initDataTables(panel);
+        initServidoresFilterChips(panel);
         initInteractiveToggles(panel);
         initMobileDescriptions(panel);
         initClickableRows(panel);

--- a/web/static/js/pages/cidade-bootstrap.js
+++ b/web/static/js/pages/cidade-bootstrap.js
@@ -73,6 +73,7 @@ async function bootstrapCityReport(municipio, uf, dataInicio, dataFim) {
             servPanel.innerHTML = buildServidoresPanel(servData);
             servPanel.setAttribute('aria-busy', 'false');
             initDataTables(servPanel);
+            initServidoresFilterChips(servPanel);
             initMobileDescriptions(servPanel);
             initClickableRows(servPanel);
         } else {

--- a/web/static/js/pages/main.js
+++ b/web/static/js/pages/main.js
@@ -1,6 +1,7 @@
 // === pages/main.js ===
 document.addEventListener('DOMContentLoaded', () => {
     initDataTables(document);
+    initServidoresFilterChips(document);
     initCidadeAutocomplete();
     initInteractiveToggles(document);
     initClickableRows(document);

--- a/web/templates/partials/top_servidores.html
+++ b/web/templates/partials/top_servidores.html
@@ -1,4 +1,13 @@
 {% if servidores %}
+{# Contagens por flag para os chips de filtro (calculadas server-side, uma vez por render). #}
+{% set _ceaf = servidores|selectattr('flag_ceaf_expulso')|list|length %}
+{% set _inid = servidores|selectattr('flag_socio_inidoneidade')|list|length %}
+{% set _durante = servidores|selectattr('total_pago_durante_vinculo')|list|length %}
+{% set _bf = servidores|selectattr('flag_bolsa_familia')|list|length %}
+{% set _sanc = servidores|selectattr('flag_socio_sancionado')|list|length %}
+{% set _multi = servidores|selectattr('flag_multi_empresa')|list|length %}
+{% set _alto = servidores|selectattr('flag_alto_salario_socio')|list|length %}
+{% set _federal = servidores|selectattr('flag_duplo_vinculo_federal')|list|length %}
 <section class="result-block">
     <div class="table-shell js-data-table" data-page-size="10">
         {% set has_red_serv = servidores|selectattr('flag_ceaf_expulso')|list or servidores|selectattr('flag_socio_inidoneidade')|list or servidores|selectattr('total_pago_durante_vinculo')|list %}
@@ -9,6 +18,18 @@
             {% if has_yellow_serv %}<span class="color-legend-item"><span class="color-legend-dot" style="background:#f59e0b"></span> <span class="citizen-only">S&oacute;cio de empresa sancionada, recebendo Bolsa Fam&iacute;lia durante v&iacute;nculo, ou tamb&eacute;m no cadastro federal</span><span class="auditor-only">Socio de empresa com Impedimento/CNEP, Bolsa Familia durante vinculo ou vinculo federal SIAPE</span></span>{% endif %}
         </div>
         {% endif %}
+        <div class="table-filter-chips" data-servidores-filter-chips role="group" aria-label="Filtrar servidores por sinal de aten&ccedil;&atilde;o">
+            <span class="table-filter-chips__label text-sm text-muted"><span class="citizen-only">Filtrar por sinal:</span><span class="auditor-only">Filtros por flag:</span></span>
+            {% if _ceaf %}<button type="button" class="filter-chip filter-chip--red" data-flag="ceaf_expulso" aria-pressed="false"><span class="citizen-only">Expulso federal</span><span class="auditor-only">CEAF</span> <span class="filter-chip__count">{{ _ceaf }}</span></button>{% endif %}
+            {% if _inid %}<button type="button" class="filter-chip filter-chip--red" data-flag="socio_inidoneidade" aria-pressed="false"><span class="citizen-only">S&oacute;cio inid&ocirc;neo</span><span class="auditor-only">CEIS inidoneidade</span> <span class="filter-chip__count">{{ _inid }}</span></button>{% endif %}
+            {% if _durante %}<button type="button" class="filter-chip filter-chip--red" data-flag="durante_vinculo" aria-pressed="false"><span class="citizen-only">Empresa recebeu durante v&iacute;nculo</span><span class="auditor-only">Pago durante vinculo</span> <span class="filter-chip__count">{{ _durante }}</span></button>{% endif %}
+            {% if _bf %}<button type="button" class="filter-chip filter-chip--yellow" data-flag="bolsa_familia" aria-pressed="false"><span class="citizen-only">Recebe Bolsa Fam&iacute;lia</span><span class="auditor-only">Bolsa Familia</span> <span class="filter-chip__count">{{ _bf }}</span></button>{% endif %}
+            {% if _sanc %}<button type="button" class="filter-chip filter-chip--orange" data-flag="socio_sancionado" aria-pressed="false"><span class="citizen-only">S&oacute;cio de sancionada</span><span class="auditor-only">CEIS/CNEP</span> <span class="filter-chip__count">{{ _sanc }}</span></button>{% endif %}
+            {% if _multi %}<button type="button" class="filter-chip filter-chip--yellow" data-flag="multi_empresa" aria-pressed="false"><span class="citizen-only">S&oacute;cio de v&aacute;rias empresas</span><span class="auditor-only">Multi-empresa</span> <span class="filter-chip__count">{{ _multi }}</span></button>{% endif %}
+            {% if _alto %}<button type="button" class="filter-chip filter-chip--yellow" data-flag="alto_salario_socio" aria-pressed="false"><span class="citizen-only">Sal&aacute;rio alto + s&oacute;cio</span><span class="auditor-only">Salario alto + socio</span> <span class="filter-chip__count">{{ _alto }}</span></button>{% endif %}
+            {% if _federal %}<button type="button" class="filter-chip filter-chip--yellow" data-flag="duplo_vinculo_federal" aria-pressed="false"><span class="citizen-only">Tamb&eacute;m no cadastro federal</span><span class="auditor-only">Vinculo SIAPE</span> <span class="filter-chip__count">{{ _federal }}</span></button>{% endif %}
+            <button type="button" class="filter-chip filter-chip--clear" data-clear hidden><span class="citizen-only">Limpar filtros</span><span class="auditor-only">Limpar</span></button>
+        </div>
         <div class="table-actions">
             <input
                 type="search"
@@ -41,10 +62,12 @@
                     {% set cpf6 = s.cpf_digitos_6|default('')|string %}
                     {% set nome_up = s.nome_upper|default('')|string %}
                     {% set cnpjs_json = s.cnpjs_socio|default([])|tojson %}
+                    {% set _flag_durante = (s.total_pago_durante_vinculo|default(0)|float > 0) %}
+                    {% set _flag_attrs %}{% if s.flag_ceaf_expulso %} data-flag-ceaf-expulso="1"{% endif %}{% if s.flag_socio_inidoneidade %} data-flag-socio-inidoneidade="1"{% endif %}{% if _flag_durante %} data-flag-durante-vinculo="1"{% endif %}{% if s.flag_bolsa_familia %} data-flag-bolsa-familia="1"{% endif %}{% if s.flag_socio_sancionado %} data-flag-socio-sancionado="1"{% endif %}{% if s.flag_multi_empresa %} data-flag-multi-empresa="1"{% endif %}{% if s.flag_alto_salario_socio %} data-flag-alto-salario-socio="1"{% endif %}{% if s.flag_duplo_vinculo_federal %} data-flag-duplo-vinculo-federal="1"{% endif %}{% endset %}
                     {% if cpf6 and nome_up %}
-                    <tr class="clickable-row{% if s.flag_ceaf_expulso or (s.total_pago_durante_vinculo|default(0)|float > 0) or s.flag_socio_inidoneidade %} row-sancao{% elif s.flag_socio_sancionado or s.flag_bolsa_familia or s.flag_duplo_vinculo_federal %} row-sancao-leve{% endif %}" data-cargo="{{ cargo|lower }}" data-cpf6="{{ cpf6 }}" data-nome-upper="{{ nome_up }}" data-nome="{{ s.nome_servidor|default(nome_up)|clean_text }}" data-cnpjs='{{ cnpjs_json }}'>
+                    <tr class="clickable-row{% if s.flag_ceaf_expulso or _flag_durante or s.flag_socio_inidoneidade %} row-sancao{% elif s.flag_socio_sancionado or s.flag_bolsa_familia or s.flag_duplo_vinculo_federal %} row-sancao-leve{% endif %}" data-cargo="{{ cargo|lower }}" data-cpf6="{{ cpf6 }}" data-nome-upper="{{ nome_up }}" data-nome="{{ s.nome_servidor|default(nome_up)|clean_text }}" data-cnpjs='{{ cnpjs_json }}'{{ _flag_attrs }}>
                     {% else %}
-                    <tr data-cargo="{{ cargo|lower }}">
+                    <tr data-cargo="{{ cargo|lower }}"{{ _flag_attrs }}>
                     {% endif %}
                         <td data-label="Servidor" class="stack-title">{{ s.nome_servidor|clean_text }}</td>
                         <td data-label="CPF" class="auditor-only"><code class="text-sm">***.{{ cpf6[:3] }}.{{ cpf6[3:] }}-**</code></td>


### PR DESCRIPTION
Aplica **ADR-0011** (Accepted parcial � escopo: servidores) ao `TOP_SERVIDORES_RISCO`. Resolve a queixa de que em **Jo�o Pessoa** as 20 p�ginas do top 200 estavam dominadas por m�dicos com duplo v�nculo (sa�de), enterrando sinais reais de fraude.

## Mudan�as

### SQL (`web/queries/cidade.py`)
- **Remove `LIMIT 200`** de `TOP_SERVIDORES_RISCO` (variante `_DATED` herda).
- **Reescreve `ORDER BY`** � sinais reais primeiro, duplo v�nculo s� tie-breaker:
  1. `flag_ceaf_expulso` (vermelho)
  2. `flag_socio_inidoneidade` (vermelho)
  3. `(total_pago_durante_vinculo > 0)` (vermelho)
  4. `flag_bolsa_familia` (amarelo)
  5. `flag_socio_sancionado` (laranja)
  6. `flag_multi_empresa` (amarelo)
  7. `risco_score` (composto)
  8. `flag_duplo_vinculo_federal` (tie-breaker � Constitui��o permite em alguns casos)

### Frontend � Chips de filtro
- Bloco renderizado no template e no JS panel renderer.
- Chips: CEAF, Inidoneidade, "Empresa recebeu durante v�nculo", BF, S�cio sancionado, Multi-empresa, Sal�rio alto + s�cio, SIAPE.
- **Exclui** `duplo_vinculo_estadual` (decis�o de UX).
- Sem�ntica **OR** dentro do grupo + bot�o Limpar.
- Novo componente `components/servidores-filter-chips.js` plugga em `tableShell._refilter`.

### Eventos Umami (ricos)
- `servidores-filtro-toggle` ? `{flag, action: on|off, ativos, qtd_ativos, visiveis, total}`.
- `servidores-filtro-limpar` ? `{ativos_anteriores, qtd_ativos_anteriores}`.
- Padr�o kebab-case sem prefixo (mem�ria da conven��o).

### Expandable de regras de acumula��o (servidor-dialog)
- `details[data-duplo-vinculo-regras]` na se��o "V�nculos como servidor".
- Renderiza apenas quando h� v�nculo **municipal + federal SIAPE** (caso real de duplo v�nculo).
- Dual-mode citizen/auditor citando: CF/88 Art. 37 XI e XVI, EC 19/98, EC 34/2001, Lei 8.112/90 Art. 132, MP 1.230/2024 (teto R$ 46.366,19), RE 1.176.440 (Tema 1.072).
- Reusa `.bf-regras-info` CSS e padr�o Umami `secao-toggle` (section='duplo-vinculo-regras').

### ADR + ASSET_VERSION
- ADR-0011: Proposed ? Accepted (parcial) com sizing real (JP=**51.573** servidores, n�o 13k).
- `ASSET_VERSION` 116 ? 117.

## Tamanho real (medido na VM)

| Munic�pio        | Servidores |
|------------------|-----------:|
| Jo�o Pessoa      |     51.573 |
| Campina Grande   |     32.035 |
| Santa Rita       |     12.360 |
| Bayeux           |      9.978 |
| Mediana das 223  |        855 |

JP SSR sobe ~30MB. Pagina��o client-side (10/pag) absorve. Virtual scroll fica como follow-up se Lighthouse regredir.

## Checklist

- [x] ADR atualizado (0011)
- [x] `python -m compileall web -q` ?
- [x] `node -c` em todos os JS novos/editados ?
- [x] Smoke-parse Jinja do template ?
- [x] Mem�ria de Umami event naming respeitada (kebab-case, sem prefix)
- [x] Mem�ria de `bf-regras-info` como padr�o reutiliz�vel seguida
- [x] Co-authored-by Copilot

## Deploy

`etl_phase=web` � suficiente (s� mudan�a de c�digo + warm recycle). Lembrar de `rewarm_cache_keys=TOP_SERVIDORES` para refletir nova ordena��o.

