### PR TITLE
docs(analytics): catalogo Umami descobrivel + 5 eventos novos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,21 @@ the repo should be PT-BR.
    - [`docs/cache.md`](docs/cache.md) — `web_cache` + shadow rewarm
    - [`docs/deploy.md`](docs/deploy.md) — `deploy.yml` inputs and scenarios
    - [`docs/ops.md`](docs/ops.md) — runbooks (rollback, restore, backup)
+   - [`docs/analytics.md`](docs/analytics.md) — Umami event catalog (naming
+     conventions, payloads, where to consult data)
+   - [`docs/privacidade.md`](docs/privacidade.md) — LGPD, cookies, dados
+     coletados (when touching contato form, Umami, or user-facing copy)
+   - [`docs/dicionario_dados_pb.md`](docs/dicionario_dados_pb.md) — PB
+     open data column dictionary (TCE-PB, dados.pb)
+   - [`docs/plano_novas_fontes.md`](docs/plano_novas_fontes.md) — roadmap
+     for new data sources (state of integration per source)
 7. [`docs/adr/`](docs/adr/) — Architecture Decision Records (the institutional memory).
+
+**Documentation discovery rule**: every `docs/*.md` file should be listed
+above. When adding a new doc, also add it here so future agents can find it
+without `glob`/`grep` exploration. The same applies to top-level guides:
+`README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `AGENTS.md` should be cross-
+referenced from each other.
 
 ## Setup & commands
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,162 @@
+# Analytics & Umami events
+
+> Catálogo dos eventos Umami emitidos pelo frontend. **Fonte autoritativa**:
+> o comentário no topo de [`web/static/js/lib/umami-track.js`](../web/static/js/lib/umami-track.js).
+> Este documento espelha o catálogo num formato consultável e adiciona contexto
+> de UX/produto. Quando adicionar um evento novo, atualize **os dois**.
+
+## Como funciona
+
+- Wrapper: [`web/static/js/lib/umami-track.js`](../web/static/js/lib/umami-track.js)
+  expõe `trackEvent(name, props)`. Engole silenciosamente se
+  `window.umami` não estiver carregado (DNT ativado, dev sem
+  `UMAMI_WEBSITE_ID`, etc.).
+- Tracker carrega via snippet em `<head>` de `base.html` quando
+  `UMAMI_WEBSITE_ID` está setado. Self-hosted em
+  [`/_traffic/analytics/`](https://transparenciapb.org/_traffic/analytics/)
+  (admin-only, basic-auth + login Umami).
+- Privacidade: sem fingerprinting cross-site, sem Google Analytics, sem
+  Facebook Pixel. Detalhes em [`docs/privacidade.md`](privacidade.md).
+
+## Convenções de naming
+
+- **kebab-case**, **sem prefixo de página** (ex: `secao-toggle`, não
+  `cidade-secao-toggle`).
+- Nome curto e estável — vai virar coluna no painel Umami; renomear quebra
+  histórico.
+- Props extras viram colunas filtráveis. Valores simples (strings curtas,
+  numbers); evite payloads grandes ou JSON aninhado.
+- Reuse evento existente quando semântica casar (ex: `secao-toggle` para
+  qualquer `<details>` colapsável, não criar um novo evento por seção).
+
+## Catálogo
+
+### Navegação & contexto da página
+
+| Evento | Props | Onde dispara |
+|---|---|---|
+| `cidade-buscar` | `{via: 'autocomplete'}` | busca de cidade no header |
+| `cidade-visita` | `{municipio, uf}` | top-of-funnel da página de cidade |
+| `empresa-visita` | `{cnpj, nome, escopo: 'global'\|'municipio', municipio?}` | abertura da página de empresa |
+| `pagina-caso-visita` | `{slug}` | abertura de página de caso (`/caso/...`) |
+| `nav-clicado` | `{target: 'sobre'\|'glossario'\|'contato', from: 'footer'\|'overflow-menu'}` | auto-track via `data-umami-event` |
+| `outbound-click` | `{dominio, href}` | clique em link externo (origin+pathname; sem query/hash) |
+| `tour-iniciado` | `{pagina: 'cidade'\|'home'}` | usuário inicia tour guiado |
+
+### Mapa & filtros globais
+
+| Evento | Props | Onde dispara |
+|---|---|---|
+| `mapa-cidade-click` | `{cidade, metrica}` | clique em município no mapa da home |
+| `mapa-metrica-mudou` | `{metrica}` | troca da métrica visualizada no mapa |
+| `date-filter-aplicado` | `{preset, de?, ate?, municipio?}` | aplicação de filtro temporal nas páginas de cidade |
+| `modo-toggle` | `{to: 'auditor'\|'citizen'}` | toggle dual-mode citizen ↔ auditor |
+| `font-size-change` | `{level: 'normal'\|'lg'\|'xl'}` | toggle de tamanho de fonte (a11y) |
+
+### Dialogs (drilldowns)
+
+| Evento | Props | Onde dispara |
+|---|---|---|
+| `dialog-aberto` | `{tipo, municipio, ...id-fields, drilled_from?}` ¹ | abertura de dialog drilldown |
+| `dialog-tab-change` | `{tipo, de, para}` | troca de tab via **click, keyboard ou swipe** ² |
+| `dialog-fechado` | `{tipo, dwell_ms, tabs_visitadas, scroll_max_pct, drilled_to?}` ³ | pareado com `dialog-aberto`; mede engagement real |
+| `credibilidade-aberto` | — | abertura do dialog "Sobre os dados" |
+| `denuncia-info-aberto` | — | abertura do dialog "Como denunciar" |
+
+¹ Id-fields variam por tipo:
+- `tipo='empenho'` → `{empenho}`
+- `tipo='servidor'` → `{cpf6, nome}`
+- `tipo='fornecedor'` → `{cnpj, nome}`
+- `tipo='licitacao'` → `{numero, ano, modalidade}`
+- `tipo='heatmap'` → `{ano, mes}`
+- `drilled_from` aparece quando usuário navegou de um dialog para outro sem fechar (ex: `fornecedor → empenho`).
+
+² Swipe touch também dispara `dialog-tab-change` — handler manual em
+[`web/static/js/components/dialog-decorate.js`](../web/static/js/components/dialog-decorate.js)
+porque o swipe não passa pelo listener `tabs.change` do `<md-tabs>`.
+
+³ `drilled_to` presente quando o dialog "fechou" porque o usuário navegou
+para outro tipo de dialog (chain sem fechar o `md-dialog`) ou clicou voltar.
+
+### Engagement
+
+| Evento | Props | Onde dispara |
+|---|---|---|
+| `scroll-deep` | `{percent: 50\|75\|100, pagina}` | marcos discretos de scroll |
+| `pagina-saida` | `{pagina, tempo_ms, scroll_max_pct}` | uma vez por page load, no `visibilitychange`/`pagehide` (sai da aba) ⁴ |
+| `narrative-anchor-click` | `{anchor}` | clique em palavra destacada do resumo da cidade que pula pra seção |
+| `finding-card-expand` | `{tipo}` | expand de finding card (collapse não dispara) |
+| `secao-toggle` | `{section, action: 'open'\|'close'}` ⁵ | toggle genérico de `<details>` colapsável |
+| `termo-tooltip-aberto` | `{termo}` | tap numa palavra do glossário inline (`.term[data-tip]`) em touch device |
+| `explainer-aberto` | `{target}` | clique no botão "?" inline que expande "O que isso significa?" |
+| `back-to-top-clicado` | `{scroll_pct}` | clique no botão flutuante "voltar ao topo"; `scroll_pct` 0-100 mede a profundidade antes do reset |
+| `concentracao-bar-clicado` | `{rank}` | clique numa barra do card "Concentração de fornecedores" (cidade); `rank` 1..N, casa com `dialog-aberto` que dispara em seguida |
+
+⁴ Implementado em
+[`web/static/js/lib/page-engagement.js`](../web/static/js/lib/page-engagement.js).
+Respeita whitelist de páginas (cidade, empresa, caso, etc.).
+
+⁵ `section` identifica a seção (ex: `'bolsa-familia-regras'`,
+`'duplo-vinculo-regras'`, ou auto-derivado do `h4`).
+
+⁶ `tabela` vem de `data-table-id` no shell. Templates conhecidos:
+`top-servidores`, `top-fornecedores`, `result-query` (genérico Q##).
+Tabelas sem `data-table-id` no shell **não emitem** o evento — opt-in
+explícito para evitar ruído de tabelas auxiliares.
+
+### Filtros & ordenação de tabelas
+
+| Evento | Props | Onde dispara |
+|---|---|---|
+| `servidores-filtro-toggle` | `{flag, action: 'on'\|'off', ativos, qtd_ativos, visiveis, total}` | toggle de chip de filtro na tabela de servidores |
+| `servidores-filtro-limpar` | `{ativos_anteriores, qtd_ativos_anteriores, visiveis}` | botão "Limpar" dos chips de filtro |
+| `tabela-pagina-mudou` | `{tabela, de, para, total_paginas, via: 'prev'\|'next'}` ⁶ | clique em Anterior/Próxima das tabelas paginadas |
+| `empenho-table-sort` | `{coluna, direcao: 'asc'\|'desc'}` | clique em header de tabela para ordenar (dialog de empenho) |
+
+### Diversos
+
+| Evento | Props | Onde dispara |
+|---|---|---|
+| `compartilhar` | `{via: 'share-api'\|'clipboard'\|'fallback'}` | botão compartilhar |
+| `contato-enviado` | — | formulário `/contato` submitted com sucesso |
+| `api-error` | `{endpoint, status}` | drilldown via `/api/...` falhou; `status=0` = network error |
+
+## Adicionando um evento novo
+
+1. Escolha o nome seguindo as convenções acima (kebab-case, sem prefixo).
+2. Verifique se um evento existente cobre o caso. Reuse antes de criar.
+3. Disparar via `trackEvent(name, props)`:
+   ```js
+   if (typeof trackEvent === 'function') {
+       trackEvent('meu-evento', { campo1: valor1 });
+   }
+   ```
+4. Atualize **dois lugares**:
+   - Bloco de comentário no topo de
+     [`web/static/js/lib/umami-track.js`](../web/static/js/lib/umami-track.js).
+   - Tabela correspondente neste documento (`docs/analytics.md`).
+5. Se o evento for de toggle/expand, use `aria-pressed`/`aria-expanded`
+   correspondentes e teste em mobile (ver checklist mobile-first no
+   [`AGENTS.md`](../AGENTS.md)).
+
+## Auto-track via `data-umami-event`
+
+Para clicks simples sem lógica condicional, usar atributos HTML:
+
+```html
+<a href="/sobre"
+   data-umami-event="nav-clicado"
+   data-umami-event-target="sobre"
+   data-umami-event-from="footer">Sobre</a>
+```
+
+Umami captura automaticamente via delegação no `document`. Preferir
+`trackEvent()` em JS quando precisar de lógica condicional ou props
+computadas em runtime.
+
+## Onde consultar os dados
+
+- Painel: [`/_traffic/analytics/`](https://transparenciapb.org/_traffic/analytics/)
+  (admin, basic-auth + login Umami).
+- Logs do tracker: `journalctl -u cruza-umami` na VM.
+- Detalhes de infra: [`docs/ops.md`](ops.md#runbook-goaccess--umami).

--- a/web/main.py
+++ b/web/main.py
@@ -499,7 +499,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "118"
+templates.env.globals["ASSET_VERSION"] = "119"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/components/back-to-top.js
+++ b/web/static/js/components/back-to-top.js
@@ -25,6 +25,13 @@ function initBackToTop() {
 
     window.addEventListener('scroll', update, { passive: true });
     btn.addEventListener('click', () => {
+        if (typeof trackEvent === 'function') {
+            const doc = document.documentElement;
+            const y = window.scrollY || doc.scrollTop;
+            const total = Math.max(doc.scrollHeight - window.innerHeight, 1);
+            const scroll_pct = Math.max(0, Math.min(100, Math.round((y / total) * 100)));
+            trackEvent('back-to-top-clicado', { scroll_pct });
+        }
         const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         window.scrollTo({ top: 0, behavior: prefersReduced ? 'auto' : 'smooth' });
     });

--- a/web/static/js/components/concentracao-card.js
+++ b/web/static/js/components/concentracao-card.js
@@ -75,6 +75,11 @@ function _wireConcentracaoClicks(scope) {
         const cnpjCompleto = String(row.dataset.cnpjCompleto || '').replace(/\D/g, '');
         const nome = row.dataset.nome || '';
         if (!cnpjBasico || cnpjCompleto.length !== 14) return;
+        if (typeof trackEvent === 'function') {
+            const rows = Array.from(root.querySelectorAll('.chart-bar-row'));
+            const rank = rows.indexOf(row) + 1;
+            trackEvent('concentracao-bar-clicado', { rank });
+        }
         if (typeof openFornecedorDialog === 'function') {
             openFornecedorDialog(cnpjBasico, nome, null, false, nome, cnpjCompleto);
         }

--- a/web/static/js/components/data-table.js
+++ b/web/static/js/components/data-table.js
@@ -122,17 +122,40 @@ function initDataTables(root = document) {
         });
 
         prevBtn?.addEventListener('click', () => {
+            const from = page;
             page = Math.max(1, page - 1);
             renderPage();
+            _trackPageChange(tableShell, from, page, filteredRows.length, pageSize, 'prev');
         });
 
         nextBtn?.addEventListener('click', () => {
             const totalPages = Math.max(1, Math.ceil(filteredRows.length / pageSize));
+            const from = page;
             page = Math.min(totalPages, page + 1);
             renderPage();
+            _trackPageChange(tableShell, from, page, filteredRows.length, pageSize, 'next');
         });
 
         renderPage();
+    });
+}
+
+// Emite tabela-pagina-mudou no painel Umami. Identifica a tabela via
+// data-table-id (opt-in nos templates principais); cai em 'unknown' pra
+// nao spammar evento sem identificacao util. No-op se page nao mudou
+// (clique em prev na pag 1 ou next na ultima).
+function _trackPageChange(tableShell, from, to, totalRows, pageSize, via) {
+    if (from === to) return;
+    if (typeof trackEvent !== 'function') return;
+    const tabela = tableShell.dataset.tableId || 'unknown';
+    if (tabela === 'unknown') return;
+    const totalPaginas = Math.max(1, Math.ceil(totalRows / pageSize));
+    trackEvent('tabela-pagina-mudou', {
+        tabela,
+        de: from,
+        para: to,
+        total_paginas: totalPaginas,
+        via,
     });
 }
 

--- a/web/static/js/components/explainers.js
+++ b/web/static/js/components/explainers.js
@@ -21,6 +21,9 @@ function initExplainers() {
             panel.hidden = !willOpen;
             btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
             btn.classList.toggle('is-open', willOpen);
+            if (willOpen && typeof trackEvent === 'function') {
+                trackEvent('explainer-aberto', { target: targetId });
+            }
         });
     });
 }

--- a/web/static/js/components/result-table.js
+++ b/web/static/js/components/result-table.js
@@ -157,7 +157,7 @@ function buildResultTable(queryId, columns, rows, municipio) {
             <div>${legendHtml}</div>
             <md-outlined-button href="${exportHref}" data-export-link class="data-table-export"><span class="citizen-only">Baixar planilha</span><span class="auditor-only">Exportar CSV</span></md-outlined-button>
         </div>
-        <div class="table-shell js-data-table" data-page-size="10">
+        <div class="table-shell js-data-table" data-page-size="10" data-table-id="result-query">
             <div class="table-actions">
                 <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar resultados" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" inputmode="search" enterkeyhint="search">
                 <p class="table-meta text-sm text-muted" data-table-meta></p>

--- a/web/static/js/components/term-tooltip.js
+++ b/web/static/js/components/term-tooltip.js
@@ -13,7 +13,12 @@ function initTermTooltips() {
             // Em touch devices, tap alterna
             if (matchMedia('(hover: none)').matches) {
                 e.preventDefault();
+                const willOpen = !term.classList.contains('tip-open');
                 term.classList.toggle('tip-open');
+                if (willOpen && typeof trackEvent === 'function') {
+                    const termo = (term.textContent || '').trim().slice(0, 60);
+                    trackEvent('termo-tooltip-aberto', { termo });
+                }
             }
         }
     });

--- a/web/static/js/components/top-fornecedores.js
+++ b/web/static/js/components/top-fornecedores.js
@@ -60,7 +60,7 @@ function buildFornecedoresPanel(data) {
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Concentracao dos pagamentos e sinais de atencao de cada empresa. Toque em uma empresa para detalhes.</span><span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span></p>
             ${fornLegend}
         </div></div>
-        <div class="table-shell js-data-table" data-page-size="10">
+        <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores">
             <div class="table-actions">
                 <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar fornecedores">
                 <p class="table-meta text-sm text-muted" data-table-meta></p>

--- a/web/static/js/components/top-servidores.js
+++ b/web/static/js/components/top-servidores.js
@@ -112,7 +112,7 @@ function buildServidoresPanel(data) {
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, cadastro federal, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos em alguns casos, como saude e magisterio.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, vinculo municipal + federal, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite algumas acumulacoes.</span></p>
             ${servLegend}
         </div></div>
-        <div class="table-shell js-data-table" data-page-size="10">
+        <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-servidores">
             ${chipsBlock}
             <div class="table-actions">
                 <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar servidores">

--- a/web/static/js/lib/umami-track.js
+++ b/web/static/js/lib/umami-track.js
@@ -2,6 +2,8 @@
 // Wrapper safe pra window.umami.track. Sem trabalho quando o tracker nao
 // esta carregado (UMAMI_SCRIPT_URL/UMAMI_WEBSITE_ID nao setados ou DNT).
 //
+// >>> CATALOGO COMPLETO: ../../../docs/analytics.md <<<
+//
 // O snippet do Umami injeta `window.umami` quando o script eh carregado e
 // data-website-id eh valido. Em dev/preview sem essas vars, `window.umami`
 // nao existe — o wrapper engole silenciosamente em vez de quebrar a UI
@@ -11,6 +13,11 @@
 //   * Vai aparecer no painel Umami -> Events. Use nomes curtos e estaveis.
 //   * Props extras viram colunas filtraveis. Mantenha valores simples
 //     (strings curtas, numbers); evite payloads grandes.
+//   * Sem prefixo de pagina (ex: 'secao-toggle', nao 'cidade-secao-toggle').
+//
+// IMPORTANTE: ao adicionar/renomear evento, atualizar OS DOIS:
+//   1. Bloco de comentario abaixo (fonte autoritativa pra agentes/devs).
+//   2. docs/analytics.md (formato consultavel + contexto de UX).
 //
 // Eventos atuais (ver tambem README dos componentes):
 //   cidade-buscar         - {via: 'autocomplete'}
@@ -80,6 +87,42 @@
 //                           flushar a sessao do nivel atual marcando
 //                           drilled_to='back-<tipo>' e comecar nova
 //                           sessao com o tipo restaurado.
+//   servidores-filtro-toggle - {flag, action: 'on'|'off', ativos,
+//                            qtd_ativos, visiveis, total}
+//                           Toggle de chip de filtro na tabela de
+//                           servidores (PR #195 / ADR-0011). `ativos`
+//                           eh CSV ordenado de flags ativos pos-toggle.
+//   servidores-filtro-limpar - {ativos_anteriores, qtd_ativos_anteriores,
+//                            visiveis}
+//                           Botao "Limpar" dos chips de filtro.
+//   secao-toggle          - {section, action: 'open'|'close'}
+//                           Toggle generico de <details> colapsavel.
+//                           `section` identifica a secao (ex:
+//                           'bolsa-familia-regras',
+//                           'duplo-vinculo-regras' do servidor-dialog).
+//   tabela-pagina-mudou   - {tabela, de, para, total_paginas, via:
+//                            'prev'|'next'}
+//                           Click em Anterior/Proxima das tabelas
+//                           paginadas. `tabela` vem de data-table-id no
+//                           shell (opt-in por template; tabelas sem
+//                           data-table-id NAO emitem o evento). Permite
+//                           medir profundidade de exploracao por tipo
+//                           de tabela (top-servidores, top-fornecedores,
+//                           result-query).
+//   termo-tooltip-aberto  - {termo} Tap em palavra do glossario inline
+//                           (`.term[data-tip]`) em touch device. Mede
+//                           quais termos confundem leitores.
+//   explainer-aberto      - {target} Click no botao "?" inline
+//                           (`.explainer-btn[data-explainer-target]`).
+//                           `target` eh o id do panel expandido.
+//   back-to-top-clicado   - {scroll_pct} Click no botao flutuante de
+//                           voltar ao topo. `scroll_pct` (0-100) mede
+//                           profundidade real antes do reset.
+//   concentracao-bar-clicado - {rank} Click numa barra do card
+//                           "Concentracao de fornecedores" da pagina
+//                           cidade. `rank` eh 1..N (posicao do top).
+//                           Casa com `dialog-aberto` que dispara em
+//                           seguida.
 window.trackEvent = function trackEvent(name, props) {
     try {
         if (typeof window.umami !== 'undefined' && typeof window.umami.track === 'function') {

--- a/web/templates/partials/result_table.html
+++ b/web/templates/partials/result_table.html
@@ -30,7 +30,7 @@
     </div>
 
     {% if rows %}
-    <div class="table-shell js-data-table" data-page-size="12">
+    <div class="table-shell js-data-table" data-page-size="12" data-table-id="result-query">
         <div class="table-actions">
             <input
                 type="search"

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -1,6 +1,6 @@
 {% if fornecedores %}
 <section class="result-block">
-    <div class="table-shell js-data-table" data-page-size="10">
+    <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores">
         {% set has_rec_inid = fornecedores|selectattr('flag_recebeu_durante_inidoneidade')|list %}
         {% set has_rec_sancao = fornecedores|selectattr('flag_recebeu_durante_sancao_aplicavel')|list %}
         {% set has_acordo = fornecedores|selectattr('flag_acordo_leniencia')|list %}

--- a/web/templates/partials/top_servidores.html
+++ b/web/templates/partials/top_servidores.html
@@ -9,7 +9,7 @@
 {% set _alto = servidores|selectattr('flag_alto_salario_socio')|list|length %}
 {% set _federal = servidores|selectattr('flag_duplo_vinculo_federal')|list|length %}
 <section class="result-block">
-    <div class="table-shell js-data-table" data-page-size="10">
+    <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-servidores">
         {% set has_red_serv = servidores|selectattr('flag_ceaf_expulso')|list or servidores|selectattr('flag_socio_inidoneidade')|list or servidores|selectattr('total_pago_durante_vinculo')|list %}
         {% set has_yellow_serv = servidores|selectattr('flag_socio_sancionado')|list or servidores|selectattr('flag_bolsa_familia')|list or servidores|selectattr('flag_duplo_vinculo_federal')|list %}
         {% if has_red_serv or has_yellow_serv %}


### PR DESCRIPTION
## Resumo

Cria `docs/analytics.md` como fonte canônica de eventos Umami (~26 eventos),
torna documentação descobrível por agentes IA via `AGENTS.md`, e adiciona
5 eventos novos pra cobrir gaps de instrumentação detectados em audit.

## Mudanças

### Descobribilidade
- **`docs/analytics.md`** (novo) — catálogo organizado por categoria
  (Navegação, Mapa, Dialogs, Engagement, Filtros, Diversos) com props,
  onde dispara e notas de implementação.
- **`AGENTS.md`** — 4 docs órfãos (analytics, privacidade, dicionario_dados_pb,
  plano_novas_fontes) agora listados em Area guides + "Documentation
  discovery rule": todo `docs/*.md` deve estar em AGENTS.md.
- **`web/static/js/lib/umami-track.js`** — header aponta `docs/analytics.md`
  como catálogo canônico; comentário inline mantido como referência rápida.

### Eventos novos
| Evento | Props | Componente |
|---|---|---|
| `tabela-pagina-mudou` | `{tabela, de, para, total_paginas, via}` | `data-table.js` |
| `termo-tooltip-aberto` | `{termo}` | `term-tooltip.js` |
| `explainer-aberto` | `{target}` | `explainers.js` |
| `back-to-top-clicado` | `{scroll_pct}` | `back-to-top.js` |
| `concentracao-bar-clicado` | `{rank}` | `concentracao-card.js` |

**Opt-in pattern de `tabela-pagina-mudou`**: emit é no-op se `data-table-id`
ausente no shell — evita ruído de tabelas auxiliares não-mapeadas. IDs
adotados: `top-servidores`, `top-fornecedores`, `result-query`.

### Bump
- `web/main.py`: `ASSET_VERSION` 118 → 119 (mudança JS user-facing).

## Por que importa
- **Decisões de produto**: hoje sabemos quem entra na cidade mas não sabemos
  quais termos confundem (`termo-tooltip-aberto`), quem precisa de contexto
  (`explainer-aberto`), profundidade real de leitura (`back-to-top-clicado`),
  ou se as barras do top-5 fornecedores são usadas como atalho
  (`concentracao-bar-clicado`).
- **Profundidade de tabelas**: `tabela-pagina-mudou` mede se usuários
  paginam além da pág 1 — sinal forte de exploração investigativa.
- **Descobribilidade**: agentes IA (Copilot CLI, Claude Code) agora encontram
  o catálogo via AGENTS.md sem precisar `grep trackEvent` por todo `web/`.

## Estratégia de deploy

**Zero-downtime trivial** — só mudança em `web/static/*` + `docs/*` + `web/main.py`
(ASSET_VERSION bump). Sem mudança de schema/SQL/MVs.

- `etl_phase=web`
- `rewarm_cache_keys=` (vazio — nenhuma query SQL mudou, cache intacto)
- `mv_swap=` (vazio — nenhuma MV mudou)

Pipeline: build-assets → systemd restart cruza-web. Workers reiniciam com
novo manifest, browsers recebem `?v=119` no primeiro pageview pós-deploy.

## Checklist
- [x] PT-BR em identifiers/comments/commit
- [x] `Co-authored-by: Copilot` trailer
- [x] `node --check` ok nos 6 arquivos modificados
- [x] Mobile-first: 4 dos 5 eventos novos são touch-relevantes
  (`termo-tooltip-aberto` é touch-only, `back-to-top` é mobile UX core)
- [x] Estratégia de deploy documentada acima
- [x] Docs/ atualizados (analytics.md novo, AGENTS.md descobribilidade)
- [x] Sem ADR — mudança operacional/instrumentação, não arquitetural
