### PR TITLE
feat(web): fornecedores sem LIMIT + filtros + Umami

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,10 @@ before editing the relevant area.
   [`web/templates/partials/_collapsible.html`](web/templates/partials/_collapsible.html):
   `{% call collapsible(id, title, count=N, section_attrs={...}) %}…{% endcall %}`.
   Default is `open=True`. Reuse this — do not roll your own `<details>`.
+- **Build de assets é sempre disparado** no step "Restart cruza-web (after warm)"
+  do `deploy.yml` (linha ~1424) imediatamente antes do `systemctl restart`.
+  Não existe input `build_assets` no workflow_dispatch. Detalhes e racional:
+  [`docs/deploy.md`](docs/deploy.md) seção "Build de assets (sempre roda)".
 - **Service Worker cache version** in
   [`web/static/sw.js`](web/static/sw.js):
   bump `FALLBACK_CACHE_VERSION` whenever you rename assets or change the SW

--- a/docs/adr/0011-remover-limit-top-tabelas.md
+++ b/docs/adr/0011-remover-limit-top-tabelas.md
@@ -2,17 +2,21 @@
 
 ## Status
 
-Accepted (parcial) — implementado **apenas para `TOP_SERVIDORES_RISCO` /
-`TOP_SERVIDORES_RISCO_DATED`** em 2026-05-20 ([PR #195][pr195]). Demais
-LIMITs (queries Q## em `registry.py` e outras top-tabelas em `cidade.py`)
-continuam **Proposed** e serão tratados em PRs subsequentes, caso-a-caso.
+Accepted (parcial) — implementado para `TOP_SERVIDORES_RISCO` /
+`TOP_SERVIDORES_RISCO_DATED` em 2026-05-20 ([PR #195][pr195]) e para
+`TOP_FORNECEDORES` / `TOP_FORNECEDORES_DATED` (+ variantes FALLBACK) em
+2026-05-21 ([PR #198][pr198]). Demais LIMITs (queries Q## em
+`registry.py` e outras top-tabelas) continuam **Proposed** e serão
+tratados em PRs subsequentes, caso-a-caso.
 
 [pr195]: https://github.com/lucasdiniz/govbr-cruza-dados/pull/195
+[pr198]: https://github.com/lucasdiniz/govbr-cruza-dados/pull/198
 
 ## Date
 
 2026-05-17 (proposta original)
 2026-05-20 (aceitação parcial — servidores)
+2026-05-21 (aceitação parcial — fornecedores)
 
 ## Context
 
@@ -193,15 +197,29 @@ Entregue em [PR #195 — feat(web): servidores sem LIMIT + filtros][pr195]:
   prod ainda — follow-up se warm cycle aumentar significativamente.
   Não muda CACHE_DEPENDENCY_GRAPH.
 
-### Próximos passos (continuam Proposed — não entregues no PR #195)
+### Próximos passos (continuam Proposed)
 
-Nada abaixo foi implementado ainda. PRs futuras devem revisitar este ADR:
+PRs futuras devem revisitar este ADR:
 
 - LIMITs em `cidade.py:289`, `:393`, `:512`, `:614` (outras agregações de
-  top-tabelas, ainda com `LIMIT 200` hardcoded).
+  top-tabelas além de servidores e fornecedores).
 - LIMIT 500 nas ~30 queries Q## em `web/queries/registry.py`
   (linhas 169-849).
-- Aplicar o mesmo padrão de chips de filtro + ordenação por sinais reais
-  em top-fornecedores e demais top-tables.
-- Considerar virtual scroll se mobile Lighthouse regredir > 10% após PR
-  #195 estar em produção.
+- Considerar virtual scroll se mobile Lighthouse regredir > 10% após PRs
+  #195 / #198 estarem em produção.
+
+### Entregue em PR #198 — fornecedores
+
+Mesmo padrão do PR #195 aplicado a `TOP_FORNECEDORES`:
+
+- Removidos 4× `LIMIT 200` nas variantes TOP_FORNECEDORES /
+  TOP_FORNECEDORES_DATED / TOP_FORNECEDORES_FALLBACK /
+  TOP_FORNECEDORES_FALLBACK_DATED.
+- Reescrita do `ORDER BY` final para **signals-first** (inidoneidade →
+  recebeu_durante_inidoneidade → recebeu_durante_sancao_aplicavel →
+  CEIS/CNEP → leniência → inativa_irregular → PGFN → inativa →
+  `total_pago` como tiebreaker).
+- Chips de filtro (9 flags) com semântica OR e contadores SSR.
+- Eventos Umami `fornecedores-filtro-toggle` e
+  `fornecedores-filtro-limpar` (mesmas props do par servidores).
+- Issue #197 abriu cleanup do `TOP_FORNECEDORES_FALLBACK` (dead code).

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -104,12 +104,19 @@ Respeita whitelist de páginas (cidade, empresa, caso, etc.).
 Tabelas sem `data-table-id` no shell **não emitem** o evento — opt-in
 explícito para evitar ruído de tabelas auxiliares.
 
+⁷ Flags possíveis no chip de fornecedores: `inidoneidade`,
+`recebeu_durante_inidoneidade`, `recebeu_durante_sancao_aplicavel`,
+`ceis`, `cnep`, `acordo_leniencia`, `inativa_irregular`, `pgfn`, `inativa`.
+Semântica OR (union dos filtros ativos).
+
 ### Filtros & ordenação de tabelas
 
 | Evento | Props | Onde dispara |
 |---|---|---|
 | `servidores-filtro-toggle` | `{flag, action: 'on'\|'off', ativos, qtd_ativos, visiveis, total}` | toggle de chip de filtro na tabela de servidores |
 | `servidores-filtro-limpar` | `{ativos_anteriores, qtd_ativos_anteriores, visiveis}` | botão "Limpar" dos chips de filtro |
+| `fornecedores-filtro-toggle` | `{flag, action: 'on'\|'off', ativos, qtd_ativos, visiveis, total}` | toggle de chip de filtro na tabela de fornecedores ⁷ |
+| `fornecedores-filtro-limpar` | `{ativos_anteriores, qtd_ativos_anteriores, visiveis}` | botão "Limpar" dos chips de filtro de fornecedores |
 | `tabela-pagina-mudou` | `{tabela, de, para, total_paginas, via: 'prev'\|'next'}` ⁶ | clique em Anterior/Próxima das tabelas paginadas |
 | `empenho-table-sort` | `{coluna, direcao: 'asc'\|'desc'}` | clique em header de tabela para ordenar (dialog de empenho) |
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -87,6 +87,7 @@ Ordem crítica:
 7. Instala/configura Nginx, Let's Encrypt, fail2ban, GoAccess, traffic digest, Umami e systemd services ([linhas 695-827](../.github/workflows/deploy.yml)).
 8. Atualiza estatísticas hot e trata cache (`drop_cache`, skip mode, shadow reset, invalidate, warm) ([linhas 828-1164](../.github/workflows/deploy.yml)).
 9. Reinicia `cruza-web` **após** warm para evitar janela longa de cache miss ([linhas 1166-1203](../.github/workflows/deploy.yml)).
+   - **Build de assets (sempre)**: imediatamente antes do `systemctl restart cruza-web`, o step "Restart cruza-web (after warm)" roda `node scripts/build-assets.mjs` (ver detalhes na seção [Build de assets](#build-de-assets-sempre-roda)).
 10. Executa IndexNow/sitemaps/smokes e `etl.verify` ([linhas 1205-1850](../.github/workflows/deploy.yml)).
 
 ### 3. `postflight`  GitHub-hosted + OIDC
@@ -118,6 +119,29 @@ Definidos em [`../.github/workflows/deploy.yml`](../.github/workflows/deploy.yml
 | `refresh_mvs` | csv/string | vazio | Lista CSV de MVs para `REFRESH MATERIALIZED VIEW CONCURRENTLY` (zero-downtime, requer UNIQUE INDEX). Caso típico: propagar fix de dados (`run_normalize_fix=true`) nas MVs sem dropar/recriar. Ordem importa: L1 antes de L2. Sanitizado `[A-Za-z0-9_,]`. |
 
 ## Cenários típicos
+
+### Build de assets (sempre roda)
+
+Não existe input `build_assets`. O step **"Restart cruza-web (after warm)"** (`deploy.yml:1424`) roda **sempre que o job `deploy` chega no estágio de restart com sucesso**, independente de `etl_phase`. A sequência fixa é:
+
+1. `npm ci --no-audit --no-fund` se `package-lock.json` mudou (cacheado por hash).
+2. `node scripts/build-assets.mjs` — gera `web/static/dist/` (bundle hashed + `manifest.json`) via promote atômico (`dist.new` → `dist`, `dist.old` deletado).
+3. `sudo systemctl restart cruza-web`.
+
+**Por que é fixo (sem toggle):**
+
+- O manifest `web/static/dist/manifest.json` é lido **na startup do worker** e mantido em memória (`web/main.py:~574`), não relido por request.
+- Se buildássemos horas antes do restart, workers velhos serviriam HTML com hashes do manifest antigo enquanto nginx já serve `dist/` novo → 404 em assets durante a janela.
+- Manter build <1s antes do `systemctl restart` garante que workers novos sobem com o manifest correspondente ao `dist/` no disco.
+- `ASSETS_STRICT=1` (no `cruza-web.service`) faz crash loud se manifest sumir, blindando contra build parcial.
+
+**Quando o restart pula (`if: success()`):**
+
+- Qualquer step anterior do job `deploy` em failure → restart e build pulam, `cruza-web` continua no estado anterior (correto: melhor que promover código inconsistente).
+
+**Não confundir com `ASSET_VERSION` em `web/main.py`:** essa constante (`120` no momento) é o cache buster para devs/fallback quando o manifest hash falha. Bumpar manualmente quando muda o JS pipeline, mas **não substitui o build** — em prod o cache buster vem do hash do manifest.
+
+**Não confundir com `clean`:** `clean=true` é cleanup de estado ETL falho (apaga marcadores), nada a ver com build de assets.
 
 ### Deploy apenas frontend
 

--- a/web/main.py
+++ b/web/main.py
@@ -494,12 +494,13 @@ JS_FILES: list[str] = [
     "lib/run-limited.js",
     "components/data-table.js",
     "components/servidores-filter-chips.js",
+    "components/fornecedores-filter-chips.js",
     "components/clickable-rows.js",
     "components/empenhos-controller.js",
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "119"
+templates.env.globals["ASSET_VERSION"] = "120"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/queries/cidade.py
+++ b/web/queries/cidade.py
@@ -324,8 +324,6 @@ WITH top_forn AS (
       AND d.cnpj_basico IS NOT NULL
       AND EXISTS (SELECT 1 FROM estabelecimento est WHERE est.cnpj_completo = d.cpf_cnpj)
     GROUP BY d.cnpj_basico, d.nome_credor
-    ORDER BY SUM(d.valor_pago) DESC
-    LIMIT 200
 ),
 cnpjs_pagos_apos_inativa AS MATERIALIZED (
     -- CNPJs do municipio que receberam pagamento APOS o estabelecimento ficar
@@ -411,7 +409,19 @@ LEFT JOIN empresa e ON e.cnpj_basico = tf.cnpj_basico
 LEFT JOIN estabelecimento est ON est.cnpj_completo = tf.cpf_cnpj
 LEFT JOIN cnpjs_pagos_apos_inativa ci ON ci.cpf_cnpj = tf.cpf_cnpj
 ) q
-ORDER BY q.abrangencia_sancao_info IS NOT NULL DESC, q.total_pago DESC
+ORDER BY
+  -- Sinais reais primeiro (ADR-0011): empresas com inidoneidade/sancoes nao
+  -- ficam enterradas atras de orgaos publicos top de receita.
+  q.flag_inidoneidade DESC,
+  q.flag_recebeu_durante_inidoneidade DESC,
+  q.flag_recebeu_durante_sancao_aplicavel DESC,
+  (q.flag_ceis OR q.flag_cnep) DESC,
+  q.flag_acordo_leniencia DESC,
+  q.flag_inativa_irregular DESC,
+  (q.abrangencia_sancao_info IS NOT NULL) DESC,
+  q.flag_pgfn DESC,
+  q.flag_inativa DESC,
+  q.total_pago DESC
 """
 
 TOP_FORNECEDORES_FALLBACK = """
@@ -428,8 +438,6 @@ WITH top_forn AS (
       AND d.cnpj_basico IS NOT NULL
       AND EXISTS (SELECT 1 FROM estabelecimento est WHERE est.cnpj_completo = d.cpf_cnpj)
     GROUP BY d.cnpj_basico, d.nome_credor
-    ORDER BY SUM(d.valor_pago) DESC
-    LIMIT 200
 ),
 cnpjs_pagos_apos_inativa AS MATERIALIZED (
     SELECT DISTINCT d2.cpf_cnpj
@@ -527,7 +535,19 @@ LEFT JOIN empresa e ON e.cnpj_basico = tf.cnpj_basico
 LEFT JOIN estabelecimento est ON est.cnpj_completo = tf.cpf_cnpj
 LEFT JOIN cnpjs_pagos_apos_inativa ci ON ci.cpf_cnpj = tf.cpf_cnpj
 ) q
-ORDER BY q.abrangencia_sancao_info IS NOT NULL DESC, q.total_pago DESC
+ORDER BY
+  -- Sinais reais primeiro (ADR-0011): empresas com inidoneidade/sancoes nao
+  -- ficam enterradas atras de orgaos publicos top de receita.
+  q.flag_inidoneidade DESC,
+  q.flag_recebeu_durante_inidoneidade DESC,
+  q.flag_recebeu_durante_sancao_aplicavel DESC,
+  (q.flag_ceis OR q.flag_cnep) DESC,
+  q.flag_acordo_leniencia DESC,
+  q.flag_inativa_irregular DESC,
+  (q.abrangencia_sancao_info IS NOT NULL) DESC,
+  q.flag_pgfn DESC,
+  q.flag_inativa DESC,
+  q.total_pago DESC
 """
 
 # ── Variantes com filtro temporal (dated) ───────────────────────
@@ -547,8 +567,6 @@ WITH top_forn AS (
       AND d.data_empenho >= %(data_inicio)s AND d.data_empenho <= %(data_fim)s
       AND EXISTS (SELECT 1 FROM estabelecimento est WHERE est.cnpj_completo = d.cpf_cnpj)
     GROUP BY d.cnpj_basico, d.nome_credor
-    ORDER BY SUM(d.valor_pago) DESC
-    LIMIT 200
 ),
 cnpjs_pagos_apos_inativa AS MATERIALIZED (
     SELECT DISTINCT d2.cpf_cnpj
@@ -631,7 +649,19 @@ LEFT JOIN empresa e ON e.cnpj_basico = tf.cnpj_basico
 LEFT JOIN estabelecimento est ON est.cnpj_completo = tf.cpf_cnpj
 LEFT JOIN cnpjs_pagos_apos_inativa ci ON ci.cpf_cnpj = tf.cpf_cnpj
 ) q
-ORDER BY q.abrangencia_sancao_info IS NOT NULL DESC, q.total_pago DESC
+ORDER BY
+  -- Sinais reais primeiro (ADR-0011): empresas com inidoneidade/sancoes nao
+  -- ficam enterradas atras de orgaos publicos top de receita.
+  q.flag_inidoneidade DESC,
+  q.flag_recebeu_durante_inidoneidade DESC,
+  q.flag_recebeu_durante_sancao_aplicavel DESC,
+  (q.flag_ceis OR q.flag_cnep) DESC,
+  q.flag_acordo_leniencia DESC,
+  q.flag_inativa_irregular DESC,
+  (q.abrangencia_sancao_info IS NOT NULL) DESC,
+  q.flag_pgfn DESC,
+  q.flag_inativa DESC,
+  q.total_pago DESC
 """
 
 TOP_FORNECEDORES_FALLBACK_DATED = """
@@ -649,8 +679,6 @@ WITH top_forn AS (
       AND d.data_empenho >= %(data_inicio)s AND d.data_empenho <= %(data_fim)s
       AND EXISTS (SELECT 1 FROM estabelecimento est WHERE est.cnpj_completo = d.cpf_cnpj)
     GROUP BY d.cnpj_basico, d.nome_credor
-    ORDER BY SUM(d.valor_pago) DESC
-    LIMIT 200
 ),
 cnpjs_pagos_apos_inativa AS MATERIALIZED (
     SELECT DISTINCT d2.cpf_cnpj
@@ -746,7 +774,19 @@ LEFT JOIN empresa e ON e.cnpj_basico = tf.cnpj_basico
 LEFT JOIN estabelecimento est ON est.cnpj_completo = tf.cpf_cnpj
 LEFT JOIN cnpjs_pagos_apos_inativa ci ON ci.cpf_cnpj = tf.cpf_cnpj
 ) q
-ORDER BY q.abrangencia_sancao_info IS NOT NULL DESC, q.total_pago DESC
+ORDER BY
+  -- Sinais reais primeiro (ADR-0011): empresas com inidoneidade/sancoes nao
+  -- ficam enterradas atras de orgaos publicos top de receita.
+  q.flag_inidoneidade DESC,
+  q.flag_recebeu_durante_inidoneidade DESC,
+  q.flag_recebeu_durante_sancao_aplicavel DESC,
+  (q.flag_ceis OR q.flag_cnep) DESC,
+  q.flag_acordo_leniencia DESC,
+  q.flag_inativa_irregular DESC,
+  (q.abrangencia_sancao_info IS NOT NULL) DESC,
+  q.flag_pgfn DESC,
+  q.flag_inativa DESC,
+  q.total_pago DESC
 """
 
 TOP_FORNECEDORES_PNCP = None  # deprecated: non-PB removed from frontend

--- a/web/static/css/components/_dark-overrides.css
+++ b/web/static/css/components/_dark-overrides.css
@@ -195,6 +195,11 @@ body.dark-page .filter-chip--yellow.filter-chip--active {
     border-color: #f59e0b;
     color: #fde68a;
 }
+body.dark-page .filter-chip--gray.filter-chip--active {
+    background: rgba(107, 114, 128, 0.32);
+    border-color: #9ca3af;
+    color: #e5e7eb;
+}
 body.dark-page .filter-chip--active .filter-chip__count {
     background: rgba(0, 0, 0, 0.35);
     color: #fff;

--- a/web/static/css/components/data-table.css
+++ b/web/static/css/components/data-table.css
@@ -198,6 +198,11 @@ tr:hover {
     border-color: #f59e0b;
     color: #78350f;
 }
+.filter-chip--gray.filter-chip--active {
+    background: #e5e7eb;
+    border-color: #6b7280;
+    color: #1f2937;
+}
 .filter-chip--clear {
     margin-left: auto;
     color: var(--md-sys-color-primary);

--- a/web/static/js/components/fornecedores-filter-chips.js
+++ b/web/static/js/components/fornecedores-filter-chips.js
@@ -1,0 +1,82 @@
+// === components/fornecedores-filter-chips.js ===
+// Filtros de chips por flag pra tabela de fornecedores. Plugga no _refilter
+// exposto pelo data-table.js. Semantica OR: row visivel se tem >=1 dos flags
+// ativos (ou se nenhum chip ativo).
+//
+// Espelha components/servidores-filter-chips.js. Eventos Umami catalogados
+// em docs/analytics.md: fornecedores-filtro-toggle, fornecedores-filtro-limpar.
+
+function initFornecedoresFilterChips(root = document) {
+    root.querySelectorAll('[data-fornecedores-filter-chips]').forEach((chipsEl) => {
+        if (chipsEl.dataset.enhanced === 'true') return;
+        chipsEl.dataset.enhanced = 'true';
+
+        const tableShell = chipsEl.closest('.js-data-table');
+        if (!tableShell || typeof tableShell._refilter !== 'function') return;
+
+        const chips = Array.from(chipsEl.querySelectorAll('.filter-chip[data-flag]'));
+        const clearBtn = chipsEl.querySelector('[data-clear]');
+        const active = new Set();
+
+        const flagToAttr = (flag) => `data-flag-${flag.replace(/_/g, '-')}`;
+
+        const apply = () => {
+            if (!active.size) {
+                const total = tableShell._refilter(null);
+                if (clearBtn) clearBtn.hidden = true;
+                return total;
+            }
+            const attrs = Array.from(active).map(flagToAttr);
+            const matched = tableShell._refilter((row) => attrs.some((a) => row.hasAttribute(a)));
+            if (clearBtn) clearBtn.hidden = false;
+            return matched;
+        };
+
+        const trackToggle = (flag, on, visiveis) => {
+            if (typeof trackEvent !== 'function') return;
+            const ativos = Array.from(active).sort().join(',');
+            const total = tableShell.querySelectorAll('tbody tr').length;
+            trackEvent('fornecedores-filtro-toggle', {
+                flag,
+                action: on ? 'on' : 'off',
+                ativos,
+                qtd_ativos: active.size,
+                visiveis,
+                total,
+            });
+        };
+
+        chips.forEach((chip) => {
+            chip.addEventListener('click', () => {
+                const flag = chip.dataset.flag;
+                const willActivate = !active.has(flag);
+                if (willActivate) active.add(flag);
+                else active.delete(flag);
+                chip.classList.toggle('filter-chip--active', willActivate);
+                chip.setAttribute('aria-pressed', String(willActivate));
+                const matched = apply();
+                trackToggle(flag, willActivate, matched);
+            });
+        });
+
+        if (clearBtn) {
+            clearBtn.addEventListener('click', () => {
+                const ativosPrev = Array.from(active).sort().join(',');
+                const qtdPrev = active.size;
+                active.clear();
+                chips.forEach((c) => {
+                    c.classList.remove('filter-chip--active');
+                    c.setAttribute('aria-pressed', 'false');
+                });
+                const matched = apply();
+                if (typeof trackEvent === 'function') {
+                    trackEvent('fornecedores-filtro-limpar', {
+                        ativos_anteriores: ativosPrev,
+                        qtd_ativos_anteriores: qtdPrev,
+                        visiveis: matched,
+                    });
+                }
+            });
+        }
+    });
+}

--- a/web/static/js/components/top-fornecedores.js
+++ b/web/static/js/components/top-fornecedores.js
@@ -35,11 +35,58 @@ function buildFornecedoresPanel(data) {
             if (recSan) return 'row-sancao-leve';
             return '';
         })();
+        const flagAttrs = [
+            _val(r, cols, 'flag_inidoneidade') && 'data-flag-inidoneidade="1"',
+            _val(r, cols, 'flag_recebeu_durante_inidoneidade') && 'data-flag-recebeu-durante-inidoneidade="1"',
+            _val(r, cols, 'flag_recebeu_durante_sancao_aplicavel') && 'data-flag-recebeu-durante-sancao-aplicavel="1"',
+            _val(r, cols, 'flag_ceis') && 'data-flag-ceis="1"',
+            _val(r, cols, 'flag_cnep') && 'data-flag-cnep="1"',
+            _val(r, cols, 'flag_acordo_leniencia') && 'data-flag-acordo-leniencia="1"',
+            _val(r, cols, 'flag_inativa_irregular') && 'data-flag-inativa-irregular="1"',
+            _val(r, cols, 'flag_pgfn') && 'data-flag-pgfn="1"',
+            _val(r, cols, 'flag_inativa') && 'data-flag-inativa="1"',
+        ].filter(Boolean).join(' ');
         if (cnpjCompletoDigits.length !== 14) {
-            return `<tr class="row-detail-unavailable ${rowSeverityClass}" aria-disabled="true"><td data-label="Empresa" class="stack-title">${nome} <span class="detail-unavailable-hint">Detalhes indisponiveis sem CNPJ completo</span></td><td data-label="CNPJ" class="auditor-only stack-meta"><code class="text-sm">${cnpjFmt}</code></td><td data-label="Recebido" class="text-right num">${total}</td><td data-label="Empenhos" class="text-right auditor-only num">${qtd}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
+            return `<tr class="row-detail-unavailable ${rowSeverityClass}" aria-disabled="true" ${flagAttrs}><td data-label="Empresa" class="stack-title">${nome} <span class="detail-unavailable-hint">Detalhes indisponiveis sem CNPJ completo</span></td><td data-label="CNPJ" class="auditor-only stack-meta"><code class="text-sm">${cnpjFmt}</code></td><td data-label="Recebido" class="text-right num">${total}</td><td data-label="Empenhos" class="text-right auditor-only num">${qtd}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
         }
-        return `<tr class="clickable-row ${rowSeverityClass}" data-fornecedor-cnpj="${cnpjBasico}" data-fornecedor-cpf-cnpj="${_esc(cnpjCompletoDigits)}" data-fornecedor-nome="${razao || nome}" data-fornecedor-nome-credor="${nome}"><td data-label="Empresa" class="stack-title">${nome}</td><td data-label="CNPJ" class="auditor-only stack-meta"><code class="text-sm">${cnpjFmt}</code></td><td data-label="Recebido" class="text-right num">${total}</td><td data-label="Empenhos" class="text-right auditor-only num">${qtd}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
+        return `<tr class="clickable-row ${rowSeverityClass}" data-fornecedor-cnpj="${cnpjBasico}" data-fornecedor-cpf-cnpj="${_esc(cnpjCompletoDigits)}" data-fornecedor-nome="${razao || nome}" data-fornecedor-nome-credor="${nome}" ${flagAttrs}><td data-label="Empresa" class="stack-title">${nome}</td><td data-label="CNPJ" class="auditor-only stack-meta"><code class="text-sm">${cnpjFmt}</code></td><td data-label="Recebido" class="text-right num">${total}</td><td data-label="Empenhos" class="text-right auditor-only num">${qtd}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
     }).join('');
+
+    // Contagens por flag para chips
+    const _count = (pred) => data.rows.filter(r => pred(r)).length;
+    const cnt = {
+        inidoneidade: _count(r => _val(r, cols, 'flag_inidoneidade')),
+        recebeu_durante_inidoneidade: _count(r => _val(r, cols, 'flag_recebeu_durante_inidoneidade')),
+        recebeu_durante_sancao_aplicavel: _count(r => _val(r, cols, 'flag_recebeu_durante_sancao_aplicavel')),
+        ceis: _count(r => _val(r, cols, 'flag_ceis')),
+        cnep: _count(r => _val(r, cols, 'flag_cnep')),
+        acordo_leniencia: _count(r => _val(r, cols, 'flag_acordo_leniencia')),
+        inativa_irregular: _count(r => _val(r, cols, 'flag_inativa_irregular')),
+        pgfn: _count(r => _val(r, cols, 'flag_pgfn')),
+        inativa: _count(r => _val(r, cols, 'flag_inativa')),
+    };
+    const chipHtml = (flag, severity, citizenLabel, auditorLabel) => {
+        if (!cnt[flag]) return '';
+        return `<button type="button" class="filter-chip filter-chip--${severity}" data-flag="${flag}" aria-pressed="false"><span class="citizen-only">${citizenLabel}</span><span class="auditor-only">${auditorLabel}</span> <span class="filter-chip__count">${cnt[flag]}</span></button>`;
+    };
+    const chips = [
+        chipHtml('inidoneidade', 'red', 'Proibida (nacional)', 'Inidoneidade'),
+        chipHtml('recebeu_durante_inidoneidade', 'red', 'Recebeu enquanto proibida', 'Pago durante Inidoneidade'),
+        chipHtml('recebeu_durante_sancao_aplicavel', 'orange', 'Recebeu durante punicao', 'Pago durante sancao'),
+        chipHtml('ceis', 'orange', 'Sancionada (CEIS)', 'CEIS'),
+        chipHtml('cnep', 'orange', 'Lei Anticorrupcao (CNEP)', 'CNEP'),
+        chipHtml('acordo_leniencia', 'yellow', 'Acordo de leniencia', 'Leniencia'),
+        chipHtml('inativa_irregular', 'red', 'Recebeu apos baixa', 'Inativa irregular (Q70)'),
+        chipHtml('pgfn', 'yellow', 'Devendo impostos federais', 'Divida PGFN'),
+        chipHtml('inativa', 'gray', 'Empresa inativa', 'Cadastro inativo'),
+    ].join('');
+    const chipsBlock = chips
+        ? `<div class="table-filter-chips" data-fornecedores-filter-chips role="group" aria-label="Filtrar fornecedores por sinal">
+            <span class="table-filter-chips__label text-sm text-muted">${dualLabel('Filtrar por sinal:','Filtros por flag:')}</span>
+            ${chips}
+            <button type="button" class="filter-chip filter-chip--clear" data-clear hidden>${dualLabel('Limpar filtros','Limpar')}</button>
+        </div>`
+        : '';
 
     const hasRecInid = data.rows.some(r => _val(r, data.columns, 'flag_recebeu_durante_inidoneidade'));
     const hasRecSancao = data.rows.some(r => _val(r, data.columns, 'flag_recebeu_durante_sancao_aplicavel'));
@@ -61,6 +108,7 @@ function buildFornecedoresPanel(data) {
             ${fornLegend}
         </div></div>
         <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores">
+            ${chipsBlock}
             <div class="table-actions">
                 <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar fornecedores">
                 <p class="table-meta text-sm text-muted" data-table-meta></p>
@@ -83,4 +131,5 @@ function buildFornecedoresPanel(data) {
         </div>
     </section>`;
 }
+
 

--- a/web/static/js/lib/umami-track.js
+++ b/web/static/js/lib/umami-track.js
@@ -95,6 +95,18 @@
 //   servidores-filtro-limpar - {ativos_anteriores, qtd_ativos_anteriores,
 //                            visiveis}
 //                           Botao "Limpar" dos chips de filtro.
+//   fornecedores-filtro-toggle - {flag, action: 'on'|'off', ativos,
+//                            qtd_ativos, visiveis, total}
+//                           Toggle de chip de filtro na tabela de
+//                           fornecedores. Flags: inidoneidade,
+//                           recebeu_durante_inidoneidade,
+//                           recebeu_durante_sancao_aplicavel, ceis, cnep,
+//                           acordo_leniencia, inativa_irregular, pgfn,
+//                           inativa.
+//   fornecedores-filtro-limpar - {ativos_anteriores, qtd_ativos_anteriores,
+//                            visiveis}
+//                           Botao "Limpar" dos chips de filtro de
+//                           fornecedores.
 //   secao-toggle          - {section, action: 'open'|'close'}
 //                           Toggle generico de <details> colapsavel.
 //                           `section` identifica a secao (ex:

--- a/web/static/js/pages/cidade-async-panels.js
+++ b/web/static/js/pages/cidade-async-panels.js
@@ -27,6 +27,7 @@ async function loadAsyncPanel(panelName, municipio, uf) {
         panel.setAttribute('aria-busy', 'false');
         initDataTables(panel);
         initServidoresFilterChips(panel);
+        initFornecedoresFilterChips(panel);
         initInteractiveToggles(panel);
         initMobileDescriptions(panel);
         initClickableRows(panel);

--- a/web/static/js/pages/cidade-bootstrap.js
+++ b/web/static/js/pages/cidade-bootstrap.js
@@ -60,6 +60,7 @@ async function bootstrapCityReport(municipio, uf, dataInicio, dataFim) {
             fornPanel.innerHTML = buildFornecedoresPanel(batchData.TOP_FORNECEDORES);
             fornPanel.setAttribute('aria-busy', 'false');
             initDataTables(fornPanel);
+            initFornecedoresFilterChips(fornPanel);
             initMobileDescriptions(fornPanel);
             initClickableRows(fornPanel);
         }

--- a/web/static/js/pages/main.js
+++ b/web/static/js/pages/main.js
@@ -2,6 +2,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     initDataTables(document);
     initServidoresFilterChips(document);
+    initFornecedoresFilterChips(document);
     initCidadeAutocomplete();
     initInteractiveToggles(document);
     initClickableRows(document);

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -1,4 +1,14 @@
 {% if fornecedores %}
+{# Contagens por flag para os chips de filtro (server-side, uma vez por render). #}
+{% set _inid = fornecedores|selectattr('flag_inidoneidade')|list|length %}
+{% set _rec_inid = fornecedores|selectattr('flag_recebeu_durante_inidoneidade')|list|length %}
+{% set _rec_san = fornecedores|selectattr('flag_recebeu_durante_sancao_aplicavel')|list|length %}
+{% set _ceis = fornecedores|selectattr('flag_ceis')|list|length %}
+{% set _cnep = fornecedores|selectattr('flag_cnep')|list|length %}
+{% set _len = fornecedores|selectattr('flag_acordo_leniencia')|list|length %}
+{% set _inativa_irr = fornecedores|selectattr('flag_inativa_irregular')|list|length %}
+{% set _pgfn = fornecedores|selectattr('flag_pgfn')|list|length %}
+{% set _inativa = fornecedores|selectattr('flag_inativa')|list|length %}
 <section class="result-block">
     <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores">
         {% set has_rec_inid = fornecedores|selectattr('flag_recebeu_durante_inidoneidade')|list %}
@@ -9,6 +19,21 @@
             {% if has_rec_inid %}<span class="color-legend-item"><span class="color-legend-dot" style="background:#ef4444"></span> <span class="citizen-only">Recebeu enquanto proibida de contratar</span><span class="auditor-only">Recebeu durante Inidoneidade</span></span>{% endif %}
             {% if has_rec_sancao %}<span class="color-legend-item"><span class="color-legend-dot" style="background:#f59e0b"></span> <span class="citizen-only">Recebeu durante puni&ccedil;&atilde;o aplic&aacute;vel</span><span class="auditor-only">Recebeu durante sancao aplicavel</span></span>{% endif %}
             {% if has_acordo %}<span class="color-legend-item"><span class="color-legend-dot" style="background:#3b82f6"></span> <span class="citizen-only">Acordo de leni&ecirc;ncia vigente (CGU)</span><span class="auditor-only">Acordo de leniencia vigente</span></span>{% endif %}
+        </div>
+        {% endif %}
+        {% if _inid or _rec_inid or _rec_san or _ceis or _cnep or _len or _inativa_irr or _pgfn or _inativa %}
+        <div class="table-filter-chips" data-fornecedores-filter-chips role="group" aria-label="Filtrar fornecedores por sinal de aten&ccedil;&atilde;o">
+            <span class="table-filter-chips__label text-sm text-muted"><span class="citizen-only">Filtrar por sinal:</span><span class="auditor-only">Filtros por flag:</span></span>
+            {% if _inid %}<button type="button" class="filter-chip filter-chip--red" data-flag="inidoneidade" aria-pressed="false"><span class="citizen-only">Proibida (nacional)</span><span class="auditor-only">Inidoneidade</span> <span class="filter-chip__count">{{ _inid }}</span></button>{% endif %}
+            {% if _rec_inid %}<button type="button" class="filter-chip filter-chip--red" data-flag="recebeu_durante_inidoneidade" aria-pressed="false"><span class="citizen-only">Recebeu enquanto proibida</span><span class="auditor-only">Pago durante Inidoneidade</span> <span class="filter-chip__count">{{ _rec_inid }}</span></button>{% endif %}
+            {% if _rec_san %}<button type="button" class="filter-chip filter-chip--orange" data-flag="recebeu_durante_sancao_aplicavel" aria-pressed="false"><span class="citizen-only">Recebeu durante puni&ccedil;&atilde;o</span><span class="auditor-only">Pago durante sancao</span> <span class="filter-chip__count">{{ _rec_san }}</span></button>{% endif %}
+            {% if _ceis %}<button type="button" class="filter-chip filter-chip--orange" data-flag="ceis" aria-pressed="false"><span class="citizen-only">Sancionada (CEIS)</span><span class="auditor-only">CEIS</span> <span class="filter-chip__count">{{ _ceis }}</span></button>{% endif %}
+            {% if _cnep %}<button type="button" class="filter-chip filter-chip--orange" data-flag="cnep" aria-pressed="false"><span class="citizen-only">Lei Anticorrup&ccedil;&atilde;o (CNEP)</span><span class="auditor-only">CNEP</span> <span class="filter-chip__count">{{ _cnep }}</span></button>{% endif %}
+            {% if _len %}<button type="button" class="filter-chip filter-chip--yellow" data-flag="acordo_leniencia" aria-pressed="false"><span class="citizen-only">Acordo de leni&ecirc;ncia</span><span class="auditor-only">Leniencia</span> <span class="filter-chip__count">{{ _len }}</span></button>{% endif %}
+            {% if _inativa_irr %}<button type="button" class="filter-chip filter-chip--red" data-flag="inativa_irregular" aria-pressed="false"><span class="citizen-only">Recebeu ap&oacute;s baixa</span><span class="auditor-only">Inativa irregular (Q70)</span> <span class="filter-chip__count">{{ _inativa_irr }}</span></button>{% endif %}
+            {% if _pgfn %}<button type="button" class="filter-chip filter-chip--yellow" data-flag="pgfn" aria-pressed="false"><span class="citizen-only">Devendo impostos federais</span><span class="auditor-only">Divida PGFN</span> <span class="filter-chip__count">{{ _pgfn }}</span></button>{% endif %}
+            {% if _inativa %}<button type="button" class="filter-chip filter-chip--gray" data-flag="inativa" aria-pressed="false"><span class="citizen-only">Empresa inativa</span><span class="auditor-only">Cadastro inativo</span> <span class="filter-chip__count">{{ _inativa }}</span></button>{% endif %}
+            <button type="button" class="filter-chip filter-chip--clear" data-clear hidden><span class="citizen-only">Limpar filtros</span><span class="auditor-only">Limpar</span></button>
         </div>
         {% endif %}
         <div class="table-actions">
@@ -42,6 +67,7 @@
                      {% if f.flag_recebeu_durante_inidoneidade %}{% set row_extra = ' row-sancao' %}
                      {% elif f.flag_recebeu_durante_sancao_aplicavel %}{% set row_extra = ' row-sancao-leve' %}
                      {% else %}{% set row_extra = '' %}{% endif %}
+                    {% set _flag_attrs %}{% if f.flag_inidoneidade %} data-flag-inidoneidade="1"{% endif %}{% if f.flag_recebeu_durante_inidoneidade %} data-flag-recebeu-durante-inidoneidade="1"{% endif %}{% if f.flag_recebeu_durante_sancao_aplicavel %} data-flag-recebeu-durante-sancao-aplicavel="1"{% endif %}{% if f.flag_ceis %} data-flag-ceis="1"{% endif %}{% if f.flag_cnep %} data-flag-cnep="1"{% endif %}{% if f.flag_acordo_leniencia %} data-flag-acordo-leniencia="1"{% endif %}{% if f.flag_inativa_irregular %} data-flag-inativa-irregular="1"{% endif %}{% if f.flag_pgfn %} data-flag-pgfn="1"{% endif %}{% if f.flag_inativa %} data-flag-inativa="1"{% endif %}{% endset %}
                     {% set cnpj_completo_digits = f.cnpj_completo|default('', true)|string|replace('.', '')|replace('/', '')|replace('-', '') %}
                     {% if cnpj_completo_digits|length == 14 %}
                     <tr class="clickable-row{{ row_extra }}"
@@ -49,9 +75,9 @@
                         data-fornecedor-cpf-cnpj="{{ cnpj_completo_digits }}"
                         data-fornecedor-nome="{{ (f.razao_social or f.nome_credor)|clean_text }}"
                         data-fornecedor-nome-credor="{{ f.nome_credor|clean_text }}"
-                        data-empresa-url="/empresa/{{ cnpj_completo_digits }}">
+                        data-empresa-url="/empresa/{{ cnpj_completo_digits }}"{{ _flag_attrs }}>
                     {% else %}
-                    <tr class="row-detail-unavailable{{ row_extra }}" aria-disabled="true">
+                    <tr class="row-detail-unavailable{{ row_extra }}" aria-disabled="true"{{ _flag_attrs }}>
                     {% endif %}
                         <td data-label="Empresa" class="stack-title">{{ f.nome_credor|clean_text }}{% if cnpj_completo_digits|length != 14 %} <span class="detail-unavailable-hint">Detalhes indisponiveis sem CNPJ completo</span>{% endif %}</td>
                         <td data-label="CNPJ" class="auditor-only"><code class="text-sm">{{ f.cnpj_basico[:2] }}.{{ f.cnpj_basico[2:5] }}.{{ f.cnpj_basico[5:8] }}/****-**</code></td>


### PR DESCRIPTION
## Resumo

Aplica o mesmo padrao do PR #195 (servidores sem LIMIT + filtros + Umami) a tabela **Top Fornecedores**.

## O que muda

| Area | Mudanca |
|---|---|
| SQL | Remove `LIMIT 200` das 4 variantes `TOP_FORNECEDORES` (full / fallback / dated / fallback_dated). Reescreve `ORDER BY` signals-first com `total_pago` como tiebreaker. |
| Frontend | Novo componente `fornecedores-filter-chips.js` (9 chips OR-semantica) + `data-flag-*` attrs por linha. SSR no template + paridade no renderer JS de batch. |
| CSS | Adiciona `.filter-chip--gray.filter-chip--active` (light + dark) para o chip de `inativa`. |
| Umami | Eventos `fornecedores-filtro-toggle` e `fornecedores-filtro-limpar` catalogados em docs/analytics.md + header de umami-track.js. |
| Infra | `ASSET_VERSION` 119 -> 120. |
| Docs | ADR-0011 promovido para *Accepted (parcial - servidores + fornecedores)* + `docs/deploy.md` ganha secao explicando que `build-assets` sempre roda (nao existe input `build_assets`). |

## Validacao em prod (top 20 Joao Pessoa)

Top 20 com nova ordenacao - **TODAS as 20 linhas tem `flag_inidoneidade=TRUE`** (sinal forte de que signals-first reordena bem; o top antigo por `total_pago` enterrava inidoneas atras de orgaos publicos).

Dentro do bloco de inidoneidade, tiebreaker por `total_pago DESC` funciona conforme esperado (ex: MARBELLA RESIDENCE 7.09M antes de BIDDEN 0.22M no grupo `I+C+P`).

## Por que importa

- **Completude**: usuario pode auditar todos os fornecedores de uma cidade (nao so o top-200 por `total_pago`). JP tem milhares de fornecedores no recorte.
- **Sinais primeiro**: empresas com inidoneidade ou recebimento durante sancao aparecem no topo, mesmo com valor pago menor.
- **Filtros visuais**: chips com contadores SSR permitem recorte rapido por tipo de sinal.

## Deploy

- `etl_phase=web` (sem ETL/SQL)
- `rewarm_cache_keys=TOP_FORNECEDORES` (shadow rewarm seletivo - cobre variantes dated por base match)

`build-assets` roda automaticamente no step de restart - nao precisa de input.

## Checklist

- [x] Working language PT-BR
- [x] Sem pandas / sem ORM
- [x] Co-authored-by Copilot em todos os commits
- [x] `python -m compileall web -q` ok
- [x] `node --check` em todos JS modificados
- [x] Jinja smoke-parse do template ok
- [x] ADR atualizada
- [x] Catalogo Umami (docs/analytics.md) atualizado
- [x] Validado em prod com top 20 de JP

## Followups

- Issue #197 (cleanup `TOP_FORNECEDORES_FALLBACK` dead code) - mesmo escopo, separada para good-first-issue.