### PR TITLE
feat(web): progressive loading nas tabelas top-servidores e top-fornecedores

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -118,6 +118,7 @@ Semântica OR (union dos filtros ativos).
 | `fornecedores-filtro-toggle` | `{flag, action: 'on'\|'off', ativos, qtd_ativos, visiveis, total}` | toggle de chip de filtro na tabela de fornecedores ⁷ |
 | `fornecedores-filtro-limpar` | `{ativos_anteriores, qtd_ativos_anteriores, visiveis}` | botão "Limpar" dos chips de filtro de fornecedores |
 | `tabela-pagina-mudou` | `{tabela, de, para, total_paginas, via: 'prev'\|'next'}` ⁶ | clique em Anterior/Próxima das tabelas paginadas |
+| `tabela-hidratada` | `{tabela, total, initial, ms_to_hydrate, forced}` ⁶ | tabelas top-servidores/top-fornecedores com > 100 rows usam progressive loading: SSR emite `initial` rows em `<tbody>` + resto em `<script type="text/html" data-rest-rows>`. Evento dispara no momento em que o tail é hidratado (via `requestIdleCallback` ou ao primeiro user input). `forced=true` quando usuário interagiu antes do RIC disparar. Permite monitorar TTI real em mid-tier mobile. |
 | `empenho-table-sort` | `{coluna, direcao: 'asc'\|'desc'}` | clique em header de tabela para ordenar (dialog de empenho) |
 
 ### Diversos

--- a/web/main.py
+++ b/web/main.py
@@ -500,7 +500,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "120"
+templates.env.globals["ASSET_VERSION"] = "121"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/components/data-table.js
+++ b/web/static/js/components/data-table.js
@@ -9,11 +9,73 @@ function initDataTables(root = document) {
         const pageLabel = tableShell.querySelector('[data-page-label]');
         const prevBtn = tableShell.querySelector('[data-page-prev]');
         const nextBtn = tableShell.querySelector('[data-page-next]');
-        const rows = Array.from(tableShell.querySelectorAll('tbody tr'));
+        let rows = Array.from(tableShell.querySelectorAll('tbody tr'));
         const pageSize = Number(tableShell.dataset.pageSize || 12);
         let filteredRows = rows;
         let page = 1;
         let externalFilter = null; // set by toggles (e.g. ocultar medicos)
+
+        // === Progressive loading (PR #199) ===
+        // Tabelas grandes (top-servidores/top-fornecedores em JP tem 51k/13k rows)
+        // viraram TTI lento por SSR sincrono de DOM massivo. Template emite
+        // primeira leva (50 rows) em <tbody> real + tail em
+        // <script type="text/html" data-rest-rows> (inert text, sem custo de DOM).
+        // Hidratamos o tail apos paint inicial via requestIdleCallback.
+        //
+        // Hidratacao = idempotente:
+        //   1. lookup do <script data-rest-rows>; se nao existe, no-op
+        //   2. parse innerHTML em <table><tbody> auxiliar
+        //   3. append novos <tr> no tbody real
+        //   4. recolect rows, re-init clickable, applyFilters + renderPage
+        //   5. emit umami `tabela-hidratada`
+        //
+        // Force-flush: capture-phase listener no tableShell para click/input/keydown.
+        // Qualquer interacao do usuario ANTES do RIC disparar forca hidratacao
+        // sincrona imediata. Evita race onde chip click filtra apenas as 50 iniciais.
+        const tbody = tableShell.querySelector('tbody');
+        const restScript = tableShell.querySelector('script[type="text/html"][data-rest-rows]');
+        const hasProgressive = !!(restScript && tbody);
+        let hydrated = !hasProgressive;
+        let hydrateScheduled = 0;
+        let hydrationStartTs = 0;
+
+        const _hydrateRest = (forced = false) => {
+            if (hydrated) return;
+            hydrated = true;
+            if (hydrateScheduled && typeof cancelIdleCallback === 'function') {
+                cancelIdleCallback(hydrateScheduled);
+            }
+            hydrateScheduled = 0;
+            const t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+            const html = restScript.textContent || '';
+            const tmp = document.createElement('table');
+            tmp.innerHTML = '<tbody>' + html + '</tbody>';
+            const tmpBody = tmp.querySelector('tbody');
+            const frag = document.createDocumentFragment();
+            while (tmpBody && tmpBody.firstChild) frag.appendChild(tmpBody.firstChild);
+            tbody.appendChild(frag);
+            restScript.remove();
+            rows = Array.from(tbody.querySelectorAll('tr'));
+            if (typeof initClickableRows === 'function') {
+                try { initClickableRows(tbody); } catch (e) { /* no-op */ }
+            }
+            applyFilters();
+            renderPage();
+            const t1 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+            const ms = Math.round(t1 - (hydrationStartTs || t0));
+            if (typeof trackEvent === 'function') {
+                const tabela = tableShell.dataset.tableId || 'unknown';
+                if (tabela !== 'unknown') {
+                    trackEvent('tabela-hidratada', {
+                        tabela,
+                        total: Number(tableShell.dataset.progressiveTotal || rows.length),
+                        initial: Number(tableShell.dataset.progressiveInitial || 0),
+                        ms_to_hydrate: ms,
+                        forced,
+                    });
+                }
+            }
+        };
 
         const applyFilters = () => {
             const term = filterInput ? filterInput.value.trim().toLowerCase() : '';
@@ -137,6 +199,21 @@ function initDataTables(root = document) {
         });
 
         renderPage();
+
+        if (hasProgressive) {
+            hydrationStartTs = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+            const flushOnInteraction = () => _hydrateRest(true);
+            // Capture-phase: roda ANTES dos handlers de filtro/chip/sort/paginacao,
+            // garantindo que applyFilters() veja a lista completa de rows.
+            tableShell.addEventListener('click', flushOnInteraction, { capture: true, once: true });
+            tableShell.addEventListener('input', flushOnInteraction, { capture: true, once: true });
+            tableShell.addEventListener('keydown', flushOnInteraction, { capture: true, once: true });
+            if (typeof requestIdleCallback === 'function') {
+                hydrateScheduled = requestIdleCallback(() => _hydrateRest(false), { timeout: 1500 });
+            } else {
+                setTimeout(() => _hydrateRest(false), 0);
+            }
+        }
     });
 }
 

--- a/web/static/js/components/top-fornecedores.js
+++ b/web/static/js/components/top-fornecedores.js
@@ -1,7 +1,7 @@
 // === components/top-fornecedores.js ===
 function buildFornecedoresPanel(data) {
     const cols = data.columns;
-    const bodyRows = data.rows.map(r => {
+    const rowHtmlList = data.rows.map(r => {
         const cnpjBasico = _esc(_val(r, cols, 'cnpj_basico') || '');
         const cnpjCompleto = _val(r, cols, 'cnpj_completo') || '';
         const cnpjFmt = _formatCnpj(cnpjBasico, cnpjCompleto);
@@ -50,7 +50,22 @@ function buildFornecedoresPanel(data) {
             return `<tr class="row-detail-unavailable ${rowSeverityClass}" aria-disabled="true" ${flagAttrs}><td data-label="Empresa" class="stack-title">${nome} <span class="detail-unavailable-hint">Detalhes indisponiveis sem CNPJ completo</span></td><td data-label="CNPJ" class="auditor-only stack-meta"><code class="text-sm">${cnpjFmt}</code></td><td data-label="Recebido" class="text-right num">${total}</td><td data-label="Empenhos" class="text-right auditor-only num">${qtd}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
         }
         return `<tr class="clickable-row ${rowSeverityClass}" data-fornecedor-cnpj="${cnpjBasico}" data-fornecedor-cpf-cnpj="${_esc(cnpjCompletoDigits)}" data-fornecedor-nome="${razao || nome}" data-fornecedor-nome-credor="${nome}" ${flagAttrs}><td data-label="Empresa" class="stack-title">${nome}</td><td data-label="CNPJ" class="auditor-only stack-meta"><code class="text-sm">${cnpjFmt}</code></td><td data-label="Recebido" class="text-right num">${total}</td><td data-label="Empenhos" class="text-right auditor-only num">${qtd}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
-    }).join('');
+    });
+    const _PROGRESSIVE_THRESHOLD = 100;
+    const _INITIAL_N = 50;
+    const _hasProgressive = rowHtmlList.length > _PROGRESSIVE_THRESHOLD;
+    const _initialN = _hasProgressive ? _INITIAL_N : rowHtmlList.length;
+    // Split: initial vai pro <tbody>; tail vai pra <script type="text/html"> data-rest-rows
+    // (data-table.js hidrata via requestIdleCallback). Mesmo padrao do SSR
+    // — ver web/templates/partials/top_fornecedores.html.
+    const initialRowsHtml = rowHtmlList.slice(0, _initialN).join('');
+    const tailRowsHtml = _hasProgressive ? rowHtmlList.slice(_initialN).join('') : '';
+    const tailScript = _hasProgressive
+        ? `<script type="text/html" data-rest-rows>${tailRowsHtml}</script>`
+        : '';
+    const _shellAttrs = _hasProgressive
+        ? ` data-progressive-total="${rowHtmlList.length}" data-progressive-initial="${_initialN}"`
+        : '';
 
     // Contagens por flag para chips
     const _count = (pred) => data.rows.filter(r => pred(r)).length;
@@ -107,7 +122,7 @@ function buildFornecedoresPanel(data) {
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Concentracao dos pagamentos e sinais de atencao de cada empresa. Toque em uma empresa para detalhes.</span><span class="auditor-only">Concentracao de pagamentos e sinais automaticos de cada fornecedor. Clique em um fornecedor para ver detalhes.</span></p>
             ${fornLegend}
         </div></div>
-        <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores">
+        <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores"${_shellAttrs}>
             ${chipsBlock}
             <div class="table-actions">
                 <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar fornecedores">
@@ -121,8 +136,9 @@ function buildFornecedoresPanel(data) {
                     <th class="text-right auditor-only">Empenhos</th>
                     <th><span class="citizen-only">Sinais</span><span class="auditor-only">Sinais de Atencao</span></th>
                 </tr></thead>
-                <tbody>${bodyRows}</tbody>
+                <tbody>${initialRowsHtml}</tbody>
             </table></div>
+            ${tailScript}
             <div class="table-pagination">
                 <md-text-button data-page-prev>Anterior</md-text-button>
                 <p class="text-sm text-muted" data-page-label></p>

--- a/web/static/js/components/top-servidores.js
+++ b/web/static/js/components/top-servidores.js
@@ -13,7 +13,7 @@ function buildServidoresPanel(data) {
         return aScore - bScore;
     });
 
-    const bodyRows = sortedRows.map(r => {
+    const rowHtmlList = sortedRows.map(r => {
         const nome = _esc(_val(r, cols, 'nome_servidor'));
         const cargoRaw = _val(r, cols, 'cargo') || '-';
         const cargo = _esc(cargoRaw);
@@ -59,7 +59,22 @@ function buildServidoresPanel(data) {
         const rowClass = (ceafExpulso || totalPagoRow || socioInidoneidade) ? 'clickable-row row-sancao' : (socioSancionado || bolsaFamilia || vinculoFederal) ? 'clickable-row row-sancao-leve' : 'clickable-row';
         const cpfFmt = cpf6.length === 6 ? `***.${cpf6.slice(0,3)}.${cpf6.slice(3,6)}-**` : '';
         return `<tr data-cargo="${_esc(String(cargoRaw).toLowerCase())}" ${hasDetail ? `class="${rowClass}"` : ''}${detailAttrs} ${flagAttrs}><td data-label="Servidor" class="stack-title">${nome}</td><td data-label="CPF" class="auditor-only stack-meta"><code class="text-sm">${cpfFmt}</code></td><td data-label="Cargo" class="stack-meta">${cargo}</td><td data-label="Maior salario" class="text-right num">${salario}</td><td data-label="Sinais" class="stack-badges">${badges}</td></tr>`;
-    }).join('');
+    });
+    const _PROGRESSIVE_THRESHOLD = 100;
+    const _INITIAL_N = 50;
+    const _hasProgressive = rowHtmlList.length > _PROGRESSIVE_THRESHOLD;
+    const _initialN = _hasProgressive ? _INITIAL_N : rowHtmlList.length;
+    // Split: initial vai pro <tbody> real; tail entra em <script type="text/html">
+    // data-rest-rows. data-table.js hidrata via requestIdleCallback (mesmo
+    // padrao do SSR — ver web/templates/partials/top_servidores.html).
+    const initialRowsHtml = rowHtmlList.slice(0, _initialN).join('');
+    const tailRowsHtml = _hasProgressive ? rowHtmlList.slice(_initialN).join('') : '';
+    const tailScript = _hasProgressive
+        ? `<script type="text/html" data-rest-rows>${tailRowsHtml}</script>`
+        : '';
+    const _shellAttrs = _hasProgressive
+        ? ` data-progressive-total="${rowHtmlList.length}" data-progressive-initial="${_initialN}"`
+        : '';
 
     // Contagens por flag para os chips
     const _count = (flag, pred) => data.rows.filter(r => pred(r)).length;
@@ -112,7 +127,7 @@ function buildServidoresPanel(data) {
             <p class="text-muted text-sm mobile-collapsible-desc"><span class="citizen-only">Servidores com pelo menos um sinal incomum nos cruzamentos automatizados: socio de empresa, cadastro federal, beneficio social irregular, ou acumulacao atipica. A Constituicao permite dois vinculos em alguns casos, como saude e magisterio.</span><span class="auditor-only">Servidores que apresentam ao menos um sinal de risco nos cruzamentos automaticos: vinculo societario com fornecedores, vinculo municipal + federal, recebimento de beneficio social ou acumulacao atipica. A Constituicao (art. 37, XVI) admite algumas acumulacoes.</span></p>
             ${servLegend}
         </div></div>
-        <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-servidores">
+        <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-servidores"${_shellAttrs}>
             ${chipsBlock}
             <div class="table-actions">
                 <input type="search" class="table-filter" placeholder="Filtrar nesta tabela" aria-label="Filtrar servidores">
@@ -120,8 +135,9 @@ function buildServidoresPanel(data) {
             </div>
             <div class="tbl-wrap"><table class="stack-mobile">
                 <thead><tr><th>Servidor</th><th class="auditor-only">CPF</th><th>Cargo</th><th class="text-right">${dualLabel('Maior salario','Maior Salario')}</th><th>${dualLabel('Sinais','Sinais de Atencao')}</th></tr></thead>
-                <tbody>${bodyRows}</tbody>
+                <tbody>${initialRowsHtml}</tbody>
             </table></div>
+            ${tailScript}
             <div class="table-pagination">
                 <md-text-button data-page-prev>Anterior</md-text-button>
                 <p class="text-sm text-muted" data-page-label></p>

--- a/web/static/js/lib/umami-track.js
+++ b/web/static/js/lib/umami-track.js
@@ -121,6 +121,18 @@
 //                           medir profundidade de exploracao por tipo
 //                           de tabela (top-servidores, top-fornecedores,
 //                           result-query).
+//   tabela-hidratada      - {tabela, total, initial, ms_to_hydrate,
+//                            forced: true|false}
+//                           Tabelas top-servidores/top-fornecedores com
+//                           > 100 rows usam progressive loading (PR #199):
+//                           SSR emite as primeiras `initial` rows em
+//                           <tbody> + o resto em
+//                           <script type="text/html" data-rest-rows>.
+//                           Evento dispara no momento em que o tail e
+//                           hidratado (via requestIdleCallback ou ao
+//                           primeiro user input). `forced=true` quando
+//                           usuario interagiu antes do RIC disparar.
+//                           Permite monitorar TTI real em mid-tier mobile.
 //   termo-tooltip-aberto  - {termo} Tap em palavra do glossario inline
 //                           (`.term[data-tip]`) em touch device. Mede
 //                           quais termos confundem leitores.

--- a/web/templates/partials/_top_table_macros.html
+++ b/web/templates/partials/_top_table_macros.html
@@ -1,0 +1,92 @@
+{# Macros compartilhados entre top_servidores.html e top_fornecedores.html.
+
+   Extraidos para suportar progressive loading: o template loopa a primeira
+   leva (initial batch) dentro do <tbody> real e o restante dentro de um
+   <script type="text/html" data-rest-rows> (texto inerte, sem custo de DOM).
+   data-table.js hidrata o tail via innerHTML em requestIdleCallback.
+
+   Mantenha a saida do macro IDENTICA ao que existia inline antes do PR de
+   progressive loading — qualquer drift quebra:
+     - filtros (data-flag-* attrs)
+     - clickable rows (data-cpf6, data-fornecedor-cnpj, etc)
+     - chip counts (calculados server-side a partir da lista completa)
+#}
+
+{% macro render_servidor_row(s) %}
+  {%- set cargo = (s.cargo or "-")|clean_text -%}
+  {%- set cpf6 = s.cpf_digitos_6|default('')|string -%}
+  {%- set nome_up = s.nome_upper|default('')|string -%}
+  {%- set cnpjs_json = s.cnpjs_socio|default([])|tojson -%}
+  {%- set _flag_durante = (s.total_pago_durante_vinculo|default(0)|float > 0) -%}
+  {%- set _flag_attrs %}{% if s.flag_ceaf_expulso %} data-flag-ceaf-expulso="1"{% endif %}{% if s.flag_socio_inidoneidade %} data-flag-socio-inidoneidade="1"{% endif %}{% if _flag_durante %} data-flag-durante-vinculo="1"{% endif %}{% if s.flag_bolsa_familia %} data-flag-bolsa-familia="1"{% endif %}{% if s.flag_socio_sancionado %} data-flag-socio-sancionado="1"{% endif %}{% if s.flag_multi_empresa %} data-flag-multi-empresa="1"{% endif %}{% if s.flag_alto_salario_socio %} data-flag-alto-salario-socio="1"{% endif %}{% if s.flag_duplo_vinculo_federal %} data-flag-duplo-vinculo-federal="1"{% endif %}{% endset -%}
+  {% if cpf6 and nome_up %}
+  <tr class="clickable-row{% if s.flag_ceaf_expulso or _flag_durante or s.flag_socio_inidoneidade %} row-sancao{% elif s.flag_socio_sancionado or s.flag_bolsa_familia or s.flag_duplo_vinculo_federal %} row-sancao-leve{% endif %}" data-cargo="{{ cargo|lower }}" data-cpf6="{{ cpf6 }}" data-nome-upper="{{ nome_up }}" data-nome="{{ s.nome_servidor|default(nome_up)|clean_text }}" data-cnpjs='{{ cnpjs_json }}'{{ _flag_attrs }}>
+  {% else %}
+  <tr data-cargo="{{ cargo|lower }}"{{ _flag_attrs }}>
+  {% endif %}
+      <td data-label="Servidor" class="stack-title">{{ s.nome_servidor|clean_text }}</td>
+      <td data-label="CPF" class="auditor-only"><code class="text-sm">***.{{ cpf6[:3] }}.{{ cpf6[3:] }}-**</code></td>
+      <td data-label="Cargo">{{ cargo }}</td>
+      <td data-label="Maior salario" class="text-right num">{{ s.maior_salario|default(0)|short_brl }}</td>
+      <td data-label="Sinais" class="stack-badges">
+          {% if s.flag_ceaf_expulso %}<span class="badge badge-red"><span class="citizen-only">Expulso do servi&ccedil;o p&uacute;blico federal</span><span class="auditor-only">Expulso da Adm. Federal (CEAF)</span></span>{% endif %}
+          {% if s.total_pago_durante_vinculo|default(0)|float > 0 %}
+              <span class="badge badge-red"><span class="citizen-only">Empresa ligada a ele recebeu {{ s.total_pago_durante_vinculo|short_brl }} enquanto era servidor</span><span class="auditor-only">Empresa recebeu {{ s.total_pago_durante_vinculo|short_brl }} durante vinculo</span></span>
+          {% endif %}
+          {% if s.flag_duplo_vinculo_federal %}<span class="badge badge-yellow" title="Sinal de revis&atilde;o: a Constitui&ccedil;&atilde;o admite acumula&ccedil;&atilde;o em alguns casos, como sa&uacute;de e magist&eacute;rio."><span class="citizen-only">Tamb&eacute;m aparece no cadastro federal</span><span class="auditor-only">Vinculo municipal + federal (SIAPE)</span></span>{% endif %}
+          {% if s.flag_multi_empresa %}
+              <span class="badge badge-yellow"><span class="citizen-only">S&oacute;cio de {{ s.qtd_empresas_socio|default('v&aacute;rias') }} empresas</span><span class="auditor-only">Socio de {{ s.qtd_empresas_socio|default('varias') }} empresas</span></span>
+          {% endif %}
+          {% if s.flag_bolsa_familia %}<span class="badge badge-yellow"><span class="citizen-only">Recebe Bolsa Fam&iacute;lia sendo servidor</span><span class="auditor-only">Bolsa Familia durante vinculo</span></span>{% endif %}
+          {% if s.flag_alto_salario_socio %}<span class="badge badge-yellow"><span class="citizen-only">Sal&aacute;rio alto + s&oacute;cio de empresa</span><span class="auditor-only">Salario alto + vinculo societario</span></span>{% endif %}
+          {% if s.flag_socio_inidoneidade %}<span class="badge badge-red"><span class="citizen-only">S&oacute;cio de empresa proibida de contratar com o governo</span><span class="auditor-only">Socio de empresa com Inidoneidade (CEIS)</span></span>
+          {% elif s.flag_socio_sancionado %}<span class="badge badge-orange"><span class="citizen-only">S&oacute;cio de empresa sancionada pelo governo</span><span class="auditor-only">Socio de empresa sancionada (CEIS/CNEP)</span></span>{% endif %}
+          {% if not s.flag_ceaf_expulso and not s.flag_conflito_interesses and not s.flag_multi_empresa and not s.flag_bolsa_familia and not s.flag_duplo_vinculo_federal and not s.flag_alto_salario_socio and not s.flag_socio_sancionado and not s.flag_socio_inidoneidade and not (s.total_pago_durante_vinculo|default(0)|float > 0) %}
+              <span class="text-sm text-muted"><span class="citizen-only">Sem sinais espec&iacute;ficos detectados</span><span class="auditor-only">Sem sinal automatico</span></span>
+          {% endif %}
+      </td>
+  </tr>
+{% endmacro %}
+
+{% macro render_fornecedor_row(f) %}
+  {%- if f.flag_recebeu_durante_inidoneidade %}{% set row_extra = ' row-sancao' %}
+  {%- elif f.flag_recebeu_durante_sancao_aplicavel %}{% set row_extra = ' row-sancao-leve' %}
+  {%- else %}{% set row_extra = '' %}{% endif -%}
+  {%- set _flag_attrs %}{% if f.flag_inidoneidade %} data-flag-inidoneidade="1"{% endif %}{% if f.flag_recebeu_durante_inidoneidade %} data-flag-recebeu-durante-inidoneidade="1"{% endif %}{% if f.flag_recebeu_durante_sancao_aplicavel %} data-flag-recebeu-durante-sancao-aplicavel="1"{% endif %}{% if f.flag_ceis %} data-flag-ceis="1"{% endif %}{% if f.flag_cnep %} data-flag-cnep="1"{% endif %}{% if f.flag_acordo_leniencia %} data-flag-acordo-leniencia="1"{% endif %}{% if f.flag_inativa_irregular %} data-flag-inativa-irregular="1"{% endif %}{% if f.flag_pgfn %} data-flag-pgfn="1"{% endif %}{% if f.flag_inativa %} data-flag-inativa="1"{% endif %}{% endset -%}
+  {%- set cnpj_completo_digits = f.cnpj_completo|default('', true)|string|replace('.', '')|replace('/', '')|replace('-', '') -%}
+  {% if cnpj_completo_digits|length == 14 %}
+  <tr class="clickable-row{{ row_extra }}"
+      data-fornecedor-cnpj="{{ f.cnpj_basico }}"
+      data-fornecedor-cpf-cnpj="{{ cnpj_completo_digits }}"
+      data-fornecedor-nome="{{ (f.razao_social or f.nome_credor)|clean_text }}"
+      data-fornecedor-nome-credor="{{ f.nome_credor|clean_text }}"
+      data-empresa-url="/empresa/{{ cnpj_completo_digits }}"{{ _flag_attrs }}>
+  {% else %}
+  <tr class="row-detail-unavailable{{ row_extra }}" aria-disabled="true"{{ _flag_attrs }}>
+  {% endif %}
+      <td data-label="Empresa" class="stack-title">{{ f.nome_credor|clean_text }}{% if cnpj_completo_digits|length != 14 %} <span class="detail-unavailable-hint">Detalhes indisponiveis sem CNPJ completo</span>{% endif %}</td>
+      <td data-label="CNPJ" class="auditor-only"><code class="text-sm">{{ f.cnpj_basico[:2] }}.{{ f.cnpj_basico[2:5] }}.{{ f.cnpj_basico[5:8] }}/****-**</code></td>
+      <td data-label="Recebido" class="text-right num">{{ (f.total_pago or f.total_contratado)|default(0)|short_brl }}</td>
+      <td data-label="Empenhos" class="text-right auditor-only num">{{ (f.qtd_empenhos or f.qtd_contratos)|default(0)|short_number }}</td>
+      <td data-label="Sinais" class="stack-badges">
+          {% set scope_suffix = '' %}
+          {% if f.abrangencia_sancao_info %}
+              {% set info_clean = f.abrangencia_sancao_info|replace('!', '') %}
+              {% if 'Nacional' in info_clean %}
+                  {% set scope_suffix = ' (Nacional)' %}
+              {% elif '(' in info_clean %}
+                  {% set scope_suffix = ' ' + info_clean[info_clean.index('('):] %}
+              {% endif %}
+          {% endif %}
+          {% if f.flag_inidoneidade %}<span class="badge badge-red"><span class="citizen-only">Proibida de contratar (nacional)</span><span class="auditor-only">Inidoneidade - CEIS (Nacional)</span></span>
+          {% elif f.flag_ceis %}<span class="badge badge-orange" title="CEIS - Cadastro de Empresas Inidoneas e Suspensas. Motivos variam: fraude em licitacao, descumprimento contratual, documentacao irregular, etc."><span class="citizen-only">Impedida de contratar (CEIS){{ scope_suffix|truncate(55, True) }}</span><span class="auditor-only">Impedimento - CEIS{{ scope_suffix|truncate(55, True) }}</span></span>{% endif %}
+          {% if f.flag_cnep %}<span class="badge badge-orange" title="CNEP - Cadastro Nacional de Empresas Punidas pela Lei Anticorrupcao (Lei 12.846/2013)."><span class="citizen-only">Punida (Lei Anticorrup&ccedil;&atilde;o){{ scope_suffix|truncate(55, True) }}</span><span class="auditor-only">CNEP{{ scope_suffix|truncate(55, True) }}</span></span>{% endif %}
+          {% if f.flag_acordo_leniencia %}<span class="badge badge-blue"><span class="citizen-only">Acordo de leni&ecirc;ncia</span><span class="auditor-only">Acordo de Leniencia</span></span>{% endif %}
+          {% if f.flag_pgfn %}<span class="badge badge-yellow"><span class="citizen-only">Devendo impostos federais</span><span class="auditor-only">Divida ativa</span></span>{% endif %}
+          {% if f.flag_inativa %}<span class="badge badge-gray"><span class="citizen-only">Empresa inativa na Receita</span><span class="auditor-only">Cadastro inativo</span></span>{% endif %}
+          {% if not f.flag_inidoneidade and not f.flag_ceis and not f.flag_cnep and not f.flag_acordo_leniencia and not f.flag_pgfn and not f.flag_inativa %}
+              <span class="text-sm text-muted"><span class="citizen-only">Sem problemas detectados</span><span class="auditor-only">Sem sinal automatico</span></span>
+          {% endif %}
+      </td>
+  </tr>
+{% endmacro %}

--- a/web/templates/partials/top_fornecedores.html
+++ b/web/templates/partials/top_fornecedores.html
@@ -1,4 +1,11 @@
 {% if fornecedores %}
+{% import 'partials/_top_table_macros.html' as _tt %}
+{# Threshold de progressive loading: abaixo de 100 rows, full SSR.
+   Acima, primeiras 50 rows em <tbody> + resto em <script type="text/html">
+   hidratado pelo data-table.js apos o initial paint. #}
+{% set _total_forn = fornecedores|length %}
+{% set _progressive_forn = _total_forn > 100 %}
+{% set _initial_n = 50 if _progressive_forn else _total_forn %}
 {# Contagens por flag para os chips de filtro (server-side, uma vez por render). #}
 {% set _inid = fornecedores|selectattr('flag_inidoneidade')|list|length %}
 {% set _rec_inid = fornecedores|selectattr('flag_recebeu_durante_inidoneidade')|list|length %}
@@ -10,7 +17,7 @@
 {% set _pgfn = fornecedores|selectattr('flag_pgfn')|list|length %}
 {% set _inativa = fornecedores|selectattr('flag_inativa')|list|length %}
 <section class="result-block">
-    <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores">
+    <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-fornecedores"{% if _progressive_forn %} data-progressive-total="{{ _total_forn }}" data-progressive-initial="{{ _initial_n }}"{% endif %}>
         {% set has_rec_inid = fornecedores|selectattr('flag_recebeu_durante_inidoneidade')|list %}
         {% set has_rec_sancao = fornecedores|selectattr('flag_recebeu_durante_sancao_aplicavel')|list %}
         {% set has_acordo = fornecedores|selectattr('flag_acordo_leniencia')|list %}
@@ -63,51 +70,14 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for f in fornecedores %}
-                     {% if f.flag_recebeu_durante_inidoneidade %}{% set row_extra = ' row-sancao' %}
-                     {% elif f.flag_recebeu_durante_sancao_aplicavel %}{% set row_extra = ' row-sancao-leve' %}
-                     {% else %}{% set row_extra = '' %}{% endif %}
-                    {% set _flag_attrs %}{% if f.flag_inidoneidade %} data-flag-inidoneidade="1"{% endif %}{% if f.flag_recebeu_durante_inidoneidade %} data-flag-recebeu-durante-inidoneidade="1"{% endif %}{% if f.flag_recebeu_durante_sancao_aplicavel %} data-flag-recebeu-durante-sancao-aplicavel="1"{% endif %}{% if f.flag_ceis %} data-flag-ceis="1"{% endif %}{% if f.flag_cnep %} data-flag-cnep="1"{% endif %}{% if f.flag_acordo_leniencia %} data-flag-acordo-leniencia="1"{% endif %}{% if f.flag_inativa_irregular %} data-flag-inativa-irregular="1"{% endif %}{% if f.flag_pgfn %} data-flag-pgfn="1"{% endif %}{% if f.flag_inativa %} data-flag-inativa="1"{% endif %}{% endset %}
-                    {% set cnpj_completo_digits = f.cnpj_completo|default('', true)|string|replace('.', '')|replace('/', '')|replace('-', '') %}
-                    {% if cnpj_completo_digits|length == 14 %}
-                    <tr class="clickable-row{{ row_extra }}"
-                        data-fornecedor-cnpj="{{ f.cnpj_basico }}"
-                        data-fornecedor-cpf-cnpj="{{ cnpj_completo_digits }}"
-                        data-fornecedor-nome="{{ (f.razao_social or f.nome_credor)|clean_text }}"
-                        data-fornecedor-nome-credor="{{ f.nome_credor|clean_text }}"
-                        data-empresa-url="/empresa/{{ cnpj_completo_digits }}"{{ _flag_attrs }}>
-                    {% else %}
-                    <tr class="row-detail-unavailable{{ row_extra }}" aria-disabled="true"{{ _flag_attrs }}>
-                    {% endif %}
-                        <td data-label="Empresa" class="stack-title">{{ f.nome_credor|clean_text }}{% if cnpj_completo_digits|length != 14 %} <span class="detail-unavailable-hint">Detalhes indisponiveis sem CNPJ completo</span>{% endif %}</td>
-                        <td data-label="CNPJ" class="auditor-only"><code class="text-sm">{{ f.cnpj_basico[:2] }}.{{ f.cnpj_basico[2:5] }}.{{ f.cnpj_basico[5:8] }}/****-**</code></td>
-                        <td data-label="Recebido" class="text-right num">{{ (f.total_pago or f.total_contratado)|default(0)|short_brl }}</td>
-                        <td data-label="Empenhos" class="text-right auditor-only num">{{ (f.qtd_empenhos or f.qtd_contratos)|default(0)|short_number }}</td>
-                        <td data-label="Sinais" class="stack-badges">
-                            {% set scope_suffix = '' %}
-                            {% if f.abrangencia_sancao_info %}
-                                {% set info_clean = f.abrangencia_sancao_info|replace('!', '') %}
-                                {% if 'Nacional' in info_clean %}
-                                    {% set scope_suffix = ' (Nacional)' %}
-                                {% elif '(' in info_clean %}
-                                    {% set scope_suffix = ' ' + info_clean[info_clean.index('('):] %}
-                                {% endif %}
-                            {% endif %}
-                            {% if f.flag_inidoneidade %}<span class="badge badge-red"><span class="citizen-only">Proibida de contratar (nacional)</span><span class="auditor-only">Inidoneidade - CEIS (Nacional)</span></span>
-                            {% elif f.flag_ceis %}<span class="badge badge-orange" title="CEIS - Cadastro de Empresas Inidoneas e Suspensas. Motivos variam: fraude em licitacao, descumprimento contratual, documentacao irregular, etc."><span class="citizen-only">Impedida de contratar (CEIS){{ scope_suffix|truncate(55, True) }}</span><span class="auditor-only">Impedimento - CEIS{{ scope_suffix|truncate(55, True) }}</span></span>{% endif %}
-                            {% if f.flag_cnep %}<span class="badge badge-orange" title="CNEP - Cadastro Nacional de Empresas Punidas pela Lei Anticorrupcao (Lei 12.846/2013)."><span class="citizen-only">Punida (Lei Anticorrup&ccedil;&atilde;o){{ scope_suffix|truncate(55, True) }}</span><span class="auditor-only">CNEP{{ scope_suffix|truncate(55, True) }}</span></span>{% endif %}
-                            {% if f.flag_acordo_leniencia %}<span class="badge badge-blue"><span class="citizen-only">Acordo de leni&ecirc;ncia</span><span class="auditor-only">Acordo de Leniencia</span></span>{% endif %}
-                            {% if f.flag_pgfn %}<span class="badge badge-yellow"><span class="citizen-only">Devendo impostos federais</span><span class="auditor-only">Divida ativa</span></span>{% endif %}
-                            {% if f.flag_inativa %}<span class="badge badge-gray"><span class="citizen-only">Empresa inativa na Receita</span><span class="auditor-only">Cadastro inativo</span></span>{% endif %}
-                            {% if not f.flag_inidoneidade and not f.flag_ceis and not f.flag_cnep and not f.flag_acordo_leniencia and not f.flag_pgfn and not f.flag_inativa %}
-                                <span class="text-sm text-muted"><span class="citizen-only">Sem problemas detectados</span><span class="auditor-only">Sem sinal automatico</span></span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% endfor %}
+                    {% for f in fornecedores[:_initial_n] %}{{ _tt.render_fornecedor_row(f) }}{% endfor %}
                 </tbody>
             </table>
         </div>
+        {% if _progressive_forn %}
+        {# Tail rows como texto inerte. innerHTML hidratado por data-table.js. #}
+        <script type="text/html" data-rest-rows>{% for f in fornecedores[_initial_n:] %}{{ _tt.render_fornecedor_row(f) }}{% endfor %}</script>
+        {% endif %}
         <div class="table-pagination">
             <md-text-button data-page-prev>Anterior</md-text-button>
             <p class="text-sm text-muted" data-page-label></p>

--- a/web/templates/partials/top_servidores.html
+++ b/web/templates/partials/top_servidores.html
@@ -1,4 +1,11 @@
-{% if servidores %}
+﻿{% if servidores %}
+{% import 'partials/_top_table_macros.html' as _tt %}
+{# Threshold de progressive loading: abaixo de 100 rows, full SSR.
+   Acima, primeiras 50 rows em <tbody> + resto em <script type="text/html">
+   hidratado pelo data-table.js apos o initial paint. #}
+{% set _total_serv = servidores|length %}
+{% set _progressive_serv = _total_serv > 100 %}
+{% set _initial_n = 50 if _progressive_serv else _total_serv %}
 {# Contagens por flag para os chips de filtro (calculadas server-side, uma vez por render). #}
 {% set _ceaf = servidores|selectattr('flag_ceaf_expulso')|list|length %}
 {% set _inid = servidores|selectattr('flag_socio_inidoneidade')|list|length %}
@@ -9,7 +16,7 @@
 {% set _alto = servidores|selectattr('flag_alto_salario_socio')|list|length %}
 {% set _federal = servidores|selectattr('flag_duplo_vinculo_federal')|list|length %}
 <section class="result-block">
-    <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-servidores">
+    <div class="table-shell js-data-table" data-page-size="10" data-table-id="top-servidores"{% if _progressive_serv %} data-progressive-total="{{ _total_serv }}" data-progressive-initial="{{ _initial_n }}"{% endif %}>
         {% set has_red_serv = servidores|selectattr('flag_ceaf_expulso')|list or servidores|selectattr('flag_socio_inidoneidade')|list or servidores|selectattr('total_pago_durante_vinculo')|list %}
         {% set has_yellow_serv = servidores|selectattr('flag_socio_sancionado')|list or servidores|selectattr('flag_bolsa_familia')|list or servidores|selectattr('flag_duplo_vinculo_federal')|list %}
         {% if has_red_serv or has_yellow_serv %}
@@ -57,44 +64,15 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for s in servidores %}
-                    {% set cargo = (s.cargo or "-")|clean_text %}
-                    {% set cpf6 = s.cpf_digitos_6|default('')|string %}
-                    {% set nome_up = s.nome_upper|default('')|string %}
-                    {% set cnpjs_json = s.cnpjs_socio|default([])|tojson %}
-                    {% set _flag_durante = (s.total_pago_durante_vinculo|default(0)|float > 0) %}
-                    {% set _flag_attrs %}{% if s.flag_ceaf_expulso %} data-flag-ceaf-expulso="1"{% endif %}{% if s.flag_socio_inidoneidade %} data-flag-socio-inidoneidade="1"{% endif %}{% if _flag_durante %} data-flag-durante-vinculo="1"{% endif %}{% if s.flag_bolsa_familia %} data-flag-bolsa-familia="1"{% endif %}{% if s.flag_socio_sancionado %} data-flag-socio-sancionado="1"{% endif %}{% if s.flag_multi_empresa %} data-flag-multi-empresa="1"{% endif %}{% if s.flag_alto_salario_socio %} data-flag-alto-salario-socio="1"{% endif %}{% if s.flag_duplo_vinculo_federal %} data-flag-duplo-vinculo-federal="1"{% endif %}{% endset %}
-                    {% if cpf6 and nome_up %}
-                    <tr class="clickable-row{% if s.flag_ceaf_expulso or _flag_durante or s.flag_socio_inidoneidade %} row-sancao{% elif s.flag_socio_sancionado or s.flag_bolsa_familia or s.flag_duplo_vinculo_federal %} row-sancao-leve{% endif %}" data-cargo="{{ cargo|lower }}" data-cpf6="{{ cpf6 }}" data-nome-upper="{{ nome_up }}" data-nome="{{ s.nome_servidor|default(nome_up)|clean_text }}" data-cnpjs='{{ cnpjs_json }}'{{ _flag_attrs }}>
-                    {% else %}
-                    <tr data-cargo="{{ cargo|lower }}"{{ _flag_attrs }}>
-                    {% endif %}
-                        <td data-label="Servidor" class="stack-title">{{ s.nome_servidor|clean_text }}</td>
-                        <td data-label="CPF" class="auditor-only"><code class="text-sm">***.{{ cpf6[:3] }}.{{ cpf6[3:] }}-**</code></td>
-                        <td data-label="Cargo">{{ cargo }}</td>
-                        <td data-label="Maior salario" class="text-right num">{{ s.maior_salario|default(0)|short_brl }}</td>
-                        <td data-label="Sinais" class="stack-badges">
-                            {% if s.flag_ceaf_expulso %}<span class="badge badge-red"><span class="citizen-only">Expulso do servi&ccedil;o p&uacute;blico federal</span><span class="auditor-only">Expulso da Adm. Federal (CEAF)</span></span>{% endif %}
-                            {% if s.total_pago_durante_vinculo|default(0)|float > 0 %}
-                                <span class="badge badge-red"><span class="citizen-only">Empresa ligada a ele recebeu {{ s.total_pago_durante_vinculo|short_brl }} enquanto era servidor</span><span class="auditor-only">Empresa recebeu {{ s.total_pago_durante_vinculo|short_brl }} durante vinculo</span></span>
-                            {% endif %}
-                            {% if s.flag_duplo_vinculo_federal %}<span class="badge badge-yellow" title="Sinal de revis&atilde;o: a Constitui&ccedil;&atilde;o admite acumula&ccedil;&atilde;o em alguns casos, como sa&uacute;de e magist&eacute;rio."><span class="citizen-only">Tamb&eacute;m aparece no cadastro federal</span><span class="auditor-only">Vinculo municipal + federal (SIAPE)</span></span>{% endif %}
-                            {% if s.flag_multi_empresa %}
-                                <span class="badge badge-yellow"><span class="citizen-only">S&oacute;cio de {{ s.qtd_empresas_socio|default('v&aacute;rias') }} empresas</span><span class="auditor-only">Socio de {{ s.qtd_empresas_socio|default('varias') }} empresas</span></span>
-                            {% endif %}
-                            {% if s.flag_bolsa_familia %}<span class="badge badge-yellow"><span class="citizen-only">Recebe Bolsa Fam&iacute;lia sendo servidor</span><span class="auditor-only">Bolsa Familia durante vinculo</span></span>{% endif %}
-                            {% if s.flag_alto_salario_socio %}<span class="badge badge-yellow"><span class="citizen-only">Sal&aacute;rio alto + s&oacute;cio de empresa</span><span class="auditor-only">Salario alto + vinculo societario</span></span>{% endif %}
-                            {% if s.flag_socio_inidoneidade %}<span class="badge badge-red"><span class="citizen-only">S&oacute;cio de empresa proibida de contratar com o governo</span><span class="auditor-only">Socio de empresa com Inidoneidade (CEIS)</span></span>
-                            {% elif s.flag_socio_sancionado %}<span class="badge badge-orange"><span class="citizen-only">S&oacute;cio de empresa sancionada pelo governo</span><span class="auditor-only">Socio de empresa sancionada (CEIS/CNEP)</span></span>{% endif %}
-                            {% if not s.flag_ceaf_expulso and not s.flag_conflito_interesses and not s.flag_multi_empresa and not s.flag_bolsa_familia and not s.flag_duplo_vinculo_federal and not s.flag_alto_salario_socio and not s.flag_socio_sancionado and not s.flag_socio_inidoneidade and not (s.total_pago_durante_vinculo|default(0)|float > 0) %}
-                                <span class="text-sm text-muted"><span class="citizen-only">Sem sinais espec&iacute;ficos detectados</span><span class="auditor-only">Sem sinal automatico</span></span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% endfor %}
+                    {% for s in servidores[:_initial_n] %}{{ _tt.render_servidor_row(s) }}{% endfor %}
                 </tbody>
             </table>
         </div>
+        {% if _progressive_serv %}
+        {# Tail rows como texto inerte. innerHTML hidratado por data-table.js
+           em requestIdleCallback ou ao primeiro user interaction. #}
+        <script type="text/html" data-rest-rows>{% for s in servidores[_initial_n:] %}{{ _tt.render_servidor_row(s) }}{% endfor %}</script>
+        {% endif %}
         <div class="table-pagination">
             <md-text-button data-page-prev>Anterior</md-text-button>
             <p class="text-sm text-muted" data-page-label></p>


### PR DESCRIPTION
## Problema

Apos PR #195 (remover `LIMIT 200` em top-servidores) e PR #198 (mesmo em
top-fornecedores), Joao Pessoa renderiza **~51k rows** de servidores e
**milhares** de fornecedores. O SSR sincrono desse DOM massivo trava o
main thread em parse + layout por varios segundos no mid-tier mobile,
segurando o TTI/responsividade da pagina cidade.

## Solucao: progressive loading via `<script type="text/html">`

Split SSR em duas fases:

1. **Initial batch** (50 rows) renderizado no `<tbody>` real -- usuario ja
   ve as rows mais importantes (sao as primeiras pelo ranking de risco).
2. **Tail** embarcado em `<script type="text/html" data-rest-rows>...</script>`
   -- texto inerte, sem custo de DOM tree (browser nao constroi nodes).
3. `data-table.js` agenda hidratacao via `requestIdleCallback(hydrate, { timeout: 1500 })`.
4. **Force-flush**: capture-phase listener no shell para `click`/`input`/`keydown`
   garante que qualquer interacao do usuario antes do RIC disparar hidrata
   sincronamente, evitando race onde chip click filtra apenas as 50 iniciais.
5. **Threshold**: progressive ativa apenas com `> 100 rows`. Abaixo disso,
   full SSR (sem custo extra, sem complexidade).

## Mudancas

| Arquivo | O que mudou |
|---|---|
| `web/templates/partials/_top_table_macros.html` (NOVO) | Macros `render_servidor_row` + `render_fornecedor_row` extraidos do HTML inline para evitar duplicacao entre initial e tail. |
| `web/templates/partials/top_servidores.html` | Import macro; split em `<tbody>` initial + `<script data-rest-rows>` tail; data-progressive-* attrs no shell. |
| `web/templates/partials/top_fornecedores.html` | Idem. |
| `web/static/js/components/data-table.js` | `_hydrateRest()` idempotente + RIC schedule + capture-phase force-flush + re-init clickable rows + emit `tabela-hidratada`. |
| `web/static/js/components/top-servidores.js` | Mesmo split nos batch renderers usados pelo `cidade-async-panels`. |
| `web/static/js/components/top-fornecedores.js` | Idem. |
| `web/static/js/lib/umami-track.js` | Header pointer do novo evento. |
| `docs/analytics.md` | Catalogo do evento `tabela-hidratada`. |
| `web/main.py` | Bump `ASSET_VERSION` 120 -> 121. |

## Novo evento Umami

```
tabela-hidratada { tabela, total, initial, ms_to_hydrate, forced }
```

`forced=true` quando user interagiu antes do RIC disparar. Permite
monitorar TTI real em campo (mid-tier mobile vs desktop).

## Trade-offs

- **TTI ganha muito**: parse + layout caem de ~51k DOM nodes para ~50 no
  paint inicial. Tail e adicionado quando o browser esta idle.
- **TTFB inalterado**: HTML wire size e identico (apenas reposicionado).
- **Counts dos chips ficam corretos**: Jinja calcula `selectattr|length`
  da lista completa server-side, ANTES do split. Mostra "X" mesmo com
  hidratacao pendente.
- **Filtros/sort/paginacao**: o force-flush garante consistencia -- se
  user clicar em chip antes do RIC, hidratacao roda sync no capture phase,
  depois o chip-click handler ve a lista completa.
- **`clickable-rows`** e idempotente via `data-click-init` flag -- ok
  re-chamar sobre tbody hidratado.

## Smoke checks

```
node --check web/static/js/components/data-table.js          OK
node --check web/static/js/components/top-servidores.js      OK
node --check web/static/js/components/top-fornecedores.js    OK
python -m compileall web -q                                  OK
Jinja parse top_servidores/top_fornecedores/_top_table_macros OK
```

## Deploy strategy proposta

- `etl_phase=web` (sem ETL/SQL/MV).
- **SEM** `rewarm_cache_keys` -- esta PR so muda HTML/JS de partial render;
  `cached_query()` devolve cols/rows iguais ao antes. Templates sao
  renderizados a cada request (nao cacheados), entao restart do
  `cruza-web` e suficiente.
- Build de assets sempre roda (deploy.yml ja faz isso por padrao apos PR #198).
- Validacao pos-deploy: abrir Joao Pessoa, conferir initial paint rapido
  + filtros/chips funcionando apos ~1s.

## Checklist

- [x] AGENTS.md / docs/ -- evento Umami catalogado em `docs/analytics.md`
- [x] ADR -- nao aplicavel (otimizacao de render dentro da convencao existente)
- [x] `python -m compileall web -q`
- [x] Co-authored-by: Copilot trailer

---

Reviews paralelos sendo solicitados a Opus 4.7 + GPT 5.5.
