### PR TITLE
fix(web): dialog SOS GAS — tab CNEP por raiz + Carregando ao reabrir

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -500,7 +500,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "121"
+templates.env.globals["ASSET_VERSION"] = "122"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/routes/cidade.py
+++ b/web/routes/cidade.py
@@ -51,8 +51,8 @@ from web.queries.empresa import (
     EMPRESA_LENIENCIA_EFEITOS_BY_ID,
     EMPRESA_MATRIZ_BY_BASICO,
     EMPRESA_PGFN_BY_CNPJ,
-    EMPRESA_SANCOES_CEIS_BY_CNPJ,
-    EMPRESA_SANCOES_CNEP_BY_CNPJ,
+    EMPRESA_SANCOES_CEIS_BY_BASICO,
+    EMPRESA_SANCOES_CNEP_BY_BASICO,
     EMPRESA_SOCIOS_BY_BASICO,
 )
 from web.queries.licitacao import (
@@ -2133,8 +2133,13 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                     top_elementos.append(r)
                 result["top_elementos"] = top_elementos
 
-                # Sancoes CEIS
-                cur.execute(EMPRESA_SANCOES_CEIS_BY_CNPJ, (cpf_cnpj,))
+                # Sancoes CEIS/CNEP — filtra por CNPJ raiz (8 dig) pra
+                # coincidir com mv_empresa_pb.cnep_agg / ceis_agg (que
+                # tambem agregam por LEFT(cpf_cnpj_norm, 8)) e com a pagina
+                # /empresa/{cnpj}. Sem isso, sancoes registradas num
+                # estabelecimento irmao (mesma raiz, ordem != 0001) ficavam
+                # invisiveis no dialog mesmo com a row flag CNEP/CEIS ligada.
+                cur.execute(EMPRESA_SANCOES_CEIS_BY_BASICO, (cnpj_basico,))
                 san_cols = [d[0] for d in cur.description]
                 san_rows = cur.fetchall()
                 sancoes = []
@@ -2146,8 +2151,8 @@ async def get_fornecedor_detalhes(payload: dict = Body(...)):
                             r[k] = v.isoformat()
                     sancoes.append(r)
 
-                # Sancoes CNEP
-                cur.execute(EMPRESA_SANCOES_CNEP_BY_CNPJ, (cpf_cnpj,))
+                # Sancoes CNEP (mesma logica BY_BASICO da CEIS acima)
+                cur.execute(EMPRESA_SANCOES_CNEP_BY_BASICO, (cnpj_basico,))
                 cnep_cols = [d[0] for d in cur.description]
                 cnep_rows = cur.fetchall()
                 for row in cnep_rows:

--- a/web/static/js/components/dialog-history-swipe.js
+++ b/web/static/js/components/dialog-history-swipe.js
@@ -18,6 +18,13 @@
 //      _dialogUrlClear() em vez de tentar history.back() (que sairia
 //      da pagina).
 let _dialogHistoryState = false;
+// Flag: history.back() chamado por nos mesmos em _dialogOnClose. O
+// popstate resultante eh apenas "consume the pushState" e nao deve ser
+// re-interpretado como user-back (que dispararia bumpSeq + close). Sem
+// essa flag, um popstate atrasado que chega depois do user reabrir o
+// dialog invalida o seq da nova abertura e o body fica preso em
+// "Carregando..." (continuacao do await falha o _dialogSeqValid).
+let _popstateFromSelfBack = false;
 
 function _dialogOnOpen() {
     const dialog = document.getElementById('empresa-dialog');
@@ -44,13 +51,29 @@ function _dialogOnOpen() {
 }
 
 function _dialogOnClose() {
+    const dialog = document.getElementById('empresa-dialog');
+    // Reabertura durante animacao de close: o user clicou no botao close
+    // (dialog.open=false imediatamente, anim em curso) e em seguida abriu
+    // outro card antes do 'closed' event disparar. Quando o 'closed'
+    // finalmente roda, dialog.open ja eh true de novo. Pular este ciclo
+    // — caso contrario _dialogBumpSeq invalidaria a continuacao do fetch
+    // da nova abertura e o body ficaria preso em "Carregando..." sem
+    // chamar /detalhes (cache hit + seq guard => early return).
+    if (dialog && dialog.open) return;
     _dialogReset();
     if (typeof _dialogBumpSeq === 'function') _dialogBumpSeq();
     if (_dialogHistoryState) {
         _dialogHistoryState = false;
         if (history.state && history.state.tpbDialog) {
-            // Removemos nosso state do historico sem disparar navegacao
-            try { history.back(); } catch { /* ignore */ }
+            // Removemos nosso state do historico sem disparar navegacao.
+            // O popstate resultante eh nosso — marca pra que o listener
+            // global nao re-trate como back do user.
+            _popstateFromSelfBack = true;
+            // Fallback de seguranca: se por algum motivo o popstate nao
+            // disparar (edge: browser bloqueou back), limpa a flag depois
+            // de 1s pra nao engolir um back legitimo subsequente.
+            setTimeout(() => { _popstateFromSelfBack = false; }, 1000);
+            try { history.back(); } catch { _popstateFromSelfBack = false; }
         }
     } else if (typeof _dialogUrlClear === 'function') {
         // Edge case: dialog foi restaurado via URL (sem pushState próprio).
@@ -60,6 +83,17 @@ function _dialogOnClose() {
 }
 
 window.addEventListener('popstate', () => {
+    // Popstate disparado pela nossa propria chamada history.back() em
+    // _dialogOnClose — apenas consome o state, nao fecha nada (dialog ja
+    // estava fechando/fechado). Sem essa guarda, se o user reabrir o
+    // dialog antes do popstate task processar, o handler abaixo enxerga
+    // dialog.open=true e bumpa seq + dispara close, deixando a nova
+    // abertura em "Carregando..." e fechando logo em seguida.
+    if (_popstateFromSelfBack) {
+        _popstateFromSelfBack = false;
+        _dialogHistoryState = false;
+        return;
+    }
     const dialog = document.getElementById('empresa-dialog');
     if (!dialog || !dialog.open) {
         _dialogHistoryState = false;


### PR DESCRIPTION
﻿## Bugs corrigidos

### 1. Tab Sancoes nao aparece no dialog de fornecedor com CNEP

**Caso concreto:** SOS GAS LTDA (CNPJ `09266128000176`) em Joao Pessoa. Linha com flag CNEP ativa, mas dialog abria sem a tab "Sancoes".

**Causa:** `/api/fornecedor/detalhes` usava `EMPRESA_SANCOES_{CEIS,CNEP}_BY_CNPJ` (filtro por `cpf_cnpj_norm = <14d>`), mas a flag CNEP na linha vem de `mv_empresa_pb.cnep_agg` que agrega por `LEFT(cpf_cnpj_norm, 8)` (raiz). Sancoes registradas em estabelecimentos irmaos da mesma raiz ficavam invisiveis no dialog mesmo aparecendo em `/empresa/{cnpj}`.

**Fix:** dialog usa `EMPRESA_SANCOES_{CEIS,CNEP}_BY_BASICO` (mesmas queries da pagina `/empresa/`), passando `cnpj_basico = cpf_cnpj[:8]`. Coerencia garantida entre flag, dialog e perfil agregado.

### 2. Dialog fica preso em "Carregando..." ao reabrir

**Repro:** abrir SOS GAS, fechar, reabrir → body permanece "Carregando..." e `/api/fornecedor/detalhes` nunca eh chamado. Tambem reportado em dialogs de servidor e empresa.

**Causa:** race entre `_dialogOnClose` / `popstate` e a reabertura:
1. User reabre durante anim de close → `dialog.show()` reativa o dialog (`dialog.open=true`) com seq=N+1.
2. Cache hit em `_fetchXxxDetails` → continuacao do await agendada como microtask.
3. `'closed'` event do ciclo anterior dispara DEPOIS → `_dialogOnClose` reseta + `_dialogBumpSeq` (seq=N+2) + `history.back()`.
4. Microtask roda → `_dialogSeqValid(N+1)` falha (seq atual=N+2) → early return → body fica em "Carregando...".
5. Popstate atrasado fecha o dialog (`dialog.open=true` → bumpSeq + close).

**Fix:** duas guardas em `dialog-history-swipe.js`:
- `_dialogOnClose` retorna cedo se `dialog.open=true` (reabertura em curso → ignora o `'closed'` do ciclo antigo).
- Popstate disparado pela nossa propria `history.back()` eh marcado com flag `_popstateFromSelfBack` e ignorado pelo handler global (com fallback de 1s pra nao engolir back legitimo).

Cache de detalhes (`_detailCache`) mascarava o problema: sem re-fetch, nada visivel no Network tab.

## Arquivos

- `web/routes/cidade.py` — import + 2 usos de queries CEIS/CNEP no `/api/fornecedor/detalhes`.
- `web/static/js/components/dialog-history-swipe.js` — `_dialogOnClose` guard + popstate self-back flag.
- `web/main.py` — `ASSET_VERSION` 121 -> 122.

Rebuild de bundle: `core.56976da6.min.js` (sera regerado no deploy via `node scripts/build-assets.mjs`).

## Mobile-first

Sem mudancas de layout. Logica de close/reopen afeta gesto swipe-to-close e back fisico do Android (que tambem dispara popstate) — guardas mantem fluxo Android intacto (popstate `_popstateFromSelfBack=false` segue caminho normal de fechar dialog).

## Deploy

- **`etl_phase=web`** — sem mudancas SQL/MV/ETL.
- **Sem `mv_swap`** — nenhuma MV alterada.
- **Sem `rewarm_cache_keys`** — apenas rota Python + JS bundle; schema/cache inalterados.
- **Zero-downtime:** sync de codigo + rebuild assets + `systemctl restart cruza-web`. Atomic deploy pelo proprio workflow.
- **Sem queries novas** — `EMPRESA_SANCOES_{CEIS,CNEP}_BY_BASICO` ja existem (usadas em `/empresa/`) e ja batem com indices em `sql/19_indices_queries.sql` (`idx_ceis/cnep_cnpj_basico_j`).

## Como validar pos-deploy

1. Abrir `https://transparenciapb.org/cidade/joao-pessoa` → tabela fornecedores → clicar SOS GAS.
2. Confirmar tab "Sancoes" presente com 2 entradas CNEP.
3. Fechar o dialog → reabrir SOS GAS imediatamente.
4. Confirmar dialog carrega normalmente (sem ficar em "Carregando..."). Network tab mostra hit no `/api/fornecedor/detalhes` (primeira abertura) e cache hit nas reaberturas seguintes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
