### PR TITLE
fix(web): dialog Carregando ao reabrir mesmo fornecedor (cache hit race)

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -500,7 +500,7 @@ JS_FILES: list[str] = [
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "122"
+templates.env.globals["ASSET_VERSION"] = "123"
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/web/static/js/components/dialog-url-state.js
+++ b/web/static/js/components/dialog-url-state.js
@@ -32,9 +32,22 @@ function _dialogNextSeq() {
     return ++_dialogReqSeq;
 }
 function _dialogSeqValid(seq) {
-    if (seq !== _dialogReqSeq) return false;
-    const dialog = document.getElementById('empresa-dialog');
-    return !!(dialog && dialog.open);
+    // Match-seq-only. Anteriormente exigíamos dialog.open=true como
+    // defesa extra, mas isso quebrava o caminho de cache-hit no reabrir
+    // do mesmo dialog: a continuação do await rodava antes do md-dialog
+    // propagar open=true via Lit reactive update (microtask race).
+    // Sintoma: body preso em "Carregando..." sem chamada /detalhes.
+    // O bump-on-close em _dialogOnClose já invalida fetches inflight
+    // quando o usuário fecha; abrir outro dialog faz _dialogNextSeq que
+    // muda _dialogReqSeq — esse check basta. Render para body fechado
+    // é inofensivo (não exibe).
+    if (seq !== _dialogReqSeq) {
+        if (typeof console !== 'undefined' && console.warn) {
+            console.warn('[dialog-seq] mismatch', { captured: seq, current: _dialogReqSeq });
+        }
+        return false;
+    }
+    return true;
 }
 function _dialogBumpSeq() {
     _dialogReqSeq++;


### PR DESCRIPTION
## Problema

Reabrir o **mesmo** dialog de fornecedor (open X → close X → open X) deixava o body preso em `Carregando...` em 100% dos casos (Safari + Chromium), sem disparar `/api/fornecedor/detalhes`. Abrir um fornecedor **diferente** funcionava.

## Diagnostico

O bug correlaciona com cache HIT vs MISS em `_detailCache`:
- Diferente -> cache miss -> fetch real -> latencia da rede da tempo do `dialog.open` propagar -> render ok.
- Mesmo -> cache hit -> promise ja resolvida -> continuacao roda no proximo microtask, antes do md-dialog (Lit) refletir `open=true` via update reativa.

`_dialogSeqValid` exigia `dialog.open=true` como defesa extra. Na corrida do microtask, o getter retornava `false` -> early return -> body preso.

## Fix

Remove o check `dialog.open` de `_dialogSeqValid`. Match de seq sozinho cobre todos os cenarios:
- `_dialogBumpSeq` em close/popstate invalida fetches inflight.
- `_dialogNextSeq` em abertura nova muda `_dialogReqSeq`.
- Render para body fechado e inofensivo.

Adiciona `console.warn` em mismatch pra diagnostico futuro.

## Deploy

- `etl_phase=web` — apenas codigo JS + bump `ASSET_VERSION 122 -> 123`.
- Zero downtime: `systemctl restart cruza-web` pelo runner (~2s).
- Sem mudancas SQL/MV/cache. Nenhum `rewarm_cache_keys` necessario.
- Bundle: `core.ba16e75f.min.js`.

## Mobile-first review

- Sem mudanca de UI/UX. Apenas guard JS. Afeta todos os viewports igualmente.
- Touch targets, contraste, performance: inalterados.