### PR TITLE
feat(empresa): citacao em processos do TCE-PB DOE (ADR-0014)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1455,6 +1455,13 @@ jobs:
           echo "=== Asset build OK ==="
           ls -la web/static/dist/
 
+          # ADR-0014: garante cache dir do proxy TCE-PB DOE (PDFs imutaveis
+          # por hash). Idempotente. Permissoes: cruza-web user owns it.
+          # Tamanho esperado: ~5GB max (10k PDFs * 500KB).
+          sudo mkdir -p /var/cache/cruza-web/tce-pb
+          sudo chown -R cruza-web:cruza-web /var/cache/cruza-web/tce-pb || true
+          sudo chmod 0755 /var/cache/cruza-web/tce-pb
+
           # restart funciona em servico ativo OU inativo (alias de stop+start).
           sudo systemctl restart cruza-web
           # Aguarda port 8000 responder (workers spawnam em ~3-5s).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -524,7 +524,7 @@ jobs:
           cd ${{ env.PROJECT_DIR }}
           source .env 2>/dev/null || true
           PASS="${POSTGRES_PASSWORD:-${{ secrets.DB_PASSWORD }}}"
-          for sql_file in sql/40_contato_messages.sql; do
+          for sql_file in sql/40_contato_messages.sql sql/42_tce_pb_decisao.sql; do
             if [ -f "$sql_file" ]; then
               echo "=== Applying $sql_file ==="
               PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 -f "$sql_file"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -753,23 +753,36 @@ jobs:
       # ── Specific phase ──
       - name: "ETL: Phase ${{ inputs.etl_phase }}"
         if: inputs.etl_phase != 'sql' && inputs.etl_phase != 'all' && inputs.etl_phase != 'web' && inputs.etl_phase != 'incremental'
+        # Passa o input via env: ao inves de interpolar direto no bash.
+        # Interpolacao direta com ${{ inputs.etl_phase }} dentro de heredoc
+        # bash permitiria shell injection via workflow_dispatch (input string
+        # livre fechando aspa e injetando comando). Com env:, $PHASE_INPUT
+        # vira variavel de ambiente nao expandida pelo shell.
+        env:
+          PHASE_INPUT: ${{ inputs.etl_phase }}
         run: |
           set -e
           sudo systemctl restart tor 2>/dev/null || true
           cd ${{ env.PROJECT_DIR }}
           source venv/bin/activate
-          echo "=== ETL from phase ${{ inputs.etl_phase }} ==="
+          echo "=== ETL from phase $PHASE_INPUT ==="
           # Suporta dois formatos:
-          #   "N"        -> roda da Fase N ate o fim (compat)
+          #   "N"        -> roda da Fase N (1-based index) ate o fim (compat)
           #   "only:N"   -> roda APENAS a Fase N (cirurgico, nao dispara fases
           #                 seguintes que podem fazer DROP CASCADE de MVs)
-          PHASE_INPUT="${{ inputs.etl_phase }}"
-          if [[ "$PHASE_INPUT" == only:* ]]; then
+          # IMPORTANTE: N e o INDICE 1-based na lista `phases` de run_all.py,
+          # NAO o label "Fase X" do tuple. Use:
+          #   python -c "from etl.run_all import phases; [print(i+1, m) for i,(_,m) in enumerate(phases)]"
+          # para descobrir o indice de uma fase especifica.
+          if [[ "$PHASE_INPUT" =~ ^only:[0-9]+$ ]]; then
             PHASE_NUM="${PHASE_INPUT#only:}"
             echo "=== Running ONLY phase $PHASE_NUM ==="
             python -m etl.run_all --only "$PHASE_NUM" 2>&1
-          else
+          elif [[ "$PHASE_INPUT" =~ ^[0-9]+$ ]]; then
             python -m etl.run_all "$PHASE_INPUT" 2>&1
+          else
+            echo "::error::etl_phase invalido: '$PHASE_INPUT'. Esperado: numero, 'only:N', 'all', 'sql', 'web', 'incremental'."
+            exit 1
           fi
 
       # ── Run fraud queries (opt-in, demora ~30min) ──

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -770,9 +770,9 @@ jobs:
           #   "N"        -> roda da Fase N (1-based index) ate o fim (compat)
           #   "only:N"   -> roda APENAS a Fase N (cirurgico, nao dispara fases
           #                 seguintes que podem fazer DROP CASCADE de MVs)
-          # IMPORTANTE: N e o INDICE 1-based na lista `phases` de run_all.py,
+          # IMPORTANTE: N e o INDICE 1-based na lista `PHASES` de run_all.py,
           # NAO o label "Fase X" do tuple. Use:
-          #   python -c "from etl.run_all import phases; [print(i+1, m) for i,(_,m) in enumerate(phases)]"
+          #   python -c "from etl.run_all import PHASES; [print(i+1, m) for i,(_,m) in enumerate(PHASES)]"
           # para descobrir o indice de uma fase especifica.
           if [[ "$PHASE_INPUT" =~ ^only:[0-9]+$ ]]; then
             PHASE_NUM="${PHASE_INPUT#only:}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       etl_phase:
-        description: 'ETL phase: "web" (code sync + web deploy only), "sql" (schema+views), "incremental" (incremental ETL framework — TCE-PB + Dados-PB), phase number (e.g. "18"), or "all" (full ETL)'
+        description: 'ETL phase: "web" (code sync + web deploy only), "sql" (schema+views), "incremental" (incremental ETL framework — TCE-PB + Dados-PB), phase number (e.g. "18" runs phase 18..end), "only:N" (runs ONLY phase N — cirurgico), or "all" (full ETL)'
         required: false
         default: 'all'
       clean:
@@ -759,7 +759,18 @@ jobs:
           cd ${{ env.PROJECT_DIR }}
           source venv/bin/activate
           echo "=== ETL from phase ${{ inputs.etl_phase }} ==="
-          python -m etl.run_all "${{ inputs.etl_phase }}" 2>&1
+          # Suporta dois formatos:
+          #   "N"        -> roda da Fase N ate o fim (compat)
+          #   "only:N"   -> roda APENAS a Fase N (cirurgico, nao dispara fases
+          #                 seguintes que podem fazer DROP CASCADE de MVs)
+          PHASE_INPUT="${{ inputs.etl_phase }}"
+          if [[ "$PHASE_INPUT" == only:* ]]; then
+            PHASE_NUM="${PHASE_INPUT#only:}"
+            echo "=== Running ONLY phase $PHASE_NUM ==="
+            python -m etl.run_all --only "$PHASE_NUM" 2>&1
+          else
+            python -m etl.run_all "$PHASE_INPUT" 2>&1
+          fi
 
       # ── Run fraud queries (opt-in, demora ~30min) ──
       - name: Run queries

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Carrega ~350M registros (~210GB raw) de 18+ fontes públicas brasileiras em um P
 - **Observabilidade self-hosted** — Umami + GoAccess + traffic-digest
 - **Auto-resize VM Azure** (B2 → B4 + Standard SSD → Premium SSD) por etl_phase, custos prorrateados por hora
 
-Fontes integradas: Receita Federal, PNCP, TCE-PB, dados.pb.gov.br, TSE, PGFN, SIAPE, Bolsa Família, CPGF, BNDES, ComprasNet, emendas parlamentares, sanções (CEIS/CNEP/CEAF), renúncias fiscais, viagens a serviço e acordos de leniência.
+Fontes integradas: Receita Federal, PNCP, TCE-PB (despesas + DOE/acórdãos), dados.pb.gov.br, TSE, PGFN, SIAPE, Bolsa Família, CPGF, BNDES, ComprasNet, emendas parlamentares, sanções (CEIS/CNEP/CEAF), renúncias fiscais, viagens a serviço e acordos de leniência.
 
 ## Quickstart
 

--- a/deploy/mv_updates/mv_empresa_pb.sql
+++ b/deploy/mv_updates/mv_empresa_pb.sql
@@ -148,6 +148,11 @@ SELECT
     -- Divida e sancoes
     COALESCE(div.total_divida, 0) AS total_divida_pgfn,
     COALESCE(ceis.vigente, FALSE) AS flag_ceis_vigente,
+    -- TCE-PB DOE (ADR-0014)
+    COALESCE(tcedoe.qtd_processos, 0)::int AS qtd_processos_tce_pb,
+    COALESCE(tcedoe.qtd_processos_irregular, 0)::int AS qtd_processos_tce_pb_irregular,
+    COALESCE(tcedoe.qtd_processos_multa, 0)::int AS qtd_processos_tce_pb_multa,
+    COALESCE(tcedoe.qtd_processos_debito, 0)::int AS qtd_processos_tce_pb_debito,
     -- Flags
     (est.situacao_cadastral IS NULL OR est.situacao_cadastral <> 2) AS flag_inativa,
     (e.capital_social < 10000 AND COALESCE(tce.total_pago, 0) + COALESCE(pbe.total_empenho, 0) > 500000) AS flag_capital_desproporcional,
@@ -167,7 +172,8 @@ LEFT JOIN pb_sau_agg pbs ON pbs.cnpj_basico = pc.cnpj_basico
 LEFT JOIN pb_conv_agg pbv ON pbv.cnpj_basico = pc.cnpj_basico
 LEFT JOIN lic_agg lic ON lic.cnpj_basico = pc.cnpj_basico
 LEFT JOIN divida_agg div ON div.cnpj_basico = pc.cnpj_basico
-LEFT JOIN ceis_agg ceis ON ceis.cnpj_basico = pc.cnpj_basico;
+LEFT JOIN ceis_agg ceis ON ceis.cnpj_basico = pc.cnpj_basico
+LEFT JOIN mv_empresa_tce_pb tcedoe ON tcedoe.cnpj_basico = pc.cnpj_basico;
 
 CREATE UNIQUE INDEX idx_mv_epb_cnpj_swap ON mv_empresa_pb_swap(cnpj_basico);
 CREATE INDEX idx_mv_epb_inativa_swap ON mv_empresa_pb_swap(cnpj_basico) WHERE flag_inativa;
@@ -175,3 +181,4 @@ CREATE INDEX idx_mv_epb_ceis_swap ON mv_empresa_pb_swap(cnpj_basico) WHERE flag_
 CREATE INDEX idx_mv_epb_capital_swap ON mv_empresa_pb_swap(cnpj_basico) WHERE flag_capital_desproporcional;
 CREATE INDEX idx_mv_epb_multi_swap ON mv_empresa_pb_swap(cnpj_basico) WHERE flag_multi_municipal;
 CREATE INDEX idx_mv_epb_endereco_swap ON mv_empresa_pb_swap(logradouro, numero) WHERE logradouro IS NOT NULL;
+CREATE INDEX idx_mv_epb_tce_pb_swap ON mv_empresa_pb_swap(cnpj_basico) WHERE qtd_processos_tce_pb > 0;

--- a/deploy/mv_updates/mv_empresa_tce_pb.sql
+++ b/deploy/mv_updates/mv_empresa_tce_pb.sql
@@ -1,0 +1,115 @@
+-- =============================================================================
+-- mv_empresa_tce_pb — atomic swap (ADR-0014)
+-- =============================================================================
+-- Agregado por cnpj_basico de processos/decisoes do TCE-PB.
+-- Source: tce_pb_decisao + tce_pb_decisao_cnpj (populadas por etl/23_tce_pb_doe.py).
+--
+-- Convencao do framework (etl/mv_swap.py): identifiers usam sufixo `_swap`,
+-- que sera removido pelo swap atomico.
+-- =============================================================================
+
+CREATE MATERIALIZED VIEW mv_empresa_tce_pb_swap AS
+WITH base AS (
+    SELECT
+        LEFT(dc.cnpj, 8)              AS cnpj_basico,
+        d._nk_md5,
+        d.hash_publicacao,
+        d.num_processo,
+        d.ano_processo,
+        d.tipo_decisao,
+        d.orgao_julgador,
+        d.fase,
+        d.data_sessao,
+        d.tipo_materia,
+        d.resultado,
+        d.aplicou_multa,
+        d.imputou_debito,
+        COALESCE(d.valor_multa_rs, 0)  AS valor_multa_rs,
+        COALESCE(d.valor_debito_rs, 0) AS valor_debito_rs,
+        d.municipio_inferido
+    FROM tce_pb_decisao d
+    JOIN tce_pb_decisao_cnpj dc ON dc.decisao_md5 = d._nk_md5
+    WHERE d.tipo_materia <> 'atos_pessoal'
+      AND EXISTS (
+          SELECT 1 FROM estabelecimento e
+          WHERE e.cnpj_basico = LEFT(dc.cnpj, 8)
+      )
+),
+processos AS (
+    SELECT
+        cnpj_basico,
+        num_processo,
+        ano_processo,
+        MAX(tipo_materia)               AS tipo_materia,
+        MAX(orgao_julgador)             AS orgao,
+        MAX(municipio_inferido)         AS municipio,
+        MAX(data_sessao)                AS ultima_sessao,
+        COUNT(*)                        AS qtd_decisoes,
+        MIN(CASE resultado
+              WHEN 'irregular'        THEN 1
+              WHEN 'regular_ressalva' THEN 2
+              WHEN 'regular'          THEN 3
+              ELSE 4
+            END)                        AS pior_resultado_rank,
+        bool_or(aplicou_multa)          AS tem_multa,
+        bool_or(imputou_debito)         AS tem_debito,
+        SUM(valor_multa_rs)             AS multa_total_rs,
+        SUM(valor_debito_rs)            AS debito_total_rs,
+        jsonb_agg(
+            jsonb_build_object(
+                'hash',   hash_publicacao,
+                'fase',   fase,
+                'data',   data_sessao,
+                'result', resultado
+            )
+            ORDER BY data_sessao DESC NULLS LAST
+        )                               AS decisoes_json
+    FROM base
+    GROUP BY cnpj_basico, num_processo, ano_processo
+)
+SELECT
+    p.cnpj_basico,
+    COUNT(*)::int                                                  AS qtd_processos,
+    SUM(p.qtd_decisoes)::int                                       AS qtd_decisoes,
+    COUNT(*) FILTER (WHERE p.pior_resultado_rank = 1)::int         AS qtd_processos_irregular,
+    COUNT(*) FILTER (WHERE p.tem_multa)::int                       AS qtd_processos_multa,
+    COUNT(*) FILTER (WHERE p.tem_debito)::int                      AS qtd_processos_debito,
+    COALESCE(SUM(p.multa_total_rs), 0)::numeric(14,2)              AS multa_total_rs,
+    COALESCE(SUM(p.debito_total_rs), 0)::numeric(14,2)             AS debito_total_rs,
+    MAX(p.ultima_sessao)                                           AS ultima_decisao_em,
+    (
+        SELECT jsonb_agg(row_to_json(top20)::jsonb)
+        FROM (
+            SELECT
+                p2.num_processo,
+                p2.ano_processo,
+                p2.tipo_materia,
+                p2.orgao,
+                p2.municipio,
+                p2.ultima_sessao,
+                p2.qtd_decisoes,
+                CASE p2.pior_resultado_rank
+                    WHEN 1 THEN 'irregular'
+                    WHEN 2 THEN 'regular_ressalva'
+                    WHEN 3 THEN 'regular'
+                    ELSE        'indef'
+                END                        AS pior_resultado,
+                p2.tem_multa,
+                p2.tem_debito,
+                p2.decisoes_json           AS decisoes
+            FROM processos p2
+            WHERE p2.cnpj_basico = p.cnpj_basico
+            ORDER BY p2.ultima_sessao DESC NULLS LAST,
+                     p2.ano_processo DESC,
+                     p2.num_processo DESC
+            LIMIT 20
+        ) top20
+    )                                                              AS processos_json
+FROM processos p
+GROUP BY p.cnpj_basico;
+
+CREATE UNIQUE INDEX idx_mv_empresa_tce_pb_cnpj_swap ON mv_empresa_tce_pb_swap(cnpj_basico);
+CREATE INDEX idx_mv_empresa_tce_pb_irregular_swap  ON mv_empresa_tce_pb_swap(cnpj_basico)
+    WHERE qtd_processos_irregular > 0;
+CREATE INDEX idx_mv_empresa_tce_pb_multa_swap      ON mv_empresa_tce_pb_swap(cnpj_basico)
+    WHERE qtd_processos_multa > 0 OR qtd_processos_debito > 0;

--- a/docs/adr/0014-tce-pb-doe-mvp.md
+++ b/docs/adr/0014-tce-pb-doe-mvp.md
@@ -141,9 +141,16 @@ passos sao downtime ZERO estrito; documentamos a janela real de cada passo.
 | Etapa | Input deploy.yml | Tempo | Degradacao real |
 |---|---|---|---|
 | 1. Schema + web + bootstrap MV vazia | `etl_phase=web` (aplica `sql/42_*.sql`) | ~5 min | ~2s janela 502s no restart cruza-web (uvicorn single-process; limitacao conhecida) |
-| 2. Bootstrap ETL + REFRESH CONCURRENTLY da MV L1 | `etl_phase=18` (Fase 18 TCE-PB DOE) | ~3-4h | 0 (ETL em background; REFRESH CONCURRENTLY nao bloqueia leitores) |
-| 3. mv_swap da L2 (`mv_empresa_pb` ganha 4 colunas) | `etl_phase=web` + `mv_swap=mv_empresa_pb` | ~10-30 min | janela de minutos com **L2 dependentes** (`mv_municipio_pb_kpi_score`, `mv_municipio_pb_mapa`, `v_risk_score_pb`, `mv_q67_dated_pb`) servindo `0 rows` durante REFRESH pos-swap (sem CONCURRENTLY). Cache `web_cache` cobre 99% do trafego, entao impacto real e marginal |
-| 4. Shadow rewarm | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30-60 min | 0 (shadow pattern; live rows servem trafego ate swap atomico) |
+| 2. Bootstrap ETL + REFRESH CONCURRENTLY da MV L1 | `etl_phase=only:18` (roda APENAS Fase 18) | ~3-4h | 0 (ETL em background; REFRESH CONCURRENTLY nao bloqueia leitores) |
+| 3. mv_swap da L2 (`mv_empresa_pb` ganha 4 colunas) | `etl_phase=web` + `mv_swap=mv_empresa_pb` | ~10-30 min | janela curta com **apenas `v_risk_score_pb`** (view normal, recriada via DDL instantaneamente). `mv_municipio_pb_kpi_score`, `mv_municipio_pb_mapa`, `mv_q67_dated_pb`, `v_risk_score_empresa` **nao** dependem de `mv_empresa_pb` (verificado em `sql/12_views.sql` apos review v3). Impacto trafego real: marginal |
+| 4. Shadow rewarm | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30-60 min | 0 (shadow pattern; live rows servem trafego ate swap atomico). Custo extra do warm devido a lookup `EMPRESA_TCE_PB_DOE_BY_BASICO` em 143k empresas: **~5-7 min** (lookup PK em MV indexada) |
+
+**CRITICO — passo 2 usa `only:18`, nao `18`:** `etl/run_all.py` interpreta
+arg numerico como **start_phase** (roda da Fase N ate o fim). `etl_phase=18`
+rodaria Fase 18 + Fase 19 (`etl.21_views`), que faz `DROP ... CASCADE` de
+TODAS as MVs no topo de `sql/12_views.sql` — anula a estrategia e causa 1-2h
+de downtime. PR #202 adicionou modo `--only N` em `run_all.py` e formato
+`only:N` em `deploy.yml` para o caso cirurgico.
 
 **Por que NAO swap conjunto da L1 + L2 (correcao do "swap conjunto" v1/v2):**
 `etl/mv_swap.py` itera CSV uma MV por vez, com COMMIT entre swaps — nao e
@@ -160,8 +167,10 @@ REFRESH CONCURRENTLY do passo 2 e qualquer mv_swap futuro funcionem.
 **Rollback honesto (BLOCKER-3 corrigido):** `mv_swap.py:283` faz
 `DROP CASCADE`, NAO mantem `<mv>_old` — rollback exige re-swap com SQL
 pre-mudanca (`deploy/mv_updates/mv_empresa_pb.sql` da branch anterior) +
-REFRESH em cadeia. Plano: tagear commit pre-deploy + ter `mv_empresa_pb.sql`
-"pre" pronto antes de iniciar.
+REFRESH em cadeia. Plano: **antes do merge**, tagear o commit pre-PR (HEAD
+de `main` no momento) como `pre-tce-pb-doe`; usar `git checkout pre-tce-pb-doe
+-- deploy/mv_updates/mv_empresa_pb.sql sql/12_views.sql` para extrair o SQL
+de rollback se necessario.
 
 **Rollback do ETL apos passo 3:** `TRUNCATE tce_pb_decisao*` por si so deixa
 MVs apontando para decisoes inexistentes (MV e snapshot, nao segue TRUNCATE).

--- a/docs/adr/0014-tce-pb-doe-mvp.md
+++ b/docs/adr/0014-tce-pb-doe-mvp.md
@@ -34,8 +34,9 @@ Implementacao em **PR unico** abrangendo:
 
 2. **ETL classico** (`etl/23_tce_pb_doe.py`): download (4 workers + retry
    exponencial calibrado em 9.935 PDFs) + parse pdfminer.six + UPSERT
-   idempotente com gating por `parser_version`. Registrado como **Fase 20**
-   em `etl/run_all.py`.
+   idempotente com gating por `parser_version`. Registrado como **Fase 18**
+   em `etl/run_all.py` (antes da Fase 19 Views, para que `mv_empresa_tce_pb`
+   ja tenha dados quando criada).
 
 3. **MV L1** `mv_empresa_tce_pb` (em `sql/12_views.sql` +
    `deploy/mv_updates/mv_empresa_tce_pb.sql` para swap atomico):

--- a/docs/adr/0014-tce-pb-doe-mvp.md
+++ b/docs/adr/0014-tce-pb-doe-mvp.md
@@ -152,13 +152,13 @@ TODAS as MVs no topo de `sql/12_views.sql` — anula a estrategia e causa 1-2h
 de downtime. PR #202 adicionou modo `--only N` em `run_all.py` e formato
 `only:N` em `deploy.yml` para o caso cirurgico.
 
-**Importante — N e o INDICE 1-based na lista `phases` de `etl/run_all.py`, NAO o label "Fase X"
+**Importante — N e o INDICE 1-based na lista `PHASES` de `etl/run_all.py`, NAO o label "Fase X"
 do tuple.** O label "Fase 18: TCE-PB DOE" e historico (preservado pra nao
 renumerar labels antigos); o indice real do tuple `etl.23_tce_pb_doe` na
 lista e **23** (item 23 contando a partir de 1). Para confirmar antes de
 qualquer deploy `only:`:
 ```bash
-python -c "from etl.run_all import phases; [print(i+1, m) for i,(_,m) in enumerate(phases)]"
+python -c "from etl.run_all import PHASES; [print(i+1, m) for i,(_,m) in enumerate(PHASES)]"
 ```
 
 **Por que NAO swap conjunto da L1 + L2 (correcao do "swap conjunto" v1/v2):**

--- a/docs/adr/0014-tce-pb-doe-mvp.md
+++ b/docs/adr/0014-tce-pb-doe-mvp.md
@@ -132,36 +132,49 @@ existente se `EXCLUDED.parser_version > current OR text_sha256 IS
 DISTINCT`. Bumpar `PARSER_VERSION` em `etl/23_tce_pb_doe.py` + rodar
 `--reprocess-all` reaplica heuristicas sem refazer download.
 
-## Estrategia de deploy (zero-downtime)
+## Estrategia de deploy
 
-| Etapa | Input deploy.yml | Tempo | Downtime |
+Esta secao reflete as **limitacoes reais** do framework `mv_swap.py` descobertas
+em reviews automaticos (Opus 4.7 + GPT 5.5) na evolucao deste PR. Nem todos os
+passos sao downtime ZERO estrito; documentamos a janela real de cada passo.
+
+| Etapa | Input deploy.yml | Tempo | Degradacao real |
 |---|---|---|---|
-| 1. Schema (CREATE TABLE IF NOT EXISTS) | `etl_phase=web` (aplica `sql/42_*.sql` via step "Apply web app schemas") | ~5s | 0 |
-| 2. Bootstrap ETL (download + parse + load) | `etl_phase=18` (Fase 18 TCE-PB DOE) | ~3-4h | 0 (background) |
-| 3. Provisionar cache dir na VM | automatico via deploy step "Restart cruza-web" | <1s | 0 |
-| 4. MV L1 nova + MV L2 atualizada (swap conjunto) | `mv_swap=mv_empresa_tce_pb,mv_empresa_pb` | ~1s bloqueio | ~1s |
-| 5. Frontend | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30min warm | 0 |
+| 1. Schema + web + bootstrap MV vazia | `etl_phase=web` (aplica `sql/42_*.sql`) | ~5 min | ~2s janela 502s no restart cruza-web (uvicorn single-process; limitacao conhecida) |
+| 2. Bootstrap ETL + REFRESH CONCURRENTLY da MV L1 | `etl_phase=18` (Fase 18 TCE-PB DOE) | ~3-4h | 0 (ETL em background; REFRESH CONCURRENTLY nao bloqueia leitores) |
+| 3. mv_swap da L2 (`mv_empresa_pb` ganha 4 colunas) | `etl_phase=web` + `mv_swap=mv_empresa_pb` | ~10-30 min | janela de minutos com **L2 dependentes** (`mv_municipio_pb_kpi_score`, `mv_municipio_pb_mapa`, `v_risk_score_pb`, `mv_q67_dated_pb`) servindo `0 rows` durante REFRESH pos-swap (sem CONCURRENTLY). Cache `web_cache` cobre 99% do trafego, entao impacto real e marginal |
+| 4. Shadow rewarm | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30-60 min | 0 (shadow pattern; live rows servem trafego ate swap atomico) |
 
-**Importante — swap conjunto obrigatorio (MED-1 review Opus):** apos este
-PR, `mv_empresa_pb` tem dependencia DDL real em `mv_empresa_tce_pb` (LEFT
-JOIN). `etl/mv_swap.py` faz `DROP ... CASCADE` na transacao atomica, entao
-swapar `mv_empresa_tce_pb` sozinho derruba `mv_empresa_pb` por CASCADE,
-deixando a L2 vazia ate o REFRESH terminar (minutos para 4M+ rows). **Todo
-swap futuro deve incluir as duas MVs juntas:** `mv_swap=mv_empresa_tce_pb,mv_empresa_pb`.
-O rewarm seletivo so deve disparar apos o swap das duas.
+**Por que NAO swap conjunto da L1 + L2 (correcao do "swap conjunto" v1/v2):**
+`etl/mv_swap.py` itera CSV uma MV por vez, com COMMIT entre swaps — nao e
+transacional multi-MV. Mais grave: swap de `mv_empresa_tce_pb` (L1) faria
+`DROP CASCADE` que derrubaria `mv_empresa_pb` (L2) entre os dois swaps. Por isso
+a estrategia evita swapar L1: usa `REFRESH CONCURRENTLY` (zero-downtime) para a
+L1 e reserva `mv_swap` apenas para a L2 que **muda de schema** neste PR.
 
-**O que NAO fazer:** `etl_phase=sql` neste PR. Esse comando dispara
-`etl.21_views` que executa `DROP MATERIALIZED VIEW ... CASCADE` de TODAS
-as MVs no topo de `sql/12_views.sql` e recria do zero — 1-2h de downtime
-com paginas `/empresa/*`, `/cidade/*`, `/servidor/*` quebradas. Use o
-caminho mv_swap acima.
+**Bootstrap da L1 (BLOCKER-1 dos reviews):** `mv_swap` aborta se a MV nao
+existir. `sql/42_tce_pb_decisao.sql` cria `mv_empresa_tce_pb` como vazia via
+`CREATE MATERIALIZED VIEW IF NOT EXISTS` no passo 1, garantindo que o
+REFRESH CONCURRENTLY do passo 2 e qualquer mv_swap futuro funcionem.
+
+**Rollback honesto (BLOCKER-3 corrigido):** `mv_swap.py:283` faz
+`DROP CASCADE`, NAO mantem `<mv>_old` — rollback exige re-swap com SQL
+pre-mudanca (`deploy/mv_updates/mv_empresa_pb.sql` da branch anterior) +
+REFRESH em cadeia. Plano: tagear commit pre-deploy + ter `mv_empresa_pb.sql`
+"pre" pronto antes de iniciar.
+
+**Rollback do ETL apos passo 3:** `TRUNCATE tce_pb_decisao*` por si so deixa
+MVs apontando para decisoes inexistentes (MV e snapshot, nao segue TRUNCATE).
+Apos rollback de dados, requer `REFRESH MATERIALIZED VIEW CONCURRENTLY mv_empresa_tce_pb`
++ `REFRESH MATERIALIZED VIEW mv_empresa_pb` + cadeia L2.
+
+**O que NAO fazer:** `etl_phase=sql` neste PR. Dispara `etl.21_views` que
+executa `DROP MATERIALIZED VIEW ... CASCADE` de TODAS as MVs no topo de
+`sql/12_views.sql` — 1-2h de downtime com paginas quebradas.
 
 Cache keys afetadas: prefixos `EMPRESA_PERFIL:<cnpj>` e
-`EMPRESA_PERFIL_MUN:<cnpj>:<slug>` — populadas pelo `web/warm_cache.py`.
-Shadow rewarm seletivo via `rewarm_cache_keys` (memoria zero-downtime).
-
-Rollback: `mv_swap` mantem versao anterior renomeada com sufixo
-(`<mv>_old`), instantaneo (~1s).
+`EMPRESA_PERFIL_MUN:<cnpj>:<slug>`. Match exato (NAO substring) em
+`rewarm_cache_keys` — usar ambos literais.
 
 ## Provisionamento do diretorio de cache
 

--- a/docs/adr/0014-tce-pb-doe-mvp.md
+++ b/docs/adr/0014-tce-pb-doe-mvp.md
@@ -1,0 +1,204 @@
+# ADR-0014: TCE-PB DOE — empresa citada em processos
+
+- Status: Accepted
+- Data: 2026-05-22
+- Decisores: Lucas (maintainer)
+- Tags: etl, fonte-de-dados, web, mv, frontend, lgpd
+
+## Contexto
+
+O Tribunal de Contas do Estado da Paraiba publica diariamente em
+`https://publicacao.tce.pb.gov.br/decisao.php?ano=YYYY` o **Diario Oficial
+Eletronico do TCE-PB (DOE-TCE-PB)** com decisoes/acordaos de processos
+(PCAs, licitacoes, denuncias, contratos, recursos etc). Cada decisao tem
+um hash estavel como ID e um PDF imutavel servido em
+`https://publicacao.tce.pb.gov.br/<hash>`.
+
+Nao havia integracao com essa fonte. Empresas fornecedoras de prefeituras
+PB que aparecem em processos do TCE-PB (irregulares, com multa, com
+debito imputado) eram invisiveis no nosso fluxo de risco/fraude.
+
+## Decisao
+
+Adicionar uma feature MVP em `/empresa/<cnpj>`:
+
+> **"TCE-PB — processos publicados no DOE"** — count + tabela de processos
+> em que o CNPJ aparece, com visualizacao embed do PDF da decisao via
+> backend proxy (anti-`X-Frame-Options`).
+
+Implementacao em **PR unico** abrangendo:
+
+1. **Schema** (`sql/42_tce_pb_decisao.sql`): tabelas
+   `tce_pb_decisao` (PK=`_nk_md5` md5 de NK natural) e
+   `tce_pb_decisao_cnpj` (FK CASCADE) — bag de CNPJs por decisao.
+
+2. **ETL classico** (`etl/23_tce_pb_doe.py`): download (4 workers + retry
+   exponencial calibrado em 9.935 PDFs) + parse pdfminer.six + UPSERT
+   idempotente com gating por `parser_version`. Registrado como **Fase 20**
+   em `etl/run_all.py`.
+
+3. **MV L1** `mv_empresa_tce_pb` (em `sql/12_views.sql` +
+   `deploy/mv_updates/mv_empresa_tce_pb.sql` para swap atomico):
+   agregado por `cnpj_basico` com jsonb embarcado dos top 20 processos
+   mais recentes (cada processo agrupa N decisoes).
+
+4. **MV L2** `mv_empresa_pb` ganha 4 colunas `qtd_processos_tce_pb*`
+   (badge em listas). O jsonb completo fica em `mv_empresa_tce_pb`,
+   consultado separadamente pela rota de empresa (query barata, indexada
+   por `cnpj_basico`).
+
+5. **Rota proxy** `/api/tce-pb/decisao/<hash>.pdf` em
+   `web/routes/tce_pb.py`: whitelist por `tce_pb_decisao.hash_publicacao`,
+   cache local em `/var/cache/cruza-web/tce-pb/<2-prefix>/<hash>.pdf`,
+   reescreve `Content-Disposition: inline` (default) ou `attachment`
+   (com `?download=1`).
+
+6. **Frontend**: secao colapsavel
+   `partials/empresa/_tce_pb_doe.html` + dialog MD3 full-screen com iframe
+   apontando pra rota proxy (mobile-first, touch ≥44px).
+
+## Calibracao quantitativa (N=9.935 PDFs, 2024-2026)
+
+Antes de implementar, baixamos uma amostra grande (alvo: 10k decisoes
+individuais) e analisamos viabilidade:
+
+| Metrica | Valor |
+|---|---|
+| PDFs baixados | 9.935 / 10.000 (0,65% bloqueio Cloudflare persistente) |
+| Densidade CNPJ por PDF | 6,4% (545 PDFs citam ≥1 CNPJ) |
+| **CNPJs distintos no corpus** | **659** |
+| CNPJs validos contra base RFB local | 646 / 659 (98%) |
+| CNPJs UF=PB | 381 (59%) |
+| **CNPJs que sao fornecedores de pelo menos 1 cidade PB** | **459 / 659 (69,7%)** |
+
+A densidade alta de fornecedores ja cadastrados na nossa base justifica
+o esforco de ETL + MV + proxy: 459 CNPJs entrarao com sinal qualificado.
+
+### Calibracao de regex
+
+Iteramos sobre o corpus parcial (N=5.491) ate convergir nestes padroes:
+
+- `irregular`: `\bjulgar?\s+irregular|contas?\s+irregulares?|julgou-se\s+irregular`
+- `regular_ressalva`: `regular(?:es)?\s+com\s+ressalva|aprova[çc][ãa]o\s+com\s+ressalva`
+- `regular` (com lookahead pra nao vazar): `\bjulgar?\s+regular(?!\s+(?:com\s+ressalva|irregular))|\bparecer\s+favor[áa]vel\b`
+- `aplicou_multa`: `aplicar?\s+multa|impor?\s+multa`
+- `imputou_debito`: `imputa[çc][ãa]o\s+de\s+d[ée]bito|imputar?\s+d[ée]bito|ressarcimento[^\n]{0,40}R\$`
+
+Excluimos `tipo_materia=atos_pessoal` dos agregados (57,9% do volume mas
+apenas 0,1% irregular — ruido puro).
+
+### Padrao de download Cloudflare-friendly
+
+Testes empiricos:
+
+| Config | Resultado |
+|---|---|
+| 12 workers, sem retry | ~70% HTTP 520 |
+| **4 workers + retry exponencial {520, 429, 503, timeout}, backoff 2→4→8→16→30s** | **0,65% erro, 3,6 PDFs/s sustentado** |
+
+## Bloqueios e solucoes
+
+### Bloqueio: `X-Frame-Options: SAMEORIGIN` no PDF
+
+TCE-PB serve `https://publicacao.tce.pb.gov.br/<hash>` com cabecalhos:
+
+- `Content-Disposition: attachment` (forca download)
+- `X-Frame-Options: SAMEORIGIN` (impede iframe externo)
+
+Embedding direto e impossivel.
+
+**Solucao**: rota proxy `/api/tce-pb/decisao/<hash>.pdf` que:
+
+1. Valida `hash` contra regex `^[a-f0-9]{32}$` (impede path traversal).
+2. Valida que `hash` existe em `tce_pb_decisao` (anti-open-proxy — sem
+    isso, qualquer hash seria buscado upstream).
+3. Cacheia localmente em
+    `/var/cache/cruza-web/tce-pb/<2-prefix>/<hash>.pdf`. PDFs sao
+    imutaveis por hash (CDN TCE-PB), entao cache "for-ever" e seguro.
+4. Reescreve `Content-Disposition` para `inline` (ou `attachment` com
+    `?download=1`).
+5. `Cache-Control: public, max-age=2592000, immutable` (30 dias).
+
+### LGPD
+
+3% dos PDFs contem CPF cru. NAO persistimos — apenas `cpf_digitos_6`
+(prefixo padronizado pelo projeto). Esta camada nao indexa pessoas (v2).
+
+### Parser version
+
+Schema reserva coluna `parser_version SMALLINT`. UPSERT so atualiza row
+existente se `EXCLUDED.parser_version > current OR text_sha256 IS
+DISTINCT`. Bumpar `PARSER_VERSION` em `etl/23_tce_pb_doe.py` + rodar
+`--reprocess-all` reaplica heuristicas sem refazer download.
+
+## Estrategia de deploy (zero-downtime)
+
+| Etapa | Input deploy.yml | Tempo | Downtime |
+|---|---|---|---|
+| 1. Schema (CREATE TABLE IF NOT EXISTS) | `etl_phase=sql` | ~30s | 0 |
+| 2. Bootstrap ETL (download + parse + load) | `etl_phase=20` ou via `etl_phase=incremental` futura | ~3-4h | 0 (background) |
+| 3. Provisionar cache dir na VM | manual ou via deploy step | <1s | 0 |
+| 4. MV L1 nova | `mv_swap=mv_empresa_tce_pb` | ~1s bloqueio | ~1s |
+| 5. MV L2 atualizada | `mv_swap=mv_empresa_pb` | ~1s bloqueio | ~1s |
+| 6. Frontend | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30min warm | 0 |
+
+Cache keys afetadas: prefixos `EMPRESA_PERFIL:<cnpj>` e
+`EMPRESA_PERFIL_MUN:<cnpj>:<slug>` — populadas pelo `web/warm_cache.py`.
+Shadow rewarm seletivo via `rewarm_cache_keys` (memoria zero-downtime).
+
+Rollback: `mv_swap` mantem versao anterior renomeada com sufixo
+(`<mv>_old`), instantaneo (~1s).
+
+## Provisionamento do diretorio de cache
+
+`/var/cache/cruza-web/tce-pb/` precisa existir e ser writable pelo
+usuario do servico `cruza-web`. Adicionar step ao `deploy.yml` ou
+documentar em `docs/ops.md` como pre-requisito do PR.
+
+## Consequencias
+
+### Positivas
+
+- 459 CNPJs com sinal qualificado de TCE-PB direto na pagina de empresa.
+- PDFs embedded na nossa origem (UX > sair pro portal externo).
+- Fundacao reutilizavel pra v2 (servidores/pessoas, cidades).
+- Schema versionado (`parser_version`) permite iterar regex sem
+  refazer download.
+
+### Negativas / debt
+
+- Spec do framework incremental P1-P6 **nao** existe ainda (framework e
+  CSV-only — PDFs nao se encaixam). Atualizacao diaria roda via Fase 20
+  com `--only-recent N`. Documentado como limitacao conhecida.
+- Cache do proxy pode crescer. Stub atual nao tem eviction. ~5GB max
+  esperado pra 10k PDFs. Adicionar LRU em v2 se necessario.
+- Regex de parsing tem `~5%` taxa de `resultado=indef` — ok pro MVP,
+  mas alvo pra calibracao continua.
+
+## Alternativas consideradas
+
+1. **Embed do iframe direto na origem do TCE-PB**: impossivel
+   (`X-Frame-Options: SAMEORIGIN`).
+2. **Renderizar PDFs em imagens**: caro (pdf2image + storage de
+   thumbnails) e perde UX nativa (busca, zoom).
+3. **Apenas link externo "ver no TCE-PB"**: perde a feature de
+   "ver decisao sem sair do site" — questao central que motivou a
+   feature.
+4. **JSONB completo em `mv_empresa_pb`**: dobra o tamanho da MV
+   (~70k empresas × ~5KB jsonb medio = ~350MB) e atrasa refresh.
+   Manter jsonb em MV separada (`mv_empresa_tce_pb`) e consultar
+   sob demanda e mais barato.
+
+## Referencias
+
+- `etl/23_tce_pb_doe.py` — ETL phase (Fase 20 em `etl/run_all.py`)
+- `sql/42_tce_pb_decisao.sql` — schema
+- `sql/12_views.sql` — `mv_empresa_tce_pb` + coluna em `mv_empresa_pb`
+- `deploy/mv_updates/mv_empresa_tce_pb.sql` — swap atomico
+- `deploy/mv_updates/mv_empresa_pb.sql` — swap atomico (atualizado)
+- `web/routes/tce_pb.py` — rota proxy
+- `web/templates/partials/empresa/_tce_pb_doe.html` — secao colapsavel
+- `web/static/js/components/tce-pdf-viewer.js` — dialog viewer
+- `web/static/css/components/tce-pdf-viewer.css` — estilo mobile-first
+- ADR-0006 — mv_swap atomico (mecanismo reutilizado)
+- ADR-0013 — zero-downtime web (estrategia herdada)

--- a/docs/adr/0014-tce-pb-doe-mvp.md
+++ b/docs/adr/0014-tce-pb-doe-mvp.md
@@ -135,12 +135,25 @@ DISTINCT`. Bumpar `PARSER_VERSION` em `etl/23_tce_pb_doe.py` + rodar
 
 | Etapa | Input deploy.yml | Tempo | Downtime |
 |---|---|---|---|
-| 1. Schema (CREATE TABLE IF NOT EXISTS) | `etl_phase=sql` | ~30s | 0 |
-| 2. Bootstrap ETL (download + parse + load) | `etl_phase=20` ou via `etl_phase=incremental` futura | ~3-4h | 0 (background) |
-| 3. Provisionar cache dir na VM | manual ou via deploy step | <1s | 0 |
-| 4. MV L1 nova | `mv_swap=mv_empresa_tce_pb` | ~1s bloqueio | ~1s |
-| 5. MV L2 atualizada | `mv_swap=mv_empresa_pb` | ~1s bloqueio | ~1s |
-| 6. Frontend | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30min warm | 0 |
+| 1. Schema (CREATE TABLE IF NOT EXISTS) | `etl_phase=web` (aplica `sql/42_*.sql` via step "Apply web app schemas") | ~5s | 0 |
+| 2. Bootstrap ETL (download + parse + load) | `etl_phase=18` (Fase 18 TCE-PB DOE) | ~3-4h | 0 (background) |
+| 3. Provisionar cache dir na VM | automatico via deploy step "Restart cruza-web" | <1s | 0 |
+| 4. MV L1 nova + MV L2 atualizada (swap conjunto) | `mv_swap=mv_empresa_tce_pb,mv_empresa_pb` | ~1s bloqueio | ~1s |
+| 5. Frontend | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30min warm | 0 |
+
+**Importante — swap conjunto obrigatorio (MED-1 review Opus):** apos este
+PR, `mv_empresa_pb` tem dependencia DDL real em `mv_empresa_tce_pb` (LEFT
+JOIN). `etl/mv_swap.py` faz `DROP ... CASCADE` na transacao atomica, entao
+swapar `mv_empresa_tce_pb` sozinho derruba `mv_empresa_pb` por CASCADE,
+deixando a L2 vazia ate o REFRESH terminar (minutos para 4M+ rows). **Todo
+swap futuro deve incluir as duas MVs juntas:** `mv_swap=mv_empresa_tce_pb,mv_empresa_pb`.
+O rewarm seletivo so deve disparar apos o swap das duas.
+
+**O que NAO fazer:** `etl_phase=sql` neste PR. Esse comando dispara
+`etl.21_views` que executa `DROP MATERIALIZED VIEW ... CASCADE` de TODAS
+as MVs no topo de `sql/12_views.sql` e recria do zero — 1-2h de downtime
+com paginas `/empresa/*`, `/cidade/*`, `/servidor/*` quebradas. Use o
+caminho mv_swap acima.
 
 Cache keys afetadas: prefixos `EMPRESA_PERFIL:<cnpj>` e
 `EMPRESA_PERFIL_MUN:<cnpj>:<slug>` — populadas pelo `web/warm_cache.py`.

--- a/docs/adr/0014-tce-pb-doe-mvp.md
+++ b/docs/adr/0014-tce-pb-doe-mvp.md
@@ -141,16 +141,25 @@ passos sao downtime ZERO estrito; documentamos a janela real de cada passo.
 | Etapa | Input deploy.yml | Tempo | Degradacao real |
 |---|---|---|---|
 | 1. Schema + web + bootstrap MV vazia | `etl_phase=web` (aplica `sql/42_*.sql`) | ~5 min | ~2s janela 502s no restart cruza-web (uvicorn single-process; limitacao conhecida) |
-| 2. Bootstrap ETL + REFRESH CONCURRENTLY da MV L1 | `etl_phase=only:18` (roda APENAS Fase 18) | ~3-4h | 0 (ETL em background; REFRESH CONCURRENTLY nao bloqueia leitores) |
+| 2. Bootstrap ETL + REFRESH CONCURRENTLY da MV L1 | `etl_phase=only:23` (roda APENAS a Fase TCE-PB DOE) | ~3-4h | 0 (ETL em background; REFRESH CONCURRENTLY nao bloqueia leitores) |
 | 3. mv_swap da L2 (`mv_empresa_pb` ganha 4 colunas) | `etl_phase=web` + `mv_swap=mv_empresa_pb` | ~10-30 min | janela curta com **apenas `v_risk_score_pb`** (view normal, recriada via DDL instantaneamente). `mv_municipio_pb_kpi_score`, `mv_municipio_pb_mapa`, `mv_q67_dated_pb`, `v_risk_score_empresa` **nao** dependem de `mv_empresa_pb` (verificado em `sql/12_views.sql` apos review v3). Impacto trafego real: marginal |
 | 4. Shadow rewarm | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30-60 min | 0 (shadow pattern; live rows servem trafego ate swap atomico). Custo extra do warm devido a lookup `EMPRESA_TCE_PB_DOE_BY_BASICO` em 143k empresas: **~5-7 min** (lookup PK em MV indexada) |
 
-**CRITICO — passo 2 usa `only:18`, nao `18`:** `etl/run_all.py` interpreta
-arg numerico como **start_phase** (roda da Fase N ate o fim). `etl_phase=18`
-rodaria Fase 18 + Fase 19 (`etl.21_views`), que faz `DROP ... CASCADE` de
+**CRITICO — passo 2 usa `only:23`, nao `23` nem `only:18`:** `etl/run_all.py` interpreta
+arg numerico como **start_phase** (roda da Fase N ate o fim). `etl_phase=23`
+rodaria Fase TCE-PB DOE + Fase Views (`etl.21_views`), que faz `DROP ... CASCADE` de
 TODAS as MVs no topo de `sql/12_views.sql` — anula a estrategia e causa 1-2h
 de downtime. PR #202 adicionou modo `--only N` em `run_all.py` e formato
 `only:N` em `deploy.yml` para o caso cirurgico.
+
+**Importante — N e o INDICE 1-based na lista `phases` de `etl/run_all.py`, NAO o label "Fase X"
+do tuple.** O label "Fase 18: TCE-PB DOE" e historico (preservado pra nao
+renumerar labels antigos); o indice real do tuple `etl.23_tce_pb_doe` na
+lista e **23** (item 23 contando a partir de 1). Para confirmar antes de
+qualquer deploy `only:`:
+```bash
+python -c "from etl.run_all import phases; [print(i+1, m) for i,(_,m) in enumerate(phases)]"
+```
 
 **Por que NAO swap conjunto da L1 + L2 (correcao do "swap conjunto" v1/v2):**
 `etl/mv_swap.py` itera CSV uma MV por vez, com COMMIT entre swaps — nao e

--- a/etl/23_tce_pb_doe.py
+++ b/etl/23_tce_pb_doe.py
@@ -707,7 +707,30 @@ def run(argv: list[str] | None = None) -> None:
     finally:
         conn.close()
 
-    # ── 4. Cleanup (PDFs sao streaming) ─────────────────────────────────
+    # ── 4. Refresh da MV L1 (zero-downtime, dados frescos disponiveis) ──
+    # REFRESH CONCURRENTLY requer UNIQUE INDEX (idx_mv_empresa_tce_pb_cnpj). Sem
+    # CONCURRENTLY, REFRESH bloqueia leitores; com, nao. Se a MV ainda nao existe
+    # (deploy quebrado, sem schema), log e segue — mv_swap posterior cobre.
+    refresh_conn = get_conn()
+    refresh_conn.autocommit = True
+    try:
+        with refresh_conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM pg_matviews WHERE matviewname='mv_empresa_tce_pb'"
+            )
+            if cur.fetchone():
+                print("    REFRESH MATERIALIZED VIEW CONCURRENTLY mv_empresa_tce_pb...",
+                      flush=True)
+                t_ref = time.time()
+                cur.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY mv_empresa_tce_pb")
+                print(f"    Refresh OK em {time.time() - t_ref:.1f}s.", flush=True)
+            else:
+                print("    mv_empresa_tce_pb nao existe (rode mv_swap ou etl_phase=sql).",
+                      flush=True)
+    finally:
+        refresh_conn.close()
+
+    # ── 5. Cleanup (PDFs sao streaming) ─────────────────────────────────
     # Apaga SO os PDFs efetivamente persistidos neste run. Erros de parse e
     # PDFs deixados por runs anteriores ficam preservados para retry.
     if not args.no_cleanup:

--- a/etl/23_tce_pb_doe.py
+++ b/etl/23_tce_pb_doe.py
@@ -1,0 +1,708 @@
+"""Fase 20: TCE-PB DOE eletronico - decisoes individuais.
+
+Baixa, parseia e carrega decisoes (acordaos/decisoes singulares/resolucoes) do
+Tribunal de Contas do Estado da Paraiba a partir de https://publicacao.tce.pb.gov.br.
+
+Cada PDF e uma decisao individual. Um processo (NNNNN/AA) agrupa 1..N decisoes
+ao longo do tempo (decisao inicial, embargos, recurso). Ver ADR-0014.
+
+Pipeline por PDF:
+  1. Listar hashes via index HTML (decisao.php?ano=YYYY).
+  2. Baixar PDF se ainda nao temos (4 workers + retry exp em {520,429,503,timeout}).
+  3. Extrair texto via pdfminer.six.
+  4. Classificar tipo_materia (filename slug + fallback header).
+  5. Classificar resultado (regex calibradas em N=9.935 PDFs - ver ADR-0014).
+  6. Extrair CNPJs, valor multa/debito, municipio inferido, data_sessao.
+  7. UPSERT em tce_pb_decisao (PK=_nk_md5, parser_version) + CASCADE em tce_pb_decisao_cnpj.
+  8. Descartar PDF apos persistir (pipeline streaming - nao armazenar).
+
+Uso:
+  python -m etl.23_tce_pb_doe                       # backfill completo (2008-hoje)
+  python -m etl.23_tce_pb_doe --anos 2024,2025
+  python -m etl.23_tce_pb_doe --only-recent 30      # ultimos N dias (incremental)
+  python -m etl.23_tce_pb_doe --skip-download       # so reprocessa PDFs ja em disco
+  python -m etl.23_tce_pb_doe --reprocess-all       # forca reparse mesmo se parser_version match
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import os
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date, timedelta
+from html.parser import HTMLParser
+from multiprocessing import Pool
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from etl.config import DATA_DIR, SQL_DIR
+from etl.db import get_conn, table_count
+
+PARSER_VERSION = 1
+
+DOE_DIR = DATA_DIR / "tce_pb_doe"
+DOE_INDEX = "https://publicacao.tce.pb.gov.br/decisao.php?ano={ano}"
+DOE_PDF = "https://publicacao.tce.pb.gov.br/{hash}"
+
+_UA = "transparenciapb-etl/1.0"
+_DOWNLOAD_WORKERS = 4
+_DOWNLOAD_BACKOFF_MAX = 30
+_DOWNLOAD_MAX_RETRIES = 5
+_PARSE_WORKERS = 8
+
+# Anos disponiveis no portal (verificado em 2026-05).
+DEFAULT_ANO_INICIO = 2008
+
+
+# ── Padroes de filename TCE-PB ─────────────────────────────────────────────
+# Exemplo completo (truncado para 73 chars no HTML do index):
+#   proc_04498_22_decisao_singular_ds2tc_00125_24_decisao_inicial_sessao_13_03_2024.pdf
+# Truncado:
+#   proc_04498_22_decisao_singular_ds2tc_00125_24_decisao_inicial_sessao_13_03_202
+# Regex tolera truncamento — captura o que conseguir, completa data via texto.
+_PAT_FILENAME = re.compile(
+    r"^proc_(\d{4,5})_(\d{2})_"          # num_processo, ano_processo (YY)
+    r"([a-z_]+?)_"                       # tipo_decisao slug (acordao | decisao_singular | resolucao_processual...)
+    r"([a-z0-9]{3,6})_"                  # orgao slug (apltc/ac1tc/ac2tc/ds1tc/ds2tc/dspltc/rc1tc...)
+    r"(\d{3,5})_(\d{2})_"                # num_decisao, ano_decisao (YY)
+    r"([a-z0-9_]+?)_"                    # fase slug
+    r"sessao_(\d{2})_(\d{2})_(\d{2,4})", # data sessao (DD MM YYYY, com YYYY truncado as vezes)
+    re.IGNORECASE,
+)
+
+_PAT_DATA_SESSAO = re.compile(
+    r"Sess[ãa]o\s+(?:do\s+dia\s+)?(\d{2})/(\d{2})/(\d{4})",
+    re.IGNORECASE,
+)
+
+_PAT_CNPJ = re.compile(r"\b(\d{2})\.(\d{3})\.(\d{3})/(\d{4})-(\d{2})\b")
+
+# Classificador de tipo_materia por slug do tipo_decisao
+_TIPO_MATERIA_FROM_SLUG = {
+    "atos_pessoal": "atos_pessoal",
+    "aposentadoria": "atos_pessoal",
+    "pensao": "atos_pessoal",
+}
+
+# Heuristicas calibradas em N=9.935 PDFs (ver ADR-0014).
+_PAT_IRREGULAR = re.compile(
+    r"\bjulgar?\s+irregular|contas?\s+irregulares?|julgou-se\s+irregular",
+    re.IGNORECASE,
+)
+_PAT_REG_RESSALVA = re.compile(
+    r"regular(?:es)?\s+com\s+ressalva|aprova[çc][ãa]o\s+com\s+ressalva",
+    re.IGNORECASE,
+)
+_PAT_REGULAR = re.compile(
+    r"\bjulgar?\s+regular(?!\s+(?:com\s+ressalva|irregular))"
+    r"|\bparecer\s+favor[áa]vel\b",
+    re.IGNORECASE,
+)
+_PAT_MULTA = re.compile(
+    r"aplicar?\s+multa|impor?\s+multa|aplicac[ãa]o\s+de\s+multa",
+    re.IGNORECASE,
+)
+_PAT_DEBITO = re.compile(
+    r"imputa[çc][ãa]o\s+de\s+d[ée]bito|imputar?\s+d[ée]bito|ressarcimento[^\n]{0,40}R\$",
+    re.IGNORECASE,
+)
+_PAT_VALOR_MULTA = re.compile(
+    r"multa[^\n]{0,80}R\$\s*([\d\.\,]+)",
+    re.IGNORECASE,
+)
+_PAT_VALOR_DEBITO = re.compile(
+    r"d[ée]bito[^\n]{0,80}R\$\s*([\d\.\,]+)",
+    re.IGNORECASE,
+)
+_PAT_MUNICIPIO = re.compile(
+    r"(?:Munic[íi]pio|Prefeitura\s+Municipal)\s+(?:de\s+)?([A-ZÁÉÍÓÚÂÊÔÃÕÇ][A-Za-zÁÉÍÓÚÂÊÔÃÕÇáéíóúâêôãõç\s\-']{2,50}?)(?=\s*[\,\.\-/]|\s+e\s+)",
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Crawl da listagem (extrai pares hash/filename do HTML do index)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _DOEIndexParser(HTMLParser):
+    """Extrai (hash, filename) de cada <a href='/HASH'>NAME</a>."""
+
+    def __init__(self):
+        super().__init__()
+        self.items: list[tuple[str, str]] = []
+        self._cur_hash: str | None = None
+        self._cur_text: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "a":
+            return
+        href = dict(attrs).get("href", "")
+        m = re.match(r"^/?([a-f0-9]{32})$", href)
+        if m:
+            self._cur_hash = m.group(1)
+            self._cur_text = []
+
+    def handle_data(self, data):
+        if self._cur_hash:
+            self._cur_text.append(data)
+
+    def handle_endtag(self, tag):
+        if tag == "a" and self._cur_hash:
+            name = "".join(self._cur_text).strip()
+            if name:
+                self.items.append((self._cur_hash, name))
+            self._cur_hash = None
+            self._cur_text = []
+
+
+def fetch_doe_index(ano: int) -> list[tuple[str, str]]:
+    """Retorna lista de (hash, filename_truncado) para um ano do DOE TCE-PB."""
+    url = DOE_INDEX.format(ano=ano)
+    req = Request(url, headers={"User-Agent": _UA})
+    with urlopen(req, timeout=120) as r:
+        html = r.read().decode("utf-8", errors="replace")
+    p = _DOEIndexParser()
+    p.feed(html)
+    return p.items
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Download (4 workers + exp backoff em 520/429/503/timeout)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _download_one(item) -> tuple[str, str, int]:
+    """Worker: baixa um PDF. Retorna (hash, status, bytes)."""
+    h, dest_dir = item
+    path = dest_dir / f"{h}.pdf"
+    if path.exists() and path.stat().st_size > 1000:
+        return (h, "skip", path.stat().st_size)
+    backoff = 2
+    for _ in range(_DOWNLOAD_MAX_RETRIES):
+        try:
+            req = Request(DOE_PDF.format(hash=h), headers={"User-Agent": _UA})
+            with urlopen(req, timeout=60) as r:
+                data = r.read()
+            if len(data) < 1000:
+                return (h, "err:tiny", 0)
+            path.write_bytes(data)
+            return (h, "ok", len(data))
+        except Exception as e:
+            msg = str(e).lower()
+            transitorio = any(c in msg for c in ("520", "429", "503")) or "timed out" in msg
+            if transitorio:
+                time.sleep(backoff)
+                backoff = min(backoff * 2, _DOWNLOAD_BACKOFF_MAX)
+                continue
+            return (h, f"err:{type(e).__name__}", 0)
+    return (h, "err:max_retries", 0)
+
+
+def download_decisoes(hashes: list[str], dest_dir: Path) -> dict:
+    """Baixa os PDFs em paralelo (4 workers + backoff). Idempotente.
+
+    Retorna stats {ok, skip, err, bytes}.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    # Limpa zero-bytes/tiny files de runs anteriores
+    for f in dest_dir.glob("*.pdf"):
+        if f.stat().st_size < 1000:
+            f.unlink()
+
+    items = [(h, dest_dir) for h in hashes]
+    t0 = time.time()
+    ok = skip = err = 0
+    total_bytes = 0
+    errors_sample: list[str] = []
+
+    with ThreadPoolExecutor(max_workers=_DOWNLOAD_WORKERS) as pool:
+        futs = [pool.submit(_download_one, it) for it in items]
+        for i, fut in enumerate(as_completed(futs), 1):
+            h, status, sz = fut.result()
+            if status == "ok":
+                ok += 1
+                total_bytes += sz
+            elif status == "skip":
+                skip += 1
+                total_bytes += sz
+            else:
+                err += 1
+                if len(errors_sample) < 20:
+                    errors_sample.append(f"{h}: {status}")
+            if i % 100 == 0 or i == len(items):
+                elapsed = time.time() - t0
+                rate = i / elapsed if elapsed else 0
+                eta = (len(items) - i) / rate if rate else 0
+                mb = total_bytes / 1024 / 1024
+                print(
+                    f"    [{i:5d}/{len(items)}] ok={ok} skip={skip} err={err} | "
+                    f"{mb:.1f}MB ({mb/elapsed if elapsed else 0:.2f}MB/s) | "
+                    f"rate={rate:.1f}/s ETA={eta:.0f}s",
+                    flush=True,
+                )
+
+    if errors_sample:
+        print("    Sample de erros:", flush=True)
+        for e in errors_sample:
+            print(f"      {e}", flush=True)
+
+    return {"ok": ok, "skip": skip, "err": err, "bytes": total_bytes}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Parse (pdfminer + classificadores calibrados)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _parse_filename(name: str) -> dict:
+    """Best-effort: extrai campos do filename (que vem truncado em 73 chars do HTML)."""
+    m = _PAT_FILENAME.match(name or "")
+    if not m:
+        return {}
+    g = m.groups()
+    yyyy = g[9]
+    if len(yyyy) == 2:
+        yyyy = "20" + yyyy
+    return {
+        "num_processo": g[0].lstrip("0") or "0",
+        "ano_processo": int("20" + g[1]),
+        "tipo_decisao_slug": g[2].lower(),
+        "orgao_julgador": g[3].lower(),
+        "num_decisao": g[4].lstrip("0") or "0",
+        "ano_decisao": int("20" + g[5]),
+        "fase": g[6].lower(),
+        "data_sessao": f"{yyyy}-{g[8]}-{g[7]}" if len(yyyy) == 4 else None,
+    }
+
+
+def _classify_tipo_materia(slug_decisao: str, text_head: str) -> str:
+    if slug_decisao:
+        s = slug_decisao.lower()
+        if s in _TIPO_MATERIA_FROM_SLUG:
+            return _TIPO_MATERIA_FROM_SLUG[s]
+    head = (text_head or "").upper()
+    if "APOSENTADORIA" in head or "PENSÃO" in head or "PENSAO" in head or "REFORMA" in head:
+        return "atos_pessoal"
+    if "DENÚNCIA" in head or "DENUNCIA" in head:
+        return "denuncia"
+    if "REPRESENTAÇÃO" in head or "REPRESENTACAO" in head:
+        return "representacao"
+    if "PRESTAÇÃO DE CONTAS" in head or "PRESTACAO DE CONTAS" in head:
+        return "pca"
+    if "TOMADA DE CONTAS" in head:
+        return "tce_especial"
+    if "LICITAÇÃO" in head or "LICITACAO" in head or "PREGÃO" in head or "PREGAO" in head:
+        return "licitacao"
+    if "CONTRATO" in head:
+        return "contrato"
+    if "EMBARGOS" in head:
+        return "embargos"
+    if "RECURSO" in head or "AGRAVO" in head:
+        return "recurso"
+    return "indef"
+
+
+def _classify_resultado(text: str) -> str:
+    if _PAT_IRREGULAR.search(text):
+        return "irregular"
+    if _PAT_REG_RESSALVA.search(text):
+        return "regular_ressalva"
+    if _PAT_REGULAR.search(text):
+        return "regular"
+    return "indef"
+
+
+def _parse_brl(s: str) -> float | None:
+    if not s:
+        return None
+    s = s.strip().rstrip(".,")
+    s = s.replace(".", "").replace(",", ".")
+    try:
+        v = float(s)
+        if v <= 0 or v > 1e10:
+            return None
+        return round(v, 2)
+    except ValueError:
+        return None
+
+
+def _extract_municipio(text_head: str) -> str | None:
+    m = _PAT_MUNICIPIO.search(text_head or "")
+    if not m:
+        return None
+    name = m.group(1).strip().rstrip(",.").strip()
+    return name[:120] if name else None
+
+
+def _extract_data_sessao(text: str) -> str | None:
+    m = _PAT_DATA_SESSAO.search(text or "")
+    if not m:
+        return None
+    dd, mm, yyyy = m.groups()
+    return f"{yyyy}-{mm}-{dd}"
+
+
+def parse_pdf(pdf_path: Path, filename_hint: str) -> dict | None:
+    """Lê um PDF e retorna dict com campos extraidos. None se filename irreparavel."""
+    # Importacao lazy — pdfminer e dep heavy.
+    from pdfminer.high_level import extract_text
+
+    try:
+        text = extract_text(str(pdf_path)) or ""
+    except Exception as e:
+        return {"error": f"pdfminer:{type(e).__name__}", "raw_error": str(e)[:200]}
+
+    text = text.replace("\u00a0", " ")
+    head = text[:2000]
+    body = text  # full body para regex de resultado/valor/cnpj
+
+    fn = _parse_filename(filename_hint)
+    if not fn:
+        return {"error": "filename_unparseable", "filename": filename_hint}
+
+    tipo_materia = _classify_tipo_materia(fn.get("tipo_decisao_slug", ""), head)
+    resultado = _classify_resultado(body)
+    data_sessao = fn.get("data_sessao") or _extract_data_sessao(body)
+
+    aplicou_multa = bool(_PAT_MULTA.search(body))
+    imputou_debito = bool(_PAT_DEBITO.search(body))
+    valor_multa = None
+    valor_debito = None
+    if aplicou_multa:
+        m = _PAT_VALOR_MULTA.search(body)
+        if m:
+            valor_multa = _parse_brl(m.group(1))
+    if imputou_debito:
+        m = _PAT_VALOR_DEBITO.search(body)
+        if m:
+            valor_debito = _parse_brl(m.group(1))
+
+    cnpjs: set[str] = set()
+    for m in _PAT_CNPJ.finditer(body):
+        cnpjs.add("".join(m.groups()))
+
+    municipio = _extract_municipio(head)
+
+    text_hash = hashlib.sha256(body.encode("utf-8", errors="replace")).hexdigest()
+
+    # Tipo decisao "humanizado"
+    slug = fn.get("tipo_decisao_slug", "")
+    tipo_decisao = slug.replace("_", " ") if slug else None
+
+    return {
+        "hash_publicacao": pdf_path.stem,
+        "num_processo": fn["num_processo"],
+        "ano_processo": fn["ano_processo"],
+        "tipo_decisao": tipo_decisao[:40] if tipo_decisao else None,
+        "orgao_julgador": fn.get("orgao_julgador", "")[:10] or None,
+        "num_decisao": fn["num_decisao"],
+        "ano_decisao": fn["ano_decisao"],
+        "fase": fn["fase"][:60],
+        "data_sessao": data_sessao,
+        "tipo_materia": tipo_materia,
+        "resultado": resultado,
+        "aplicou_multa": aplicou_multa,
+        "imputou_debito": imputou_debito,
+        "valor_multa_rs": valor_multa,
+        "valor_debito_rs": valor_debito,
+        "municipio_inferido": municipio,
+        "text_sha256": text_hash,
+        "cnpjs": sorted(cnpjs),
+    }
+
+
+def _nk_md5_of(parsed: dict) -> str:
+    nk = "|".join([
+        parsed["num_processo"],
+        str(parsed["ano_processo"]),
+        parsed.get("tipo_decisao") or "",
+        parsed["num_decisao"],
+        str(parsed["ano_decisao"]),
+        parsed["fase"],
+    ])
+    return hashlib.md5(nk.encode("utf-8")).hexdigest()
+
+
+def _parse_worker(args):
+    pdf_path_s, filename_hint = args
+    pdf_path = Path(pdf_path_s)
+    try:
+        parsed = parse_pdf(pdf_path, filename_hint)
+        return (pdf_path.stem, parsed)
+    except Exception as e:
+        return (pdf_path.stem, {"error": f"worker:{type(e).__name__}", "raw_error": str(e)[:200]})
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Carga (UPSERT em tce_pb_decisao + tce_pb_decisao_cnpj)
+# ─────────────────────────────────────────────────────────────────────────
+
+_UPSERT_DECISAO = """
+INSERT INTO tce_pb_decisao (
+    _nk_md5, hash_publicacao, num_processo, ano_processo, tipo_decisao,
+    orgao_julgador, num_decisao, ano_decisao, fase, data_sessao,
+    tipo_materia, resultado, aplicou_multa, imputou_debito,
+    valor_multa_rs, valor_debito_rs, municipio_inferido, text_sha256,
+    parser_version
+) VALUES (
+    %(_nk_md5)s, %(hash_publicacao)s, %(num_processo)s, %(ano_processo)s,
+    %(tipo_decisao)s, %(orgao_julgador)s, %(num_decisao)s, %(ano_decisao)s,
+    %(fase)s, %(data_sessao)s, %(tipo_materia)s, %(resultado)s,
+    %(aplicou_multa)s, %(imputou_debito)s, %(valor_multa_rs)s,
+    %(valor_debito_rs)s, %(municipio_inferido)s, %(text_sha256)s,
+    %(parser_version)s
+)
+ON CONFLICT (_nk_md5) DO UPDATE SET
+    hash_publicacao    = EXCLUDED.hash_publicacao,
+    tipo_decisao       = EXCLUDED.tipo_decisao,
+    orgao_julgador     = EXCLUDED.orgao_julgador,
+    data_sessao        = EXCLUDED.data_sessao,
+    tipo_materia       = EXCLUDED.tipo_materia,
+    resultado          = EXCLUDED.resultado,
+    aplicou_multa      = EXCLUDED.aplicou_multa,
+    imputou_debito     = EXCLUDED.imputou_debito,
+    valor_multa_rs     = EXCLUDED.valor_multa_rs,
+    valor_debito_rs    = EXCLUDED.valor_debito_rs,
+    municipio_inferido = EXCLUDED.municipio_inferido,
+    text_sha256        = EXCLUDED.text_sha256,
+    parser_version     = EXCLUDED.parser_version,
+    ingerido_em        = now()
+WHERE tce_pb_decisao.parser_version < EXCLUDED.parser_version
+   OR tce_pb_decisao.text_sha256 IS DISTINCT FROM EXCLUDED.text_sha256
+"""
+
+
+def _persist_batch(conn, batch: list[dict]) -> None:
+    if not batch:
+        return
+    with conn.cursor() as cur:
+        for p in batch:
+            p["_nk_md5"] = _nk_md5_of(p)
+            p["parser_version"] = PARSER_VERSION
+            cur.execute(_UPSERT_DECISAO, p)
+            # Substitui o bag de CNPJs (CASCADE em delete via FK).
+            cur.execute("DELETE FROM tce_pb_decisao_cnpj WHERE decisao_md5 = %s",
+                        (p["_nk_md5"],))
+            if p["cnpjs"]:
+                args = [(p["_nk_md5"], c) for c in p["cnpjs"]]
+                cur.executemany(
+                    "INSERT INTO tce_pb_decisao_cnpj (decisao_md5, cnpj) VALUES (%s, %s)"
+                    " ON CONFLICT DO NOTHING",
+                    args,
+                )
+    conn.commit()
+
+
+def parse_and_load(conn, pdf_pairs: list[tuple[Path, str]],
+                   reprocess_all: bool = False) -> dict:
+    """Roda parsing em pool de processos e persiste em batches de 200.
+
+    pdf_pairs: lista de (pdf_path, filename_hint).
+    """
+    if not pdf_pairs:
+        return {"parsed": 0, "errors": 0, "skipped": 0}
+
+    # Filtra ja-processados (mesma parser_version) se nao reprocess_all.
+    if not reprocess_all:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT hash_publicacao FROM tce_pb_decisao "
+                "WHERE parser_version >= %s",
+                (PARSER_VERSION,),
+            )
+            done = {r[0] for r in cur.fetchall()}
+        before = len(pdf_pairs)
+        pdf_pairs = [(p, n) for (p, n) in pdf_pairs if p.stem not in done]
+        skipped = before - len(pdf_pairs)
+        if skipped:
+            print(f"    Skipping {skipped} PDFs ja na parser_version {PARSER_VERSION}.",
+                  flush=True)
+    else:
+        skipped = 0
+
+    print(f"    Parseando {len(pdf_pairs)} PDFs com {_PARSE_WORKERS} workers...",
+          flush=True)
+
+    t0 = time.time()
+    parsed = errors = 0
+    batch: list[dict] = []
+    args_list = [(str(p), n) for (p, n) in pdf_pairs]
+
+    error_samples: list[str] = []
+    with Pool(processes=_PARSE_WORKERS) as pool:
+        for i, (h, result) in enumerate(
+            pool.imap_unordered(_parse_worker, args_list, chunksize=8), 1
+        ):
+            if result is None or "error" in result:
+                errors += 1
+                if len(error_samples) < 10:
+                    err_desc = (result or {}).get("error", "unknown")
+                    error_samples.append(f"{h}: {err_desc}")
+            else:
+                batch.append(result)
+                if len(batch) >= 200:
+                    _persist_batch(conn, batch)
+                    parsed += len(batch)
+                    batch = []
+            if i % 200 == 0 or i == len(args_list):
+                elapsed = time.time() - t0
+                rate = i / elapsed if elapsed else 0
+                eta = (len(args_list) - i) / rate if rate else 0
+                print(
+                    f"    [{i:5d}/{len(args_list)}] parsed={parsed} err={errors} "
+                    f"rate={rate:.1f}/s ETA={eta:.0f}s",
+                    flush=True,
+                )
+
+    if batch:
+        _persist_batch(conn, batch)
+        parsed += len(batch)
+
+    if error_samples:
+        print("    Sample de erros de parse:", flush=True)
+        for e in error_samples:
+            print(f"      {e}", flush=True)
+
+    return {"parsed": parsed, "errors": errors, "skipped": skipped}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Orchestrator
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _ensure_schema(conn) -> None:
+    sql = (SQL_DIR / "42_tce_pb_decisao.sql").read_text(encoding="utf-8")
+    with conn.cursor() as cur:
+        cur.execute(sql)
+    conn.commit()
+
+
+def _list_local_pdfs(dest_dir: Path,
+                     index_map: dict[str, str]) -> list[tuple[Path, str]]:
+    """Cruza PDFs ja em disco com filenames do index. Filename hint vem do index."""
+    pairs: list[tuple[Path, str]] = []
+    for f in dest_dir.glob("*.pdf"):
+        if f.stat().st_size < 1000:
+            continue
+        h = f.stem
+        if h in index_map:
+            pairs.append((f, index_map[h]))
+    return pairs
+
+
+def _filter_recent(items: list[tuple[str, str]], days: int) -> list[tuple[str, str]]:
+    """Filtra items do index para os ultimos N dias (usando data_sessao do filename)."""
+    cutoff = date.today() - timedelta(days=days)
+    out: list[tuple[str, str]] = []
+    for h, name in items:
+        fn = _parse_filename(name)
+        ds = fn.get("data_sessao")
+        if not ds:
+            continue
+        try:
+            d = date.fromisoformat(ds)
+        except ValueError:
+            continue
+        if d >= cutoff:
+            out.append((h, name))
+    return out
+
+
+def run(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="etl.23_tce_pb_doe")
+    parser.add_argument("--anos", help="Anos comma-separated (default: backfill)")
+    parser.add_argument("--only-recent", type=int, metavar="N",
+                        help="Apenas decisoes dos ultimos N dias (modo incremental)")
+    parser.add_argument("--skip-download", action="store_true",
+                        help="Nao baixa - apenas reparseia PDFs ja em disco")
+    parser.add_argument("--reprocess-all", action="store_true",
+                        help="Reparseia mesmo PDFs ja na parser_version atual")
+    parser.add_argument("--no-cleanup", action="store_true",
+                        help="Nao apaga PDFs apos persistir (default: apaga)")
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if args.anos:
+        anos = [int(a) for a in args.anos.split(",")]
+    elif args.only_recent:
+        anos = [date.today().year]
+        if date.today().month <= 2:
+            anos.append(date.today().year - 1)
+    else:
+        anos = list(range(DEFAULT_ANO_INICIO, date.today().year + 1))
+
+    DOE_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"  TCE-PB DOE: anos={anos}, only_recent={args.only_recent}, "
+          f"parser_version={PARSER_VERSION}", flush=True)
+
+    # ── 1. Fetch index para todos os anos ───────────────────────────────
+    all_items: list[tuple[str, str]] = []
+    for ano in anos:
+        print(f"    Fetching index ano={ano}...", flush=True)
+        try:
+            items = fetch_doe_index(ano)
+        except Exception as e:
+            print(f"    ERRO index ano={ano}: {e}", flush=True)
+            continue
+        print(f"      {len(items)} decisoes listadas.", flush=True)
+        all_items.extend(items)
+
+    if args.only_recent:
+        before = len(all_items)
+        all_items = _filter_recent(all_items, args.only_recent)
+        print(f"    Filtrado para ultimos {args.only_recent} dias: "
+              f"{len(all_items)}/{before}", flush=True)
+
+    if not all_items:
+        print("    Nenhuma decisao a processar.", flush=True)
+        return
+
+    index_map = {h: n for h, n in all_items}
+
+    # ── 2. Download ─────────────────────────────────────────────────────
+    if args.skip_download:
+        print("    --skip-download: pulando download.", flush=True)
+    else:
+        print(f"    Baixando {len(all_items)} PDFs...", flush=True)
+        stats = download_decisoes([h for h, _ in all_items], DOE_DIR)
+        print(f"    Download: ok={stats['ok']} skip={stats['skip']} "
+              f"err={stats['err']} ({stats['bytes']/1024/1024:.0f}MB)", flush=True)
+
+    # ── 3. Parse + carga ────────────────────────────────────────────────
+    conn = get_conn()
+    try:
+        _ensure_schema(conn)
+        print("    Schema TCE-PB DOE garantido.", flush=True)
+
+        pdf_pairs = _list_local_pdfs(DOE_DIR, index_map)
+        print(f"    PDFs em disco a processar: {len(pdf_pairs)}", flush=True)
+
+        stats = parse_and_load(conn, pdf_pairs, reprocess_all=args.reprocess_all)
+        print(f"    Parse: parsed={stats['parsed']} errors={stats['errors']} "
+              f"skipped={stats['skipped']}", flush=True)
+
+        # Contagens finais
+        print(f"    tce_pb_decisao: {table_count(conn, 'tce_pb_decisao'):,}", flush=True)
+        print(f"    tce_pb_decisao_cnpj: {table_count(conn, 'tce_pb_decisao_cnpj'):,}",
+              flush=True)
+    finally:
+        conn.close()
+
+    # ── 4. Cleanup (PDFs sao streaming) ─────────────────────────────────
+    if not args.no_cleanup:
+        n = 0
+        for f in DOE_DIR.glob("*.pdf"):
+            f.unlink()
+            n += 1
+        print(f"    Cleanup: {n} PDFs removidos (streaming - nao armazenamos).",
+              flush=True)
+
+
+if __name__ == "__main__":
+    run()

--- a/etl/23_tce_pb_doe.py
+++ b/etl/23_tce_pb_doe.py
@@ -259,8 +259,16 @@ def download_decisoes(hashes: list[str], dest_dir: Path) -> dict:
 # ─────────────────────────────────────────────────────────────────────────
 
 
-def _parse_filename(name: str) -> dict:
-    """Best-effort: extrai campos do filename (que vem truncado em 73 chars do HTML)."""
+def _parse_filename(name: str, default_year: int | None = None) -> dict:
+    """Best-effort: extrai campos do filename (que vem truncado em 73 chars do HTML).
+
+    Quando `default_year` e fornecido e o YYYY no filename veio truncado
+    para 3 chars (caso comum: nomes truncados em 73 chars de largura no
+    HTML do indice), tenta completar usando `default_year` ou
+    `default_year - 1` (decisoes do ano anterior aparecem no indice do ano
+    corrente). Adicionado em PR #202 apos descobrir que `--only-recent`
+    descartava 100% das decisoes do indice 2026 (todos truncados a 3 chars).
+    """
     m = _PAT_FILENAME.match(name or "")
     if not m:
         return {}
@@ -268,6 +276,20 @@ def _parse_filename(name: str) -> dict:
     yyyy = g[9]
     if len(yyyy) == 2:
         yyyy = "20" + yyyy
+    elif len(yyyy) == 3 and default_year is not None:
+        # YYYY truncado a 3 chars: tenta default_year e default_year-1.
+        # Aceita o que comeca com os 3 chars e produz data <= hoje.
+        from datetime import date as _date
+        for candidate in (default_year, default_year - 1):
+            cand_str = str(candidate)
+            if cand_str.startswith(yyyy):
+                try:
+                    d = _date(candidate, int(g[8]), int(g[7]))
+                    if d <= _date.today():
+                        yyyy = cand_str
+                        break
+                except ValueError:
+                    continue
     return {
         "num_processo": g[0].lstrip("0") or "0",
         "ano_processo": int("20" + g[1]),
@@ -607,12 +629,17 @@ def _list_local_pdfs(dest_dir: Path,
     return pairs
 
 
-def _filter_recent(items: list[tuple[str, str]], days: int) -> list[tuple[str, str]]:
-    """Filtra items do index para os ultimos N dias (usando data_sessao do filename)."""
+def _filter_recent(items: list[tuple[str, str]], days: int,
+                   default_year: int | None = None) -> list[tuple[str, str]]:
+    """Filtra items do index para os ultimos N dias (usando data_sessao do filename).
+
+    `default_year` resolve filenames truncados a 3 chars no YYYY (caso comum
+    no indice do TCE-PB que tronca nomes a 73 chars no HTML).
+    """
     cutoff = date.today() - timedelta(days=days)
     out: list[tuple[str, str]] = []
     for h, name in items:
-        fn = _parse_filename(name)
+        fn = _parse_filename(name, default_year=default_year)
         ds = fn.get("data_sessao")
         if not ds:
             continue
@@ -653,6 +680,9 @@ def run(argv: list[str] | None = None) -> None:
           f"parser_version={PARSER_VERSION}", flush=True)
 
     # ── 1. Fetch index para todos os anos ───────────────────────────────
+    # Filtra --only-recent POR ANO (nao no concat final) para podermos passar
+    # `default_year` ao _parse_filename e resolver YYYY truncados a 3 chars
+    # (caso comum no indice do TCE-PB).
     all_items: list[tuple[str, str]] = []
     for ano in anos:
         print(f"    Fetching index ano={ano}...", flush=True)
@@ -662,13 +692,12 @@ def run(argv: list[str] | None = None) -> None:
             print(f"    ERRO index ano={ano}: {e}", flush=True)
             continue
         print(f"      {len(items)} decisoes listadas.", flush=True)
+        if args.only_recent:
+            before = len(items)
+            items = _filter_recent(items, args.only_recent, default_year=ano)
+            print(f"      Filtrado para ultimos {args.only_recent} dias: "
+                  f"{len(items)}/{before}", flush=True)
         all_items.extend(items)
-
-    if args.only_recent:
-        before = len(all_items)
-        all_items = _filter_recent(all_items, args.only_recent)
-        print(f"    Filtrado para ultimos {args.only_recent} dias: "
-              f"{len(all_items)}/{before}", flush=True)
 
     if not all_items:
         print("    Nenhuma decisao a processar.", flush=True)

--- a/etl/23_tce_pb_doe.py
+++ b/etl/23_tce_pb_doe.py
@@ -531,7 +531,13 @@ def parse_and_load(conn, pdf_pairs: list[tuple[Path, str]],
     t0 = time.time()
     parsed = errors = 0
     batch: list[dict] = []
+    persisted_hashes: set[str] = set()
     args_list = [(str(p), n) for (p, n) in pdf_pairs]
+
+    def _flush(b: list[dict]) -> None:
+        _persist_batch(conn, b)
+        for item in b:
+            persisted_hashes.add(item["hash_publicacao"])
 
     error_samples: list[str] = []
     with Pool(processes=_PARSE_WORKERS) as pool:
@@ -546,7 +552,7 @@ def parse_and_load(conn, pdf_pairs: list[tuple[Path, str]],
             else:
                 batch.append(result)
                 if len(batch) >= 200:
-                    _persist_batch(conn, batch)
+                    _flush(batch)
                     parsed += len(batch)
                     batch = []
             if i % 200 == 0 or i == len(args_list):
@@ -560,7 +566,7 @@ def parse_and_load(conn, pdf_pairs: list[tuple[Path, str]],
                 )
 
     if batch:
-        _persist_batch(conn, batch)
+        _flush(batch)
         parsed += len(batch)
 
     if error_samples:
@@ -568,7 +574,12 @@ def parse_and_load(conn, pdf_pairs: list[tuple[Path, str]],
         for e in error_samples:
             print(f"      {e}", flush=True)
 
-    return {"parsed": parsed, "errors": errors, "skipped": skipped}
+    return {
+        "parsed": parsed,
+        "errors": errors,
+        "skipped": skipped,
+        "persisted_hashes": persisted_hashes,
+    }
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -675,6 +686,7 @@ def run(argv: list[str] | None = None) -> None:
               f"err={stats['err']} ({stats['bytes']/1024/1024:.0f}MB)", flush=True)
 
     # ── 3. Parse + carga ────────────────────────────────────────────────
+    persisted_hashes: set[str] = set()
     conn = get_conn()
     try:
         _ensure_schema(conn)
@@ -686,6 +698,7 @@ def run(argv: list[str] | None = None) -> None:
         stats = parse_and_load(conn, pdf_pairs, reprocess_all=args.reprocess_all)
         print(f"    Parse: parsed={stats['parsed']} errors={stats['errors']} "
               f"skipped={stats['skipped']}", flush=True)
+        persisted_hashes = stats.get("persisted_hashes", set())
 
         # Contagens finais
         print(f"    tce_pb_decisao: {table_count(conn, 'tce_pb_decisao'):,}", flush=True)
@@ -695,12 +708,18 @@ def run(argv: list[str] | None = None) -> None:
         conn.close()
 
     # ── 4. Cleanup (PDFs sao streaming) ─────────────────────────────────
+    # Apaga SO os PDFs efetivamente persistidos neste run. Erros de parse e
+    # PDFs deixados por runs anteriores ficam preservados para retry.
     if not args.no_cleanup:
         n = 0
-        for f in DOE_DIR.glob("*.pdf"):
-            f.unlink()
-            n += 1
-        print(f"    Cleanup: {n} PDFs removidos (streaming - nao armazenamos).",
+        for h in persisted_hashes:
+            f = DOE_DIR / f"{h}.pdf"
+            try:
+                f.unlink()
+                n += 1
+            except FileNotFoundError:
+                pass
+        print(f"    Cleanup: {n} PDFs removidos (de {len(persisted_hashes)} persistidos).",
               flush=True)
 
 

--- a/etl/run_all.py
+++ b/etl/run_all.py
@@ -73,39 +73,48 @@ def _cleanup_csvs(module_name: str, succeeded_modules: set[str]):
             print(f"    Limpeza: {target} removido ({size_mb:,.0f} MB liberados)", flush=True)
 
 
+# Lista canonica de fases do ETL. Modulo-level (NAO dentro de main()) para
+# permitir inspecao programatica via:
+#   python -c "from etl.run_all import PHASES; [print(i+1, m) for i,(_,m) in enumerate(PHASES)]"
+# Esse comando e a salvaguarda institucional contra o bug do PR #202
+# (CRITICAL: confundiu label "Fase 18" com indice 1-based). N em --only N
+# ou etl_phase=N e o INDICE 1-based nesta lista, NAO o numero no label.
+PHASES = [
+    ("Fase 0: Download de dados brutos", "etl.00_download"),
+    ("Fase 1: Schema", "etl.01_schema"),
+    ("Fase 2: Dominio", "etl.02_dominio"),
+    ("Fase 3: RFB (Empresas, Estabelecimentos, Socios, Simples)", "etl.03_rfb"),
+    ("Fase 4.1-4.2: PNCP", "etl.04_pncp"),
+    ("Fase 4.3-4.5: Emendas", "etl.05_emendas"),
+    ("Fase 4.6: CPGF", "etl.06_cpgf"),
+    ("Fase 4.7-4.8+5.2: Complementar (BNDES, Holdings, ComprasNet)", "etl.09_complementar"),
+    ("Fase 5.1: PGFN", "etl.07_pgfn"),
+    ("Fase 5.3: Renuncias Fiscais", "etl.08_renuncias"),
+    ("Fase 6: Indices", "etl.10_indices"),
+    ("Fase 7: Entity Resolution (Pessoa)", "etl.11_pessoa"),
+    ("Fase 8: SIAPE (Servidores)", "etl.12_siape"),
+    ("Fase 9: Sancoes (CEIS/CNEP/CEAF/Acordos)", "etl.13_sancoes"),
+    ("Fase 10: Viagens a Servico", "etl.14_viagens"),
+    ("Fase 11: TSE Candidatos e Bens", "etl.16_tse"),
+    ("Fase 12: Bolsa Familia", "etl.17_bolsa_familia"),
+    ("Fase 13: TSE Prestacao de Contas", "etl.18_tse_prestacao"),
+    ("Fase 14: TCE-PB (Despesas, Servidores, Licitacoes, Receitas)", "etl.19_tce_pb"),
+    ("Fase 15: Dados PB (Pagamento, Empenho, Contratos, Saude, Convenios)", "etl.20_dados_pb"),
+    ("Fase 16: PNCP Itens", "etl.04b_pncp_itens"),
+    ("Fase 17: Normalizacao (colunas CPF/CNPJ + indices)", "etl.15_normalizar"),
+    # TCE-PB DOE roda ANTES das MVs: mv_empresa_tce_pb (em sql/12_views.sql)
+    # le tce_pb_decisao/tce_pb_decisao_cnpj. Se rodasse depois, MVs ficariam vazias
+    # ate o proximo refresh manual.
+    ("Fase 18: TCE-PB DOE (decisoes - download, parse, load)", "etl.23_tce_pb_doe"),
+    ("Fase 19: Views materializadas", "etl.21_views"),
+    ("Fase 20: MV sitemap empresa-municipio", "etl.22_mv_sitemap"),
+]
+
+
 def main():
     start = time.time()
 
-    phases = [
-        ("Fase 0: Download de dados brutos", "etl.00_download"),
-        ("Fase 1: Schema", "etl.01_schema"),
-        ("Fase 2: Dominio", "etl.02_dominio"),
-        ("Fase 3: RFB (Empresas, Estabelecimentos, Socios, Simples)", "etl.03_rfb"),
-        ("Fase 4.1-4.2: PNCP", "etl.04_pncp"),
-        ("Fase 4.3-4.5: Emendas", "etl.05_emendas"),
-        ("Fase 4.6: CPGF", "etl.06_cpgf"),
-        ("Fase 4.7-4.8+5.2: Complementar (BNDES, Holdings, ComprasNet)", "etl.09_complementar"),
-        ("Fase 5.1: PGFN", "etl.07_pgfn"),
-        ("Fase 5.3: Renuncias Fiscais", "etl.08_renuncias"),
-        ("Fase 6: Indices", "etl.10_indices"),
-        ("Fase 7: Entity Resolution (Pessoa)", "etl.11_pessoa"),
-        ("Fase 8: SIAPE (Servidores)", "etl.12_siape"),
-        ("Fase 9: Sancoes (CEIS/CNEP/CEAF/Acordos)", "etl.13_sancoes"),
-        ("Fase 10: Viagens a Servico", "etl.14_viagens"),
-        ("Fase 11: TSE Candidatos e Bens", "etl.16_tse"),
-        ("Fase 12: Bolsa Familia", "etl.17_bolsa_familia"),
-        ("Fase 13: TSE Prestacao de Contas", "etl.18_tse_prestacao"),
-        ("Fase 14: TCE-PB (Despesas, Servidores, Licitacoes, Receitas)", "etl.19_tce_pb"),
-        ("Fase 15: Dados PB (Pagamento, Empenho, Contratos, Saude, Convenios)", "etl.20_dados_pb"),
-        ("Fase 16: PNCP Itens", "etl.04b_pncp_itens"),
-        ("Fase 17: Normalizacao (colunas CPF/CNPJ + indices)", "etl.15_normalizar"),
-        # TCE-PB DOE roda ANTES das MVs: mv_empresa_tce_pb (em sql/12_views.sql)
-        # le tce_pb_decisao/tce_pb_decisao_cnpj. Se rodasse depois, MVs ficariam vazias
-        # ate o proximo refresh manual.
-        ("Fase 18: TCE-PB DOE (decisoes - download, parse, load)", "etl.23_tce_pb_doe"),
-        ("Fase 19: Views materializadas", "etl.21_views"),
-        ("Fase 20: MV sitemap empresa-municipio", "etl.22_mv_sitemap"),
-    ]
+    phases = PHASES
 
     errors = []
     succeeded: set[str] = set()

--- a/etl/run_all.py
+++ b/etl/run_all.py
@@ -110,13 +110,35 @@ def main():
     errors = []
     succeeded: set[str] = set()
 
-    # Permite rodar fase específica: python -m etl.run_all 3
+    # Permite rodar fase específica:
+    #   python -m etl.run_all 3        -> roda da Fase 3 ate o fim
+    #   python -m etl.run_all --only 18 -> roda APENAS a Fase 18
+    # Modo --only e necessario para deploys cirurgicos que NAO querem disparar
+    # fases subsequentes (ex.: rodar so a Fase 18 sem disparar Fase 19=Views
+    # que faz DROP CASCADE de todas as MVs). Adicionado em PR #202 (ADR-0014).
     start_phase = 0
-    if len(sys.argv) > 1:
+    only_phase: int | None = None
+    args = sys.argv[1:]
+    if args and args[0] == "--only":
+        if len(args) < 2:
+            print("Uso: python -m etl.run_all --only <fase>", flush=True)
+            sys.exit(1)
         try:
-            start_phase = int(sys.argv[1]) - 1
+            only_phase = int(args[1]) - 1
+        except ValueError:
+            print(f"Uso: python -m etl.run_all --only <fase>", flush=True)
+            print(f"  Fases: 1-{len(phases)}", flush=True)
+            sys.exit(1)
+        if only_phase < 0 or only_phase >= len(phases):
+            print(f"Fase fora do intervalo: 1-{len(phases)}", flush=True)
+            sys.exit(1)
+        start_phase = only_phase
+    elif args:
+        try:
+            start_phase = int(args[0]) - 1
         except ValueError:
             print(f"Uso: python -m etl.run_all [fase_inicial]", flush=True)
+            print(f"     python -m etl.run_all --only <fase>", flush=True)
             print(f"  Fases: 1-{len(phases)}", flush=True)
             sys.exit(1)
 
@@ -127,6 +149,8 @@ def main():
     for i, (name, module_name) in enumerate(phases):
         if i < start_phase:
             continue
+        if only_phase is not None and i > only_phase:
+            break
 
         phase_start = time.time()
         print(f"\n{'='*60}", flush=True)

--- a/etl/run_all.py
+++ b/etl/run_all.py
@@ -99,9 +99,12 @@ def main():
         ("Fase 15: Dados PB (Pagamento, Empenho, Contratos, Saude, Convenios)", "etl.20_dados_pb"),
         ("Fase 16: PNCP Itens", "etl.04b_pncp_itens"),
         ("Fase 17: Normalizacao (colunas CPF/CNPJ + indices)", "etl.15_normalizar"),
-        ("Fase 18: Views materializadas", "etl.21_views"),
-        ("Fase 19: MV sitemap empresa-municipio", "etl.22_mv_sitemap"),
-        ("Fase 20: TCE-PB DOE (decisoes - download, parse, load)", "etl.23_tce_pb_doe"),
+        # TCE-PB DOE roda ANTES das MVs: mv_empresa_tce_pb (em sql/12_views.sql)
+        # le tce_pb_decisao/tce_pb_decisao_cnpj. Se rodasse depois, MVs ficariam vazias
+        # ate o proximo refresh manual.
+        ("Fase 18: TCE-PB DOE (decisoes - download, parse, load)", "etl.23_tce_pb_doe"),
+        ("Fase 19: Views materializadas", "etl.21_views"),
+        ("Fase 20: MV sitemap empresa-municipio", "etl.22_mv_sitemap"),
     ]
 
     errors = []

--- a/etl/run_all.py
+++ b/etl/run_all.py
@@ -44,6 +44,7 @@ _CSV_DIRS: dict[str, list[str]] = {
     "etl.18_tse_prestacao": ["tse"],          # mesma pasta que 16_tse
     "etl.19_tce_pb":        ["tce_pb"],
     "etl.20_dados_pb":      ["dados_pb"],
+    # 23_tce_pb_doe nao registra dir aqui: faz cleanup proprio (streaming).
 }
 
 # Diretórios que são compartilhados entre fases — só limpamos depois que
@@ -100,6 +101,7 @@ def main():
         ("Fase 17: Normalizacao (colunas CPF/CNPJ + indices)", "etl.15_normalizar"),
         ("Fase 18: Views materializadas", "etl.21_views"),
         ("Fase 19: MV sitemap empresa-municipio", "etl.22_mv_sitemap"),
+        ("Fase 20: TCE-PB DOE (decisoes - download, parse, load)", "etl.23_tce_pb_doe"),
     ]
 
     errors = []

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -9,6 +9,7 @@ DROP VIEW IF EXISTS v_risk_score_pb CASCADE;
 DROP VIEW IF EXISTS v_risk_score_empresa CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_rede_pb CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_empresa_pb CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mv_empresa_tce_pb CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_servidor_pb_risco CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_servidor_pb_base CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS mv_q67_dated_pb CASCADE;
@@ -466,6 +467,123 @@ GROUP BY cpf_digitos_6, nome_upper;
 CREATE UNIQUE INDEX idx_mv_srvb_cpf_nome ON mv_servidor_pb_base(cpf_digitos_6, nome_upper);
 
 -- -----------------------------------------------------------------------------
+-- 4c. mv_empresa_tce_pb: Agregado de processos/decisoes do TCE-PB por empresa.
+--     Source: tce_pb_decisao + tce_pb_decisao_cnpj (populadas por etl/23_tce_pb_doe.py).
+--     Granularidade: 1 row por cnpj_basico (8 digitos) — mesma chave de mv_empresa_pb.
+--     L1: nao depende de outras MVs. Pode existir sem decisoes carregadas (MV vazia).
+--     Ver ADR-0014.
+-- -----------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mv_empresa_tce_pb AS
+WITH base AS (
+    SELECT
+        LEFT(dc.cnpj, 8)              AS cnpj_basico,
+        d._nk_md5,
+        d.hash_publicacao,
+        d.num_processo,
+        d.ano_processo,
+        d.tipo_decisao,
+        d.orgao_julgador,
+        d.fase,
+        d.data_sessao,
+        d.tipo_materia,
+        d.resultado,
+        d.aplicou_multa,
+        d.imputou_debito,
+        COALESCE(d.valor_multa_rs, 0)  AS valor_multa_rs,
+        COALESCE(d.valor_debito_rs, 0) AS valor_debito_rs,
+        d.municipio_inferido
+    FROM tce_pb_decisao d
+    JOIN tce_pb_decisao_cnpj dc ON dc.decisao_md5 = d._nk_md5
+    WHERE d.tipo_materia <> 'atos_pessoal'   -- ruido (58% do corpus, 0,1% irregular)
+      AND EXISTS (
+          SELECT 1 FROM estabelecimento e
+          WHERE e.cnpj_basico = LEFT(dc.cnpj, 8)
+      )
+),
+processos AS (
+    -- 1 row por (cnpj_basico, processo). Pior resultado e flags agregados das decisoes.
+    SELECT
+        cnpj_basico,
+        num_processo,
+        ano_processo,
+        MAX(tipo_materia)               AS tipo_materia,
+        MAX(orgao_julgador)             AS orgao,
+        MAX(municipio_inferido)         AS municipio,
+        MAX(data_sessao)                AS ultima_sessao,
+        COUNT(*)                        AS qtd_decisoes,
+        -- Pior resultado: irregular(1) < regular_ressalva(2) < regular(3) < indef(4)
+        MIN(CASE resultado
+              WHEN 'irregular'        THEN 1
+              WHEN 'regular_ressalva' THEN 2
+              WHEN 'regular'          THEN 3
+              ELSE 4
+            END)                        AS pior_resultado_rank,
+        bool_or(aplicou_multa)          AS tem_multa,
+        bool_or(imputou_debito)         AS tem_debito,
+        SUM(valor_multa_rs)             AS multa_total_rs,
+        SUM(valor_debito_rs)            AS debito_total_rs,
+        jsonb_agg(
+            jsonb_build_object(
+                'hash',   hash_publicacao,
+                'fase',   fase,
+                'data',   data_sessao,
+                'result', resultado
+            )
+            ORDER BY data_sessao DESC NULLS LAST
+        )                               AS decisoes_json
+    FROM base
+    GROUP BY cnpj_basico, num_processo, ano_processo
+)
+SELECT
+    p.cnpj_basico,
+    COUNT(*)::int                                                  AS qtd_processos,
+    SUM(p.qtd_decisoes)::int                                       AS qtd_decisoes,
+    COUNT(*) FILTER (WHERE p.pior_resultado_rank = 1)::int         AS qtd_processos_irregular,
+    COUNT(*) FILTER (WHERE p.tem_multa)::int                       AS qtd_processos_multa,
+    COUNT(*) FILTER (WHERE p.tem_debito)::int                      AS qtd_processos_debito,
+    COALESCE(SUM(p.multa_total_rs), 0)::numeric(14,2)              AS multa_total_rs,
+    COALESCE(SUM(p.debito_total_rs), 0)::numeric(14,2)             AS debito_total_rs,
+    MAX(p.ultima_sessao)                                           AS ultima_decisao_em,
+    -- Top 20 processos por data desc, embarcados como jsonb para o frontend.
+    (
+        SELECT jsonb_agg(row_to_json(top20)::jsonb)
+        FROM (
+            SELECT
+                p2.num_processo,
+                p2.ano_processo,
+                p2.tipo_materia,
+                p2.orgao,
+                p2.municipio,
+                p2.ultima_sessao,
+                p2.qtd_decisoes,
+                CASE p2.pior_resultado_rank
+                    WHEN 1 THEN 'irregular'
+                    WHEN 2 THEN 'regular_ressalva'
+                    WHEN 3 THEN 'regular'
+                    ELSE        'indef'
+                END                        AS pior_resultado,
+                p2.tem_multa,
+                p2.tem_debito,
+                p2.decisoes_json           AS decisoes
+            FROM processos p2
+            WHERE p2.cnpj_basico = p.cnpj_basico
+            ORDER BY p2.ultima_sessao DESC NULLS LAST,
+                     p2.ano_processo DESC,
+                     p2.num_processo DESC
+            LIMIT 20
+        ) top20
+    )                                                              AS processos_json
+FROM processos p
+GROUP BY p.cnpj_basico;
+
+CREATE UNIQUE INDEX idx_mv_empresa_tce_pb_cnpj ON mv_empresa_tce_pb(cnpj_basico);
+CREATE INDEX idx_mv_empresa_tce_pb_irregular  ON mv_empresa_tce_pb(cnpj_basico)
+    WHERE qtd_processos_irregular > 0;
+CREATE INDEX idx_mv_empresa_tce_pb_multa      ON mv_empresa_tce_pb(cnpj_basico)
+    WHERE qtd_processos_multa > 0 OR qtd_processos_debito > 0;
+
+
+-- -----------------------------------------------------------------------------
 -- 4b. mv_servidor_pb_risco: Enriquece base com cross-refs e flags
 --     IMPORTANTE: Abordagem stepwise com tabelas regulares.
 --     A versão CTE-única causa timeout porque:
@@ -836,6 +954,11 @@ SELECT
     -- Dívida e sanções
     COALESCE(div.total_divida, 0) AS total_divida_pgfn,
     COALESCE(ceis.vigente, FALSE) AS flag_ceis_vigente,
+    -- TCE-PB DOE (ADR-0014): apenas o count (jsonb fica em mv_empresa_tce_pb)
+    COALESCE(tcedoe.qtd_processos, 0)::int AS qtd_processos_tce_pb,
+    COALESCE(tcedoe.qtd_processos_irregular, 0)::int AS qtd_processos_tce_pb_irregular,
+    COALESCE(tcedoe.qtd_processos_multa, 0)::int AS qtd_processos_tce_pb_multa,
+    COALESCE(tcedoe.qtd_processos_debito, 0)::int AS qtd_processos_tce_pb_debito,
     -- Flags
     (est.situacao_cadastral IS NULL OR est.situacao_cadastral <> 2) AS flag_inativa,
     (e.capital_social < 10000 AND COALESCE(tce.total_pago, 0) + COALESCE(pbe.total_empenho, 0) > 500000) AS flag_capital_desproporcional,
@@ -855,7 +978,8 @@ LEFT JOIN pb_sau_agg pbs ON pbs.cnpj_basico = pc.cnpj_basico
 LEFT JOIN pb_conv_agg pbv ON pbv.cnpj_basico = pc.cnpj_basico
 LEFT JOIN lic_agg lic ON lic.cnpj_basico = pc.cnpj_basico
 LEFT JOIN divida_agg div ON div.cnpj_basico = pc.cnpj_basico
-LEFT JOIN ceis_agg ceis ON ceis.cnpj_basico = pc.cnpj_basico;
+LEFT JOIN ceis_agg ceis ON ceis.cnpj_basico = pc.cnpj_basico
+LEFT JOIN mv_empresa_tce_pb tcedoe ON tcedoe.cnpj_basico = pc.cnpj_basico;
 
 CREATE UNIQUE INDEX idx_mv_epb_cnpj ON mv_empresa_pb(cnpj_basico);
 CREATE INDEX idx_mv_epb_inativa ON mv_empresa_pb(cnpj_basico) WHERE flag_inativa;
@@ -863,6 +987,7 @@ CREATE INDEX idx_mv_epb_ceis ON mv_empresa_pb(cnpj_basico) WHERE flag_ceis_vigen
 CREATE INDEX idx_mv_epb_capital ON mv_empresa_pb(cnpj_basico) WHERE flag_capital_desproporcional;
 CREATE INDEX idx_mv_epb_multi ON mv_empresa_pb(cnpj_basico) WHERE flag_multi_municipal;
 CREATE INDEX idx_mv_epb_endereco ON mv_empresa_pb(logradouro, numero) WHERE logradouro IS NOT NULL;
+CREATE INDEX idx_mv_epb_tce_pb ON mv_empresa_pb(cnpj_basico) WHERE qtd_processos_tce_pb > 0;
 
 
 -- -----------------------------------------------------------------------------
@@ -1535,6 +1660,7 @@ GRANT SELECT ON pncp_municipio TO govbr;
 --   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_pessoa_pb;
 --   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_municipio_pb_risco;
 --   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_servidor_pb_base;
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_empresa_tce_pb;
 --   Para mv_servidor_pb_risco: DROP + re-executar steps 1-6 (não suporta REFRESH
 --   porque depende de tabelas _tmp_ intermediárias — abordagem stepwise necessária)
 --

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -472,6 +472,11 @@ CREATE UNIQUE INDEX idx_mv_srvb_cpf_nome ON mv_servidor_pb_base(cpf_digitos_6, n
 --     Granularidade: 1 row por cnpj_basico (8 digitos) — mesma chave de mv_empresa_pb.
 --     L1: nao depende de outras MVs. Pode existir sem decisoes carregadas (MV vazia).
 --     Ver ADR-0014.
+--
+--     ATENCAO DRIFT: este SELECT esta DUPLICADO em sql/42_tce_pb_decisao.sql
+--     (bootstrap idempotente, CREATE MATERIALIZED VIEW IF NOT EXISTS) para
+--     permitir mv_swap apos primeiro deploy sem rodar etl_phase=sql. Ao alterar
+--     a SELECT aqui, alterar tambem em sql/42_tce_pb_decisao.sql.
 -- -----------------------------------------------------------------------------
 CREATE MATERIALIZED VIEW mv_empresa_tce_pb AS
 WITH base AS (

--- a/sql/42_tce_pb_decisao.sql
+++ b/sql/42_tce_pb_decisao.sql
@@ -55,3 +55,118 @@ CREATE INDEX IF NOT EXISTS ix_tce_pb_decisao_cnpj_cnpj ON tce_pb_decisao_cnpj (c
 
 -- LGPD: NAO persistimos CPF cru (3% dos PDFs tem CPF completo). Para v2 (feature de pessoa)
 -- persistir apenas cpf_digitos_6 (padrao do projeto, conforme docs/privacidade.md).
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- mv_empresa_tce_pb (bootstrap idempotente)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- A definicao "viva" desta MV mora em sql/12_views.sql:476 (re-criada por
+-- etl.21_views). Aqui replicamos com IF NOT EXISTS so para o BOOTSTRAP inicial
+-- antes de mv_swap ou refresh ETL (etl/mv_swap.py:236-238 aborta se a MV nao
+-- existe). Em deploy "incremental" / "web", este bloco cria MV VAZIA na 1a vez
+-- e e no-op nas demais. ATENCAO: ao alterar a SELECT, alterar tambem
+-- sql/12_views.sql (drift checado em PR review).
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_empresa_tce_pb AS
+WITH base AS (
+    SELECT
+        LEFT(dc.cnpj, 8)              AS cnpj_basico,
+        d._nk_md5,
+        d.hash_publicacao,
+        d.num_processo,
+        d.ano_processo,
+        d.tipo_decisao,
+        d.orgao_julgador,
+        d.fase,
+        d.data_sessao,
+        d.tipo_materia,
+        d.resultado,
+        d.aplicou_multa,
+        d.imputou_debito,
+        COALESCE(d.valor_multa_rs, 0)  AS valor_multa_rs,
+        COALESCE(d.valor_debito_rs, 0) AS valor_debito_rs,
+        d.municipio_inferido
+    FROM tce_pb_decisao d
+    JOIN tce_pb_decisao_cnpj dc ON dc.decisao_md5 = d._nk_md5
+    WHERE d.tipo_materia <> 'atos_pessoal'
+      AND EXISTS (
+          SELECT 1 FROM estabelecimento e
+          WHERE e.cnpj_basico = LEFT(dc.cnpj, 8)
+      )
+),
+processos AS (
+    SELECT
+        cnpj_basico,
+        num_processo,
+        ano_processo,
+        MAX(tipo_materia)               AS tipo_materia,
+        MAX(orgao_julgador)             AS orgao,
+        MAX(municipio_inferido)         AS municipio,
+        MAX(data_sessao)                AS ultima_sessao,
+        COUNT(*)                        AS qtd_decisoes,
+        MIN(CASE resultado
+              WHEN 'irregular'        THEN 1
+              WHEN 'regular_ressalva' THEN 2
+              WHEN 'regular'          THEN 3
+              ELSE 4
+            END)                        AS pior_resultado_rank,
+        bool_or(aplicou_multa)          AS tem_multa,
+        bool_or(imputou_debito)         AS tem_debito,
+        SUM(valor_multa_rs)             AS multa_total_rs,
+        SUM(valor_debito_rs)            AS debito_total_rs,
+        jsonb_agg(
+            jsonb_build_object(
+                'hash',   hash_publicacao,
+                'fase',   fase,
+                'data',   data_sessao,
+                'result', resultado
+            )
+            ORDER BY data_sessao DESC NULLS LAST
+        )                               AS decisoes_json
+    FROM base
+    GROUP BY cnpj_basico, num_processo, ano_processo
+)
+SELECT
+    p.cnpj_basico,
+    COUNT(*)::int                                                  AS qtd_processos,
+    SUM(p.qtd_decisoes)::int                                       AS qtd_decisoes,
+    COUNT(*) FILTER (WHERE p.pior_resultado_rank = 1)::int         AS qtd_processos_irregular,
+    COUNT(*) FILTER (WHERE p.tem_multa)::int                       AS qtd_processos_multa,
+    COUNT(*) FILTER (WHERE p.tem_debito)::int                      AS qtd_processos_debito,
+    COALESCE(SUM(p.multa_total_rs), 0)::numeric(14,2)              AS multa_total_rs,
+    COALESCE(SUM(p.debito_total_rs), 0)::numeric(14,2)             AS debito_total_rs,
+    MAX(p.ultima_sessao)                                           AS ultima_decisao_em,
+    (
+        SELECT jsonb_agg(row_to_json(top20)::jsonb)
+        FROM (
+            SELECT
+                p2.num_processo,
+                p2.ano_processo,
+                p2.tipo_materia,
+                p2.orgao,
+                p2.municipio,
+                p2.ultima_sessao,
+                p2.qtd_decisoes,
+                CASE p2.pior_resultado_rank
+                    WHEN 1 THEN 'irregular'
+                    WHEN 2 THEN 'regular_ressalva'
+                    WHEN 3 THEN 'regular'
+                    ELSE        'indef'
+                END                        AS pior_resultado,
+                p2.tem_multa,
+                p2.tem_debito,
+                p2.decisoes_json           AS decisoes
+            FROM processos p2
+            WHERE p2.cnpj_basico = p.cnpj_basico
+            ORDER BY p2.ultima_sessao DESC NULLS LAST,
+                     p2.ano_processo DESC,
+                     p2.num_processo DESC
+            LIMIT 20
+        ) top20
+    )                                                              AS processos_json
+FROM processos p
+GROUP BY p.cnpj_basico;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_empresa_tce_pb_cnpj      ON mv_empresa_tce_pb(cnpj_basico);
+CREATE INDEX        IF NOT EXISTS idx_mv_empresa_tce_pb_irregular ON mv_empresa_tce_pb(cnpj_basico)
+    WHERE qtd_processos_irregular > 0;
+CREATE INDEX        IF NOT EXISTS idx_mv_empresa_tce_pb_multa     ON mv_empresa_tce_pb(cnpj_basico)
+    WHERE qtd_processos_multa > 0 OR qtd_processos_debito > 0;

--- a/sql/42_tce_pb_decisao.sql
+++ b/sql/42_tce_pb_decisao.sql
@@ -1,0 +1,57 @@
+-- Decisoes individuais do TCE-PB extraidas do DOE eletronico.
+-- Fonte: https://publicacao.tce.pb.gov.br/decisao.php?ano=YYYY
+-- Cada PDF e uma decisao individual (acordao, decisao_singular, resolucao etc).
+-- Um processo (NNNNN/AA) agrupa 1..N decisoes ao longo do tempo.
+--
+-- Estrategia de parsing: ver etl/23_tce_pb_doe.py.
+-- ADR-0014 documenta a feature "Empresa citada em processos do TCE-PB".
+
+CREATE TABLE IF NOT EXISTS tce_pb_decisao (
+    _nk_md5            CHAR(32) PRIMARY KEY,
+    hash_publicacao    CHAR(32) NOT NULL UNIQUE,
+    num_processo       VARCHAR(10) NOT NULL,
+    ano_processo       SMALLINT    NOT NULL,
+    tipo_decisao       VARCHAR(40),
+    orgao_julgador     VARCHAR(10),
+    num_decisao        VARCHAR(10),
+    ano_decisao        SMALLINT,
+    fase               VARCHAR(60),
+    data_sessao        DATE,
+    tipo_materia       VARCHAR(20) NOT NULL,
+    resultado          VARCHAR(20),
+    aplicou_multa      BOOLEAN NOT NULL DEFAULT false,
+    imputou_debito     BOOLEAN NOT NULL DEFAULT false,
+    valor_multa_rs     NUMERIC(14,2),
+    valor_debito_rs    NUMERIC(14,2),
+    municipio_inferido VARCHAR(120),
+    text_sha256        CHAR(64),
+    parser_version     SMALLINT NOT NULL DEFAULT 1,
+    ingerido_em        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  tce_pb_decisao IS 'Decisoes individuais do TCE-PB extraidas do DOE. Uma linha = um PDF de publicacao.tce.pb.gov.br. ADR-0014.';
+COMMENT ON COLUMN tce_pb_decisao._nk_md5 IS 'md5(num_processo||ano_processo||tipo_decisao||num_decisao||ano_decisao||fase). NK estavel; permite reprocess sem mudar PK.';
+COMMENT ON COLUMN tce_pb_decisao.hash_publicacao IS 'Hash de 32 chars que o TCE-PB usa como URL publica (publicacao.tce.pb.gov.br/<hash>). Imutavel por decisao.';
+COMMENT ON COLUMN tce_pb_decisao.tipo_materia IS 'Classificacao por dominio: pca, licitacao, denuncia, contrato, representacao, recurso, embargos, tce_especial, atos_pessoal (excluido de agregados), indef.';
+COMMENT ON COLUMN tce_pb_decisao.resultado IS 'Output do classificador: irregular | regular_ressalva | regular | indef. Calibrado em 9.935 PDFs (ver ADR-0014).';
+COMMENT ON COLUMN tce_pb_decisao.parser_version IS 'Versao do parser que produziu esta linha. Bump = reprocess sem refazer download.';
+
+CREATE INDEX IF NOT EXISTS ix_tce_pb_decisao_proc       ON tce_pb_decisao (num_processo, ano_processo);
+CREATE INDEX IF NOT EXISTS ix_tce_pb_decisao_data       ON tce_pb_decisao (data_sessao DESC);
+CREATE INDEX IF NOT EXISTS ix_tce_pb_decisao_municipio  ON tce_pb_decisao (lower(municipio_inferido));
+CREATE INDEX IF NOT EXISTS ix_tce_pb_decisao_tipo_mat   ON tce_pb_decisao (tipo_materia) WHERE tipo_materia <> 'atos_pessoal';
+
+-- ── CNPJs citados em cada decisao ────────────────────────────────────────────
+-- 1 decisao → N CNPJs. Modelo append-only (CASCADE no delete da decisao garante coerencia).
+CREATE TABLE IF NOT EXISTS tce_pb_decisao_cnpj (
+    decisao_md5  CHAR(32) NOT NULL REFERENCES tce_pb_decisao(_nk_md5) ON DELETE CASCADE,
+    cnpj         CHAR(14) NOT NULL,
+    PRIMARY KEY (decisao_md5, cnpj)
+);
+
+COMMENT ON TABLE tce_pb_decisao_cnpj IS 'Bag de CNPJs (14 digitos) citados em cada decisao do TCE-PB. ADR-0014.';
+
+CREATE INDEX IF NOT EXISTS ix_tce_pb_decisao_cnpj_cnpj ON tce_pb_decisao_cnpj (cnpj);
+
+-- LGPD: NAO persistimos CPF cru (3% dos PDFs tem CPF completo). Para v2 (feature de pessoa)
+-- persistir apenas cpf_digitos_6 (padrao do projeto, conforme docs/privacidade.md).

--- a/web/main.py
+++ b/web/main.py
@@ -18,6 +18,7 @@ from web.routes.mapa import router as mapa_router
 from web.routes.og_image import router as og_router
 from web.routes.contato import build_router as build_contato_router
 from web.routes.seo import router as seo_router
+from web.routes.tce_pb import router as tce_pb_router
 
 _dir = Path(__file__).resolve().parent
 
@@ -186,6 +187,88 @@ templates.env.filters["short_number"] = _format_short_number
 templates.env.filters["short_brl"] = _format_short_brl
 templates.env.filters["clean_text"] = _clean_text
 templates.env.filters["date_br"] = _format_date_br
+
+
+# ----------- Filtros TCE-PB DOE (ADR-0014) -----------
+_TCE_TIPO_MATERIA_LABEL = {
+    "pca":            "PCA",
+    "licitacao":      "Licitação",
+    "denuncia":       "Denúncia",
+    "contrato":       "Contrato",
+    "representacao":  "Representação",
+    "embargos":       "Embargos",
+    "recurso":        "Recurso",
+    "tce_especial":   "TCE",
+    "atos_pessoal":   "Atos de pessoal",
+    "indef":          "—",
+}
+_TCE_ORGAO_LABEL = {
+    "apltc":  "Pleno",
+    "ac1tc":  "1ª Câmara",
+    "ac2tc":  "2ª Câmara",
+    "ds1tc":  "DS-1",
+    "ds2tc":  "DS-2",
+    "dspltc": "DS-Pleno",
+    "rc1tc":  "Relatoria-1",
+}
+_TCE_FASE_LABEL = {
+    "decisao_inicial":         "Decisão inicial",
+    "embargos_de_declaracao":  "Embargos",
+    "recurso":                 "Recurso",
+    "ag_reg":                  "Agravo regimental",
+    "resolucao":               "Resolução",
+}
+_TCE_RESULTADO_CHIP = {
+    "irregular":        ("🔴", "Irregular",        "chip-risk"),
+    "regular_ressalva": ("🟡", "Reg. c/ ressalva", "chip-attention"),
+    "regular":          ("🟢", "Regular",          "chip-ok"),
+    "indef":            ("⚪", "Indef.",            "chip-neutral"),
+}
+
+
+def _tce_tipo_materia_label(v: Any) -> str:
+    return _TCE_TIPO_MATERIA_LABEL.get((v or "").lower(), v or "—")
+
+
+def _tce_orgao_label(v: Any) -> str:
+    return _TCE_ORGAO_LABEL.get((v or "").lower(), (v or "—").upper())
+
+
+def _tce_fase_label(v: Any) -> str:
+    return _TCE_FASE_LABEL.get((v or "").lower(), (v or "—").replace("_", " ").capitalize())
+
+
+def _tce_resultado_chip(p: Any) -> str:
+    """Renderiza chip HTML para o pior_resultado do processo."""
+    if isinstance(p, dict):
+        key = (p.get("pior_resultado") or "indef").lower()
+    else:
+        key = (str(p) or "indef").lower()
+    emoji, label, css = _TCE_RESULTADO_CHIP.get(key, _TCE_RESULTADO_CHIP["indef"])
+    return f'<span class="{css}">{emoji} {label}</span>'
+
+
+def _date_br_short(v: Any) -> str:
+    """DD/MM (sem ano) — usado em labels compactos de botão."""
+    if v is None:
+        return ""
+    s = str(v).strip()
+    if not s:
+        return ""
+    if "-" in s[:10]:
+        try:
+            yyyy, mm, dd = s[:10].split("-")
+            return f"{dd}/{mm}"
+        except ValueError:
+            return s
+    return s
+
+
+templates.env.filters["tipo_materia_label"] = _tce_tipo_materia_label
+templates.env.filters["orgao_label"] = _tce_orgao_label
+templates.env.filters["fase_label"] = _tce_fase_label
+templates.env.filters["resultado_chip"] = _tce_resultado_chip
+templates.env.filters["date_br_short"] = _date_br_short
 
 
 # ----------- Metadata de colunas para tabelas de achados (Fase 1/cidadao) -----------
@@ -497,10 +580,13 @@ JS_FILES: list[str] = [
     "components/fornecedores-filter-chips.js",
     "components/clickable-rows.js",
     "components/empenhos-controller.js",
+    # tce-pdf-viewer: dialog MD3 c/ iframe pro proxy /api/tce-pb/decisao/<hash>.pdf
+    # (ADR-0014). No-op em paginas sem .tce-view-btn / #tce-pdf-dialog.
+    "components/tce-pdf-viewer.js",
     "pages/main.js",
 ]
 templates.env.globals["JS_FILES"] = JS_FILES
-templates.env.globals["ASSET_VERSION"] = "123"
+templates.env.globals["ASSET_VERSION"] = "124"
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -667,6 +753,7 @@ app.include_router(mapa_router)
 app.include_router(og_router)
 app.include_router(build_contato_router(templates))
 app.include_router(seo_router)
+app.include_router(tce_pb_router)
 
 
 # Fase 12 - erros amigaveis em vez de stack traces

--- a/web/queries/empresa.py
+++ b/web/queries/empresa.py
@@ -623,3 +623,28 @@ EMPRESAS_MUNICIPIOS_QUALIFICADAS_TODOS = """
     FROM mv_empresa_municipio_pagantes
     ORDER BY total_pago DESC NULLS LAST, cnpj_completo, municipio
 """
+
+
+# TCE-PB DOE: agregado de processos da MV mv_empresa_tce_pb (ADR-0014).
+# Retorna 1 row com jsonb processos_json embedded, ou 0 rows se a
+# empresa nao tem citacao em DOE.
+EMPRESA_TCE_PB_DOE_BY_BASICO = """
+    SELECT
+        qtd_processos,
+        qtd_decisoes,
+        qtd_processos_irregular,
+        qtd_processos_multa,
+        qtd_processos_debito,
+        multa_total_rs,
+        debito_total_rs,
+        ultima_decisao_em,
+        processos_json
+    FROM mv_empresa_tce_pb
+    WHERE cnpj_basico = %s
+"""
+
+# Whitelist hash para a rota proxy /api/tce-pb/decisao/<hash>.pdf.
+# Garante que so servimos PDFs ja indexados (anti-open-proxy).
+TCE_PB_DECISAO_BY_HASH = """
+    SELECT 1 FROM tce_pb_decisao WHERE hash_publicacao = %s LIMIT 1
+"""

--- a/web/routes/empresa.py
+++ b/web/routes/empresa.py
@@ -58,6 +58,7 @@ from web.queries.empresa import (
     EMPRESA_SANCOES_CNEP_BY_BASICO,
     EMPRESA_SOCIOS_BY_BASICO,
     EMPRESA_STATS_BY_MUN,
+    EMPRESA_TCE_PB_DOE_BY_BASICO,
     EMPRESA_TOP_ELEMENTOS_BY_MUN,
     EMPRESA_TOP_ELEMENTOS_GLOBAL_BY_BASICO,
 )
@@ -324,6 +325,21 @@ def _fetch_cadastral_block(cur, cnpj_completo: str, cnpj_basico: str,
     cnt_row = cur.fetchone()
     empenhos_total_global = int(cnt_row[0]) if cnt_row else 0
 
+    # TCE-PB DOE (ADR-0014): mv_empresa_tce_pb retorna 0 ou 1 row.
+    # Empresas sem citacao recebem tce_pb=None (template oculta secao).
+    tce_pb_doe = None
+    try:
+        cur.execute(EMPRESA_TCE_PB_DOE_BY_BASICO, (cnpj_basico,))
+        tce_row = cur.fetchone()
+        if tce_row:
+            tce_cols = [d[0] for d in cur.description]
+            tce_pb_doe = _convert_row(_row_to_dict(tce_cols, tce_row))
+    except Exception:
+        # MV pode nao existir ainda (deploy de schema antes do MV swap).
+        # Falha silenciosa preserva backward compat.
+        _log.warning("mv_empresa_tce_pb indisponivel para %s", cnpj_basico,
+                     exc_info=True)
+
     return {
         "estabelecimento": estabelecimento,
         "matriz": matriz,
@@ -336,6 +352,7 @@ def _fetch_cadastral_block(cur, cnpj_completo: str, cnpj_basico: str,
         "monthly_global": monthly_global,
         "empenhos_global": empenhos_global,
         "empenhos_total_global": empenhos_total_global,
+        "tce_pb_doe": tce_pb_doe,
     }
 
 
@@ -488,6 +505,7 @@ def compute_empresa_perfil_dict(
         # entries pre-PR nao tem esses campos, frontend faz fallback live.
         "empenhos_global": cadastral.get("empenhos_global", []),
         "empenhos_total_global": cadastral.get("empenhos_total_global", 0),
+        "tce_pb_doe": cadastral.get("tce_pb_doe"),
         "kpi_total_pb": total_pb_geral,
         "kpi_qtd_municipios": qtd_municipios,
         "kpi_qtd_empenhos": qtd_empenhos_pb,
@@ -607,6 +625,7 @@ def compute_empresa_municipio_perfil_dict(
         "pgfn": cadastral["pgfn"],
         "acordos_leniencia": cadastral["acordos_leniencia"],
         "agregados": agregados,
+        "tce_pb_doe": cadastral.get("tce_pb_doe"),
         "municipios_pagantes": cadastral["municipios_pagantes"],
         # Pagamentos restritos ao municipio:
         "municipio": municipio,

--- a/web/routes/tce_pb.py
+++ b/web/routes/tce_pb.py
@@ -26,6 +26,7 @@ import asyncio
 import logging
 import os
 import re
+import tempfile
 from pathlib import Path
 from typing import Optional
 from urllib.request import Request as _UrlRequest, urlopen
@@ -89,11 +90,30 @@ async def _fetch_and_cache(h: str) -> Optional[Path]:
     data = await asyncio.to_thread(_fetch_sync)
     if data is None or len(data) < 1000:
         return None
+    # Valida magic number antes de cachear: TCE-PB ocasionalmente serve HTML
+    # de manutencao / Cloudflare challenge com HTTP 200. Sem este check, o
+    # HTML seria cacheado como PDF por 30 dias (Cache-Control: immutable).
+    if not data[:4].startswith(b"%PDF"):
+        _log.warning("TCE-PB %s retornou non-PDF (%dB)", h[:8], len(data))
+        return None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".pdf.tmp")
-        tmp.write_bytes(data)
-        tmp.replace(path)
+        # tmp unico por requisicao para evitar corrida entre workers concorrentes
+        # baixando o mesmo hash (cada um escreveria no mesmo tmp e poderia
+        # expor PDF parcial via replace).
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{h}-", suffix=".pdf.tmp", dir=str(path.parent)
+        )
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(tmp_fd, "wb") as fh:
+                fh.write(data)
+                fh.flush()
+                os.fsync(fh.fileno())
+            tmp.replace(path)
+        finally:
+            if tmp.exists():
+                tmp.unlink(missing_ok=True)
         return path
     except Exception:
         _log.exception("falha ao gravar cache PDF TCE-PB %s", h[:8])

--- a/web/routes/tce_pb.py
+++ b/web/routes/tce_pb.py
@@ -1,0 +1,138 @@
+"""Proxy/visualizacao de PDFs do DOE-TCE-PB (ADR-0014).
+
+O publicacao.tce.pb.gov.br serve os PDFs com:
+- Content-Disposition: attachment (forca download)
+- X-Frame-Options: SAMEORIGIN (bloqueia iframe externo)
+
+Para permitir embed no nosso site sem reproduzir a politica restritiva
+da fonte, este endpoint:
+
+1. Valida que o hash esta whitelistado em tce_pb_decisao (anti-open-proxy).
+2. Cacheia localmente em /var/cache/cruza-web/tce-pb/<2-prefix>/<hash>.pdf
+   (PDFs sao imutaveis por hash — TCE-PB usa o hash como ID estavel).
+3. Reescreve Content-Disposition para inline (default) ou attachment
+   (com ?download=1).
+4. Streamada via FileResponse com Cache-Control de 30 dias.
+
+Seguranca:
+- HASH_RE garante apenas [a-f0-9]{32} (impede traversal).
+- Rate limit via nginx (zone separada).
+- Log de acesso com hash prefix + IP truncado (LGPD).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Optional
+from urllib.request import Request as _UrlRequest, urlopen
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import FileResponse
+
+from web.db import get_conn
+from web.queries.empresa import TCE_PB_DECISAO_BY_HASH
+
+router = APIRouter()
+_log = logging.getLogger("transparencia.tce_pb")
+
+_HASH_RE = re.compile(r"^[a-f0-9]{32}$")
+_TCE_BASE_URL = "https://publicacao.tce.pb.gov.br"
+_CACHE_DIR = Path(os.environ.get(
+    "TCE_PB_CACHE_DIR", "/var/cache/cruza-web/tce-pb"
+))
+_TIMEOUT_SECS = 60.0
+_USER_AGENT = "transparenciapb-proxy/1.0 (+https://transparenciapb.org)"
+
+
+def _hash_whitelisted(h: str) -> bool:
+    """True se o hash esta em tce_pb_decisao (anti-open-proxy)."""
+    try:
+        with get_conn() as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(TCE_PB_DECISAO_BY_HASH, (h,))
+                return cur.fetchone() is not None
+    except Exception:
+        _log.exception("falha ao consultar tce_pb_decisao")
+        return False
+
+
+def _cache_path(h: str) -> Path:
+    return _CACHE_DIR / h[:2] / f"{h}.pdf"
+
+
+async def _fetch_and_cache(h: str) -> Optional[Path]:
+    """Baixa o PDF do TCE-PB e grava no cache local. None em falha."""
+    path = _cache_path(h)
+    if path.exists() and path.stat().st_size > 1000:
+        return path
+
+    def _fetch_sync() -> Optional[bytes]:
+        req = _UrlRequest(
+            f"{_TCE_BASE_URL}/{h}",
+            headers={"User-Agent": _USER_AGENT},
+        )
+        try:
+            with urlopen(req, timeout=_TIMEOUT_SECS) as r:
+                if r.status != 200:
+                    _log.warning("TCE-PB %s retornou %s", h[:8], r.status)
+                    return None
+                return r.read()
+        except Exception:
+            _log.exception("falha ao baixar PDF TCE-PB %s", h[:8])
+            return None
+
+    data = await asyncio.to_thread(_fetch_sync)
+    if data is None or len(data) < 1000:
+        return None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".pdf.tmp")
+        tmp.write_bytes(data)
+        tmp.replace(path)
+        return path
+    except Exception:
+        _log.exception("falha ao gravar cache PDF TCE-PB %s", h[:8])
+        return None
+
+
+@router.get("/api/tce-pb/decisao/{h}.pdf")
+async def decisao_pdf(
+    request: Request,
+    h: str,
+    download: int = Query(0, ge=0, le=1),
+):
+    """Serve o PDF da decisao via proxy.
+
+    GET /api/tce-pb/decisao/<hash>.pdf         -> inline (iframe-friendly)
+    GET /api/tce-pb/decisao/<hash>.pdf?download=1 -> attachment
+    """
+    if not _HASH_RE.fullmatch(h):
+        raise HTTPException(status_code=400, detail="hash invalido")
+
+    if not _hash_whitelisted(h):
+        raise HTTPException(status_code=404, detail="decisao nao encontrada")
+
+    path = await _fetch_and_cache(h)
+    if path is None:
+        raise HTTPException(status_code=502, detail="upstream TCE-PB indisponivel")
+
+    disp = "attachment" if download else "inline"
+    filename = f"tce-pb-{h}.pdf"
+    headers = {
+        "Content-Disposition": f'{disp}; filename="{filename}"',
+        # Hash imutavel -> cacheavel por 30 dias.
+        "Cache-Control": "public, max-age=2592000, immutable",
+        "X-Content-Type-Options": "nosniff",
+        # Permite embed na nossa propria origem.
+        "X-Frame-Options": "SAMEORIGIN",
+    }
+    return FileResponse(
+        path=str(path),
+        media_type="application/pdf",
+        headers=headers,
+    )

--- a/web/static/css/components/tce-pdf-viewer.css
+++ b/web/static/css/components/tce-pdf-viewer.css
@@ -1,0 +1,153 @@
+/* === tce-pdf-viewer.css ===
+ * ADR-0014 — Estilo do visualizador embed de PDFs do DOE-TCE-PB
+ * e da secao "TCE-PB — processos publicados no DOE" em /empresa/<cnpj>.
+ *
+ * Mobile-first. Touch targets >= 44px (memoria: mobile-first UX).
+ */
+
+/* ---- Sumario com chips ---- */
+.tce-doe-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0.75rem 0 1rem;
+}
+
+.tce-doe-summary .chip-risk,
+.tce-doe-summary .chip-attention,
+.tce-doe-summary .chip-ok,
+.tce-doe-summary .chip-neutral {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 16px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.2;
+}
+
+.tce-doe-summary .chip-risk {
+    background: var(--md-sys-color-error-container, #ffdad6);
+    color: var(--md-sys-color-on-error-container, #410002);
+}
+
+.tce-doe-summary .chip-attention {
+    background: var(--md-sys-color-tertiary-container, #ffddb5);
+    color: var(--md-sys-color-on-tertiary-container, #2c1700);
+}
+
+.tce-doe-summary .chip-ok {
+    background: var(--md-sys-color-secondary-container, #d6e4ff);
+    color: var(--md-sys-color-on-secondary-container, #001b3d);
+}
+
+/* ---- Chips inline na celula "Resultado" ---- */
+.tce-doe-processos .chip-risk,
+.tce-doe-processos .chip-attention,
+.tce-doe-processos .chip-ok,
+.tce-doe-processos .chip-neutral {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.tce-doe-processos .chip-risk      { background: #ffdad6; color: #410002; }
+.tce-doe-processos .chip-attention { background: #ffddb5; color: #2c1700; }
+.tce-doe-processos .chip-ok        { background: #d6e4ff; color: #001b3d; }
+.tce-doe-processos .chip-neutral   { background: var(--md-sys-color-surface-variant, #e7e0ec); color: var(--md-sys-color-on-surface-variant, #49454f); }
+
+.tce-doe-processos .chip-risk-mini {
+    margin-left: 0.25rem;
+    font-size: 0.875rem;
+    cursor: help;
+}
+
+/* ---- Acoes (botoes view + busca CSE) ---- */
+.tce-doe-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+}
+
+.tce-view-btn {
+    /* Touch target mobile-first (memoria: ≥44px) */
+    min-height: 44px;
+    --md-text-button-container-shape: 8px;
+}
+
+.tce-cse-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    text-decoration: none;
+    font-size: 1.1rem;
+    border-radius: 8px;
+    transition: background-color .15s ease;
+}
+
+.tce-cse-link:hover,
+.tce-cse-link:focus-visible {
+    background: var(--md-sys-color-surface-variant, #e7e0ec);
+}
+
+/* ---- Disclaimer rodape ---- */
+.disclaimer-tce {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-left: 3px solid var(--md-sys-color-outline, #79747e);
+    background: var(--md-sys-color-surface-container, #f3edf7);
+    color: var(--md-sys-color-on-surface-variant, #49454f);
+    border-radius: 0 4px 4px 0;
+}
+
+/* ---- Dialog de visualizacao do PDF ---- */
+.pdf-dialog-fullscreen {
+    --md-dialog-container-max-width: min(95vw, 1100px);
+    max-width: min(95vw, 1100px);
+    width: 95vw;
+    height: 95vh;
+    max-height: 95vh;
+}
+
+.pdf-dialog-body {
+    padding: 0 !important;
+    height: calc(95vh - 130px);
+    min-height: 60vh;
+    overflow: hidden;
+}
+
+.pdf-dialog-body iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #525659;  /* fundo neutro do PDF.js do Chromium */
+}
+
+.md3-link-button {
+    text-decoration: none;
+    display: inline-flex;
+}
+
+/* ---- Mobile (≤600px): dialog ocupa viewport inteira ---- */
+@media (max-width: 600px) {
+    .pdf-dialog-fullscreen {
+        width: 100vw;
+        height: 100vh;
+        max-width: 100vw;
+        max-height: 100vh;
+        border-radius: 0;
+        --md-dialog-container-shape: 0;
+    }
+    .pdf-dialog-body {
+        height: calc(100vh - 130px);
+    }
+    .tce-doe-actions {
+        gap: 0.5rem;  /* mais espaco entre touch targets */
+    }
+}

--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -64,6 +64,7 @@
 @import url("./components/skeleton.css");
 @import url("./components/snackbar.css");
 @import url("./components/tooltip.css");
+@import url("./components/tce-pdf-viewer.css");
 @import url("./components/topnav.css");
 @import url("./components/tour.css");
 /* _mobile.css MUST come last within the components layer: it contains the

--- a/web/static/js/components/tce-pdf-viewer.js
+++ b/web/static/js/components/tce-pdf-viewer.js
@@ -1,0 +1,82 @@
+// === components/tce-pdf-viewer.js ===
+// ADR-0014 — Visualizador de PDFs do DOE-TCE-PB.
+//
+// Cada botao .tce-view-btn carrega data-tce-hash + data-tce-label.
+// Ao clicar:
+//   1. Aguarda upgrade dos custom elements (whenMD3Ready).
+//   2. Atualiza titulo e src do iframe apontando pra /api/tce-pb/decisao/<hash>.pdf
+//      (proxy local que reescreve Content-Disposition pra inline — ver
+//      web/routes/tce_pb.py).
+//   3. Wireup do botao "Baixar" e do link "Abrir no TCE-PB".
+//   4. dispatch evento Umami 'tce-pdf-view' com prefixo do hash (anonimo).
+//   5. Ao fechar o dialog, limpa src do iframe (libera memoria do PDF.js
+//      do browser).
+function initTcePdfViewer() {
+    const dialog = document.getElementById('tce-pdf-dialog');
+    if (!dialog) return;
+    const buttons = document.querySelectorAll('.tce-view-btn');
+    if (!buttons.length) return;
+
+    const ready = typeof window.whenMD3Ready === 'function'
+        ? window.whenMD3Ready()
+        : Promise.resolve();
+
+    ready.then(() => {
+        const frame   = document.getElementById('tce-pdf-frame');
+        const title   = document.getElementById('tce-pdf-title');
+        const btnDl   = document.getElementById('tce-pdf-download');
+        const linkTce = document.getElementById('tce-pdf-open-tce');
+        const btnCls  = document.getElementById('tce-pdf-close');
+        if (!frame || !title || !btnDl || !linkTce) return;
+
+        buttons.forEach((btn) => {
+            btn.addEventListener('click', () => {
+                const h = btn.dataset.tceHash;
+                const label = btn.dataset.tceLabel || 'Decisao TCE-PB';
+                if (!h || !/^[a-f0-9]{32}$/.test(h)) return;
+
+                title.textContent = label;
+                // #view=FitH pede ao viewer nativo do browser pra abrir
+                // ajustado a largura. Funciona em Chromium e Firefox.
+                frame.src = `/api/tce-pb/decisao/${h}.pdf#view=FitH`;
+
+                btnDl.onclick = () => {
+                    window.location.href = `/api/tce-pb/decisao/${h}.pdf?download=1`;
+                };
+                linkTce.href = `https://publicacao.tce.pb.gov.br/${h}`;
+
+                if (dialog.show) {
+                    dialog.show();
+                } else {
+                    dialog.setAttribute('open', '');
+                }
+
+                if (typeof trackEvent === 'function') {
+                    trackEvent('tce-pdf-view', { hash: h.slice(0, 8) });
+                }
+            });
+        });
+
+        // Limpa src ao fechar (libera memoria; evita PDF renderizado
+        // permanecer em background carregando).
+        const cleanup = () => {
+            if (frame.src && frame.src !== 'about:blank') {
+                frame.src = 'about:blank';
+            }
+        };
+        dialog.addEventListener('close', cleanup);
+        dialog.addEventListener('closed', cleanup);
+        if (btnCls) {
+            btnCls.addEventListener('click', () => {
+                if (dialog.close) dialog.close();
+                else dialog.removeAttribute('open');
+            });
+        }
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTcePdfViewer);
+} else {
+    initTcePdfViewer();
+}

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -9,7 +9,7 @@
 // Fallback estatico (FALLBACK_CACHE_VERSION) é usado quando manifest indisponível
 // (dev mode sem build, ou race no deploy).
 
-const FALLBACK_CACHE_VERSION = 'tpb-v49-fallback';
+const FALLBACK_CACHE_VERSION = 'tpb-v50-fallback';
 
 // Lista mínima usada APENAS quando manifest.json não pode ser fetched.
 // Mantém PWA instalável mesmo em deploy race / 404 transitorio.

--- a/web/templates/partials/empresa/_tce_pb_doe.html
+++ b/web/templates/partials/empresa/_tce_pb_doe.html
@@ -1,0 +1,111 @@
+{# TCE-PB DOE: empresa citada em processos/decisoes (ADR-0014).
+   Source: mv_empresa_tce_pb (jsonb processos_json). #}
+{% set tce = tce_pb_doe %}
+{% if tce and (tce.qtd_processos or 0) > 0 %}
+{% from "partials/_collapsible.html" import collapsible %}
+{% set qtd_proc = tce.qtd_processos | int %}
+{% set qtd_dec  = tce.qtd_decisoes | int %}
+{% set qtd_irr  = tce.qtd_processos_irregular | int %}
+{% set qtd_mul  = tce.qtd_processos_multa | int %}
+{% set qtd_deb  = tce.qtd_processos_debito | int %}
+{% call collapsible('tce-pb-doe', 'TCE-PB — processos publicados no DOE', count=qtd_proc) %}
+<p class="text-sm text-muted">
+    Esta empresa foi citada em <strong>{{ qtd_proc }}</strong> processo{{ 's' if qtd_proc > 1 else '' }}
+    do Tribunal de Contas do Estado da Paraiba, totalizando <strong>{{ qtd_dec }}</strong>
+    decis{{ 'oes' if qtd_dec > 1 else 'ao' }} publicada{{ 's' if qtd_dec > 1 else '' }} no
+    <a href="https://publicacao.tce.pb.gov.br/" target="_blank" rel="noopener nofollow">DOE-TCE-PB</a>.
+    Ultima decisao em <strong>{{ tce.ultima_decisao_em | date_br }}</strong>.
+</p>
+
+<div class="tce-doe-summary">
+    {% if qtd_irr > 0 %}<span class="chip-attention">🟠 {{ qtd_irr }} c/ irregularidade</span>{% endif %}
+    {% if qtd_mul > 0 %}<span class="chip-risk">🔴 {{ qtd_mul }} c/ multa aplicada</span>{% endif %}
+    {% if qtd_deb > 0 %}<span class="chip-risk">🔴 {{ qtd_deb }} c/ debito imputado</span>{% endif %}
+    {% if qtd_irr == 0 and qtd_mul == 0 and qtd_deb == 0 %}
+        <span class="chip-ok">🟢 Sem condenacoes detectadas no corpus indexado</span>
+    {% endif %}
+</div>
+
+<div class="tbl-wrap">
+    <table class="stack-mobile tce-doe-processos">
+        <thead>
+            <tr>
+                <th>Processo</th>
+                <th>Tipo</th>
+                <th>Orgao</th>
+                <th>Municipio</th>
+                <th>Ultima sessao</th>
+                <th>Decisoes</th>
+                <th>Resultado</th>
+                <th>Acoes</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for p in (tce.processos_json or []) %}
+            <tr>
+                <td data-label="Processo">
+                    <code class="text-sm">{{ p.num_processo }}/{{ '%02d' % ((p.ano_processo|int) % 100) }}</code>
+                </td>
+                <td data-label="Tipo">{{ p.tipo_materia | tipo_materia_label }}</td>
+                <td data-label="Orgao">{{ p.orgao | orgao_label }}</td>
+                <td data-label="Municipio">{{ p.municipio | clean_text or '—' }}</td>
+                <td data-label="Ultima sessao">{{ p.ultima_sessao | date_br }}</td>
+                <td data-label="Decisoes" class="num">{{ p.qtd_decisoes }}</td>
+                <td data-label="Resultado">
+                    {{ p | resultado_chip | safe }}
+                    {% if p.tem_multa %}<span class="chip-risk-mini" title="Multa aplicada">⚠️</span>{% endif %}
+                    {% if p.tem_debito %}<span class="chip-risk-mini" title="Debito imputado">💰</span>{% endif %}
+                </td>
+                <td data-label="Acoes" class="tce-doe-actions">
+                    {% for d in (p.decisoes or []) %}
+                    <md-text-button
+                        class="tce-view-btn"
+                        data-tce-hash="{{ d.hash }}"
+                        data-tce-label="Processo {{ p.num_processo }}/{{ p.ano_processo }} — {{ d.fase | fase_label }} ({{ d.data | date_br }})"
+                        title="Visualizar PDF da decisao">
+                        <span class="material-symbols-outlined" slot="icon">picture_as_pdf</span>
+                        {{ d.data | date_br_short }}
+                    </md-text-button>
+                    {% endfor %}
+                    <a class="tce-cse-link"
+                       href="https://cse.google.com/cse?cx=005536785968125846686&q={{ p.num_processo }}/{{ p.ano_processo }}"
+                       target="_blank" rel="noopener nofollow"
+                       title="Buscar este processo no portal TCE-PB">🔍</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+<p class="text-sm disclaimer-tce">
+    Dados extraidos automaticamente das publicacoes em
+    <a href="https://publicacao.tce.pb.gov.br/" target="_blank" rel="noopener nofollow">publicacao.tce.pb.gov.br</a>.
+    A presenca de uma empresa em processo do TCE-PB <strong>nao</strong> implica
+    condenacao ou irregularidade — consulte sempre a integra do acordao no portal oficial.
+</p>
+
+{# Dialog reutilizavel para visualizacao do PDF. Uma instancia por pagina. #}
+<md-dialog id="tce-pdf-dialog" class="pdf-dialog-fullscreen">
+    <div slot="headline" id="tce-pdf-title">Decisao TCE-PB</div>
+    <div slot="content" class="pdf-dialog-body">
+        <iframe id="tce-pdf-frame" title="Visualizador de PDF da decisao" loading="lazy"></iframe>
+    </div>
+    <div slot="actions">
+        <md-text-button id="tce-pdf-download">
+            <span class="material-symbols-outlined" slot="icon">download</span>
+            Baixar
+        </md-text-button>
+        <a id="tce-pdf-open-tce"
+           href="https://publicacao.tce.pb.gov.br/" target="_blank" rel="noopener nofollow"
+           class="md3-link-button">
+            <md-text-button>
+                <span class="material-symbols-outlined" slot="icon">open_in_new</span>
+                Abrir no TCE-PB
+            </md-text-button>
+        </a>
+        <md-text-button id="tce-pdf-close" form="" value="close">Fechar</md-text-button>
+    </div>
+</md-dialog>
+{% endcall %}
+{% endif %}

--- a/web/templates/results/empresa.html
+++ b/web/templates/results/empresa.html
@@ -99,6 +99,7 @@
     {% include "partials/empresa/_sancoes.html" %}
     {% include "partials/empresa/_pgfn.html" %}
     {% include "partials/empresa/_leniencia.html" %}
+    {% include "partials/empresa/_tce_pb_doe.html" %}
     {% include "partials/empresa/_municipios_pagantes.html" %}
     {% include "partials/empresa/_socios.html" %}
 


### PR DESCRIPTION
## Resumo

Feature MVP **"TCE-PB - processos publicados no DOE"** em `/empresa/<cnpj>`: count + tabela de processos do TCE-PB em que o CNPJ aparece, com visualizacao embed do PDF da decisao via backend proxy.

**Calibrado em N=9.935 PDFs (2024-2026)**:
- 659 CNPJs distintos citados
- 646/659 (98%) existem na base RFB
- **459/659 (69,7%) sao fornecedores de pelo menos 1 cidade PB** -> sinal qualificado direto na pagina de empresa.

Decisoes arquiteturais detalhadas em **[ADR-0014](docs/adr/0014-tce-pb-doe-mvp.md)**.

## O que entra

| Camada | Arquivo |
|---|---|
| Schema | `sql/42_tce_pb_decisao.sql` (tce_pb_decisao + tce_pb_decisao_cnpj) |
| ETL | `etl/23_tce_pb_doe.py` registrado como **Fase 18** em `etl/run_all.py` (antes da Fase 19 Views, para que `mv_empresa_tce_pb` ja tenha dados quando criada) |
| MV L1 nova | `mv_empresa_tce_pb` em `sql/12_views.sql` + `deploy/mv_updates/mv_empresa_tce_pb.sql` |
| MV L2 atualizada | `mv_empresa_pb` ganha 4 colunas `qtd_processos_tce_pb*` |
| Proxy PDF | `web/routes/tce_pb.py` -> `/api/tce-pb/decisao/<hash>.pdf` |
| Template | `web/templates/partials/empresa/_tce_pb_doe.html` + dialog MD3 full-screen |
| JS | `web/static/js/components/tce-pdf-viewer.js` (whenMD3Ready gate) |
| CSS | `web/static/css/components/tce-pdf-viewer.css` mobile-first |
| Filtros Jinja | 5 novos: `tipo_materia_label`, `orgao_label`, `fase_label`, `resultado_chip`, `date_br_short` |
| Bumps | ASSET_VERSION 123->124, FALLBACK_CACHE_VERSION v49->v50 |

## Bloqueios resolvidos

- TCE-PB serve PDFs com `Content-Disposition: attachment` + `X-Frame-Options: SAMEORIGIN` -> iframe direto impossivel. **Proxy local** com whitelist (anti-open-proxy) + cache em `/var/cache/cruza-web/tce-pb/<2-prefix>/<hash>.pdf`. Cache valida magic `%PDF` antes de gravar (evita cachear HTML de manutencao do Cloudflare como PDF por 30 dias).
- Cloudflare aplica rate-limit agressivo no portal TCE-PB. Padrao **4 workers + retry exponencial em {520,429,503,timeout}** sustenta 3,6 PDFs/s com 0,65% erro.

## Deploy (zero-downtime)

> **Importante:** NAO usar `etl_phase=sql` neste PR. Esse comando dispara `etl.21_views` que faz DROP CASCADE de TODAS as MVs no topo de `sql/12_views.sql` -> 1-2h de downtime com paginas `/empresa/*`, `/cidade/*`, `/servidor/*` quebradas.

| Ordem | Input deploy.yml | Tempo | Downtime |
|---|---|---|---|
| 1 | `etl_phase=web` (aplica `sql/42_*.sql` via step "Apply web app schemas", idempotente) | ~5s | 0 |
| 2 | `etl_phase=18` (Fase 18 TCE-PB DOE: download + parse + load) | ~3-4h | 0 (background) |
| 3 | `mv_swap=mv_empresa_tce_pb,mv_empresa_pb` (**swap conjunto obrigatorio** - L2 depende de L1 via LEFT JOIN, CASCADE) | ~1s | ~1s |
| 4 | `etl_phase=web` + `rewarm_cache_keys=EMPRESA_PERFIL,EMPRESA_PERFIL_MUN` | ~30min warm | 0 |

Cache dir `/var/cache/cruza-web/tce-pb/` provisionado automaticamente no step **Restart cruza-web** (idempotente, owned by cruza-web user).

Rollback: `mv_swap` mantem versao anterior com sufixo `_old`; reverter e instantaneo.

## Fixes pos-review

Reviews automaticos (Opus 4.7 + GPT 5.5) convergiram em 2 HIGH + 4 MEDIUM bugs. Todos corrigidos no commit `96761d0`:

- **HIGH** `sql/42_*.sql` agora aplicado no step "Apply web app schemas" do deploy.yml
- **HIGH** Fase DOE movida para antes das Views (Fase 18, era Fase 20)
- **MED** Cleanup de PDFs apaga so hashes persistidos no run (era glob global)
- **MED** Proxy valida magic `%PDF` antes de cachear
- **MED** Tmp file unico por requisicao (era `.pdf.tmp` compartilhado, race)
- **DOC** ADR e PR description reescritos com caminho mv_swap correto

## PR Checklist

- [x] README atualizado (fontes integradas inclui DOE/acordaos TCE-PB)
- [x] ADR-0014 criado com calibracao quantitativa + estrategia de deploy revisada
- [x] `python -m compileall etl web -q` limpo
- [x] Mobile-first: dialog full-screen <=600px, touch targets >=44px
- [x] FALLBACK_CACHE_VERSION bumpado (sw.js)
- [x] Co-authored-by: Copilot trailer
- [x] LGPD: nao persistimos CPF cru (so digitos_6)
- [x] Reviews automaticos: 2 HIGH + 4 MEDIUM corrigidos