### PR TITLE
fix(etl-incremental): NK sintetica md5 para tabelas TCE-PB (ADR-0014)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,11 @@ on:
         description: 'CSV de bucket_ids para limitar processamento (e.g. "2026-02,2026-03"). Vazio = todos buckets enumerados pela spec. Util para BF onde rodar 38 buckets toma horas.'
         required: false
         default: ''
+      rebootstrap_tce_pb:
+        description: 'ONE-OFF (ADR-0014): re-bootstrap --force das 4 specs tce_pb apos sql/42z, p/ re-baselinar o target_schema_hash do etl_watermark (a coluna _nk_md5 muda o hash e o guard de schema-drift bloquearia o runner). Necessario na 1a migracao porque deploys falhos previos ja bootstraparam tce_pb com o schema antigo. REMOVER apos rodar 1x em prod. So aplica com etl_phase=incremental + TCE-PB no escopo.'
+        required: false
+        type: boolean
+        default: false
       drop_cache:
         description: 'TRUNCATE web_cache antes do warm. Use APENAS em mudancas de schema. Por padrao (false), cache antigo eh preservado e UPSERT-ado (evita 12-18h sem cache).'
         required: false
@@ -740,6 +745,22 @@ jobs:
             echo "=== sql/42z (tce_pb: dedupe + UNIQUE INDEX CONCURRENTLY) ==="
             PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \
               -f sql/42z_tce_pb_finalize.sql
+
+            # ONE-OFF (ADR-0014): re-baselinar o target_schema_hash do watermark.
+            # A coluna _nk_md5 adicionada por sql/42 muda o schema da tabela; o
+            # guard _check_target_schema_drift compara o hash atual com o do
+            # bootstrap e ABORTA o runner se diferem. Deploys falhos previos
+            # (2026-06-23) ja bootstraparam tce_pb com o schema ANTIGO, entao o
+            # 1o run pos-migracao driftaria. --force faz DELETE+INSERT do
+            # watermark (last_value=NULL) -> o 1o run reprocessa os buckets
+            # (idempotente via _nk_md5). REMOVER este input apos rodar 1x.
+            if [ "${{ inputs.rebootstrap_tce_pb }}" = "true" ]; then
+              echo "=== Re-bootstrap --force das specs tce_pb (one-off, ADR-0014) ==="
+              for TBL in tce_pb_despesa tce_pb_servidor tce_pb_licitacao tce_pb_receita; do
+                python -m etl.incremental.bootstrap_watermark \
+                  --source tce_pb --table "$TBL" --force 2>&1
+              done
+            fi
           fi
 
           # Framework incremental runner

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -730,8 +730,8 @@ jobs:
           # Idempotente: sql/42 e CREATE OR REPLACE / ADD COLUMN IF NOT EXISTS;
           # populate e WHERE _nk_md5 IS NULL (0 rows apos a 1a vez); sql/42z
           # pula dedupe se index existe e usa CREATE INDEX IF NOT EXISTS.
-          # 1a execucao popula ~40M rows (~60-75 min); execucoes seguintes sao
-          # rapidas. Mesmo design do bloco bolsa_familia acima.
+          # 1a execucao popula ~40M rows (~3,5h no teste local end-to-end);
+          # execucoes seguintes sao rapidas. Mesmo design do bloco bolsa_familia.
           if [ "$TCE_PB_IN_SCOPE" = "true" ]; then
             echo "=== sql/42 (tce_pb: _nk_md5 cols + triggers + hash fns) ==="
             PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -689,6 +689,15 @@ jobs:
             BF_IN_SCOPE=true
           fi
 
+          # Determinar se TCE-PB esta no escopo (qualquer spec tce_pb.*).
+          # Vazio = todas as specs -> TCE-PB incluso. (ADR-0014)
+          TCE_PB_IN_SCOPE=false
+          if [ -z "${{ inputs.incremental_only }}" ]; then
+            TCE_PB_IN_SCOPE=true
+          elif echo "${{ inputs.incremental_only }}" | grep -qE "(^|,)tce_pb\."; then
+            TCE_PB_IN_SCOPE=true
+          fi
+
           # Migration idempotente sql/41 antes do runner (apenas se BF in scope).
           # Aplica defs (cols, COMMENTs, trigger, procedure). ON_ERROR_STOP=1 +
           # SEM --single-transaction. As DDL aqui sao seguras em transacao;
@@ -711,6 +720,28 @@ jobs:
               -f sql/41z_bolsa_familia_finalize.sql
           fi
 
+          # Migration TCE-PB synthetic md5 NK (ADR-0014), antes do runner para
+          # que o UNIQUE INDEX _nk_md5 exista quando o ON CONFLICT rodar.
+          # Idempotente: sql/42 e CREATE OR REPLACE / ADD COLUMN IF NOT EXISTS;
+          # populate e WHERE _nk_md5 IS NULL (0 rows apos a 1a vez); sql/42z
+          # pula dedupe se index existe e usa CREATE INDEX IF NOT EXISTS.
+          # 1a execucao popula ~40M rows (~60-75 min); execucoes seguintes sao
+          # rapidas. Mesmo design do bloco bolsa_familia acima.
+          if [ "$TCE_PB_IN_SCOPE" = "true" ]; then
+            echo "=== sql/42 (tce_pb: _nk_md5 cols + triggers + hash fns) ==="
+            PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \
+              -f sql/42_tce_pb_synthetic_nk.sql
+
+            # Populate _nk_md5 (4 tabelas) via psycopg2 autocommit (CALL via
+            # psql wrappa em transacao -> COMMIT-em-PROCEDURE falha no PG 16).
+            echo "=== Populate _nk_md5 tce_pb (BATCHED via psycopg2 autocommit) ==="
+            python -m etl.refresh_post_incremental --source tce_pb --populate-only
+
+            echo "=== sql/42z (tce_pb: dedupe + UNIQUE INDEX CONCURRENTLY) ==="
+            PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \
+              -f sql/42z_tce_pb_finalize.sql
+          fi
+
           # Framework incremental runner
           if [ -n "${{ inputs.incremental_only }}" ]; then
             python -m etl.incremental.runner \
@@ -725,6 +756,15 @@ jobs:
           if [ "$BF_IN_SCOPE" = "true" ]; then
             echo "=== Refresh MVs apos bolsa_familia ==="
             python -m etl.refresh_post_incremental --source bolsa_familia 2>&1
+          fi
+
+          # Refresh das MVs PB que dependem das tabelas tce_pb_* (L1 -> L2).
+          # Sem isso, o shadow rewarm/warm subsequente leria MVs stale e o swap
+          # atomico promoveria cache velho (ADR-0014). Hard-fail se algum
+          # REFRESH lancar.
+          if [ "$TCE_PB_IN_SCOPE" = "true" ]; then
+            echo "=== Refresh MVs PB apos tce_pb (L1 -> L2) ==="
+            python -m etl.refresh_post_incremental --source tce_pb 2>&1
           fi
 
           # Refresh da MV de sitemap apos incremental: mv_empresa_municipio_pagantes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -746,6 +746,24 @@ jobs:
             PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \
               -f sql/42z_tce_pb_finalize.sql
 
+            # Garante zero-downtime no refresh da mv_q67_dated_pb. As demais
+            # MVs do hook TCE-PB ja possuem UNIQUE INDEX no sql/12_views.sql.
+            Q67_HAS_VALID_UNIQUE=$(PGPASSWORD="$PASS" psql -U govbr -d govbr -Atc "
+              SELECT EXISTS (
+                SELECT 1
+                FROM pg_index i
+                JOIN pg_class c ON c.oid = i.indrelid
+                WHERE c.relname = 'mv_q67_dated_pb'
+                  AND i.indisunique AND i.indisvalid
+                  AND i.indpred IS NULL AND i.indexprs IS NULL
+              )
+            ")
+            if [ "$Q67_HAS_VALID_UNIQUE" != "t" ]; then
+              echo "=== UNIQUE INDEX mv_q67_dated_pb (pre-flight refresh concorrente) ==="
+              PGPASSWORD="$PASS" psql -U govbr -d govbr -v ON_ERROR_STOP=1 \
+                -f sql/15b_add_unique_index_mv_q67.sql
+            fi
+
             # ONE-OFF (ADR-0014): re-baselinar o target_schema_hash do watermark.
             # A coluna _nk_md5 adicionada por sql/42 muda o schema da tabela; o
             # guard _check_target_schema_drift compara o hash atual com o do
@@ -779,7 +797,7 @@ jobs:
             python -m etl.refresh_post_incremental --source bolsa_familia 2>&1
           fi
 
-          # Refresh das MVs PB que dependem das tabelas tce_pb_* (L1 -> L2).
+          # Refresh concorrente das MVs PB dependentes (L1 -> L2).
           # Sem isso, o shadow rewarm/warm subsequente leria MVs stale e o swap
           # atomico promoveria cache velho (ADR-0014). Hard-fail se algum
           # REFRESH lancar.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,8 @@ parse clean as of PR #155. See those PRs for the exact pattern.
   `etl_admin.nk_md5_<tabela>_row(<tabela>)` (chamada pelo trigger **e** pelo
   populate — zero drift). Populate + refresh de MVs em
   [`etl/refresh_post_incremental.py`](etl/refresh_post_incremental.py)
-  (`--source tce_pb`). 1º populate de ~40M rows leva ~60-75 min (uma vez).
+  (`--source tce_pb`). 1º populate de ~40M rows levou ~3,5h no teste local
+  end-to-end (uma vez).
 - **Idempotência cross-boundary TCE-PB** (ADR-0014): o hash `_nk_md5` exclui
   cols de normalização (`cnpj_basico`, `cpf_digitos` em despesa; `cpf_digitos_6`,
   `nome_upper` em servidor; `*_proponente` em licitação; e `ano` SÓ em despesa,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,27 @@ parse clean as of PR #155. See those PRs for the exact pattern.
   Framework agora suporta `spec.csv_header_rewrites: dict[str, str]` que
   mapeia raw → SQL-safe antes do match com `spec.columns`. Default `{}` =
   no-op para specs existentes (TCE-PB / Dados-PB / pb_extras).
+- **TCE-PB usa NK synthetic md5** (ADR-0014): as 4 tabelas `tce_pb_*` migraram
+  para `_nk_md5` (`nk_synthetic_md5=True`). Motivo: a NK natural de
+  `tce_pb_despesa` tem **1037 grupos de colisão reais** (registros financeiros
+  distintos, não duplicatas → NK natural perderia dados), e `tce_pb_servidor`
+  tem **90k+ NULLs** em cols da NK (`municipio`, `nome_servidor`) que um
+  `UNIQUE INDEX` trataria como distintos → double-load. `sql/30`/`sql/31` foram
+  **deprecados** (a NK natural não serve). Defs em
+  [`sql/42_tce_pb_synthetic_nk.sql`](sql/42_tce_pb_synthetic_nk.sql), finalize
+  (dedupe + index) em [`sql/42z_tce_pb_finalize.sql`](sql/42z_tce_pb_finalize.sql).
+  O hash é definido **uma vez** por tabela em
+  `etl_admin.nk_md5_<tabela>_row(<tabela>)` (chamada pelo trigger **e** pelo
+  populate — zero drift). Populate + refresh de MVs em
+  [`etl/refresh_post_incremental.py`](etl/refresh_post_incremental.py)
+  (`--source tce_pb`). 1º populate de ~40M rows leva ~60-75 min (uma vez).
+- **Idempotência cross-boundary TCE-PB** (ADR-0014): o hash `_nk_md5` exclui
+  cols de normalização (`cnpj_basico`, `ano`, `cpf_digitos`, `cpf_digitos_6`,
+  `nome_upper`, `*_proponente`) — elas ficam NULL em rows novas e preenchidas
+  em rows legacy; incluí-las quebraria a deduplicação no republish. Antes do
+  **1º incremental real**, conferir que `rows_inserted` do bucket corrente é
+  ≈ (upstream − já carregado), **não** ≈ bucket inteiro (sinal de divergência
+  de parsing clássico↔incremental → abortar).
 
 ### Git / Workflow / Deploy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,12 +378,17 @@ parse clean as of PR #155. See those PRs for the exact pattern.
   [`etl/refresh_post_incremental.py`](etl/refresh_post_incremental.py)
   (`--source tce_pb`). 1º populate de ~40M rows leva ~60-75 min (uma vez).
 - **Idempotência cross-boundary TCE-PB** (ADR-0014): o hash `_nk_md5` exclui
-  cols de normalização (`cnpj_basico`, `ano`, `cpf_digitos`, `cpf_digitos_6`,
-  `nome_upper`, `*_proponente`) — elas ficam NULL em rows novas e preenchidas
-  em rows legacy; incluí-las quebraria a deduplicação no republish. Antes do
-  **1º incremental real**, conferir que `rows_inserted` do bucket corrente é
+  cols de normalização (`cnpj_basico`, `cpf_digitos` em despesa; `cpf_digitos_6`,
+  `nome_upper` em servidor; `*_proponente` em licitação; e `ano` SÓ em despesa,
+  onde é dup de `ano_arquivo` — `receita.ano` é business col e ENTRA no hash).
+  Elas ficam NULL em rows novas e preenchidas em rows legacy; incluí-las
+  quebraria a deduplicação no republish. O hash também **normaliza** valores
+  para casar classic↔incremental: `coalesce(valor,0.00)` (o parser nulifica o
+  token cru `'0'` que o ETL clássico gravou como `0.00`) e limpeza de
+  `\t\r\n`/sentinelas no texto (`etl_admin.nk_norm_text`/`nk_norm_num`). Antes
+  do **1º incremental real**, conferir que `rows_inserted` do bucket corrente é
   ≈ (upstream − já carregado), **não** ≈ bucket inteiro (sinal de divergência
-  de parsing clássico↔incremental → abortar).
+  de parsing → abortar).
 
 ### Git / Workflow / Deploy
 

--- a/docs/adr/0014-tce-pb-incremental-nk.md
+++ b/docs/adr/0014-tce-pb-incremental-nk.md
@@ -193,9 +193,8 @@ end-to-end (populate id-range → `sql/42z` → loader 2×):
 ### Negativas / custos
 
 - **Populate inicial** de ~40M rows (despesa 16M + servidor 22M + licitação
-  318k + receita 1,2M): ~60-90 min, uma única vez (despesa ~99µs/row com hash
-  normalizado inlinável). Execuções seguintes: `WHERE _nk_md5 IS NULL` → 0
-  rows, rápido.
+  318k + receita 1,2M): ~3,5h no teste local end-to-end, uma única vez.
+  Execuções seguintes: `WHERE _nk_md5 IS NULL` → 0 rows, rápido.
 - `+1` coluna `_nk_md5` + `UNIQUE INDEX` por tabela (overhead de espaço/escrita
   aceitável).
 

--- a/docs/adr/0014-tce-pb-incremental-nk.md
+++ b/docs/adr/0014-tce-pb-incremental-nk.md
@@ -84,30 +84,47 @@ Migrar **as quatro tabelas TCE-PB para NK sintética md5**, exatamente como
    `ON CONFLICT (_nk_md5)`.
 
 2. **Single source of truth do hash**: cada tabela tem
-   `etl_admin.nk_md5_<tabela>_row(<tabela>)` (LANGUAGE sql STABLE) que é
+   `etl_admin.nk_md5_<tabela>_row(<tabela>)` (LANGUAGE sql STABLE, **sem
+   `SET search_path`** para permitir inlining — senão cada chamada de helper
+   por coluna vira function-call e o populate de 16M+ rows leva horas) que é
    chamada **tanto pelo trigger** (rows novas) **quanto pelo populate** (rows
    legacy). Evita o drift de manter o hash duplicado (a despesa tem 41 cols).
 
 3. **Hash de TODAS as colunas de negócio**, excluindo `id` e as colunas de
-   **normalização** (`cnpj_basico`, `ano`, `cpf_digitos`, `cpf_digitos_6`,
-   `nome_upper`, `cnpj_basico_proponente`, `cpf_digitos_proponente`) — que
-   ficam NULL em rows recém-inseridas e preenchidas em rows legacy; incluí-las
-   quebraria a idempotência.
+   **normalização** (`cnpj_basico`/`cpf_digitos` em despesa; `cpf_digitos_6`/
+   `nome_upper` em servidor; `*_proponente` em licitação; e `ano` **só em
+   despesa**, onde é dup de `ano_arquivo` — `receita.ano` é business col e
+   ENTRA no hash) — que ficam NULL em rows recém-inseridas e preenchidas em
+   rows legacy; incluí-las quebraria a idempotência.
+
+3b. **Normalizadores de hash** (`etl_admin.nk_norm_text` / `nk_norm_num`,
+   IMMUTABLE, inlináveis) replicam o parser incremental para casar
+   classic↔incremental (ver "Idempotência" abaixo): texto colapsa `\t\r\n`→
+   espaço + sentinelas→`''`; numérico colapsa NULL e 0 para `'0.00'`.
+
+3c. **Drop de UNIQUE INDEX da NK natural** (`sql/42` step 0c): qualquer índice
+   natural remanescente (de POCs ou `sql/30`/`sql/31` antigos) QUEBRA o upsert
+   synthetic — re-inserir uma row legacy viola o índice natural e o
+   `ON CONFLICT (_nk_md5)` não trata esse conflito. Detectado em teste local.
 
 4. **Populate batched** via `python -m etl.refresh_post_incremental
    --source tce_pb --populate-only` (psycopg2 `autocommit=True` + partial
-   index temporário; o quirk PG16 de COMMIT-em-PROCEDURE via `psql -c/-f`
-   também se aplica aqui — ver ADR-0010).
+   index temporário, **dropado antes de recriar** para auto-heal de runs
+   crashados; o quirk PG16 de COMMIT-em-PROCEDURE via `psql -c/-f` também se
+   aplica aqui — ver ADR-0010).
 
 5. **`sql/42z_tce_pb_finalize.sql`**: preflight (`_nk_md5` populado) → dedupe
    por `_nk_md5` (keep `min(id)`, statement único em DO-block, sem
    CALL/COMMIT) → `UNIQUE INDEX CONCURRENTLY ix_tce_pb_<tabela>_nk_md5` →
-   validação. Dedupe esperado: despesa 0, servidor ~23, licitação ~93,
-   receita 0.
+   validação.
 
 6. **Refresh das MVs PB** dependentes (L1→L2) em
    `etl/refresh_post_incremental.py:refresh_for_tce_pb` — sem isso o
    shadow rewarm/warm leria MVs stale e o swap atômico promoveria cache velho.
+   Refresh **adaptativo** (`_refresh_mv_adaptive`): `CONCURRENTLY` se a MV tem
+   UNIQUE INDEX, `REFRESH` simples senão (ex.: `mv_q67_dated_pb` em prod não
+   tem), skip+warning se a MV não existe. `mv_rede_pb` é **excluída** (montada
+   de `_tmp_rede_*` não reconstruídas aqui + sem UNIQUE INDEX).
 
 7. **`deploy.yml`**: detecta `TCE_PB_IN_SCOPE` e aplica `sql/42` → populate →
    `sql/42z` antes do runner, e `refresh_for_tce_pb` depois (espelha o bloco
@@ -117,19 +134,44 @@ Migrar **as quatro tabelas TCE-PB para NK sintética md5**, exatamente como
 
 Para que re-inserir um bucket já carregado pelo ETL clássico **não duplique**,
 o `_nk_md5` da row re-inserida (trigger) deve igualar o da row legacy
-(populate). Garantido porque:
+(populate). Garantido porque ambos usam a **mesma** `nk_md5_<tabela>_row`, que
+**normaliza** cada coluna do jeito que o parser incremental normaliza:
 
-- Ambos usam a **mesma** `nk_md5_<tabela>_row`.
-- TEXT: clássico (`TRIM`) e framework (`build_typed_select` → `trim`) ambos
-  aparam espaços.
-- `DECIMAL(15,2)`: escala fixa pela coluna → `::text` canônico (`'N.NN'`) nos
-  dois caminhos (validado: `10.50` armazenado → `'10.50'`).
+- TEXT (`nk_norm_text`): `\t`→espaço, `\r` removido, `\n`→espaço (==
+  `parser.py:_clean_for_tab`), depois `btrim` e sentinelas
+  (`''`/`00/00/0000`/`0000-00-00`/`NULL`)→`''`.
+- NUMÉRICO (`nk_norm_num`): `coalesce(v,0.00)::text` — o parser nulifica o
+  token cru `'0'` (`parser.py:329`) que o clássico gravou como `0.00`
+  (`DECIMAL(15,2)`); sem isso a MESMA row hashearia `'0.00'` vs `''`. Empírico
+  em prod: servidor 954 / receita 1843 rows com `valor=0` (despesa grava `'0'`
+  como NULL, então já casava).
 - `DATE`: `to_char(col,'YYYY-MM-DD')`.
 - `SMALLINT`: `::text`.
 
 Resíduo de risco: cols TEXT com sentinelas raras (`'NULL'`, `'00/00/0000'`)
 que o framework converte para NULL e o clássico manteve literais. Esperado
 ~zero em despesa; mitigado pelo **pré-flight de produção** (abaixo).
+
+### Validação local (end-to-end, 2026-06)
+
+Testado contra a base local (mesmo schema/dados que prod, 16M despesa / 22M
+servidor / 311k licitação / 1,2M receita):
+
+- Helpers unit-tested: `nk_norm_num(0.00) == nk_norm_num(NULL)`,
+  `nk_norm_text(\n) == nk_norm_text(' ')`, sentinela→`''`, código `'0'`
+  preservado.
+- Hash **determinístico**: 0 grupos de rows idênticas com hash divergente.
+- `_populate_nk_md5_table` + `UNIQUE INDEX` em licitação: OK (0 dedupe local).
+- **Loader end-to-end** (`runner --only tce_pb.tce_pb_licitacao
+  --only-buckets 2026`): 1ª run inseriu só rows novas; **2ª run inseriu 0
+  (idempotente)**.
+- **Zero double-load**: as 30 group/60 rows que compartilham a NK natural mas
+  têm `_nk_md5` divergente foram **todas** verificadas como registros
+  genuinamente distintos (objeto/descrição/data diferentes — ex.: "bolo e pão
+  francês" vs "frutas e verduras" no mesmo nº de licitação/proponente/valor) —
+  exatamente o que a NK natural colapsaria e o md5 preserva.
+- Caught+fixed: índices UNIQUE da NK natural remanescentes em local
+  bloqueavam o upsert (step 0c do `sql/42`).
 
 ## Consequences
 
@@ -143,8 +185,9 @@ que o framework converte para NULL e o clássico manteve literais. Esperado
 ### Negativas / custos
 
 - **Populate inicial** de ~40M rows (despesa 16M + servidor 22M + licitação
-  318k + receita 1,2M): ~60-75 min, uma única vez. Execuções seguintes:
-  `WHERE _nk_md5 IS NULL` → 0 rows, rápido.
+  318k + receita 1,2M): ~60-90 min, uma única vez (despesa ~99µs/row com hash
+  normalizado inlinável). Execuções seguintes: `WHERE _nk_md5 IS NULL` → 0
+  rows, rápido.
 - `+1` coluna `_nk_md5` + `UNIQUE INDEX` por tabela (overhead de espaço/escrita
   aceitável).
 

--- a/docs/adr/0014-tce-pb-incremental-nk.md
+++ b/docs/adr/0014-tce-pb-incremental-nk.md
@@ -127,8 +127,10 @@ Migrar **as quatro tabelas TCE-PB para NK sintética md5**, exatamente como
    shadow rewarm/warm leria MVs stale e o swap atômico promoveria cache velho.
    Refresh **adaptativo** (`_refresh_mv_adaptive`): `CONCURRENTLY` se a MV tem
    UNIQUE INDEX, `REFRESH` simples senão (ex.: `mv_q67_dated_pb` em prod não
-   tem), skip+warning se a MV não existe. `mv_rede_pb` é **excluída** (montada
-   de `_tmp_rede_*` não reconstruídas aqui + sem UNIQUE INDEX).
+   tinha; o deploy aplica `sql/15b_add_unique_index_mv_q67.sql` antes do hook),
+   skip+warning se a MV não existe. `mv_rede_pb` é **excluída** (montada de
+   `_tmp_rede_*` não reconstruídas aqui + sem UNIQUE INDEX). Assim, todas as
+   MVs presentes no fluxo de produção refrescam concorrentemente.
 
 7. **`deploy.yml`**: detecta `TCE_PB_IN_SCOPE` e aplica `sql/42` → populate →
    `sql/42z` antes do runner, e `refresh_for_tce_pb` depois (espelha o bloco

--- a/docs/adr/0014-tce-pb-incremental-nk.md
+++ b/docs/adr/0014-tce-pb-incremental-nk.md
@@ -1,0 +1,179 @@
+# ADR-0014: NK sintética md5 para tabelas TCE-PB no ETL incremental
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-23
+
+## Context
+
+As quatro tabelas TCE-PB (`tce_pb_despesa`, `tce_pb_servidor`,
+`tce_pb_licitacao`, `tce_pb_receita`) são carregadas pelo ETL clássico
+(`etl/19_tce_pb.py`), que faz `INSERT INTO ... SELECT` **plano**: sem dedup,
+sem `DELETE` prévio, sem `ON CONFLICT`. Re-rodar uma fase apenas **acumula
+duplicatas**. Não existe caminho de atualização incremental seguro no ETL
+clássico.
+
+Os specs do framework incremental (`etl/incremental/specs/tce_pb_*.py`,
+ADR-0004) já existiam, mas **nunca foram validados em produção**:
+
+- O `deploy.yml` nunca aplicou `sql/30` (despesa) nem `sql/31` (servidor).
+- `sql/30` criava um `UNIQUE INDEX` na NK natural **sem dedup** → falharia.
+- `sql/31` tinha o `DELETE` de dedup mas estava **truncado, sem o
+  `CREATE UNIQUE INDEX`**.
+- As tabelas em prod só têm `PRIMARY KEY (id)` — **nenhum índice na NK** →
+  o `ON CONFLICT (NK)` do framework falha com
+  `there is no unique or exclusion constraint matching the ON CONFLICT
+  specification`.
+
+Ao tentar rodar o incremental em prod (2026-06-23), os 9 buckets de despesa
+falharam com 0 rows inseridas (rollback limpo, sem corrupção). A investigação
+read-only em prod revelou dois problemas distintos que **inviabilizam a NK
+natural**:
+
+### 1. `tce_pb_despesa` — NK natural não é única (colisões reais)
+
+A NK candidata do spec (`municipio, codigo_ug, numero_empenho, data_empenho,
+codigo_subelemento, codigo_fonte_recurso, numero_obra, numero_licitacao,
+codigo_natureza, ano_arquivo`) tem **1037 grupos (2530 rows, 2019-2026)** com
+mais de uma ocorrência. Análise full-payload:
+
+- **0 dos 1037 grupos** são duplicatas reais.
+- **Todos os 1037** têm `valor_empenhado`/`valor_liquidado`/`valor_pago`/
+  `cpf_cnpj`/`nome_credor`/`historico` **distintos** — são empenhos/parcelas
+  legitimamente diferentes que a NK não distingue.
+- Adicionar `mes` à NK **não resolve** (0 grupos colapsam).
+
+Consequência: um `UNIQUE INDEX` na NK natural seria semanticamente errado, e
+`UPSERT_DO_NOTHING` **pularia silenciosamente** novos registros distintos que
+colidem na NK → perda contínua de dados a cada incremental.
+
+### 2. `tce_pb_servidor` — NULLs nas colunas da NK (double-load)
+
+A NK natural inclui colunas **NULLABLE não-coalescidas** (`nk_coalesce_cols`
+cobre só `cpf_cnpj, matricula, ano_mes, descricao_cargo`). Em prod:
+
+- `municipio`: **90.047 rows NULL**.
+- `nome_servidor`: **201 rows NULL**.
+
+Em PostgreSQL, `UNIQUE INDEX` trata `NULL` como **distinto**. Logo essas
+90k+ rows não seriam deduplicadas e o `ON CONFLICT` **não dispararia** → cada
+re-run do bucket (o framework re-baixa o bucket corrente,
+`refetch_recent_buckets=1`) **duplicaria** essas rows.
+
+### 3. `tce_pb_licitacao` / `tce_pb_receita`
+
+NK natural seria segura **hoje** (0 NULL nas cols não-coalescidas; dups são
+todas full-row idênticas: licitação 79 grupos / 93 rows, receita 0). Mas
+depender de auditoria de NULL a cada mudança de dados upstream é frágil.
+
+## Decision
+
+Migrar **as quatro tabelas TCE-PB para NK sintética md5**, exatamente como
+`bolsa_familia` (ADR-0010) e as 7 tabelas `pb_extras` (`sql/35a-d`).
+
+### Pontos críticos
+
+1. **`_nk_md5 TEXT`** em cada tabela (`sql/42_tce_pb_synthetic_nk.sql`),
+   populado por `trigger BEFORE INSERT` via
+   `etl_admin.row_hash_md5(...)` (hash injetivo `array_to_json`, `sql/35a`).
+   `nk_synthetic_md5=True` nos 4 specs → `build_upsert_sql` emite
+   `ON CONFLICT (_nk_md5)`.
+
+2. **Single source of truth do hash**: cada tabela tem
+   `etl_admin.nk_md5_<tabela>_row(<tabela>)` (LANGUAGE sql STABLE) que é
+   chamada **tanto pelo trigger** (rows novas) **quanto pelo populate** (rows
+   legacy). Evita o drift de manter o hash duplicado (a despesa tem 41 cols).
+
+3. **Hash de TODAS as colunas de negócio**, excluindo `id` e as colunas de
+   **normalização** (`cnpj_basico`, `ano`, `cpf_digitos`, `cpf_digitos_6`,
+   `nome_upper`, `cnpj_basico_proponente`, `cpf_digitos_proponente`) — que
+   ficam NULL em rows recém-inseridas e preenchidas em rows legacy; incluí-las
+   quebraria a idempotência.
+
+4. **Populate batched** via `python -m etl.refresh_post_incremental
+   --source tce_pb --populate-only` (psycopg2 `autocommit=True` + partial
+   index temporário; o quirk PG16 de COMMIT-em-PROCEDURE via `psql -c/-f`
+   também se aplica aqui — ver ADR-0010).
+
+5. **`sql/42z_tce_pb_finalize.sql`**: preflight (`_nk_md5` populado) → dedupe
+   por `_nk_md5` (keep `min(id)`, statement único em DO-block, sem
+   CALL/COMMIT) → `UNIQUE INDEX CONCURRENTLY ix_tce_pb_<tabela>_nk_md5` →
+   validação. Dedupe esperado: despesa 0, servidor ~23, licitação ~93,
+   receita 0.
+
+6. **Refresh das MVs PB** dependentes (L1→L2) em
+   `etl/refresh_post_incremental.py:refresh_for_tce_pb` — sem isso o
+   shadow rewarm/warm leria MVs stale e o swap atômico promoveria cache velho.
+
+7. **`deploy.yml`**: detecta `TCE_PB_IN_SCOPE` e aplica `sql/42` → populate →
+   `sql/42z` antes do runner, e `refresh_for_tce_pb` depois (espelha o bloco
+   `bolsa_familia`).
+
+### Idempotência cross-boundary (clássico → incremental)
+
+Para que re-inserir um bucket já carregado pelo ETL clássico **não duplique**,
+o `_nk_md5` da row re-inserida (trigger) deve igualar o da row legacy
+(populate). Garantido porque:
+
+- Ambos usam a **mesma** `nk_md5_<tabela>_row`.
+- TEXT: clássico (`TRIM`) e framework (`build_typed_select` → `trim`) ambos
+  aparam espaços.
+- `DECIMAL(15,2)`: escala fixa pela coluna → `::text` canônico (`'N.NN'`) nos
+  dois caminhos (validado: `10.50` armazenado → `'10.50'`).
+- `DATE`: `to_char(col,'YYYY-MM-DD')`.
+- `SMALLINT`: `::text`.
+
+Resíduo de risco: cols TEXT com sentinelas raras (`'NULL'`, `'00/00/0000'`)
+que o framework converte para NULL e o clássico manteve literais. Esperado
+~zero em despesa; mitigado pelo **pré-flight de produção** (abaixo).
+
+## Consequences
+
+### Positivas
+
+- TCE-PB ganha atualização incremental **idempotente** real (o gap original:
+  servidor abril/2026 só tinha 4.040 de ~255k rows).
+- Sem perda de registros distintos (despesa) nem double-load (servidor).
+- Uniforme com `bolsa_familia` + `pb_extras` → uma única forma de revisar.
+
+### Negativas / custos
+
+- **Populate inicial** de ~40M rows (despesa 16M + servidor 22M + licitação
+  318k + receita 1,2M): ~60-75 min, uma única vez. Execuções seguintes:
+  `WHERE _nk_md5 IS NULL` → 0 rows, rápido.
+- `+1` coluna `_nk_md5` + `UNIQUE INDEX` por tabela (overhead de espaço/escrita
+  aceitável).
+
+### Pré-flight obrigatório de produção (antes do 1º run real)
+
+Como a idempotência cross-boundary depende de paridade de parsing
+clássico↔incremental, antes do primeiro incremental de produção: rodar o
+bucket corrente e **conferir o `rows_inserted`** — deve ser ≈ (contagem
+upstream − contagem já carregada), **não** ≈ bucket inteiro. Se for ≈ bucket
+inteiro, há divergência de parsing (double-load) e o run deve ser abortado e
+investigado. Os `UNIQUE INDEX ix_tce_pb_*_nk_md5` impedem colisões exatas mas
+não rows logicamente-iguais com hash divergente.
+
+## Alternatives considered
+
+- **NK natural + UNIQUE INDEX** (`sql/30`/`sql/31` originais): rejeitada —
+  despesa tem 1037 colisões reais (perda de dados) e servidor tem 90k NULLs
+  na NK (double-load). Frágil para licitação/receita (auditoria de NULL).
+- **`DedupeStrategy.APPEND`** (sem `ON CONFLICT`): rejeitada — republish do
+  bucket duplicaria tudo (o spec comenta isso).
+- **Recarregar via ETL clássico** (`etl/19_tce_pb.py --anos 2026`): rejeitada
+  — `INSERT` plano sem dedup duplicaria 2026 inteiro; e o usuário exige evitar
+  ETL completo.
+
+## References
+
+- ADR-0004 (framework incremental P1-P6)
+- ADR-0010 (Bolsa Família incremental — mesmo padrão synthetic md5)
+- `sql/35a-d` (padrão `pb_extras`)
+- `sql/42_tce_pb_synthetic_nk.sql`, `sql/42z_tce_pb_finalize.sql`
+- `etl/refresh_post_incremental.py` (`populate_nk_md5_tce_pb`,
+  `refresh_for_tce_pb`)

--- a/docs/adr/0014-tce-pb-incremental-nk.md
+++ b/docs/adr/0014-tce-pb-incremental-nk.md
@@ -108,10 +108,14 @@ Migrar **as quatro tabelas TCE-PB para NK sintética md5**, exatamente como
    `ON CONFLICT (_nk_md5)` não trata esse conflito. Detectado em teste local.
 
 4. **Populate batched** via `python -m etl.refresh_post_incremental
-   --source tce_pb --populate-only` (psycopg2 `autocommit=True` + partial
-   index temporário, **dropado antes de recriar** para auto-heal de runs
-   crashados; o quirk PG16 de COMMIT-em-PROCEDURE via `psql -c/-f` também se
-   aplica aqui — ver ADR-0010).
+   --source tce_pb --populate-only` (psycopg2 `autocommit=True`; o quirk PG16
+   de COMMIT-em-PROCEDURE via `psql -c/-f` também se aplica aqui — ver
+   ADR-0010). **Batching por faixa de `id`** (PK range por batch), não
+   `WHERE _nk_md5 IS NULL ORDER BY id LIMIT N`: em tabelas grandes esse padrão
+   acumula dead tuples no índice parcial e o Index-Only-Scan degrada
+   (quase-quadrático: 44s→109s/batch medido na despesa 16M). A faixa de `id`
+   escaneia cada range uma vez via a PK (taxa estável ~300µs/row na despesa,
+   41 cols). Idempotente/resumível pelo filtro `_nk_md5 IS NULL`.
 
 5. **`sql/42z_tce_pb_finalize.sql`**: preflight (`_nk_md5` populado) → dedupe
    por `_nk_md5` (keep `min(id)`, statement único em DO-block, sem

--- a/docs/adr/0014-tce-pb-incremental-nk.md
+++ b/docs/adr/0014-tce-pb-incremental-nk.md
@@ -159,23 +159,27 @@ que o framework converte para NULL e o clássico manteve literais. Esperado
 ### Validação local (end-to-end, 2026-06)
 
 Testado contra a base local (mesmo schema/dados que prod, 16M despesa / 22M
-servidor / 311k licitação / 1,2M receita):
+servidor / 311k licitação / 1,2M receita). **As 4 tabelas** passaram o teste
+end-to-end (populate id-range → `sql/42z` → loader 2×):
 
 - Helpers unit-tested: `nk_norm_num(0.00) == nk_norm_num(NULL)`,
   `nk_norm_text(\n) == nk_norm_text(' ')`, sentinela→`''`, código `'0'`
-  preservado.
-- Hash **determinístico**: 0 grupos de rows idênticas com hash divergente.
-- `_populate_nk_md5_table` + `UNIQUE INDEX` em licitação: OK (0 dedupe local).
-- **Loader end-to-end** (`runner --only tce_pb.tce_pb_licitacao
-  --only-buckets 2026`): 1ª run inseriu só rows novas; **2ª run inseriu 0
-  (idempotente)**.
-- **Zero double-load**: as 30 group/60 rows que compartilham a NK natural mas
-  têm `_nk_md5` divergente foram **todas** verificadas como registros
-  genuinamente distintos (objeto/descrição/data diferentes — ex.: "bolo e pão
-  francês" vs "frutas e verduras" no mesmo nº de licitação/proponente/valor) —
-  exatamente o que a NK natural colapsaria e o md5 preserva.
-- Caught+fixed: índices UNIQUE da NK natural remanescentes em local
-  bloqueavam o upsert (step 0c do `sql/42`).
+  preservado. Hash **determinístico** (0 grupos de rows idênticas com hash
+  divergente).
+- **Loader 2ª run = 0 (idempotente) nas 4 tabelas**; 1ª run inseriu só o delta
+  legítimo (servidor +847k, despesa +476k — dados novos de 2026).
+- **Zero double-load**: na licitação, as 30 grupos/60 rows que compartilham a
+  NK natural mas têm `_nk_md5` divergente foram **todas** verificadas como
+  registros genuinamente distintos (ex.: "bolo e pão francês" vs "frutas e
+  verduras" no mesmo nº licitação) — o md5 preserva o que a NK natural
+  colapsaria.
+- **Decimal fix validado** (receita): após o loader, `valor IS NULL` = 0 e 0
+  grupos com `0.00`+`NULL` juntos — as 1843 rows `valor=0` casaram, sem
+  double-load.
+- Achados pegos só no teste local (corrigidos): (a) índices UNIQUE da NK
+  natural remanescentes bloqueavam o upsert (`sql/42` step 0c); (b) populate
+  degradava com `LIMIT`+índice parcial → trocado por faixa de `id`;
+  (c) `SchemaDriftError` por watermark stale → input one-off `rebootstrap_tce_pb`.
 
 ## Consequences
 
@@ -195,6 +199,26 @@ servidor / 311k licitação / 1,2M receita):
 - `+1` coluna `_nk_md5` + `UNIQUE INDEX` por tabela (overhead de espaço/escrita
   aceitável).
 
+### Schema-drift guard: re-bootstrap obrigatório na 1ª migração
+
+`etl/incremental/orchestrator.py:_check_target_schema_drift` recomputa o hash
+do schema do target e compara com `etl_watermark.target_schema_hash` capturado
+no bootstrap; se diferem, **aborta o runner** (`SchemaDriftError`). Como `sql/42`
+ADICIONA a coluna `_nk_md5`, o hash muda. Os deploys falhos de 2026-06-23 já
+bootstraparam as 4 specs `tce_pb` com o schema ANTIGO (sem `_nk_md5`), então o
+1º run pós-migração driftaria e falharia (confirmado em teste local na despesa).
+
+Fix: o input one-off **`rebootstrap_tce_pb=true`** roda
+`bootstrap_watermark --force` para as 4 specs após `sql/42z`, re-baselinando o
+`target_schema_hash`. `--force` faz DELETE+INSERT do watermark
+(`last_value=NULL`), então o 1º run reprocessa os buckets — idempotente via
+`_nk_md5` (insere só o delta). Escopar com `incremental_only_buckets` (ex.:
+`2026`) evita reprocessar todos os anos. **Remover o input após rodar 1x em
+prod** (technical debt; ver "One-off inputs hygiene" em `docs/deploy.md`).
+
+Ambientes sem watermark prévio de `tce_pb` não precisam do input (o
+auto-bootstrap do runner captura o schema novo já com `_nk_md5`).
+
 ### Pré-flight obrigatório de produção (antes do 1º run real)
 
 Como a idempotência cross-boundary depende de paridade de parsing
@@ -204,6 +228,11 @@ upstream − contagem já carregada), **não** ≈ bucket inteiro. Se for ≈ bu
 inteiro, há divergência de parsing (double-load) e o run deve ser abortado e
 investigado. Os `UNIQUE INDEX ix_tce_pb_*_nk_md5` impedem colisões exatas mas
 não rows logicamente-iguais com hash divergente.
+
+Procedimento da 1ª migração em prod (resumo):
+`etl_phase=incremental` + `incremental_only=tce_pb.tce_pb_despesa,...` (as 4) +
+`rebootstrap_tce_pb=true` + `incremental_only_buckets=2026` +
+`refresh_mvs`/`rewarm_cache_keys` conforme o padrão de cache.
 
 ## Alternatives considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ veja [`docs/architecture.md`](../architecture.md).
 | ADR-0011 | [Remover LIMIT 200/500 dos top resultados de cidade](0011-remover-limit-top-tabelas.md) | Proposed | 2026-05-17 |
 | ADR-0012 | [Páginas dedicadas para empenhos (`/empenho/pj/...` e `/empenho/pf/...`)](0012-paginas-dedicadas-empenho.md) | Proposed | 2026-05-19 |
 | ADR-0013 | [Zero-downtime no web (deploys + VM resize)](0013-zero-downtime-web.md) | Proposed | 2026-05-19 |
+| ADR-0014 | [NK sintética md5 para tabelas TCE-PB no ETL incremental](0014-tce-pb-incremental-nk.md) | Accepted | 2026-06-23 |
 
 ## Convenções
 

--- a/docs/etl-incremental-guide.md
+++ b/docs/etl-incremental-guide.md
@@ -336,6 +336,39 @@ ilustra dois pontos não cobertos pelo exemplo padrão:
    Step `ETL: Incremental` no deploy.yml chama automaticamente quando BF
    está no escopo da run.
 
+### Caso especial: TCE-PB (ADR-0014)
+
+As 4 tabelas `tce_pb_*` (despesa/servidor/licitação/receita) também usam
+`nk_synthetic_md5=True`, mas por motivos diferentes de BF — vale como exemplo
+de **por que a NK natural pode ser insegura mesmo quando "parece" única**:
+
+1. **Colisões reais na NK** (`tce_pb_despesa`): 1037 grupos compartilham a NK
+   candidata mas têm valores financeiros distintos (não são duplicatas). Um
+   `UNIQUE INDEX` na NK seria errado e `UPSERT_DO_NOTHING` **descartaria
+   registros novos legítimos**. Sempre rode o profiling full-payload (passo 1),
+   não só `COUNT(*) > 1` na NK.
+
+2. **NULLs em cols da NK** (`tce_pb_servidor`): `municipio` (90k) e
+   `nome_servidor` (201) são NULL. Como `UNIQUE INDEX` trata NULL como
+   **distinto** em PG, essas rows **nunca deduplicam** e re-runs duplicam.
+   Sempre verifique NULL nas cols não-coalescidas da NK antes de optar por NK
+   natural.
+
+3. **Hash single-source-of-truth**: para tabelas largas (despesa = 41 cols),
+   o hash é definido **uma vez** em `etl_admin.nk_md5_<tabela>_row(<tabela>)`
+   (LANGUAGE sql STABLE), chamada pelo trigger **e** pelo populate
+   (`etl/refresh_post_incremental.py:_populate_nk_md5_table`). Evita o drift de
+   duplicar 41 colunas entre trigger e populate.
+
+4. **Excluir cols de normalização do hash**: `cnpj_basico`, `ano`,
+   `cpf_digitos`, `cpf_digitos_6`, `nome_upper`, `*_proponente` ficam NULL em
+   rows recém-inseridas (populadas por fase posterior) e preenchidas em legacy
+   → incluí-las quebraria a idempotência no republish.
+
+Defs em [`sql/42_tce_pb_synthetic_nk.sql`](../sql/42_tce_pb_synthetic_nk.sql),
+finalize em [`sql/42z_tce_pb_finalize.sql`](../sql/42z_tce_pb_finalize.sql).
+`SOURCE_REFRESH_FNS["tce_pb"] = refresh_for_tce_pb` (MVs PB L1→L2).
+
 ### Padrão de uso (acionamento)
 
 ```bash

--- a/docs/etl-incremental-guide.md
+++ b/docs/etl-incremental-guide.md
@@ -360,10 +360,14 @@ de **por que a NK natural pode ser insegura mesmo quando "parece" única**:
    (`etl/refresh_post_incremental.py:_populate_nk_md5_table`). Evita o drift de
    duplicar 41 colunas entre trigger e populate.
 
-4. **Excluir cols de normalização do hash**: `cnpj_basico`, `ano`,
-   `cpf_digitos`, `cpf_digitos_6`, `nome_upper`, `*_proponente` ficam NULL em
+4. **Excluir cols de normalização do hash**: `cnpj_basico`/`cpf_digitos`
+   (despesa), `cpf_digitos_6`/`nome_upper` (servidor), `*_proponente`
+   (licitação), e `ano` **só em despesa** (dup de `ano_arquivo`) ficam NULL em
    rows recém-inseridas (populadas por fase posterior) e preenchidas em legacy
-   → incluí-las quebraria a idempotência no republish.
+   → incluí-las quebraria a idempotência. (`receita.ano` é business col e ENTRA
+   no hash.) O hash ainda **normaliza** valores para casar classic↔incremental
+   via `etl_admin.nk_norm_text`/`nk_norm_num` (limpa `\t\r\n`/sentinelas;
+   `coalesce(valor,0.00)` porque o parser nulifica o token cru `'0'`).
 
 Defs em [`sql/42_tce_pb_synthetic_nk.sql`](../sql/42_tce_pb_synthetic_nk.sql),
 finalize em [`sql/42z_tce_pb_finalize.sql`](../sql/42z_tce_pb_finalize.sql).

--- a/etl/incremental/specs/tce_pb_despesa.py
+++ b/etl/incremental/specs/tce_pb_despesa.py
@@ -124,6 +124,26 @@ for c in COLUMNS_OLD:
 SPEC = LoaderSpec(
     source="tce_pb",
     table="tce_pb_despesa",
+    # natural_key abaixo e DECLARATIVO (semantico). Quando nk_synthetic_md5=True
+    # (abaixo), build_upsert_sql usa ON CONFLICT (_nk_md5) — NAO estas colunas.
+    #
+    # Por que synthetic md5 e nao NK natural (ADR-0014):
+    #   Analise empirica em prod (2026-06) revelou que esta combinacao de
+    #   colunas NAO e unica: 1037 grupos (2530 rows, 2019-2026) compartilham
+    #   a NK mas tem valor_empenhado/valor_liquidado/valor_pago/cpf_cnpj/
+    #   nome_credor/historico DISTINTOS — sao empenhos/parcelas legitimamente
+    #   diferentes, nao duplicatas. Adicionar `mes` NAO resolve (0 grupos
+    #   colapsam). Um UNIQUE INDEX nesta NK seria semanticamente errado e
+    #   UPSERT_DO_NOTHING PULARIA silenciosamente novos registros distintos
+    #   que colidem na NK -> perda continua de dados a cada incremental.
+    #
+    #   Synthetic md5 (hash de TODAS as 41 cols de negocio) so colapsa rows
+    #   byte-a-byte identicas (true duplicates do ETL classico legacy). Cobre
+    #   100% sem perda. Padrao das 7 tabelas pb_extras (sql/35a-d) e de
+    #   bolsa_familia (sql/41). Requer:
+    #     * coluna _nk_md5 (sql/42 step 1)
+    #     * trigger BEFORE INSERT compute_nk_md5_tce_pb_despesa (sql/42 step 2)
+    #     * UNIQUE INDEX ix_tce_pb_despesa_nk_md5 (sql/42z)
     natural_key=[
         "municipio", "codigo_unidade_gestora", "numero_empenho", "data_empenho",
         "codigo_subelemento", "codigo_fonte_recurso",
@@ -132,6 +152,7 @@ SPEC = LoaderSpec(
     ],
     cursor_strategy=CursorStrategy.YEAR_WINDOW,
     dedupe_strategy=DedupeStrategy.UPSERT_DO_NOTHING,
+    nk_synthetic_md5=True,
     columns=COLUMNS,
     column_types=COLUMN_TYPES,
     column_renames=COLUMN_RENAMES,

--- a/etl/incremental/specs/tce_pb_licitacao.py
+++ b/etl/incremental/specs/tce_pb_licitacao.py
@@ -66,6 +66,9 @@ SPEC = LoaderSpec(
     ],
     cursor_strategy=CursorStrategy.YEAR_WINDOW,
     dedupe_strategy=DedupeStrategy.UPSERT_DO_NOTHING,
+    # nk_synthetic_md5=True -> ON CONFLICT (_nk_md5). md5 por uniformidade com
+    # despesa/servidor (ADR-0014). Requer sql/42 + sql/42z.
+    nk_synthetic_md5=True,
     columns=COLUMNS,
     column_types=COLUMN_TYPES,
     column_renames=COLUMN_RENAMES,

--- a/etl/incremental/specs/tce_pb_receita.py
+++ b/etl/incremental/specs/tce_pb_receita.py
@@ -65,6 +65,9 @@ SPEC = LoaderSpec(
     ],
     cursor_strategy=CursorStrategy.YEAR_WINDOW,
     dedupe_strategy=DedupeStrategy.UPSERT_DO_NOTHING,
+    # nk_synthetic_md5=True -> ON CONFLICT (_nk_md5). md5 por uniformidade com
+    # despesa/servidor (ADR-0014). Requer sql/42 + sql/42z.
+    nk_synthetic_md5=True,
     columns=COLUMNS,
     column_types=COLUMN_TYPES,
     column_renames=COLUMN_RENAMES,

--- a/etl/incremental/specs/tce_pb_servidor.py
+++ b/etl/incremental/specs/tce_pb_servidor.py
@@ -90,6 +90,13 @@ SPEC = LoaderSpec(
     ],
     cursor_strategy=CursorStrategy.YEAR_WINDOW,
     dedupe_strategy=DedupeStrategy.UPSERT_DO_NOTHING,
+    # natural_key abaixo e DECLARATIVO. nk_synthetic_md5=True -> build_upsert_sql
+    # usa ON CONFLICT (_nk_md5). Por que md5 e nao NK natural (ADR-0014):
+    # municipio (90.047 rows) e nome_servidor (201) tem NULL e fazem parte da
+    # NK natural; UNIQUE INDEX trata NULL como distinto -> ON CONFLICT nao
+    # dispara -> re-run do bucket DUPLICARIA essas rows. md5 (coalesce->'')
+    # trata NULL uniformemente. Requer sql/42 (col+trigger) + sql/42z (index).
+    nk_synthetic_md5=True,
     columns=COLUMNS,
     column_types=COLUMN_TYPES,
     column_renames=COLUMN_RENAMES,

--- a/etl/refresh_post_incremental.py
+++ b/etl/refresh_post_incremental.py
@@ -179,6 +179,13 @@ def _populate_nk_md5_table(conn, table: str, batch_size: int = 100_000) -> None:
     total = 0
     try:
         with conn.cursor() as cur:
+            # Pre-drop defensivo: se um run anterior crashou no meio, pode ter
+            # deixado o index INVALID (CONCURRENTLY interrompido). CREATE ...
+            # IF NOT EXISTS NAO recria um index INVALID existente, e o planner
+            # o ignora -> batches viram seq scan O(n) catastrofico. DROP antes
+            # garante estado limpo a cada run (Gemini review).
+            logger.info("dropping any stale partial index %s ...", idx)
+            cur.execute(f"DROP INDEX IF EXISTS {idx}")
             logger.info("creating temporary partial index %s ...", idx)
             cur.execute(
                 f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {idx} "
@@ -313,9 +320,14 @@ def refresh_for_bolsa_familia(conn) -> None:
     logger.info("refresh_for_bolsa_familia: DONE em %.1fs (%.1f min)", total_dt, total_dt / 60)
 
 
-# MVs PB que dependem das tabelas tce_pb_*, em ordem L1 -> L2 (sql/12_views.sql).
-# REFRESH CONCURRENTLY (cada MV tem UNIQUE INDEX). _tmp_bf NAO e reconstruido
-# aqui: reflete o estado atual de bolsa_familia, que nao muda num run TCE-PB.
+# MVs PB que dependem DIRETAMENTE das tabelas tce_pb_*, em ordem L1 -> L2
+# (sql/12_views.sql). _tmp_bf NAO e reconstruido aqui: reflete o estado atual
+# de bolsa_familia, que nao muda num run TCE-PB.
+#
+# mv_rede_pb foi DELIBERADAMENTE excluida: e montada a partir das tabelas
+# _tmp_rede_* (socio/fornecedor/servidor/credor/doador-campanha) que NAO sao
+# reconstruidas aqui — um REFRESH apenas re-le _tmp_rede_* stale (no-op util) e,
+# alem disso, mv_rede_pb nao tem UNIQUE INDEX (REFRESH CONCURRENTLY falharia).
 _TCE_PB_MVS_L1 = (
     "mv_empresa_governo",
     "mv_servidor_pb_base",
@@ -325,19 +337,57 @@ _TCE_PB_MVS_L1 = (
 _TCE_PB_MVS_L2 = (
     "mv_servidor_pb_risco",
     "mv_empresa_pb",
-    "mv_rede_pb",
     "mv_municipio_pb_kpi_score",
     "mv_municipio_pb_mapa",
     "mv_q67_dated_pb",
 )
 
 
+def _refresh_mv_adaptive(conn, mv: str) -> None:
+    """REFRESH de uma MV escolhendo o modo certo:
+      - CONCURRENTLY se a MV tem UNIQUE INDEX (zero-downtime);
+      - REFRESH simples (lock ACCESS EXCLUSIVE breve) se NAO tem (ex.:
+        mv_q67_dated_pb em prod) — CONCURRENTLY exigiria UNIQUE INDEX e
+        falharia;
+      - skip + warning se a MV nao existe (drift entre ambientes).
+
+    Erros reais de REFRESH propagam (hard-fail) — so o caso "sem unique index"
+    e tratado, nao mascaramos falhas de dados.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_class WHERE relname = %s AND relkind = 'm'", (mv,)
+        )
+        if cur.fetchone() is None:
+            logger.warning("MV %s nao existe — skip refresh (drift?)", mv)
+            return
+        cur.execute(
+            "SELECT bool_or(coalesce(i.indisunique, false)) "
+            "FROM pg_index i JOIN pg_class c ON c.oid = i.indrelid "
+            "WHERE c.relname = %s",
+            (mv,),
+        )
+        has_unique = bool(cur.fetchone()[0])
+
+    if has_unique:
+        _run_sql(conn, f"REFRESH {mv} (CONCURRENTLY)",
+                 f"REFRESH MATERIALIZED VIEW CONCURRENTLY {mv}", autocommit=True)
+    else:
+        logger.warning(
+            "MV %s sem UNIQUE INDEX — REFRESH simples (lock breve, nao-concurrent)",
+            mv,
+        )
+        _run_sql(conn, f"REFRESH {mv} (plain)",
+                 f"REFRESH MATERIALIZED VIEW {mv}", autocommit=True)
+
+
 def refresh_for_tce_pb(conn) -> None:
     """Refresh das MVs que dependem das tabelas TCE-PB (despesa/servidor/
     licitacao/receita), em ordem L1 -> L2.
 
-    Hard-fail: qualquer REFRESH que lance aborta o script (exit 1) — preferimos
-    falhar o deploy a deixar o warm/shadow rewarm subsequente ler MV stale.
+    Hard-fail: qualquer REFRESH que lance (erro real) aborta o script (exit 1) —
+    preferimos falhar o deploy a deixar o warm/shadow rewarm subsequente ler MV
+    stale. MVs sem UNIQUE INDEX usam REFRESH simples (ver _refresh_mv_adaptive).
 
     NOTA: mv_empresa_municipio_pagantes (sitemap) e refrescada a parte por
     etl.22_mv_sitemap no proprio step do deploy.
@@ -352,12 +402,7 @@ def refresh_for_tce_pb(conn) -> None:
         _run_sql(conn, f"ANALYZE {table}", f"ANALYZE {table}")
 
     for mv in _TCE_PB_MVS_L1 + _TCE_PB_MVS_L2:
-        _run_sql(
-            conn,
-            f"REFRESH {mv}",
-            f"REFRESH MATERIALIZED VIEW CONCURRENTLY {mv}",
-            autocommit=True,
-        )
+        _refresh_mv_adaptive(conn, mv)
 
     total_dt = time.time() - total_t0
     logger.info("refresh_for_tce_pb: DONE em %.1fs (%.1f min)", total_dt, total_dt / 60)

--- a/etl/refresh_post_incremental.py
+++ b/etl/refresh_post_incremental.py
@@ -142,6 +142,85 @@ def populate_nk_md5_bolsa_familia(conn, batch_size: int = 100_000) -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# TCE-PB: synthetic md5 NK (ADR-0014)
+# ──────────────────────────────────────────────────────────────────────────
+# Tabelas TCE-PB que usam _nk_md5 (sql/42 + sql/42z). A funcao de hash
+# etl_admin.nk_md5_<tabela>_row e single source of truth (trigger E populate
+# chamam a mesma), evitando drift.
+TCE_PB_MD5_TABLES: tuple[str, ...] = (
+    "tce_pb_despesa",
+    "tce_pb_servidor",
+    "tce_pb_licitacao",
+    "tce_pb_receita",
+)
+
+
+def _populate_nk_md5_table(conn, table: str, batch_size: int = 100_000) -> None:
+    """Popula _nk_md5 em batches numa tabela TCE-PB via row-function SQL.
+
+    Reusa etl_admin.nk_md5_<table>_row (mesma funcao do trigger) — zero drift
+    entre rows novas (trigger) e legacy (populate).
+
+    Padrao identico ao populate de bolsa_familia (ADR-0010):
+      * psycopg2 autocommit=True (COMMIT entre batches; psql -c/-f wrappa em
+        transacao implicita e o COMMIT-em-PROCEDURE falha no PG 16).
+      * partial index temporario WHERE _nk_md5 IS NULL para o WHERE IS NULL
+        nao virar seq scan O(n) por batch (trabalho quadratico).
+      * idempotente/resumivel: WHERE _nk_md5 IS NULL.
+    """
+    if table not in TCE_PB_MD5_TABLES:
+        raise ValueError(f"tabela TCE-PB desconhecida: {table!r}")
+    hash_fn = f"etl_admin.nk_md5_{table}_row"
+    idx = f"_tmp_idx_{table}_nk_md5_null"
+    logger.info("populate _nk_md5 %s: BATCH_SIZE=%d", table, batch_size)
+    prev_autocommit = conn.autocommit
+    conn.autocommit = True
+    t0 = time.time()
+    total = 0
+    try:
+        with conn.cursor() as cur:
+            logger.info("creating temporary partial index %s ...", idx)
+            cur.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {idx} "
+                f"ON {table} (id) WHERE _nk_md5 IS NULL"
+            )
+            cur.execute(f"ANALYZE {table}")
+
+            while True:
+                cur.execute(
+                    f"UPDATE {table} t SET _nk_md5 = {hash_fn}(t) "
+                    f"WHERE t.id IN ("
+                    f"  SELECT id FROM {table} WHERE _nk_md5 IS NULL "
+                    f"  ORDER BY id LIMIT %s)",
+                    (batch_size,),
+                )
+                n = cur.rowcount
+                if n == 0:
+                    break
+                total += n
+                logger.info(
+                    "populate _nk_md5 %s: total %s rows (%.0fs)",
+                    table, f"{total:,}", time.time() - t0,
+                )
+
+            logger.info("dropping temporary partial index %s ...", idx)
+            cur.execute(f"DROP INDEX IF EXISTS {idx}")
+    finally:
+        conn.autocommit = prev_autocommit
+    logger.info(
+        "populate _nk_md5 %s: DONE — %d rows em %.0fs",
+        table, total, time.time() - t0,
+    )
+
+
+def populate_nk_md5_tce_pb(conn, batch_size: int = 100_000) -> None:
+    """Popula _nk_md5 em todas as 4 tabelas TCE-PB (despesa/servidor/licitacao/
+    receita). Chamado pelo deploy entre sql/42 e sql/42z."""
+    for table in TCE_PB_MD5_TABLES:
+        _populate_nk_md5_table(conn, table, batch_size=batch_size)
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # Refresh por source
 # ──────────────────────────────────────────────────────────────────────────
 
@@ -234,12 +313,63 @@ def refresh_for_bolsa_familia(conn) -> None:
     logger.info("refresh_for_bolsa_familia: DONE em %.1fs (%.1f min)", total_dt, total_dt / 60)
 
 
+# MVs PB que dependem das tabelas tce_pb_*, em ordem L1 -> L2 (sql/12_views.sql).
+# REFRESH CONCURRENTLY (cada MV tem UNIQUE INDEX). _tmp_bf NAO e reconstruido
+# aqui: reflete o estado atual de bolsa_familia, que nao muda num run TCE-PB.
+_TCE_PB_MVS_L1 = (
+    "mv_empresa_governo",
+    "mv_servidor_pb_base",
+    "mv_municipio_pb_risco",
+    "mv_pessoa_pb",
+)
+_TCE_PB_MVS_L2 = (
+    "mv_servidor_pb_risco",
+    "mv_empresa_pb",
+    "mv_rede_pb",
+    "mv_municipio_pb_kpi_score",
+    "mv_municipio_pb_mapa",
+    "mv_q67_dated_pb",
+)
+
+
+def refresh_for_tce_pb(conn) -> None:
+    """Refresh das MVs que dependem das tabelas TCE-PB (despesa/servidor/
+    licitacao/receita), em ordem L1 -> L2.
+
+    Hard-fail: qualquer REFRESH que lance aborta o script (exit 1) — preferimos
+    falhar o deploy a deixar o warm/shadow rewarm subsequente ler MV stale.
+
+    NOTA: mv_empresa_municipio_pagantes (sitemap) e refrescada a parte por
+    etl.22_mv_sitemap no proprio step do deploy.
+    """
+    logger.info("=" * 60)
+    logger.info("refresh_for_tce_pb: iniciando (L1 -> L2)")
+    logger.info("=" * 60)
+    total_t0 = time.time()
+
+    # ANALYZE das tabelas base antes das queries pesadas das MVs.
+    for table in TCE_PB_MD5_TABLES:
+        _run_sql(conn, f"ANALYZE {table}", f"ANALYZE {table}")
+
+    for mv in _TCE_PB_MVS_L1 + _TCE_PB_MVS_L2:
+        _run_sql(
+            conn,
+            f"REFRESH {mv}",
+            f"REFRESH MATERIALIZED VIEW CONCURRENTLY {mv}",
+            autocommit=True,
+        )
+
+    total_dt = time.time() - total_t0
+    logger.info("refresh_for_tce_pb: DONE em %.1fs (%.1f min)", total_dt, total_dt / 60)
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Registry — fontes que tem refresh hooks
 # ──────────────────────────────────────────────────────────────────────────
 
 SOURCE_REFRESH_FNS: dict[str, Callable] = {
     "bolsa_familia": refresh_for_bolsa_familia,
+    "tce_pb": refresh_for_tce_pb,
 }
 
 
@@ -261,7 +391,7 @@ def main():
         "--populate-only",
         action="store_true",
         help="So roda populate_nk_md5 (sem MV refresh). Usado entre sql/41 e "
-             "sql/41z no deploy step. Apenas para source=bolsa_familia.",
+             "sql/41z (bolsa_familia) ou sql/42 e sql/42z (tce_pb) no deploy.",
     )
     parser.add_argument(
         "--dsn",
@@ -277,10 +407,15 @@ def main():
     conn = psycopg2.connect(args.dsn)
     try:
         if args.populate_only:
-            if args.source != "bolsa_familia":
-                logger.error("--populate-only so suporta source=bolsa_familia")
+            if args.source == "bolsa_familia":
+                populate_nk_md5_bolsa_familia(conn)
+            elif args.source == "tce_pb":
+                populate_nk_md5_tce_pb(conn)
+            else:
+                logger.error(
+                    "--populate-only so suporta source=bolsa_familia|tce_pb"
+                )
                 return 2
-            populate_nk_md5_bolsa_familia(conn)
         else:
             fn = SOURCE_REFRESH_FNS[args.source]
             fn(conn)

--- a/etl/refresh_post_incremental.py
+++ b/etl/refresh_post_incremental.py
@@ -155,63 +155,61 @@ TCE_PB_MD5_TABLES: tuple[str, ...] = (
 )
 
 
-def _populate_nk_md5_table(conn, table: str, batch_size: int = 100_000) -> None:
+def _populate_nk_md5_table(conn, table: str, batch_size: int = 200_000) -> None:
     """Popula _nk_md5 em batches numa tabela TCE-PB via row-function SQL.
 
     Reusa etl_admin.nk_md5_<table>_row (mesma funcao do trigger) — zero drift
     entre rows novas (trigger) e legacy (populate).
 
-    Padrao identico ao populate de bolsa_familia (ADR-0010):
-      * psycopg2 autocommit=True (COMMIT entre batches; psql -c/-f wrappa em
-        transacao implicita e o COMMIT-em-PROCEDURE falha no PG 16).
-      * partial index temporario WHERE _nk_md5 IS NULL para o WHERE IS NULL
-        nao virar seq scan O(n) por batch (trabalho quadratico).
-      * idempotente/resumivel: WHERE _nk_md5 IS NULL.
+    Batching por FAIXA DE id (PK) — cada batch faz UPDATE de um range
+    [lo, lo+batch) filtrando _nk_md5 IS NULL. Cada faixa e escaneada UMA vez via
+    o indice da PK, sem depender de um indice parcial que encolhe.
+
+    Por que NAO usar `WHERE _nk_md5 IS NULL ORDER BY id LIMIT N` (padrao BF):
+    em tabelas grandes (despesa 16M) cada UPDATE deixa dead tuples no indice
+    parcial `WHERE _nk_md5 IS NULL`; como autovacuum nao acompanha o ritmo, o
+    Index-Only-Scan passa a pular milhoes de entradas mortas -> tempo por batch
+    cresce (degradacao quase-quadratica observada: 44s -> 109s/batch). A faixa
+    de id evita isso (escaneia cada range uma vez).
+
+    psycopg2 autocommit=True: COMMIT entre batches (psql -c/-f wrappa em
+    transacao implicita e o COMMIT-em-PROCEDURE falharia no PG 16).
+    Idempotente/resumivel: o filtro _nk_md5 IS NULL pula faixas ja populadas.
     """
     if table not in TCE_PB_MD5_TABLES:
         raise ValueError(f"tabela TCE-PB desconhecida: {table!r}")
     hash_fn = f"etl_admin.nk_md5_{table}_row"
-    idx = f"_tmp_idx_{table}_nk_md5_null"
-    logger.info("populate _nk_md5 %s: BATCH_SIZE=%d", table, batch_size)
+    logger.info("populate _nk_md5 %s: BATCH_SIZE=%d (id-range)", table, batch_size)
     prev_autocommit = conn.autocommit
     conn.autocommit = True
     t0 = time.time()
     total = 0
     try:
         with conn.cursor() as cur:
-            # Pre-drop defensivo: se um run anterior crashou no meio, pode ter
-            # deixado o index INVALID (CONCURRENTLY interrompido). CREATE ...
-            # IF NOT EXISTS NAO recria um index INVALID existente, e o planner
-            # o ignora -> batches viram seq scan O(n) catastrofico. DROP antes
-            # garante estado limpo a cada run (Gemini review).
-            logger.info("dropping any stale partial index %s ...", idx)
-            cur.execute(f"DROP INDEX IF EXISTS {idx}")
-            logger.info("creating temporary partial index %s ...", idx)
             cur.execute(
-                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {idx} "
-                f"ON {table} (id) WHERE _nk_md5 IS NULL"
+                f"SELECT min(id), max(id) FROM {table} WHERE _nk_md5 IS NULL"
             )
-            cur.execute(f"ANALYZE {table}")
+            lo, hi = cur.fetchone()
+            if lo is None:
+                logger.info("populate _nk_md5 %s: nada a fazer (ja populado)", table)
+                return
 
-            while True:
+            cur_id = lo
+            while cur_id <= hi:
                 cur.execute(
                     f"UPDATE {table} t SET _nk_md5 = {hash_fn}(t) "
-                    f"WHERE t.id IN ("
-                    f"  SELECT id FROM {table} WHERE _nk_md5 IS NULL "
-                    f"  ORDER BY id LIMIT %s)",
-                    (batch_size,),
+                    f"WHERE t.id >= %s AND t.id < %s AND t._nk_md5 IS NULL",
+                    (cur_id, cur_id + batch_size),
                 )
                 n = cur.rowcount
-                if n == 0:
-                    break
                 total += n
-                logger.info(
-                    "populate _nk_md5 %s: total %s rows (%.0fs)",
-                    table, f"{total:,}", time.time() - t0,
-                )
-
-            logger.info("dropping temporary partial index %s ...", idx)
-            cur.execute(f"DROP INDEX IF EXISTS {idx}")
+                cur_id += batch_size
+                if n:
+                    logger.info(
+                        "populate _nk_md5 %s: ~%s/%s ids, %s rows (%.0fs)",
+                        table, f"{min(cur_id, hi + 1):,}", f"{hi:,}",
+                        f"{total:,}", time.time() - t0,
+                    )
     finally:
         conn.autocommit = prev_autocommit
     logger.info(

--- a/sql/12_views.sql
+++ b/sql/12_views.sql
@@ -1511,6 +1511,10 @@ JOIN pgfn_agg pg ON pg.cnpj_basico = d.cnpj_basico;
 CREATE INDEX idx_mv_q67_dated_mun_ano
     ON mv_q67_dated_pb(municipio, ano, divida_pgfn DESC);
 
+-- Necessario para REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX idx_mv_q67_dated_unique
+    ON mv_q67_dated_pb(municipio, ano, cnpj_basico) NULLS NOT DISTINCT;
+
 
 -- =============================================================================
 -- TABELA AUXILIAR: pncp_municipio (lista distinta de municípios PNCP)

--- a/sql/30_tce_pb_despesa_natural_keys.sql
+++ b/sql/30_tce_pb_despesa_natural_keys.sql
@@ -1,22 +1,16 @@
--- TCE-PB despesa: UNIQUE INDEX expression-based (resolve '' vs NULL)
+-- TCE-PB despesa: NK natural — DEPRECATED (ADR-0014)
 --
--- Legacy ETL pode ter inserido literal '' em cols opcionais; nosso
--- incremental converte CSV vazio para NULL. ON CONFLICT precisa tratar
--- '' e NULL como equivalentes.
+-- A NK natural de tce_pb_despesa NAO e unica: analise empirica em prod (2026-06)
+-- encontrou 1037 grupos (2530 rows) que compartilham esta NK mas sao registros
+-- financeiros DISTINTOS (valor_*/cpf_cnpj/nome_credor/historico diferentes).
+-- Um UNIQUE INDEX nesta NK seria semanticamente errado e UPSERT_DO_NOTHING
+-- pularia registros distintos silenciosamente.
 --
--- Solução: COALESCE(NULLIF(col, ''), '__NULL__')
---   '' → '__NULL__', NULL → '__NULL__', 'X' → 'X'
+-- Substituida por synthetic md5 (_nk_md5):
+--   * sql/42_tce_pb_synthetic_nk.sql  (coluna + trigger + funcao de hash)
+--   * sql/42z_tce_pb_finalize.sql     (dedupe + UNIQUE INDEX ix_tce_pb_despesa_nk_md5)
 --
--- ON CONFLICT em build_upsert_sql precisa usar EXATAMENTE a mesma expressão.
+-- Este arquivo agora apenas REMOVE o index natural antigo (caso runs/POCs
+-- anteriores o tenham criado). NAO recria o UNIQUE INDEX natural.
 
 DROP INDEX IF EXISTS ix_tce_pb_despesa_nk;
-
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_tce_pb_despesa_nk
-ON tce_pb_despesa (
-    municipio, codigo_ug, numero_empenho, data_empenho, ano_arquivo,
-    COALESCE(NULLIF(codigo_subelemento, ''), '__NULL__'),
-    COALESCE(NULLIF(codigo_fonte_recurso, ''), '__NULL__'),
-    COALESCE(NULLIF(numero_obra, ''), '__NULL__'),
-    COALESCE(NULLIF(numero_licitacao, ''), '__NULL__'),
-    COALESCE(NULLIF(codigo_natureza, ''), '__NULL__')
-);

--- a/sql/31_tce_pb_servidor_natural_keys.sql
+++ b/sql/31_tce_pb_servidor_natural_keys.sql
@@ -4,19 +4,13 @@
 --              tipo_cargo, valor_vantagem, descricao_cargo, nome_servidor,
 --              data_admissao)
 -- Pos cleanup de 23 grupos full-row identical, NK eh unique.
+--
+-- DEPRECATED (ADR-0014): a NK natural inclui colunas NULLABLE nao-coalescidas
+-- (municipio: 90.047 NULL; nome_servidor: 201 NULL em prod 2026-06). UNIQUE
+-- INDEX trata NULL como DISTINTO -> ON CONFLICT nao dispara -> re-run do bucket
+-- DUPLICARIA. Substituida por synthetic md5 (_nk_md5):
+--   * sql/42_tce_pb_synthetic_nk.sql  (coluna + trigger + funcao de hash)
+--   * sql/42z_tce_pb_finalize.sql     (dedupe por _nk_md5 + UNIQUE INDEX)
+-- No-op intencional (dedupe + index vivem em sql/42z).
 
--- Step 1: remover full-row dup groups (mantem 1 ocorrencia por NK)
-DELETE FROM tce_pb_servidor
-WHERE id IN (
-  SELECT id FROM (
-    SELECT id, ROW_NUMBER() OVER (
-      PARTITION BY municipio, codigo_ug, cpf_cnpj, matricula, ano_mes,
-                   tipo_cargo, valor_vantagem, descricao_cargo,
-                   nome_servidor, data_admissao
-      ORDER BY id
-    ) AS rn
-    FROM tce_pb_servidor
-    WHERE municipio IS NOT NULL AND codigo_ug IS NOT NULL
-      AND cpf_cnpj IS NOT NULL AND matricula IS NOT NULL AND ano_mes IS NOT NULL
-  ) ranked WHERE rn > 1
-);
+-- (sem statements — ver sql/42z_tce_pb_finalize.sql)

--- a/sql/42_tce_pb_synthetic_nk.sql
+++ b/sql/42_tce_pb_synthetic_nk.sql
@@ -44,11 +44,16 @@
 --   * DECIMAL(15,2): escala fixa pela coluna -> ::text canonico ('N.NN') em
 --     ambos os caminhos (validado: 10.50 armazenado -> '10.50').
 --   * DATE: to_char(col,'YYYY-MM-DD').
---   * SMALLINT (ano/ano_arquivo/ano_licitacao): ::text.
--- Cols de NORMALIZACAO (cnpj_basico, ano, cpf_digitos, cpf_digitos_6,
--- nome_upper, cnpj_basico_proponente, cpf_digitos_proponente) sao EXCLUIDAS:
--- ficam NULL em rows recem-inseridas (populadas por fase posterior) e
--- preenchidas em rows legacy -> inclui-las quebraria a idempotencia.
+--   * SMALLINT (ano_arquivo/ano_licitacao/receita.ano): ::text.
+-- Cols de NORMALIZACAO sao EXCLUIDAS do hash (ficam NULL em rows recem-
+-- inseridas, populadas por fase posterior, e preenchidas em rows legacy ->
+-- inclui-las quebraria a idempotencia):
+--   * despesa:   cnpj_basico, cpf_digitos, e `ano` (SMALLINT dup de
+--                ano_arquivo criada pela normalizacao — o hash usa ano_arquivo).
+--   * servidor:  cpf_digitos_6, nome_upper.
+--   * licitacao: cnpj_basico_proponente, cpf_digitos_proponente.
+-- ATENCAO: `receita.ano` NAO e coluna de normalizacao — e business col do CSV
+-- e ESTA incluida no hash de receita.
 --
 -- Ver ADR-0014 e docs/etl-incremental-guide.md.
 
@@ -73,6 +78,56 @@ END $$;
 
 
 -- ============================================================================
+-- 0c. Remover UNIQUE INDEX da NK natural (se existir) — ADR-0014
+-- ============================================================================
+-- A NK natural foi abandonada (despesa tem 1037 colisoes reais; servidor tem
+-- 90k NULLs na NK). Um UNIQUE INDEX natural remanescente (de POCs antigos ou
+-- sql/30/sql/31) QUEBRA o upsert synthetic: re-inserir uma row legacy viola o
+-- index natural, e o ON CONFLICT (_nk_md5) NAO trata esse conflito ->
+-- UniqueViolation aborta o bucket. (Detectado em teste local: o loader falhava
+-- com "viola a restricao de unicidade ix_tce_pb_licitacao_nk".) Idempotente.
+DROP INDEX IF EXISTS ix_tce_pb_despesa_nk;
+DROP INDEX IF EXISTS ix_tce_pb_servidor_nk;
+DROP INDEX IF EXISTS ix_tce_pb_licitacao_nk;
+DROP INDEX IF EXISTS ix_tce_pb_receita_nk;
+
+
+-- ============================================================================
+-- 0b. Normalizadores de hash (REPLICAM o parser incremental) — ADR-0014
+-- ============================================================================
+-- O ETL classico (etl/19_tce_pb.py) e o framework incremental armazenam o
+-- MESMO valor de CSV de formas diferentes. Para que rows legacy (populate) e
+-- re-inseridas (trigger) gerem o MESMO _nk_md5, o hash normaliza cada coluna
+-- da forma que o parser incremental normaliza. Aplicado nos DOIS caminhos.
+--
+-- TEXTO (replica etl/incremental/parser.py:_clean_for_tab + staging trim +
+-- sentinelas):
+--   \t -> espaco, \r removido, \n -> espaco; depois trim; e
+--   '' / 00/00/0000 / 0000-00-00 / NULL  ->  '' (sentinelas viram vazio).
+-- Sem caracteres especiais e o no-op de trim — nao muda o hash de dados ja
+-- limpos (validado: prod tem 0 rows com \n/\t nas cols de texto).
+CREATE OR REPLACE FUNCTION etl_admin.nk_norm_text(v text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT coalesce(
+    nullif(nullif(nullif(nullif(
+      btrim(translate(replace(v, E'\r', ''), E'\t\n', '  ')),
+    ''), '00/00/0000'), '0000-00-00'), 'NULL'),
+  '')
+$$;
+
+-- NUMERO: o parser incremental nulifica o token cru '0' (parser.py:329
+-- `IN ('', '0', 'NULL') -> NULL`), enquanto o ETL classico armazena '0' como
+-- 0.00 (DECIMAL(15,2)). Sem normalizacao, a MESMA row hashearia '0.00' (legacy)
+-- vs '' (incremental) e duplicaria (91k+ rows com valor_pago='0' so em
+-- despesas-2026). coalesce(v,0.00) colapsa NULL e 0.00 para '0.00'; valores
+-- nao-nulos ficam identicos ao ::text canonico do DECIMAL(15,2).
+CREATE OR REPLACE FUNCTION etl_admin.nk_norm_num(v numeric)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT coalesce(v, 0.00)::text
+$$;
+
+
+-- ============================================================================
 -- tce_pb_despesa
 -- ============================================================================
 ALTER TABLE tce_pb_despesa ADD COLUMN IF NOT EXISTS _nk_md5 TEXT;
@@ -85,29 +140,29 @@ COMMENT ON COLUMN tce_pb_despesa._nk_md5 IS
 CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_despesa_row(r tce_pb_despesa)
 RETURNS text AS $func$
   SELECT etl_admin.row_hash_md5(
-    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
-    coalesce(r.descricao_ug, ''), coalesce(r.numero_empenho, ''),
-    to_char(r.data_empenho, 'YYYY-MM-DD'), coalesce(r.mes, ''),
-    coalesce(r.cpf_cnpj, ''), coalesce(r.nome_credor, ''),
-    coalesce(r.valor_empenhado::text, ''), coalesce(r.valor_liquidado::text, ''),
-    coalesce(r.valor_pago::text, ''), coalesce(r.codigo_unidade_orcamentaria, ''),
-    coalesce(r.descricao_unidade_orcamentaria, ''), coalesce(r.codigo_funcao, ''),
-    coalesce(r.funcao, ''), coalesce(r.codigo_subfuncao, ''),
-    coalesce(r.subfuncao, ''), coalesce(r.codigo_programa, ''),
-    coalesce(r.programa, ''), coalesce(r.codigo_acao, ''),
-    coalesce(r.acao, ''), coalesce(r.codigo_categoria_economica, ''),
-    coalesce(r.categoria_economica, ''), coalesce(r.codigo_natureza, ''),
-    coalesce(r.grupo_natureza_despesa, ''), coalesce(r.codigo_modalidade_aplicacao, ''),
-    coalesce(r.modalidade_aplicacao, ''), coalesce(r.codigo_elemento_despesa, ''),
-    coalesce(r.elemento_despesa, ''), coalesce(r.codigo_subelemento, ''),
-    coalesce(r.codigo_subelemento_exibicao, ''), coalesce(r.numero_licitacao, ''),
-    coalesce(r.modalidade_licitacao, ''), coalesce(r.numero_obra, ''),
-    coalesce(r.historico, ''), coalesce(r.codigo_fonte_recurso, ''),
-    coalesce(r.descricao_fonte_recurso, ''), coalesce(r.ano_fonte, ''),
-    coalesce(r.co, ''), coalesce(r.descricao_co, ''),
+    etl_admin.nk_norm_text(r.municipio), etl_admin.nk_norm_text(r.codigo_ug),
+    etl_admin.nk_norm_text(r.descricao_ug), etl_admin.nk_norm_text(r.numero_empenho),
+    to_char(r.data_empenho, 'YYYY-MM-DD'), etl_admin.nk_norm_text(r.mes),
+    etl_admin.nk_norm_text(r.cpf_cnpj), etl_admin.nk_norm_text(r.nome_credor),
+    etl_admin.nk_norm_num(r.valor_empenhado), etl_admin.nk_norm_num(r.valor_liquidado),
+    etl_admin.nk_norm_num(r.valor_pago), etl_admin.nk_norm_text(r.codigo_unidade_orcamentaria),
+    etl_admin.nk_norm_text(r.descricao_unidade_orcamentaria), etl_admin.nk_norm_text(r.codigo_funcao),
+    etl_admin.nk_norm_text(r.funcao), etl_admin.nk_norm_text(r.codigo_subfuncao),
+    etl_admin.nk_norm_text(r.subfuncao), etl_admin.nk_norm_text(r.codigo_programa),
+    etl_admin.nk_norm_text(r.programa), etl_admin.nk_norm_text(r.codigo_acao),
+    etl_admin.nk_norm_text(r.acao), etl_admin.nk_norm_text(r.codigo_categoria_economica),
+    etl_admin.nk_norm_text(r.categoria_economica), etl_admin.nk_norm_text(r.codigo_natureza),
+    etl_admin.nk_norm_text(r.grupo_natureza_despesa), etl_admin.nk_norm_text(r.codigo_modalidade_aplicacao),
+    etl_admin.nk_norm_text(r.modalidade_aplicacao), etl_admin.nk_norm_text(r.codigo_elemento_despesa),
+    etl_admin.nk_norm_text(r.elemento_despesa), etl_admin.nk_norm_text(r.codigo_subelemento),
+    etl_admin.nk_norm_text(r.codigo_subelemento_exibicao), etl_admin.nk_norm_text(r.numero_licitacao),
+    etl_admin.nk_norm_text(r.modalidade_licitacao), etl_admin.nk_norm_text(r.numero_obra),
+    etl_admin.nk_norm_text(r.historico), etl_admin.nk_norm_text(r.codigo_fonte_recurso),
+    etl_admin.nk_norm_text(r.descricao_fonte_recurso), etl_admin.nk_norm_text(r.ano_fonte),
+    etl_admin.nk_norm_text(r.co), etl_admin.nk_norm_text(r.descricao_co),
     coalesce(r.ano_arquivo::text, '')
   )
-$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+$func$ LANGUAGE sql STABLE;
 
 CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_despesa()
 RETURNS trigger AS $func$
@@ -136,14 +191,14 @@ COMMENT ON COLUMN tce_pb_servidor._nk_md5 IS
 CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_servidor_row(r tce_pb_servidor)
 RETURNS text AS $func$
   SELECT etl_admin.row_hash_md5(
-    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
-    coalesce(r.descricao_ug, ''), coalesce(r.cpf_cnpj, ''),
-    coalesce(r.nome_servidor, ''), coalesce(r.tipo_cargo, ''),
-    coalesce(r.descricao_cargo, ''), coalesce(r.valor_vantagem::text, ''),
-    to_char(r.data_admissao, 'YYYY-MM-DD'), coalesce(r.matricula, ''),
-    coalesce(r.ano_mes, '')
+    etl_admin.nk_norm_text(r.municipio), etl_admin.nk_norm_text(r.codigo_ug),
+    etl_admin.nk_norm_text(r.descricao_ug), etl_admin.nk_norm_text(r.cpf_cnpj),
+    etl_admin.nk_norm_text(r.nome_servidor), etl_admin.nk_norm_text(r.tipo_cargo),
+    etl_admin.nk_norm_text(r.descricao_cargo), etl_admin.nk_norm_num(r.valor_vantagem),
+    to_char(r.data_admissao, 'YYYY-MM-DD'), etl_admin.nk_norm_text(r.matricula),
+    etl_admin.nk_norm_text(r.ano_mes)
   )
-$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+$func$ LANGUAGE sql STABLE;
 
 CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_servidor()
 RETURNS trigger AS $func$
@@ -171,15 +226,15 @@ COMMENT ON COLUMN tce_pb_licitacao._nk_md5 IS
 CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_licitacao_row(r tce_pb_licitacao)
 RETURNS text AS $func$
   SELECT etl_admin.row_hash_md5(
-    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
-    coalesce(r.descricao_ug, ''), coalesce(r.numero_licitacao, ''),
-    coalesce(r.numero_protocolo_tce, ''), coalesce(r.ano_licitacao::text, ''),
-    coalesce(r.modalidade, ''), coalesce(r.objeto_licitacao, ''),
-    to_char(r.data_homologacao, 'YYYY-MM-DD'), coalesce(r.nome_proponente, ''),
-    coalesce(r.cpf_cnpj_proponente, ''), coalesce(r.valor_ofertado::text, ''),
-    coalesce(r.situacao_proposta, '')
+    etl_admin.nk_norm_text(r.municipio), etl_admin.nk_norm_text(r.codigo_ug),
+    etl_admin.nk_norm_text(r.descricao_ug), etl_admin.nk_norm_text(r.numero_licitacao),
+    etl_admin.nk_norm_text(r.numero_protocolo_tce), coalesce(r.ano_licitacao::text, ''),
+    etl_admin.nk_norm_text(r.modalidade), etl_admin.nk_norm_text(r.objeto_licitacao),
+    to_char(r.data_homologacao, 'YYYY-MM-DD'), etl_admin.nk_norm_text(r.nome_proponente),
+    etl_admin.nk_norm_text(r.cpf_cnpj_proponente), etl_admin.nk_norm_num(r.valor_ofertado),
+    etl_admin.nk_norm_text(r.situacao_proposta)
   )
-$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+$func$ LANGUAGE sql STABLE;
 
 CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_licitacao()
 RETURNS trigger AS $func$
@@ -207,15 +262,15 @@ COMMENT ON COLUMN tce_pb_receita._nk_md5 IS
 CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_receita_row(r tce_pb_receita)
 RETURNS text AS $func$
   SELECT etl_admin.row_hash_md5(
-    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
-    coalesce(r.descricao_ug, ''), coalesce(r.mes_ano, ''),
-    coalesce(r.ano::text, ''), coalesce(r.codigo_receita, ''),
-    coalesce(r.descricao_receita, ''), coalesce(r.tipo_atualizacao_receita, ''),
-    coalesce(r.valor::text, ''), coalesce(r.codigo_fonte_recurso, ''),
-    coalesce(r.descricao_fonte_recurso, ''), coalesce(r.co, ''),
-    coalesce(r.descricao_co, '')
+    etl_admin.nk_norm_text(r.municipio), etl_admin.nk_norm_text(r.codigo_ug),
+    etl_admin.nk_norm_text(r.descricao_ug), etl_admin.nk_norm_text(r.mes_ano),
+    coalesce(r.ano::text, ''), etl_admin.nk_norm_text(r.codigo_receita),
+    etl_admin.nk_norm_text(r.descricao_receita), etl_admin.nk_norm_text(r.tipo_atualizacao_receita),
+    etl_admin.nk_norm_num(r.valor), etl_admin.nk_norm_text(r.codigo_fonte_recurso),
+    etl_admin.nk_norm_text(r.descricao_fonte_recurso), etl_admin.nk_norm_text(r.co),
+    etl_admin.nk_norm_text(r.descricao_co)
   )
-$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+$func$ LANGUAGE sql STABLE;
 
 CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_receita()
 RETURNS trigger AS $func$

--- a/sql/42_tce_pb_synthetic_nk.sql
+++ b/sql/42_tce_pb_synthetic_nk.sql
@@ -1,0 +1,238 @@
+-- Migration: tce_pb_despesa/servidor/licitacao/receita para NK sintetica md5.
+-- Framework ETL incremental (P1-P6). Padrao sql/35a-d (pb_extras) e sql/41 (BF).
+--
+-- Aplicada pelo step "ETL: Incremental" do deploy.yml quando TCE-PB esta no
+-- escopo (etl_phase=incremental). Idempotente — pode ser re-aplicada sem dano.
+--
+-- IMPORTANTE: os UNIQUE INDEX CONCURRENTLY ficam em sql/42z (rodam APOS o
+-- populate). Esta migration so tem DDL segura em transacao. Aplicar via
+-- `psql -v ON_ERROR_STOP=1 -f` SEM `--single-transaction`.
+--
+-- ── Por que synthetic md5 e nao NK natural? (ADR-0014) ──────────────────────
+--
+-- Analise empirica em prod (2026-06):
+--
+-- 1. tce_pb_despesa (16.2M rows): a NK candidata do spec tem 1037 grupos
+--    (2530 rows) com >1 ocorrencia, e ZERO sao duplicatas — todos tem
+--    valor_*/cpf_cnpj/nome_credor/historico DISTINTOS (empenhos/parcelas
+--    legitimamente diferentes que a NK nao distingue). UNIQUE INDEX na NK
+--    seria errado e UPSERT_DO_NOTHING PULARIA novos registros distintos.
+--
+-- 2. tce_pb_servidor (22.2M rows): a NK natural inclui colunas NULLABLE
+--    nao-coalescidas (municipio: 90.047 NULL; nome_servidor: 201 NULL). Em
+--    PostgreSQL, UNIQUE INDEX trata NULL como DISTINTO, entao essas 90k+ rows
+--    NAO seriam deduplicadas e ON CONFLICT NAO dispararia -> cada re-run do
+--    bucket DUPLICARIA essas rows. NK natural e inseguro aqui.
+--
+-- 3. tce_pb_licitacao / tce_pb_receita: NK natural seria segura hoje
+--    (0 NULL nas cols nao-coalescidas), mas usamos md5 por UNIFORMIDADE e
+--    para nao depender de auditoria de NULL a cada mudanca de dados upstream.
+--
+-- Synthetic md5 (hash de TODAS as cols de negocio) so colapsa rows
+-- byte-a-byte identicas (true duplicates do ETL classico, que fazia INSERT
+-- plano sem dedup). Cobre 100% sem perda e trata NULL uniformemente
+-- (coalesce -> '').
+--
+-- ── Idempotencia cross-boundary (ETL classico -> incremental) ──────────────
+--
+-- Para que re-inserir um bucket ja carregado NAO duplique, o _nk_md5 de uma
+-- row re-inserida (trigger) deve igualar o da row legacy (populate). Garantido
+-- porque ambos usam a MESMA funcao de hash (etl_admin.nk_md5_<tabela>_row,
+-- single source of truth) e os valores armazenados sao canonicos:
+--   * TEXT: ETL classico (etl/19_tce_pb.py) e o framework (build_typed_select)
+--     ambos aplicam trim. coalesce(col,'').
+--   * DECIMAL(15,2): escala fixa pela coluna -> ::text canonico ('N.NN') em
+--     ambos os caminhos (validado: 10.50 armazenado -> '10.50').
+--   * DATE: to_char(col,'YYYY-MM-DD').
+--   * SMALLINT (ano/ano_arquivo/ano_licitacao): ::text.
+-- Cols de NORMALIZACAO (cnpj_basico, ano, cpf_digitos, cpf_digitos_6,
+-- nome_upper, cnpj_basico_proponente, cpf_digitos_proponente) sao EXCLUIDAS:
+-- ficam NULL em rows recem-inseridas (populadas por fase posterior) e
+-- preenchidas em rows legacy -> inclui-las quebraria a idempotencia.
+--
+-- Ver ADR-0014 e docs/etl-incremental-guide.md.
+
+
+-- ============================================================================
+-- 0. Pre-flight: a funcao de hash injetiva precisa existir (sql/35a)
+-- ============================================================================
+-- etl_admin.row_hash_md5() usa array_to_json (injective). NAO redefinimos aqui
+-- para evitar drift entre trigger (rows novas) e populate (rows legacy).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'etl_admin' AND p.proname = 'row_hash_md5'
+    ) THEN
+        RAISE EXCEPTION
+            'etl_admin.row_hash_md5() ausente. Rode sql/35a_pb_extras_synthetic_nk_columns.sql '
+            'antes (schema base; aplicado por etl_phase=sql ou ETL completo).';
+    END IF;
+END $$;
+
+
+-- ============================================================================
+-- tce_pb_despesa
+-- ============================================================================
+ALTER TABLE tce_pb_despesa ADD COLUMN IF NOT EXISTS _nk_md5 TEXT;
+COMMENT ON COLUMN tce_pb_despesa._nk_md5 IS
+    'Hash md5 (injetivo) das 41 cols de negocio. Trigger BEFORE INSERT. '
+    'UNIQUE INDEX garante idempotencia sem perder registros distintos que '
+    'compartilham a NK natural (1037 grupos de colisao reais). Ver ADR-0014.';
+
+-- Single source of truth do hash (trigger E populate chamam esta funcao).
+CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_despesa_row(r tce_pb_despesa)
+RETURNS text AS $func$
+  SELECT etl_admin.row_hash_md5(
+    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
+    coalesce(r.descricao_ug, ''), coalesce(r.numero_empenho, ''),
+    to_char(r.data_empenho, 'YYYY-MM-DD'), coalesce(r.mes, ''),
+    coalesce(r.cpf_cnpj, ''), coalesce(r.nome_credor, ''),
+    coalesce(r.valor_empenhado::text, ''), coalesce(r.valor_liquidado::text, ''),
+    coalesce(r.valor_pago::text, ''), coalesce(r.codigo_unidade_orcamentaria, ''),
+    coalesce(r.descricao_unidade_orcamentaria, ''), coalesce(r.codigo_funcao, ''),
+    coalesce(r.funcao, ''), coalesce(r.codigo_subfuncao, ''),
+    coalesce(r.subfuncao, ''), coalesce(r.codigo_programa, ''),
+    coalesce(r.programa, ''), coalesce(r.codigo_acao, ''),
+    coalesce(r.acao, ''), coalesce(r.codigo_categoria_economica, ''),
+    coalesce(r.categoria_economica, ''), coalesce(r.codigo_natureza, ''),
+    coalesce(r.grupo_natureza_despesa, ''), coalesce(r.codigo_modalidade_aplicacao, ''),
+    coalesce(r.modalidade_aplicacao, ''), coalesce(r.codigo_elemento_despesa, ''),
+    coalesce(r.elemento_despesa, ''), coalesce(r.codigo_subelemento, ''),
+    coalesce(r.codigo_subelemento_exibicao, ''), coalesce(r.numero_licitacao, ''),
+    coalesce(r.modalidade_licitacao, ''), coalesce(r.numero_obra, ''),
+    coalesce(r.historico, ''), coalesce(r.codigo_fonte_recurso, ''),
+    coalesce(r.descricao_fonte_recurso, ''), coalesce(r.ano_fonte, ''),
+    coalesce(r.co, ''), coalesce(r.descricao_co, ''),
+    coalesce(r.ano_arquivo::text, '')
+  )
+$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+
+CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_despesa()
+RETURNS trigger AS $func$
+BEGIN
+  IF NEW._nk_md5 IS NULL THEN
+    NEW._nk_md5 := etl_admin.nk_md5_tce_pb_despesa_row(NEW);
+  END IF;
+  RETURN NEW;
+END
+$func$ LANGUAGE plpgsql SET search_path = pg_catalog, public;
+
+DROP TRIGGER IF EXISTS trg_compute_nk_md5 ON tce_pb_despesa;
+CREATE TRIGGER trg_compute_nk_md5 BEFORE INSERT ON tce_pb_despesa
+FOR EACH ROW EXECUTE FUNCTION etl_admin.compute_nk_md5_tce_pb_despesa();
+
+
+-- ============================================================================
+-- tce_pb_servidor
+-- ============================================================================
+ALTER TABLE tce_pb_servidor ADD COLUMN IF NOT EXISTS _nk_md5 TEXT;
+COMMENT ON COLUMN tce_pb_servidor._nk_md5 IS
+    'Hash md5 (injetivo) das 11 cols de negocio. Trigger BEFORE INSERT. '
+    'NK natural inviavel: municipio/nome_servidor tem NULLs e UNIQUE trata '
+    'NULL como distinto -> double-load. Ver ADR-0014.';
+
+CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_servidor_row(r tce_pb_servidor)
+RETURNS text AS $func$
+  SELECT etl_admin.row_hash_md5(
+    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
+    coalesce(r.descricao_ug, ''), coalesce(r.cpf_cnpj, ''),
+    coalesce(r.nome_servidor, ''), coalesce(r.tipo_cargo, ''),
+    coalesce(r.descricao_cargo, ''), coalesce(r.valor_vantagem::text, ''),
+    to_char(r.data_admissao, 'YYYY-MM-DD'), coalesce(r.matricula, ''),
+    coalesce(r.ano_mes, '')
+  )
+$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+
+CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_servidor()
+RETURNS trigger AS $func$
+BEGIN
+  IF NEW._nk_md5 IS NULL THEN
+    NEW._nk_md5 := etl_admin.nk_md5_tce_pb_servidor_row(NEW);
+  END IF;
+  RETURN NEW;
+END
+$func$ LANGUAGE plpgsql SET search_path = pg_catalog, public;
+
+DROP TRIGGER IF EXISTS trg_compute_nk_md5 ON tce_pb_servidor;
+CREATE TRIGGER trg_compute_nk_md5 BEFORE INSERT ON tce_pb_servidor
+FOR EACH ROW EXECUTE FUNCTION etl_admin.compute_nk_md5_tce_pb_servidor();
+
+
+-- ============================================================================
+-- tce_pb_licitacao
+-- ============================================================================
+ALTER TABLE tce_pb_licitacao ADD COLUMN IF NOT EXISTS _nk_md5 TEXT;
+COMMENT ON COLUMN tce_pb_licitacao._nk_md5 IS
+    'Hash md5 (injetivo) das 13 cols de negocio. Trigger BEFORE INSERT. '
+    'Synthetic NK por uniformidade com despesa/servidor. Ver ADR-0014.';
+
+CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_licitacao_row(r tce_pb_licitacao)
+RETURNS text AS $func$
+  SELECT etl_admin.row_hash_md5(
+    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
+    coalesce(r.descricao_ug, ''), coalesce(r.numero_licitacao, ''),
+    coalesce(r.numero_protocolo_tce, ''), coalesce(r.ano_licitacao::text, ''),
+    coalesce(r.modalidade, ''), coalesce(r.objeto_licitacao, ''),
+    to_char(r.data_homologacao, 'YYYY-MM-DD'), coalesce(r.nome_proponente, ''),
+    coalesce(r.cpf_cnpj_proponente, ''), coalesce(r.valor_ofertado::text, ''),
+    coalesce(r.situacao_proposta, '')
+  )
+$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+
+CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_licitacao()
+RETURNS trigger AS $func$
+BEGIN
+  IF NEW._nk_md5 IS NULL THEN
+    NEW._nk_md5 := etl_admin.nk_md5_tce_pb_licitacao_row(NEW);
+  END IF;
+  RETURN NEW;
+END
+$func$ LANGUAGE plpgsql SET search_path = pg_catalog, public;
+
+DROP TRIGGER IF EXISTS trg_compute_nk_md5 ON tce_pb_licitacao;
+CREATE TRIGGER trg_compute_nk_md5 BEFORE INSERT ON tce_pb_licitacao
+FOR EACH ROW EXECUTE FUNCTION etl_admin.compute_nk_md5_tce_pb_licitacao();
+
+
+-- ============================================================================
+-- tce_pb_receita
+-- ============================================================================
+ALTER TABLE tce_pb_receita ADD COLUMN IF NOT EXISTS _nk_md5 TEXT;
+COMMENT ON COLUMN tce_pb_receita._nk_md5 IS
+    'Hash md5 (injetivo) das 13 cols de negocio. Trigger BEFORE INSERT. '
+    'Synthetic NK por uniformidade com despesa/servidor. Ver ADR-0014.';
+
+CREATE OR REPLACE FUNCTION etl_admin.nk_md5_tce_pb_receita_row(r tce_pb_receita)
+RETURNS text AS $func$
+  SELECT etl_admin.row_hash_md5(
+    coalesce(r.municipio, ''), coalesce(r.codigo_ug, ''),
+    coalesce(r.descricao_ug, ''), coalesce(r.mes_ano, ''),
+    coalesce(r.ano::text, ''), coalesce(r.codigo_receita, ''),
+    coalesce(r.descricao_receita, ''), coalesce(r.tipo_atualizacao_receita, ''),
+    coalesce(r.valor::text, ''), coalesce(r.codigo_fonte_recurso, ''),
+    coalesce(r.descricao_fonte_recurso, ''), coalesce(r.co, ''),
+    coalesce(r.descricao_co, '')
+  )
+$func$ LANGUAGE sql STABLE SET search_path = pg_catalog, public;
+
+CREATE OR REPLACE FUNCTION etl_admin.compute_nk_md5_tce_pb_receita()
+RETURNS trigger AS $func$
+BEGIN
+  IF NEW._nk_md5 IS NULL THEN
+    NEW._nk_md5 := etl_admin.nk_md5_tce_pb_receita_row(NEW);
+  END IF;
+  RETURN NEW;
+END
+$func$ LANGUAGE plpgsql SET search_path = pg_catalog, public;
+
+DROP TRIGGER IF EXISTS trg_compute_nk_md5 ON tce_pb_receita;
+CREATE TRIGGER trg_compute_nk_md5 BEFORE INSERT ON tce_pb_receita
+FOR EACH ROW EXECUTE FUNCTION etl_admin.compute_nk_md5_tce_pb_receita();
+
+
+-- Populate de _nk_md5 nas rows legacy: feito via Python autocommit (batched +
+-- partial index), reusando as funcoes nk_md5_<tabela>_row acima:
+--   python -m etl.refresh_post_incremental --source tce_pb --populate-only
+-- Em seguida, sql/42z faz dedupe + UNIQUE INDEX. Ver ADR-0014.

--- a/sql/42z_tce_pb_finalize.sql
+++ b/sql/42z_tce_pb_finalize.sql
@@ -1,0 +1,124 @@
+-- ============================================================================
+-- sql/42z_tce_pb_finalize.sql
+--
+-- Roda APOS:
+--   1. sql/42_tce_pb_synthetic_nk.sql (cols, funcoes de hash, triggers)
+--   2. python -m etl.refresh_post_incremental --source tce_pb --populate-only
+--      (popula _nk_md5 em batches via psycopg2 autocommit — psql -c/-f wrappa
+--      CALL em transacao implicita no PG 16; ver ADR-0010/ADR-0014.)
+--
+-- Aplicar via `psql -v ON_ERROR_STOP=1 -f sql/42z_*.sql` SEM
+-- `--single-transaction` (CREATE INDEX CONCURRENTLY exige autocommit).
+--
+-- Idempotente: detecta INVALID index de runs falhos previos e refaz.
+--
+-- Dedupe esperado em prod (rows byte-a-byte identicas, true legacy dups):
+--   despesa: 0 | servidor: ~23 | licitacao: ~93 | receita: 0
+-- (DELETE inline em DO-block, statement unico — sem CALL/COMMIT-em-PROCEDURE,
+--  evita o quirk PG16. Mantem a row de menor id.)
+--
+-- Ver ADR-0014.
+
+
+-- ── Pre-flight: _nk_md5 populado em todas as 4 tabelas ──────────────────────
+DO $$
+DECLARE
+    t text;
+    n_null bigint;
+BEGIN
+    FOREACH t IN ARRAY ARRAY['tce_pb_despesa','tce_pb_servidor','tce_pb_licitacao','tce_pb_receita']
+    LOOP
+        EXECUTE format('SELECT count(*) FROM %I WHERE _nk_md5 IS NULL', t) INTO n_null;
+        IF n_null > 0 THEN
+            RAISE EXCEPTION
+                '%: % rows com _nk_md5 NULL. Rode '
+                '`python -m etl.refresh_post_incremental --source tce_pb --populate-only` '
+                'antes (NAO psql -c "CALL" — PG16 quirk; ver ADR-0014).', t, n_null;
+        END IF;
+        RAISE NOTICE '%: 100%% das rows tem _nk_md5 populado.', t;
+    END LOOP;
+END $$;
+
+
+-- ── Pre-drop INVALID indexes de runs CONCURRENTLY falhos previos ────────────
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT c.relname FROM pg_class c
+    JOIN pg_index i ON c.oid = i.indexrelid
+    WHERE c.relname IN (
+      'ix_tce_pb_despesa_nk_md5','ix_tce_pb_servidor_nk_md5',
+      'ix_tce_pb_licitacao_nk_md5','ix_tce_pb_receita_nk_md5'
+    ) AND NOT i.indisvalid
+  LOOP
+    RAISE NOTICE 'Dropping INVALID index % de run previo', r.relname;
+    EXECUTE format('DROP INDEX %I', r.relname);
+  END LOOP;
+END $$;
+
+
+-- ── Dedupe por _nk_md5 (keep min(id)); skip se UNIQUE INDEX ja existe ────────
+DO $$
+DECLARE
+    t text;
+    idx text;
+    n_deleted bigint;
+    pair text[];
+    pairs text[][] := ARRAY[
+        ['tce_pb_despesa','ix_tce_pb_despesa_nk_md5'],
+        ['tce_pb_servidor','ix_tce_pb_servidor_nk_md5'],
+        ['tce_pb_licitacao','ix_tce_pb_licitacao_nk_md5'],
+        ['tce_pb_receita','ix_tce_pb_receita_nk_md5']
+    ];
+    i int;
+BEGIN
+    FOR i IN 1 .. array_length(pairs, 1) LOOP
+        t := pairs[i][1];
+        idx := pairs[i][2];
+        IF EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = idx) THEN
+            RAISE NOTICE '% dedupe: skip (UNIQUE INDEX % ja garante invariante)', t, idx;
+            CONTINUE;
+        END IF;
+        EXECUTE format($q$
+            WITH dups AS (
+                SELECT id, ROW_NUMBER() OVER (PARTITION BY _nk_md5 ORDER BY id) AS rn
+                FROM %I WHERE _nk_md5 IS NOT NULL
+            ),
+            deleted AS (
+                DELETE FROM %I WHERE id IN (SELECT id FROM dups WHERE rn > 1) RETURNING 1
+            )
+            SELECT count(*) FROM deleted
+        $q$, t, t) INTO n_deleted;
+        RAISE NOTICE '% dedupe: % rows deletadas (mantida a mais antiga por _nk_md5)', t, n_deleted;
+    END LOOP;
+END $$;
+
+
+-- ── UNIQUE INDEX CONCURRENTLY (1 por statement, fora de transacao) ───────────
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_tce_pb_despesa_nk_md5
+  ON tce_pb_despesa (_nk_md5);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_tce_pb_servidor_nk_md5
+  ON tce_pb_servidor (_nk_md5);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_tce_pb_licitacao_nk_md5
+  ON tce_pb_licitacao (_nk_md5);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_tce_pb_receita_nk_md5
+  ON tce_pb_receita (_nk_md5);
+
+
+-- ── Validacao: todos os 4 indexes existem e estao VALID ─────────────────────
+DO $$
+DECLARE bad int;
+BEGIN
+  SELECT count(*) INTO bad FROM pg_class c
+  JOIN pg_index i ON c.oid = i.indexrelid
+  WHERE c.relname LIKE 'ix_tce_pb_%_nk_md5' AND NOT i.indisvalid;
+  IF bad > 0 THEN
+    RAISE EXCEPTION '% index(es) _nk_md5 INVALID; investigue duplicatas antes de re-rodar', bad;
+  END IF;
+
+  IF (SELECT count(*) FROM pg_indexes WHERE indexname LIKE 'ix_tce_pb_%_nk_md5') < 4 THEN
+    RAISE EXCEPTION 'Esperado 4 indexes ix_tce_pb_*_nk_md5; algum CREATE CONCURRENTLY falhou.';
+  END IF;
+  RAISE NOTICE 'Todos os 4 UNIQUE INDEX _nk_md5 validos. Pronto para upsert via synthetic NK.';
+END $$;


### PR DESCRIPTION
## Problema

O incremental TCE-PB falhava porque as quatro tabelas não possuíam restrição compatível com `ON CONFLICT`. A NK natural não é segura: `tce_pb_despesa` possui colisões entre registros financeiros legítimos e `tce_pb_servidor` possui NULLs que permitiriam duplicação em reprocessamentos.

## Solução

- NK sintética `_nk_md5` nas quatro tabelas, calculada pela mesma função no populate e no trigger.
- Normalização classic↔incremental para texto, datas e decimais.
- Populate resumível por faixas da PK `id`, sem degradação por dead tuples.
- Dedupe apenas de hashes realmente idênticos e quatro `UNIQUE INDEX CONCURRENTLY`.
- Re-bootstrap one-off dos watermarks após a alteração de schema.
- Refresh L1→L2 das MVs dependentes; todas as MVs presentes em produção refrescam concorrentemente. `mv_q67_dated_pb` recebe o índice único de `sql/15b` se necessário.
- Shadow rewarm seletivo e swap transacional do cache.

## Validação

Testado end-to-end localmente nas quatro tabelas, com aproximadamente 40 milhões de linhas legacy:

| Tabela | Delta legítimo na 1ª execução | 2ª execução |
|---|---:|---:|
| `tce_pb_despesa` | 476.501 | 0 |
| `tce_pb_servidor` | 847.139 | 0 |
| `tce_pb_licitacao` | 13.728 | 0 |
| `tce_pb_receita` | 50.388 | 0 |

Zero double-load; colisões da NK natural foram preservadas quando o conteúdo era distinto. O populate inicial levou cerca de 3,5 h no teste local. Revisão independente por seis agentes na implementação principal e dois revisores adicionais no ajuste final de refresh concorrente.

## Deploy

- `etl_phase`: `incremental`
- `incremental_only`: `tce_pb.tce_pb_despesa,tce_pb.tce_pb_servidor,tce_pb.tce_pb_licitacao,tce_pb.tce_pb_receita`
- `incremental_only_buckets`: `2026`
- `rebootstrap_tce_pb`: `true` somente nesta primeira execução
- `mv_swap`: vazio — nenhuma definição de MV é substituída; o refresh de dados será `CONCURRENTLY` usando índices únicos
- `rewarm_cache_keys`: `PERFIL,TOP_FORNECEDORES,TOP_SERVIDORES,HEATMAP,Q61,Q65,Q67,Q69,Q70,Q71,Q77`
- `invalidate_cache_keys`: vazio
- Zero downtime: MVs são atualizadas concorrentemente; o cache antigo permanece live durante o shadow rewarm e todas as chaves novas, incluindo `KPI_SUMMARY` autoexpandida, são promovidas numa única transação.

### Pre-flight obrigatório

Monitorar `rows_inserted` do bucket 2026. Deve representar apenas o delta do upstream; se se aproximar do bucket inteiro, cancelar antes do refresh e investigar divergência de parsing.

## Documentação

ADR-0014, guia incremental, `AGENTS.md` e workflow atualizados. Após o primeiro deploy bem-sucedido, remover o input one-off `rebootstrap_tce_pb`.
