### PR TITLE
fix(etl-incremental): normaliza TCE-PB antes das MVs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,6 +390,16 @@ parse clean as of PR #155. See those PRs for the exact pattern.
   do **1º incremental real**, conferir que `rows_inserted` do bucket corrente é
   ≈ (upstream − já carregado), **não** ≈ bucket inteiro (sinal de divergência
   de parsing → abortar).
+- **Normalização pós-incremental TCE-PB é obrigatória.** Os CSVs não contêm
+  `cpf_digitos_6`, `nome_upper`, `cnpj_basico`, `cpf_digitos`, `ano` nem as
+  colunas normalizadas de proponente. `refresh_for_tce_pb` chama
+  `normalize_tce_pb_incremental` antes de atualizar as MVs; sem isso, linhas
+  novas existem na base mas ficam invisíveis aos JOINs e à interface.
+- **Refresh TCE-PB respeita L1 → backing tables → L2.** Após
+  `mv_servidor_pb_base`, reconstrua `_tmp_socio_empresas`,
+  `_tmp_fornecedor_gov`, `_tmp_conflito`, `_tmp_bf`, `_tmp_duplo` e
+  `_tmp_siape_federal` com `TRUNCATE + INSERT` antes de
+  `mv_servidor_pb_risco`. Nunca use `DROP`: a MV depende dos OIDs.
 
 ### Git / Workflow / Deploy
 

--- a/docs/etl-incremental-guide.md
+++ b/docs/etl-incremental-guide.md
@@ -362,12 +362,25 @@ de **por que a NK natural pode ser insegura mesmo quando "parece" única**:
 
 4. **Excluir cols de normalização do hash**: `cnpj_basico`/`cpf_digitos`
    (despesa), `cpf_digitos_6`/`nome_upper` (servidor), `*_proponente`
-   (licitação), e `ano` **só em despesa** (dup de `ano_arquivo`) ficam NULL em
-   rows recém-inseridas (populadas por fase posterior) e preenchidas em legacy
-   → incluí-las quebraria a idempotência. (`receita.ano` é business col e ENTRA
-   no hash.) O hash ainda **normaliza** valores para casar classic↔incremental
-   via `etl_admin.nk_norm_text`/`nk_norm_num` (limpa `\t\r\n`/sentinelas;
+   (licitação), e `ano` **só em despesa** (dup de `ano_arquivo`) não vêm nos
+   CSVs e são preenchidas depois do INSERT → incluí-las quebraria a
+   idempotência. (`receita.ano` é business col e ENTRA no hash.) O hash ainda
+   **normaliza** valores para casar classic↔incremental via
+   `etl_admin.nk_norm_text`/`nk_norm_num` (limpa `\t\r\n`/sentinelas;
    `coalesce(valor,0.00)` porque o parser nulifica o token cru `'0'`).
+
+5. **Normalizar antes das MVs**: o loader genérico só insere colunas presentes
+   no CSV. `refresh_for_tce_pb` chama `normalize_tce_pb_incremental` antes do
+   `ANALYZE` e dos refreshes para preencher as colunas derivadas acima. Sem
+   esse hook, os dados brutos entram, mas linhas com `cpf_digitos_6` e
+   `nome_upper` NULL ficam invisíveis em `mv_servidor_pb_base`, no ranking e no
+   diálogo de vínculos.
+
+6. **Reconstruir backing tables entre L1 e L2**: depois de atualizar
+   `mv_servidor_pb_base`, o hook executa
+   `sql/43_tmp_servidor_post_incremental.sql` e reconstrói `_tmp_bf` na mesma
+   transação. As tabelas são atualizadas com `TRUNCATE + INSERT` para preservar
+   os OIDs usados por `mv_servidor_pb_risco`; só então a MV L2 é refrescada.
 
 Defs em [`sql/42_tce_pb_synthetic_nk.sql`](../sql/42_tce_pb_synthetic_nk.sql),
 finalize em [`sql/42z_tce_pb_finalize.sql`](../sql/42z_tce_pb_finalize.sql).

--- a/etl/refresh_post_incremental.py
+++ b/etl/refresh_post_incremental.py
@@ -154,6 +154,122 @@ TCE_PB_MD5_TABLES: tuple[str, ...] = (
     "tce_pb_receita",
 )
 
+_TCE_PB_NORMALIZATION_UPDATES: tuple[tuple[str, str], ...] = (
+    (
+        "normalize tce_pb_servidor",
+        """
+        UPDATE tce_pb_servidor
+        SET cpf_digitos_6 = CASE
+                WHEN cpf_digitos_6 IS NULL AND cpf_cnpj LIKE '***%'
+                THEN REGEXP_REPLACE(cpf_cnpj, '[^0-9]', '', 'g')
+                ELSE cpf_digitos_6
+            END,
+            nome_upper = CASE
+                WHEN nome_upper IS NULL AND nome_servidor IS NOT NULL
+                THEN UPPER(TRIM(nome_servidor))
+                ELSE nome_upper
+            END
+        WHERE (cpf_digitos_6 IS NULL AND cpf_cnpj LIKE '***%')
+           OR (nome_upper IS NULL AND nome_servidor IS NOT NULL)
+        """,
+    ),
+    (
+        "normalize tce_pb_despesa cnpj_basico",
+        """
+        UPDATE tce_pb_despesa d
+        SET cnpj_basico = LEFT(d.cpf_cnpj, 8)
+        WHERE d.cnpj_basico IS NULL
+          AND LENGTH(d.cpf_cnpj) = 14
+          AND EXISTS (
+              SELECT 1 FROM estabelecimento e
+              WHERE e.cnpj_completo = d.cpf_cnpj
+          )
+        """,
+    ),
+    (
+        "normalize tce_pb_despesa cpf_digitos",
+        """
+        UPDATE tce_pb_despesa d
+        SET cpf_digitos = SUBSTRING(d.cpf_cnpj FROM 4 FOR 11)
+        WHERE d.cpf_digitos IS NULL
+          AND LENGTH(d.cpf_cnpj) = 14
+          AND NOT EXISTS (
+              SELECT 1 FROM estabelecimento e
+              WHERE e.cnpj_completo = d.cpf_cnpj
+          )
+          AND NOT is_valid_cnpj(d.cpf_cnpj::TEXT)
+          AND is_valid_cpf(SUBSTRING(d.cpf_cnpj FROM 4 FOR 11)::TEXT)
+        """,
+    ),
+    (
+        "normalize tce_pb_despesa ano",
+        """
+        UPDATE tce_pb_despesa
+        SET ano = COALESCE(EXTRACT(YEAR FROM data_empenho)::SMALLINT, ano_arquivo)
+        WHERE ano IS NULL
+        """,
+    ),
+    (
+        "normalize tce_pb_licitacao cnpj_basico_proponente",
+        """
+        UPDATE tce_pb_licitacao
+        SET cnpj_basico_proponente = LEFT(cpf_cnpj_proponente, 8)
+        WHERE cnpj_basico_proponente IS NULL
+          AND LENGTH(cpf_cnpj_proponente) >= 14
+        """,
+    ),
+    (
+        "normalize tce_pb_licitacao cpf_digitos_proponente",
+        """
+        UPDATE tce_pb_licitacao
+        SET cpf_digitos_proponente = SUBSTRING(cpf_cnpj_proponente, 4, 6)
+        WHERE cpf_digitos_proponente IS NULL
+          AND LENGTH(cpf_cnpj_proponente) = 11
+        """,
+    ),
+)
+
+
+def normalize_tce_pb_incremental(conn) -> dict[str, int]:
+    """Preenche colunas derivadas deixadas NULL pelo loader incremental.
+
+    O ETL classico popula essas colunas em etl.15_normalizar, mas elas nao
+    fazem parte dos CSVs TCE-PB. O hook roda antes do refresh das MVs para que
+    linhas novas nao sejam invisiveis aos JOINs e filtros normalizados.
+
+    As colunas abaixo sao excluidas de _nk_md5 no ADR-0014; atualiza-las nao
+    altera a identidade sintetica nem a idempotencia do bucket.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT to_regprocedure('is_valid_cpf(text)') IS NOT NULL,
+                   to_regprocedure('is_valid_cnpj(text)') IS NOT NULL
+            """
+        )
+        has_cpf_fn, has_cnpj_fn = cur.fetchone()
+    if not has_cpf_fn or not has_cnpj_fn:
+        raise RuntimeError(
+            "normalizacao TCE-PB requer is_valid_cpf(text) e "
+            "is_valid_cnpj(text); execute etl.15_normalizar antes"
+        )
+
+    counts: dict[str, int] = {}
+    for label, sql in _TCE_PB_NORMALIZATION_UPDATES:
+        t0 = time.time()
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            counts[label] = cur.rowcount
+        if not conn.autocommit:
+            conn.commit()
+        logger.info(
+            "%s: %d rows em %.1fs",
+            label,
+            counts[label],
+            time.time() - t0,
+        )
+    return counts
+
 
 def _populate_nk_md5_table(conn, table: str, batch_size: int = 200_000) -> None:
     """Popula _nk_md5 em batches numa tabela TCE-PB via row-function SQL.
@@ -263,10 +379,7 @@ def refresh_for_bolsa_familia(conn) -> None:
     # 3. _tmp_bf rebuild via TRUNCATE+INSERT atomic.
     # Body extraido para sql/41c_tmp_bf_body.sql — drift com sql/12_views.sql
     # quebra esta logica (validado em smoke tests).
-    body = _read_sql_file("41c_tmp_bf_body.sql")
-    # Strip statement terminator do body antes de injetar — evita ambiguidade
-    # com concatenacoes futuras (Opus 4.7-high review LOW-5).
-    body_stripped = body.rstrip().rstrip(";").rstrip()
+    body_stripped = _read_sql_file("41c_tmp_bf_body.sql").rstrip().rstrip(";").rstrip()
     # TRUNCATE + INSERT atomic via transacao implicita do psycopg2
     # (autocommit=False default). Os dois statements executam em UMA
     # transacao; AccessExclusiveLock do TRUNCATE eh mantido ate o
@@ -319,8 +432,9 @@ def refresh_for_bolsa_familia(conn) -> None:
 
 
 # MVs PB que dependem DIRETAMENTE das tabelas tce_pb_*, em ordem L1 -> L2
-# (sql/12_views.sql). _tmp_bf NAO e reconstruido aqui: reflete o estado atual
-# de bolsa_familia, que nao muda num run TCE-PB.
+# (sql/12_views.sql). As backing tables de mv_servidor_pb_risco, incluindo
+# _tmp_bf, sao reconstruidas entre as camadas porque dependem da nova
+# mv_servidor_pb_base e/ou dos vinculos atualizados em tce_pb_servidor.
 #
 # mv_rede_pb foi DELIBERADAMENTE excluida: e montada a partir das tabelas
 # _tmp_rede_* (socio/fornecedor/servidor/credor/doador-campanha) que NAO sao
@@ -339,6 +453,19 @@ _TCE_PB_MVS_L2 = (
     "mv_municipio_pb_mapa",
     "mv_q67_dated_pb",
 )
+
+
+def _rebuild_servidor_tmp_after_tce_pb(conn) -> None:
+    """Reconstrói backing tables de mv_servidor_pb_risco atomicamente."""
+    tmp_sql = _read_sql_file("43_tmp_servidor_post_incremental.sql")
+    bf_body = _read_sql_file("41c_tmp_bf_body.sql").rstrip().rstrip(";").rstrip()
+    sql = f"""
+    {tmp_sql}
+    TRUNCATE TABLE _tmp_bf;
+    INSERT INTO _tmp_bf {bf_body};
+    ANALYZE _tmp_bf;
+    """
+    _run_sql(conn, "rebuild tmp servidor TCE-PB", sql)
 
 
 def _refresh_mv_adaptive(conn, mv: str) -> None:
@@ -395,11 +522,18 @@ def refresh_for_tce_pb(conn) -> None:
     logger.info("=" * 60)
     total_t0 = time.time()
 
+    normalize_tce_pb_incremental(conn)
+
     # ANALYZE das tabelas base antes das queries pesadas das MVs.
     for table in TCE_PB_MD5_TABLES:
         _run_sql(conn, f"ANALYZE {table}", f"ANALYZE {table}")
 
-    for mv in _TCE_PB_MVS_L1 + _TCE_PB_MVS_L2:
+    for mv in _TCE_PB_MVS_L1:
+        _refresh_mv_adaptive(conn, mv)
+
+    _rebuild_servidor_tmp_after_tce_pb(conn)
+
+    for mv in _TCE_PB_MVS_L2:
         _refresh_mv_adaptive(conn, mv)
 
     total_dt = time.time() - total_t0

--- a/sql/43_tmp_servidor_post_incremental.sql
+++ b/sql/43_tmp_servidor_post_incremental.sql
@@ -1,0 +1,96 @@
+-- Rebuild das tabelas auxiliares de mv_servidor_pb_risco apos TCE-PB
+-- incremental. Executado na mesma transacao do rebuild de _tmp_bf por
+-- etl/refresh_post_incremental.py, depois de mv_servidor_pb_base e antes de
+-- mv_servidor_pb_risco.
+--
+-- TRUNCATE + INSERT preserva os OIDs exigidos pela dependencia da MV.
+-- Definicoes canonicas: sql/12_views.sql, steps 1-5b.
+
+TRUNCATE TABLE
+    _tmp_socio_empresas,
+    _tmp_fornecedor_gov,
+    _tmp_conflito,
+    _tmp_duplo,
+    _tmp_siape_federal;
+
+INSERT INTO _tmp_socio_empresas
+    (cpf_digitos_6, nome_upper, qtd_empresas, cnpjs)
+SELECT srv.cpf_digitos_6,
+       srv.nome_upper,
+       COUNT(DISTINCT s.cnpj_basico) AS qtd_empresas,
+       ARRAY_AGG(DISTINCT s.cnpj_basico ORDER BY s.cnpj_basico) AS cnpjs
+FROM mv_servidor_pb_base srv
+JOIN socio s ON s.cpf_cnpj_norm = srv.cpf_digitos_6
+    AND UPPER(TRIM(s.nome)) = srv.nome_upper
+    AND s.tipo_socio = 2
+JOIN estabelecimento est ON est.cnpj_basico = s.cnpj_basico
+    AND est.cnpj_ordem = '0001'
+    AND est.situacao_cadastral = 2
+GROUP BY srv.cpf_digitos_6, srv.nome_upper;
+
+CREATE TEMP TABLE _post_inc_d_agg ON COMMIT DROP AS
+SELECT cnpj_basico, municipio, SUM(valor_pago) AS total_pago
+FROM tce_pb_despesa
+WHERE valor_pago > 0
+  AND municipio IS NOT NULL
+  AND cnpj_basico IS NOT NULL
+GROUP BY cnpj_basico, municipio;
+
+ANALYZE _post_inc_d_agg;
+
+CREATE TEMP TABLE _post_inc_se_unnest ON COMMIT DROP AS
+SELECT se.cpf_digitos_6, se.nome_upper,
+       m AS municipio, cnpj.cnpj_basico
+FROM _tmp_socio_empresas se
+JOIN mv_servidor_pb_base srv ON srv.cpf_digitos_6 = se.cpf_digitos_6
+    AND srv.nome_upper = se.nome_upper
+CROSS JOIN LATERAL unnest(se.cnpjs) AS cnpj(cnpj_basico)
+CROSS JOIN LATERAL unnest(srv.municipios) AS m;
+
+ANALYZE _post_inc_se_unnest;
+
+INSERT INTO _tmp_conflito
+    (cpf_digitos_6, nome_upper, qtd_conflitos, total_conflito)
+SELECT u.cpf_digitos_6, u.nome_upper,
+       COUNT(DISTINCT d.cnpj_basico) AS qtd_conflitos,
+       SUM(d.total_pago) AS total_conflito
+FROM _post_inc_se_unnest u
+JOIN _post_inc_d_agg d ON d.cnpj_basico = u.cnpj_basico
+    AND d.municipio = u.municipio
+GROUP BY u.cpf_digitos_6, u.nome_upper;
+
+INSERT INTO _tmp_fornecedor_gov (cpf_digitos_6, nome_upper)
+SELECT DISTINCT se.cpf_digitos_6, se.nome_upper
+FROM _tmp_socio_empresas se,
+     LATERAL unnest(se.cnpjs) AS cnpj(cnpj_basico)
+JOIN tce_pb_despesa d
+  ON d.cnpj_basico = cnpj.cnpj_basico
+ AND d.valor_pago > 0;
+
+INSERT INTO _tmp_duplo (cpf_digitos_6, nome_upper, total_estado)
+SELECT srv.cpf_digitos_6,
+       srv.nome_upper,
+       SUM(pp.valor_pagamento) AS total_estado
+FROM mv_servidor_pb_base srv
+JOIN pb_pagamento pp ON pp.cpf_digitos_6 = srv.cpf_digitos_6
+    AND pp.nome_upper = srv.nome_upper
+    AND LENGTH(pp.cpfcnpj_credor) = 11
+GROUP BY srv.cpf_digitos_6, srv.nome_upper;
+
+INSERT INTO _tmp_siape_federal (cpf_digitos_6, nome_upper)
+SELECT DISTINCT srv.cpf_digitos_6, srv.nome_upper
+FROM mv_servidor_pb_base srv
+JOIN siape_cadastro sf ON sf.cpf_digitos = srv.cpf_digitos_6
+    AND UPPER(TRIM(sf.nome)) = srv.nome_upper
+WHERE srv.cpf_digitos_6 IS NOT NULL
+  AND srv.cpf_digitos_6 != ''
+  AND srv.cpf_digitos_6 != '000000'
+  AND sf.cpf_digitos IS NOT NULL
+  AND sf.cpf_digitos != ''
+  AND sf.cpf_digitos != '000000';
+
+ANALYZE _tmp_socio_empresas;
+ANALYZE _tmp_fornecedor_gov;
+ANALYZE _tmp_conflito;
+ANALYZE _tmp_duplo;
+ANALYZE _tmp_siape_federal;

--- a/tests/incremental/test_secdef_invariants.py
+++ b/tests/incremental/test_secdef_invariants.py
@@ -26,7 +26,7 @@ CHECK_VIOLATION = "23514"
 # ─── search_path locked (R6 BLOCKING) ─────────────────────────────────────────
 
 def test_security_definer_functions_have_locked_search_path(govbr_conn):
-    """Toda função em etl_admin tem SET search_path no proconfig."""
+    """Toda função SECURITY DEFINER em etl_admin trava o search_path."""
     with govbr_conn.cursor() as cur:
         cur.execute(
             """
@@ -35,6 +35,7 @@ def test_security_definer_functions_have_locked_search_path(govbr_conn):
             FROM pg_proc p
             JOIN pg_namespace n ON n.oid = p.pronamespace
             WHERE n.nspname = 'etl_admin'
+              AND p.prosecdef
             ORDER BY p.proname
             """
         )

--- a/tests/incremental/test_tce_pb_post_incremental.py
+++ b/tests/incremental/test_tce_pb_post_incremental.py
@@ -1,0 +1,105 @@
+"""Regressoes do hook pos-incremental TCE-PB."""
+
+import pytest
+
+from etl.refresh_post_incremental import (
+    _TCE_PB_NORMALIZATION_UPDATES,
+    _rebuild_servidor_tmp_after_tce_pb,
+    normalize_tce_pb_incremental,
+)
+
+
+class _Cursor:
+    def __init__(self, executed, functions):
+        self.executed = executed
+        self.functions = functions
+        self.rowcount = 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql):
+        self.executed.append(sql)
+
+    def fetchone(self):
+        return self.functions
+
+
+class _Connection:
+    autocommit = False
+
+    def __init__(self, functions=(True, True)):
+        self.executed = []
+        self.commits = 0
+        self.functions = functions
+
+    def cursor(self):
+        return _Cursor(self.executed, self.functions)
+
+    def commit(self):
+        self.commits += 1
+
+
+def test_normalize_tce_pb_incremental_executes_all_updates():
+    conn = _Connection()
+
+    counts = normalize_tce_pb_incremental(conn)
+
+    assert len(conn.executed) == len(_TCE_PB_NORMALIZATION_UPDATES) + 1
+    assert conn.commits == len(_TCE_PB_NORMALIZATION_UPDATES)
+    assert all(count == 1 for count in counts.values())
+
+
+def test_servidor_normalization_restores_mv_join_columns():
+    servidor_sql = _TCE_PB_NORMALIZATION_UPDATES[0][1]
+
+    assert "cpf_digitos_6" in servidor_sql
+    assert "REGEXP_REPLACE(cpf_cnpj" in servidor_sql
+    assert "nome_upper" in servidor_sql
+    assert "UPPER(TRIM(nome_servidor))" in servidor_sql
+
+
+def test_normalization_fails_before_updates_without_document_functions():
+    conn = _Connection(functions=(False, True))
+
+    with pytest.raises(RuntimeError, match="is_valid_cpf"):
+        normalize_tce_pb_incremental(conn)
+
+    assert len(conn.executed) == 1
+    assert conn.commits == 0
+
+
+def test_despesa_normalization_preserves_cpf_cnpj_guard():
+    cnpj_sql = _TCE_PB_NORMALIZATION_UPDATES[1][1]
+    cpf_sql = _TCE_PB_NORMALIZATION_UPDATES[2][1]
+
+    assert "EXISTS" in cnpj_sql
+    assert "estabelecimento" in cnpj_sql
+    assert "is_valid_cnpj(d.cpf_cnpj::TEXT)" in cpf_sql
+    assert "is_valid_cpf(SUBSTRING(d.cpf_cnpj FROM 4 FOR 11)::TEXT)" in cpf_sql
+
+
+def test_tmp_rebuild_preserves_backing_table_oids(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "etl.refresh_post_incremental._read_sql_file",
+        lambda name: (
+            "TRUNCATE TABLE _tmp_socio_empresas"
+            if name == "43_tmp_servidor_post_incremental.sql"
+            else "SELECT 1"
+        ),
+    )
+    monkeypatch.setattr(
+        "etl.refresh_post_incremental._run_sql",
+        lambda conn, label, sql: captured.update(label=label, sql=sql),
+    )
+
+    _rebuild_servidor_tmp_after_tce_pb(object())
+
+    assert "TRUNCATE TABLE _tmp_socio_empresas" in captured["sql"]
+    assert "TRUNCATE TABLE _tmp_bf" in captured["sql"]
+    assert "DROP TABLE _tmp_" not in captured["sql"]


### PR DESCRIPTION
## Causa raiz

O incremental TCE-PB inseriu os dados brutos corretamente até `202605`, mas os CSVs não contêm as colunas derivadas criadas por `etl.15_normalizar`. O loader deixou essas colunas NULL e o hook refrescou as MVs sem preenchê-las.

Evidência em produção:

| Competência | Total | `cpf_digitos_6`/`nome_upper` NULL | Utilizáveis pelas MVs |
|---|---:|---:|---:|
| `202603` | 253.392 | 0 | 253.392 |
| `202604` | 255.057 | 251.017 | 4.040 |
| `202605` | 255.822 | 255.822 | 0 |

Por isso os registros existiam, mas `mv_servidor_pb_base`, rankings e diálogo de vínculos continuavam efetivamente em março.

## Correção

- `normalize_tce_pb_incremental` preenche somente colunas derivadas NULL de servidor, despesa e licitação, usando as regras canônicas de `etl/15_normalizar.py`.
- Preflight das funções CPF/CNPJ antes de qualquer UPDATE.
- A normalização acontece antes de `ANALYZE` e das MVs.
- Ordem correta: L1 (`mv_servidor_pb_base`) → rebuild transacional das seis backing tables → L2 (`mv_servidor_pb_risco`).
- Backing tables usam `TRUNCATE + INSERT`, preservando OIDs e mantendo o estado antigo se a transação falhar.
- `_nk_md5` não muda: todas as colunas normalizadas são excluídas do hash pelo ADR-0014.

## Validação

- 91 testes incrementais passaram.
- Os seis UPDATEs foram planejados localmente em transação com rollback.
- Dois reviews independentes; o segundo confirmou correspondência com `sql/12_views.sql`, transação atômica e ordem L1 → backing tables → L2.

## Deploy

- `etl_phase`: `incremental`
- `incremental_only`: `tce_pb.tce_pb_servidor`
- `incremental_only_buckets`: `2026`
- `rebootstrap_tce_pb`: `false`
- `mv_swap`: vazio — nenhuma definição de MV mudou; refresh concorrente dos snapshots existentes
- `rewarm_cache_keys`: `PERFIL,TOP_FORNECEDORES,TOP_SERVIDORES,HEATMAP,Q61,Q65,Q67,Q69,Q70,Q71,Q77`
- Zero downtime: UPDATEs usam MVCC; MVs refrescam concorrentemente; cache antigo permanece live até o shadow swap transacional.
